### PR TITLE
Map the three extracted workflow sets; queue the promotion step

### DIFF
--- a/docs/gauntlet/notes/v2-measurement-and-migration-plan.md
+++ b/docs/gauntlet/notes/v2-measurement-and-migration-plan.md
@@ -35,3 +35,15 @@ are container-relative; re-baseline before N4 budgets are set); re-run
 the opt-in real-Claude contract suite; then the N4 contract — which per
 ruling R-N0-3 cannot be written without the #17/#4 retention ruling, and
 per A-N3-1 requires #44 (journal group commit) to land first.
+
+## Addendum 2026-08-11 — the promotion step (owner catch, post-#43)
+
+The extracted workflow sets (see docs/gauntlet/runs/README.md) are all filed
+as evidence; none flow into `.sergeant/workflows/` as usable workflows. That
+promotion is the program's endgame and is now an explicit Cerberus work item,
+after #46/#47 land: curate `reference-corpus/draft-workflows/` (the 34
+adjudicated packages — the source of record, NOT the generated runs) into a
+runnable library — structure-validate each, run each through the engine on
+the fake backend as its acceptance gate, and ship as the out-of-box workflow
+set. Generated-run packages remain measurement evidence unless individually
+promoted through the same gate.

--- a/docs/gauntlet/runs/README.md
+++ b/docs/gauntlet/runs/README.md
@@ -1,0 +1,15 @@
+# Run evidence — where the extracted workflows live
+
+Three generations of extracted ICM workflow packages exist in this repo:
+
+| Set | Location | Status |
+|---|---|---|
+| **Adjudicated reference** (N1) — 966 behavior units, **34 draft workflow packages** | `reference-corpus/` (repo root) | Frozen; the curation source of record |
+| Run 2 generated (generator v1) | `docs/gauntlet/runs/n2-run2/drafts/workflows/` | Evidence only (11.8% coverage) |
+| Run 3 generated (generator v2) | `docs/gauntlet/runs/n2-run3/.sergeant/` — **note the dotted dir**: `drafts/workflows/` (18 packages) + all stage intermediates | Evidence (34.1% coverage, §22.2 met) |
+
+None of these are installed as *usable* workflows yet — `.sergeant/workflows/`
+holds only `repo-to-icm` and the `software-change` sample. The promotion step
+(curate `reference-corpus/draft-workflows/` → a runnable `.sergeant/workflows/`
+library, structure-validated and engine-tested) is queued Cerberus work — the
+program's actual endgame: making sergeant human-usable out of the box.


### PR DESCRIPTION
# What & why

Post-#43 owner catch: three generations of extracted ICM workflow packages exist in the repo — the 34 **adjudicated** reference packages (`reference-corpus/draft-workflows/`), run 2's generated set, and run 3's 18 packages (hidden in the dotted `docs/gauntlet/runs/n2-run3/.sergeant/` dir) — but all are filed as measurement evidence; none flow into `.sergeant/workflows/` as the usable library, which was the program's point.

Two docs changes:
- `docs/gauntlet/runs/README.md` — maps all three sets, flags the dotdir, states none are installed yet.
- Migration-plan addendum — the promotion step is now an explicit Cerberus work item: curate the 34 adjudicated packages (source of record, not the generated runs) into a runnable, structure-validated, engine-tested out-of-box workflow set.

## Tests

Docs only; no executable content changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWtHzL3np2Dpkhd7gi7SDP)_