### PR TITLE
scripts/probe-env.sh: session-start environment facts probe (retro item 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ Remote containers do not ship with no-mistakes — install it at session start. 
 
 Repo invariants live in this file; **per-host facts live in `docs/environments/`** (one dated, evidence-cited file per environment — cloud container, GH runner, and each new host on first contact). Never assume another environment's facts apply: measure, then record there. Fixtures asserting environment facts probe-gate per the testing rules above.
 
+Run `scripts/probe-env.sh` once at session start on **any** host, before doing anything else — it measures uid/DAC/CAP_LINUX_IMMUTABLE, disk and writable-allowance, O_DIRECT alignment behavior (open AND unaligned-write, the two-valued fact the journal's fault-injection fixtures actually branch on), network/proxy posture, Docker, and the claude/cargo/rustc toolchain, and prints them as a dated markdown table in the exact `docs/environments/` format — paste its output into that host's file. It never exits nonzero for an absent tool or negative result (only for its own bug); regression coverage lives in `scripts/probe-env-selftest.sh`, run with `bash scripts/probe-env-selftest.sh`.
+
 ## Remote-container operations
 
 These sessions run in ephemeral containers that reset without warning (three resets in one S-series day; a reset also wipes installed tools and `target/`, costing a ~10-min cold DuckDB rebuild):

--- a/docs/environments/README.md
+++ b/docs/environments/README.md
@@ -12,8 +12,10 @@ Rules:
   (run ID, journal path, command output). An undated fact is a rumor.
 - Sessions **re-measure cheaply on wake** where a probe exists rather than
   trusting a stale file; the file records the last measurement, not eternal
-  truth. (A future `scripts/probe-env.sh` should emit this file's facts
-  table for the host it runs on — see the N-series retro, item 1.)
+  truth. Run `scripts/probe-env.sh` once at session start on any host and
+  paste its table into that host's file here before doing anything else
+  (see the N-series retro, item 1) — it emits exactly this format, dated,
+  never a blank or assumed cell.
 - Test fixtures asserting environment facts must **probe-gate** (skip
   loudly where the fact doesn't hold) — the two-environment matrix in
   CLAUDE.md is the root-container/GH-runner instance of this general rule;

--- a/scripts/probe-env-selftest.sh
+++ b/scripts/probe-env-selftest.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# probe-env-selftest.sh — regression coverage for scripts/probe-env.sh's
+# honesty invariants: never a blank/unmeasured cell, never a fabricated
+# fact, never a nonzero exit because the HOST lacks a tool. Pure bash +
+# coreutils; no cargo, no network required (network probes fail soft and
+# are not asserted on here).
+#
+# This is R-S0-12 "code is code": probe-env.sh changes executable behavior
+# and needs a test that fails when a fix is reverted (LESSONS L7). Each
+# check below reproduces one fault-injection scenario from the blind-critic
+# review that shipped alongside this test (see the commit that added it).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/probe-env.sh"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/probe-env-selftest.XXXXXX")"
+FAIL=0
+
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAIL=1
+}
+pass() {
+  echo "PASS: $1"
+}
+
+# Build a stub PATH dir preloaded with real coreutils (symlinked) so a test
+# can override just the one or two binaries it cares about.
+mk_stub_path() {
+  local dir="$1"
+  shift
+  mkdir -p "$dir"
+  local t
+  for t in "$@"; do
+    local p
+    p="$(command -v "$t" 2>/dev/null || true)"
+    [ -n "$p" ] && ln -sf "$p" "$dir/$t"
+  done
+}
+
+ALL_TOOLS=(bash mktemp chmod cat tr sed awk df uname nproc python3 curl docker stat hostname grep cut date rm timeout printf id chattr)
+
+no_blank_cells() {
+  # A data row (not the header/separator) with an empty Measured-value or
+  # Evidence cell is a bug: "| Fact |  |  |" or "| Fact | val |  |".
+  grep -nE '^\| [^|]+ \| *\| ' <<<"$1" | grep -v '^| Fact |' \
+    && return 1
+  grep -nE '^\| [^|]+ \| [^|]+ \| *\|$' <<<"$1" \
+    && return 1
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 1 (baseline): plain run on this host must exit 0, produce a dated
+# header, no blank cells, and the paste-destination line.
+# ---------------------------------------------------------------------------
+out="$(bash "$TARGET" 2>/tmp/probe-env-selftest-baseline.err)"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "baseline run: expected exit 0, got $rc"
+else
+  pass "baseline run: exit 0"
+fi
+if ! grep -q '^Facts measured .* on host' <<<"$out"; then
+  fail "baseline run: missing dated header line"
+else
+  pass "baseline run: dated header present"
+fi
+if ! grep -q '^Paste destination: docs/environments/' <<<"$out"; then
+  fail "baseline run: missing paste destination line"
+else
+  pass "baseline run: paste destination present"
+fi
+if ! no_blank_cells "$out"; then
+  fail "baseline run: blank cell(s) in table"
+else
+  pass "baseline run: no blank cells"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2 (E1 regression): uid 0 with claude ABSENT from PATH must not print
+# the fabricated "IS_SANDBOX / root skip-flag refusal" measured-value row;
+# the imported claude.rs claim must appear only in Notes, if at all.
+# ---------------------------------------------------------------------------
+d="$WORK/e1"
+mk_stub_path "$d" "${ALL_TOOLS[@]}"
+rm -f "$d/claude" "$d/id"
+cat >"$d/id" <<'EOF'
+#!/bin/sh
+case "$1" in
+  -u) echo 0 ;;
+  -un) echo root ;;
+  -Gn) echo root ;;
+  -nG) echo root ;;
+  *) echo "uid=0(root) gid=0(root) groups=0(root)" ;;
+esac
+EOF
+chmod +x "$d/id"
+out="$(PATH="$d" bash "$TARGET" 2>/dev/null)"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "E1 (uid0, no claude): expected exit 0, got $rc"
+elif grep -qF 'cannot be used with root/sudo privileges' <<<"$out" && \
+     ! sed -n '/^Notes/,$p' <<<"$out" | grep -qF 'cannot be used with root/sudo privileges'; then
+  fail "E1 (uid0, no claude): imported claude.rs claim appears outside Notes section"
+elif grep -qE '^\| IS_SANDBOX / root skip-flag refusal \|' <<<"$out"; then
+  fail "E1 (uid0, no claude): stale fabricated fact row still present"
+else
+  pass "E1 (uid0, no claude): no fabricated measured-value row"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3 (E2 regression): chmod always fails (exit 1, mode unchanged) must
+# yield "unmeasurable", never a confident "NOT enforced" claim.
+# ---------------------------------------------------------------------------
+d="$WORK/e2"
+mk_stub_path "$d" "${ALL_TOOLS[@]}"
+rm -f "$d/chmod"
+cat >"$d/chmod" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+chmod +x "$d/chmod"
+out="$(PATH="$d" bash "$TARGET" 2>/dev/null)"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "E2 (chmod always fails): expected exit 0, got $rc"
+elif grep -qE '^\| DAC / permission-bit enforcement \| NOT enforced' <<<"$out"; then
+  fail "E2 (chmod always fails): wrongly reported NOT enforced when chmod couldn't change the mode"
+elif ! grep -qE '^\| DAC / permission-bit enforcement \| unmeasurable' <<<"$out"; then
+  fail "E2 (chmod always fails): DAC row did not degrade to unmeasurable"
+else
+  pass "E2 (chmod always fails): DAC row correctly unmeasurable"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4 (W2 regression): chattr +i succeeds but the inline -i cleanup
+# fails; the EXIT trap must retry it (leak guard must not be cleared on a
+# failed cleanup attempt).
+# ---------------------------------------------------------------------------
+d="$WORK/w2"
+mk_stub_path "$d" "${ALL_TOOLS[@]}"
+rm -f "$d/chattr"
+log="$WORK/w2-chattr.log"
+: >"$log"
+cat >"$d/chattr" <<EOF
+#!/bin/sh
+echo "\$*" >> "$log"
+case "\$1" in
+  +i) exit 0 ;;
+  -i) exit 1 ;;
+esac
+exit 0
+EOF
+chmod +x "$d/chattr"
+PATH="$d" bash "$TARGET" >/dev/null 2>/dev/null
+calls="$(wc -l <"$log" | tr -d ' ')"
+if [ "$calls" -lt 2 ]; then
+  fail "W2 (chattr -i fails): expected at least 2 chattr calls (inline attempt + trap retry), got $calls"
+else
+  pass "W2 (chattr -i fails): EXIT trap retried cleanup ($calls chattr calls)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5 (W3 regression): dockerd stderr warnings must not poison the JSON
+# parse of docker info's stdout.
+# ---------------------------------------------------------------------------
+d="$WORK/w3"
+mk_stub_path "$d" "${ALL_TOOLS[@]}"
+rm -f "$d/docker"
+cat >"$d/docker" <<'EOF'
+#!/bin/sh
+if [ "$1" = "--version" ]; then echo "Docker version 29.7.2, build stub"; exit 0; fi
+if [ "$1" = "info" ]; then
+  echo "WARNING: No swap limit support" >&2
+  echo "WARNING: bridge-nf-call-iptables is disabled" >&2
+  echo '{"Driver":"overlay2","CgroupVersion":"2"}'
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$d/docker"
+out="$(PATH="$d" bash "$TARGET" 2>/dev/null)"
+if grep -qE '^\| Docker:.*storage driver: unmeasurable' <<<"$out"; then
+  fail "W3 (docker stderr warnings): storage driver wrongly downgraded to unmeasurable"
+elif ! grep -qE '^\| Docker:.*storage driver: overlay2' <<<"$out"; then
+  fail "W3 (docker stderr warnings): storage driver not correctly parsed as overlay2"
+else
+  pass "W3 (docker stderr warnings): stdout/stderr split correctly, JSON parsed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6 (W4a regression): HOME unset must not trigger an unbound-variable
+# abort and must not produce blank cells.
+# ---------------------------------------------------------------------------
+out="$(env -u HOME PATH="$PATH" bash "$TARGET" 2>"$WORK/w4a.err")"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "W4a (HOME unset): expected exit 0, got $rc"
+elif grep -q 'unbound variable' "$WORK/w4a.err"; then
+  fail "W4a (HOME unset): unbound-variable error on stderr"
+elif ! no_blank_cells "$out"; then
+  fail "W4a (HOME unset): blank cell(s) in table"
+else
+  pass "W4a (HOME unset): no crash, no blank cells"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7 (W4b regression): empty PATH (no tr/sed/awk/coreutils at all) must
+# still exit 0 with no blank cells — mdcell/oneline must not depend on
+# external tools.
+# ---------------------------------------------------------------------------
+out="$(env -i PATH= HOME="$HOME" "$(command -v bash)" "$TARGET" 2>/dev/null)"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "W4b (empty PATH): expected exit 0, got $rc"
+elif ! no_blank_cells "$out"; then
+  fail "W4b (empty PATH): blank cell(s) in table"
+else
+  pass "W4b (empty PATH): no crash, no blank cells"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8 (E3 regression): O_DIRECT rows must distinguish open-refused /
+# unaligned-accepted / unaligned-rejected, not just report "open SUCCEEDS"
+# for both outcomes.
+# ---------------------------------------------------------------------------
+out="$(bash "$TARGET" 2>/dev/null)"
+if have_python3="$(command -v python3 2>/dev/null)"; [ -n "$have_python3" ]; then
+  if grep -qE '^\| O_DIRECT open\+unaligned-write .*\| open SUCCEEDS \|' <<<"$out"; then
+    fail "E3 (O_DIRECT): row still reports bare 'open SUCCEEDS' with no write-alignment outcome"
+  elif ! grep -qE '^\| O_DIRECT open\+unaligned-write .*(ACCEPTED|REJECTED|open FAILS)' <<<"$out"; then
+    fail "E3 (O_DIRECT): row missing a distinguishing alignment outcome"
+  else
+    pass "E3 (O_DIRECT): row distinguishes open vs write-alignment outcome"
+  fi
+else
+  echo "SKIPPED-ENV: E3 check needs python3, absent on this host"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: `pgrep`-adjacent hygiene — the script must not leave its scratch
+# dirs behind (this also indirectly checks the EXIT trap runs on the happy
+# path, complementing test 4's failure-path check).
+# ---------------------------------------------------------------------------
+before="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'probe-env.*' 2>/dev/null | wc -l | tr -d ' ')"
+bash "$TARGET" >/dev/null 2>/dev/null
+after="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'probe-env.*' 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$after" -gt "$before" ]; then
+  fail "cleanup: probe-env scratch dir(s) leaked under \$TMPDIR ($before -> $after)"
+else
+  pass "cleanup: no leaked scratch dirs under \$TMPDIR"
+fi
+
+echo
+if [ "$FAIL" -ne 0 ]; then
+  echo "probe-env-selftest: FAILURES ABOVE"
+  exit 1
+fi
+echo "probe-env-selftest: all checks passed"
+exit 0

--- a/scripts/probe-env.sh
+++ b/scripts/probe-env.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+# probe-env.sh — measure this host's environment facts and print them as a
+# markdown table in the docs/environments/ format.
+#
+# Retro deliverable (docs/gauntlet/notes/session-retro-n-series-2026-08-11.md,
+# item 1): nearly every hard stall in the N-series session was a collision
+# with an unmeasured container fact discovered the expensive way, mid-task.
+# Run this once at session start on ANY host and paste its table into that
+# host's docs/environments/<hostname>.md before doing anything else.
+#
+# Contract:
+#   - Every probe fails SOFT. A missing tool or a negative result prints
+#     "unmeasurable: <why>" (or the negative fact itself) and the script
+#     continues. This script never exits nonzero because a fact is absent —
+#     only because of its OWN bug (enforced by `set -u`: an unbound
+#     variable reference is a script bug, not an environment fact).
+#   - No writes outside two mktemp-created directories (one under $TMPDIR,
+#     one under $HOME), both removed unconditionally on exit via an EXIT
+#     trap, including the immutable-bit and permission-bit fixups probes
+#     need before their files can be deleted.
+#   - Output is pure stdout: the markdown table, then one "paste
+#     destination" line. No other stdout noise — findings that don't fit
+#     a fact row go in the Evidence column, not extra prose.
+set -u
+
+# ---------------------------------------------------------------------------
+# Setup: scratch dirs + unconditional cleanup
+# ---------------------------------------------------------------------------
+
+TMPDIR="${TMPDIR:-/tmp}"
+PROBE_TMP_DIR=""
+PROBE_HOME_DIR=""
+IMMUTABLE_TEST_FILE=""
+
+cleanup() {
+  if [ -n "$IMMUTABLE_TEST_FILE" ] && [ -e "$IMMUTABLE_TEST_FILE" ]; then
+    chattr -i "$IMMUTABLE_TEST_FILE" >/dev/null 2>&1 || true
+  fi
+  for d in "$PROBE_TMP_DIR" "$PROBE_HOME_DIR"; do
+    if [ -n "$d" ] && [ -d "$d" ]; then
+      chmod -R u+rwx "$d" >/dev/null 2>&1 || true
+      rm -rf "$d" >/dev/null 2>&1 || true
+    fi
+  done
+}
+trap cleanup EXIT
+
+PROBE_TMP_DIR="$(mktemp -d "${TMPDIR%/}/probe-env.XXXXXX" 2>/dev/null || true)"
+PROBE_HOME_DIR="$(mktemp -d "${HOME%/}/.probe-env.XXXXXX" 2>/dev/null || true)"
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Run a command with a wall-clock bound if `timeout` exists; otherwise run it
+# unbounded (only used for commands expected to return fast anyway).
+bounded() {
+  local secs="$1"
+  shift
+  if have timeout; then
+    timeout "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
+# One-line, pipe-escaped, markdown-table-safe rendering of a value.
+mdcell() {
+  printf '%s' "$1" | tr '\n' ' ' | sed 's/|/\\|/g'
+}
+
+FACT_NAME=()
+FACT_VALUE=()
+FACT_EVIDENCE=()
+
+add_fact() {
+  FACT_NAME+=("$1")
+  FACT_VALUE+=("$2")
+  FACT_EVIDENCE+=("$3")
+}
+
+# ---------------------------------------------------------------------------
+# uid / user / groups
+# ---------------------------------------------------------------------------
+
+uid_num="$(id -u 2>/dev/null || echo unmeasurable)"
+user_name="$(id -un 2>/dev/null || echo unmeasurable)"
+groups_list="$(id -Gn 2>/dev/null | tr ' ' ',' || echo unmeasurable)"
+add_fact "uid / user / groups" \
+  "uid=${uid_num} (${user_name}); groups: ${groups_list}" \
+  "id -u; id -un; id -Gn"
+
+# ---------------------------------------------------------------------------
+# DAC enforcement: chmod 000 self-read probe
+# ---------------------------------------------------------------------------
+
+if [ -n "$PROBE_TMP_DIR" ] && [ -d "$PROBE_TMP_DIR" ]; then
+  dac_file="$PROBE_TMP_DIR/dac_probe"
+  : > "$dac_file" 2>/dev/null
+  if [ -f "$dac_file" ]; then
+    chmod 000 "$dac_file" 2>/dev/null
+    if cat "$dac_file" >/dev/null 2>&1; then
+      dac_result="NOT enforced — chmod 000 self-read SUCCEEDED (root, or DAC override active)"
+    else
+      dac_result="enforced — chmod 000 self-read FAILED (permission denied)"
+    fi
+    chmod u+rw "$dac_file" 2>/dev/null || true
+  else
+    dac_result="unmeasurable: could not create probe file under $PROBE_TMP_DIR"
+  fi
+else
+  dac_result="unmeasurable: no writable temp dir under \$TMPDIR"
+fi
+add_fact "DAC / permission-bit enforcement" "$dac_result" \
+  "chmod 000 <file> then cat <file> as self, in a mktemp dir"
+
+# ---------------------------------------------------------------------------
+# CAP_LINUX_IMMUTABLE: chattr +i probe, cleaned up unconditionally
+# ---------------------------------------------------------------------------
+
+if ! have chattr; then
+  imm_result="unmeasurable: chattr not present on this host"
+elif [ -n "$PROBE_TMP_DIR" ] && [ -d "$PROBE_TMP_DIR" ]; then
+  imm_file="$PROBE_TMP_DIR/immutable_probe"
+  : > "$imm_file" 2>/dev/null
+  if [ -f "$imm_file" ]; then
+    imm_err="$(chattr +i "$imm_file" 2>&1)"
+    imm_rc=$?
+    if [ "$imm_rc" -eq 0 ]; then
+      IMMUTABLE_TEST_FILE="$imm_file"
+      imm_result="viable — chattr +i succeeded"
+      chattr -i "$imm_file" >/dev/null 2>&1 || true
+      IMMUTABLE_TEST_FILE=""
+    else
+      imm_result="not available — chattr +i failed: $(mdcell "$imm_err")"
+    fi
+  else
+    imm_result="unmeasurable: could not create probe file under $PROBE_TMP_DIR"
+  fi
+else
+  imm_result="unmeasurable: no writable temp dir under \$TMPDIR"
+fi
+add_fact "CAP_LINUX_IMMUTABLE" "$imm_result" \
+  "chattr +i <file> in a mktemp dir, then chattr -i to clean up"
+
+# ---------------------------------------------------------------------------
+# Disk: free space on $HOME and $TMPDIR filesystems, quota tooling
+# ---------------------------------------------------------------------------
+
+disk_fact() {
+  local dir="$1"
+  if [ -d "$dir" ]; then
+    df -Ph "$dir" 2>/dev/null | awk 'NR==2 {print $2" total, "$4" avail ("$5" used) on "$6}'
+  else
+    echo "unmeasurable: $dir does not exist"
+  fi
+}
+
+home_disk="$(disk_fact "$HOME")"
+[ -n "$home_disk" ] || home_disk="unmeasurable: df produced no output"
+add_fact "Disk free (\$HOME fs)" "$home_disk" "df -Ph \"\$HOME\""
+
+tmp_disk="$(disk_fact "$TMPDIR")"
+[ -n "$tmp_disk" ] || tmp_disk="unmeasurable: df produced no output"
+add_fact "Disk free (\$TMPDIR fs)" "$tmp_disk" "df -Ph \"\$TMPDIR\""
+
+quota_tools=()
+have quota && quota_tools+=("quota")
+have repquota && quota_tools+=("repquota")
+have xfs_quota && quota_tools+=("xfs_quota")
+if [ "${#quota_tools[@]}" -eq 0 ]; then
+  quota_result="absent (quota, repquota, xfs_quota not found)"
+else
+  quota_result="present: ${quota_tools[*]}"
+fi
+add_fact "Quota tooling" "$quota_result" "command -v quota / repquota / xfs_quota"
+
+# ---------------------------------------------------------------------------
+# O_DIRECT open behavior on $TMPDIR and $HOME's fs (python3 probe)
+# ---------------------------------------------------------------------------
+
+odirect_probe() {
+  local dir="$1"
+  if ! have python3; then
+    echo "unmeasurable: python3 not present"
+    return
+  fi
+  if [ -z "$dir" ] || [ ! -d "$dir" ]; then
+    echo "unmeasurable: no writable mktemp dir available for this fs"
+    return
+  fi
+  python3 - "$dir" <<'PYEOF' 2>&1
+import os, sys
+d = sys.argv[1]
+path = os.path.join(d, "odirect_probe")
+try:
+    flag = os.O_DIRECT
+except AttributeError:
+    print("unmeasurable: os.O_DIRECT not exposed by this python3 build")
+    sys.exit(0)
+try:
+    fd = os.open(path, os.O_RDWR | os.O_CREAT | flag, 0o600)
+    os.close(fd)
+    print("open SUCCEEDS")
+except OSError as e:
+    print("open FAILS: errno=%d (%s)" % (e.errno, e.strerror))
+finally:
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+PYEOF
+}
+
+odirect_tmp="$(odirect_probe "$PROBE_TMP_DIR")"
+add_fact "O_DIRECT open (\$TMPDIR fs)" "$(mdcell "$odirect_tmp")" \
+  "python3: os.open(path, O_RDWR|O_CREAT|O_DIRECT) in a mktemp dir under \$TMPDIR"
+
+odirect_home="$(odirect_probe "$PROBE_HOME_DIR")"
+add_fact "O_DIRECT open (\$HOME fs)" "$(mdcell "$odirect_home")" \
+  "python3: os.open(path, O_RDWR|O_CREAT|O_DIRECT) in a mktemp dir under \$HOME"
+
+# ---------------------------------------------------------------------------
+# Network posture: proxy env vars, HTTPS reachability (bounded, no error on fail)
+# ---------------------------------------------------------------------------
+
+proxy_names=(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY ALL_PROXY all_proxy)
+proxy_set=()
+for n in "${proxy_names[@]}"; do
+  v="${!n:-}"
+  if [ -n "$v" ]; then
+    proxy_set+=("$n")
+  fi
+done
+if [ "${#proxy_set[@]}" -eq 0 ]; then
+  proxy_result="none set"
+else
+  proxy_result="set: $(IFS=,; echo "${proxy_set[*]}") (values not printed — may carry embedded credentials)"
+fi
+add_fact "Proxy env vars" "$proxy_result" "checked ${#proxy_names[@]} conventional proxy var names"
+
+https_probe() {
+  local url="$1"
+  if have curl; then
+    local code rc
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$url" 2>/dev/null)"
+    rc=$?
+    if [ "$rc" -ne 0 ] || [ -z "$code" ] || [ "$code" = "000" ]; then
+      echo "unreachable (curl exit ${rc}, --max-time 5s)"
+    else
+      echo "HTTP ${code}"
+    fi
+  elif have wget; then
+    if wget -q --spider --timeout=5 "$url" >/dev/null 2>&1; then
+      echo "reachable (wget --spider, no status code captured)"
+    else
+      echo "unreachable (wget --spider failed, --timeout 5s)"
+    fi
+  else
+    echo "unmeasurable: neither curl nor wget present"
+  fi
+}
+
+gh_api="$(https_probe https://api.github.com)"
+add_fact "HTTPS reachability: api.github.com" "$gh_api" \
+  "curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://api.github.com"
+
+gh_raw="$(https_probe https://raw.githubusercontent.com)"
+add_fact "HTTPS reachability: raw.githubusercontent.com" "$gh_raw" \
+  "curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://raw.githubusercontent.com"
+
+# ---------------------------------------------------------------------------
+# Docker: presence, daemon reachability, storage driver, cgroup version,
+# user-in-docker-group. NEVER pulls images or runs containers.
+# ---------------------------------------------------------------------------
+
+if have docker; then
+  docker_ver="$(bounded 3 docker --version 2>&1 | tr -d '\n')"
+  docker_present="present ($docker_ver)"
+
+  info_raw="$(bounded 5 docker info --format '{{json .}}' 2>&1)"
+  info_rc=$?
+  if [ "$info_rc" -eq 0 ]; then
+    docker_daemon="reachable"
+    if have python3; then
+      storage_driver="$(printf '%s' "$info_raw" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get("Driver", "unknown"))
+except Exception as e:
+    print("unmeasurable: json parse failed (%s)" % e)
+' 2>/dev/null)"
+      cgroup_version="$(printf '%s' "$info_raw" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get("CgroupVersion", "unknown"))
+except Exception as e:
+    print("unmeasurable: json parse failed (%s)" % e)
+' 2>/dev/null)"
+    else
+      storage_driver="unmeasurable: python3 absent, cannot parse docker info JSON"
+      cgroup_version="unmeasurable: python3 absent, cannot parse docker info JSON"
+    fi
+  else
+    docker_daemon="not reachable (docker info exited ${info_rc}: $(mdcell "$info_raw" | cut -c1-200))"
+    storage_driver="unmeasurable: daemon unreachable"
+    cgroup_version="unmeasurable: daemon unreachable"
+  fi
+
+  if id -nG 2>/dev/null | tr ' ' '\n' | grep -qx docker; then
+    docker_group="user IS in the docker group"
+  else
+    docker_group="user NOT in the docker group (or group list unavailable)"
+  fi
+else
+  docker_present="absent (docker not found on PATH)"
+  docker_daemon="unmeasurable: docker absent"
+  storage_driver="unmeasurable: docker absent"
+  cgroup_version="unmeasurable: docker absent"
+  docker_group="unmeasurable: docker absent"
+fi
+
+add_fact "Docker: presence / daemon / storage driver / cgroup / group" \
+  "${docker_present}; daemon: ${docker_daemon}; storage driver: ${storage_driver}; cgroup: ${cgroup_version}; ${docker_group}" \
+  "docker --version; docker info --format '{{json .}}' (no pull, no run); id -nG"
+add_fact "Docker runtime lifecycle (pull/run/network/cleanup)" \
+  "runtime lifecycle unprobed (use the docs/environments checklist)" \
+  "deliberately not exercised at session start — session-start must stay cheap and offline-safe"
+
+# ---------------------------------------------------------------------------
+# claude CLI: presence, --version, auth status (loggedIn + authMethod only)
+# ---------------------------------------------------------------------------
+
+if have claude; then
+  claude_version="$(bounded 5 claude --version 2>&1 | tr -d '\n')"
+  [ -n "$claude_version" ] || claude_version="unmeasurable: claude --version produced no output"
+
+  auth_raw="$(bounded 8 claude auth status --json 2>&1)"
+  auth_rc=$?
+  if [ "$auth_rc" -ne 0 ]; then
+    auth_summary="unmeasurable: claude auth status --json exited ${auth_rc} (may not exist on this CLI version)"
+  elif have python3; then
+    auth_summary="$(printf '%s' "$auth_raw" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print("loggedIn=%r authMethod=%r" % (d.get("loggedIn"), d.get("authMethod")))
+except Exception as e:
+    print("unmeasurable: could not parse json (%s)" % e)
+' 2>/dev/null)"
+    [ -n "$auth_summary" ] || auth_summary="unmeasurable: json parse produced no output"
+  else
+    auth_summary="unmeasurable: python3 absent, declining to hand-parse JSON that may carry tokens"
+  fi
+else
+  claude_version="absent (claude not found on PATH)"
+  auth_summary="unmeasurable: claude CLI absent"
+fi
+add_fact "claude CLI" "$claude_version" "command -v claude; claude --version"
+add_fact "claude auth status" "$(mdcell "$auth_summary")" \
+  "claude auth status --json, loggedIn+authMethod fields only — never tokens"
+
+# ---------------------------------------------------------------------------
+# cargo / rustc presence and versions, PATH caveat
+# ---------------------------------------------------------------------------
+
+path_tool_fact() {
+  local tool="$1"
+  if have "$tool"; then
+    echo "$("$tool" --version 2>&1 | tr -d '\n') (on PATH)"
+  elif [ -x "$HOME/.cargo/bin/$tool" ]; then
+    echo "$("$HOME/.cargo/bin/$tool" --version 2>&1 | tr -d '\n') — found only at \$HOME/.cargo/bin, NOT on this shell's PATH; scripts must prefix PATH=\"\$HOME/.cargo/bin:\$PATH\""
+  else
+    echo "absent (not on PATH, not at \$HOME/.cargo/bin)"
+  fi
+}
+
+add_fact "cargo" "$(mdcell "$(path_tool_fact cargo)")" "command -v cargo; cargo --version; \$HOME/.cargo/bin/cargo fallback"
+add_fact "rustc" "$(mdcell "$(path_tool_fact rustc)")" "command -v rustc; rustc --version; \$HOME/.cargo/bin/rustc fallback"
+
+# ---------------------------------------------------------------------------
+# cores, kernel, container heuristic
+# ---------------------------------------------------------------------------
+
+if have nproc; then
+  cores="$(nproc 2>/dev/null)"
+else
+  cores="unmeasurable: nproc not present"
+fi
+add_fact "Cores" "$cores" "nproc"
+
+kernel="$(uname -r 2>/dev/null || echo unmeasurable)"
+add_fact "Kernel" "$kernel" "uname -r"
+
+if [ -e /.dockerenv ]; then
+  dockerenv_evidence="/.dockerenv present"
+else
+  dockerenv_evidence="/.dockerenv absent"
+fi
+if [ -r /proc/1/cgroup ]; then
+  if grep -Eq 'docker|kubepods|containerd|lxc' /proc/1/cgroup 2>/dev/null; then
+    cgroup_evidence="/proc/1/cgroup contains container markers (docker/kubepods/containerd/lxc)"
+  else
+    cgroup_evidence="/proc/1/cgroup has no docker/kubepods/containerd/lxc markers"
+  fi
+else
+  cgroup_evidence="/proc/1/cgroup unreadable"
+fi
+add_fact "Container heuristic (evidence, not a verdict)" \
+  "${dockerenv_evidence}; ${cgroup_evidence}" \
+  "test -e /.dockerenv; grep -E 'docker|kubepods|containerd|lxc' /proc/1/cgroup"
+
+# ---------------------------------------------------------------------------
+# IS_SANDBOX and root: claude skip-flag refusal (src/backend/claude.rs docs)
+# ---------------------------------------------------------------------------
+
+is_sandbox_val="${IS_SANDBOX:-<unset>}"
+if [ "$uid_num" = "0" ]; then
+  root_fact="uid 0 (root): claude --dangerously-skip-permissions is REFUSED under root/sudo (\"cannot be used with root/sudo privileges for security reasons\", exit 1) unless the spawning daemon's env sets IS_SANDBOX=1 — the adapter does not set this itself, per src/backend/claude.rs module docs. Current IS_SANDBOX=${is_sandbox_val}"
+else
+  root_fact="uid ${uid_num} (non-root): the root skip-flag refusal does not apply here. Current IS_SANDBOX=${is_sandbox_val}"
+fi
+add_fact "IS_SANDBOX / root skip-flag refusal" "$(mdcell "$root_fact")" \
+  "id -u; \$IS_SANDBOX; src/backend/claude.rs module docs (root constraint paragraph)"
+
+# ---------------------------------------------------------------------------
+# Emit: markdown table, then the paste-destination hint. Pure stdout.
+# ---------------------------------------------------------------------------
+
+hostname_val="$(hostname 2>/dev/null || uname -n 2>/dev/null || echo unknown-host)"
+
+printf '| Fact | Measured value | Evidence |\n'
+printf '|---|---|---|\n'
+i=0
+while [ "$i" -lt "${#FACT_NAME[@]}" ]; do
+  printf '| %s | %s | %s |\n' \
+    "$(mdcell "${FACT_NAME[$i]}")" \
+    "$(mdcell "${FACT_VALUE[$i]}")" \
+    "$(mdcell "${FACT_EVIDENCE[$i]}")"
+  i=$((i + 1))
+done
+
+printf '\nPaste destination: docs/environments/%s.md\n' "$hostname_val"

--- a/scripts/probe-env.sh
+++ b/scripts/probe-env.sh
@@ -6,7 +6,8 @@
 # item 1): nearly every hard stall in the N-series session was a collision
 # with an unmeasured container fact discovered the expensive way, mid-task.
 # Run this once at session start on ANY host and paste its table into that
-# host's docs/environments/<hostname>.md before doing anything else.
+# host's docs/environments/<hostname>.md before doing anything else. See
+# CLAUDE.md's "Environments" section for the workflow this script serves.
 #
 # Contract:
 #   - Every probe fails SOFT. A missing tool or a negative result prints
@@ -14,13 +15,16 @@
 #     continues. This script never exits nonzero because a fact is absent —
 #     only because of its OWN bug (enforced by `set -u`: an unbound
 #     variable reference is a script bug, not an environment fact).
+#   - Every fact row is a MEASUREMENT taken this run, not an imported claim
+#     from docs or a prior session. Anything not measured this run (e.g. a
+#     behavior documented in source but not exercised here) is prose in the
+#     Notes section below the table, never a row in the facts table.
 #   - No writes outside two mktemp-created directories (one under $TMPDIR,
 #     one under $HOME), both removed unconditionally on exit via an EXIT
 #     trap, including the immutable-bit and permission-bit fixups probes
 #     need before their files can be deleted.
-#   - Output is pure stdout: the markdown table, then one "paste
-#     destination" line. No other stdout noise — findings that don't fit
-#     a fact row go in the Evidence column, not extra prose.
+#   - Output is pure stdout: a dated header, the markdown table, a Notes
+#     section for non-measured context, then one "paste destination" line.
 set -u
 
 # ---------------------------------------------------------------------------
@@ -28,6 +32,7 @@ set -u
 # ---------------------------------------------------------------------------
 
 TMPDIR="${TMPDIR:-/tmp}"
+HOME="${HOME:-/tmp}"
 PROBE_TMP_DIR=""
 PROBE_HOME_DIR=""
 IMMUTABLE_TEST_FILE=""
@@ -54,31 +59,68 @@ PROBE_HOME_DIR="$(mktemp -d "${HOME%/}/.probe-env.XXXXXX" 2>/dev/null || true)"
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
-# Run a command with a wall-clock bound if `timeout` exists; otherwise run it
-# unbounded (only used for commands expected to return fast anyway).
+# Run a command with a wall-clock bound if `timeout` exists; otherwise print
+# an unmeasurable result rather than risk hanging. Callers that touch a
+# daemon or the network MUST go through this — never invoke unbounded.
 bounded() {
   local secs="$1"
   shift
   if have timeout; then
     timeout "$secs" "$@"
+    return $?
+  fi
+  echo "unmeasurable: no timeout(1) available to bound this probe"
+  return 111
+}
+
+# Collapse embedded newlines to spaces. Safe to apply repeatedly (idempotent)
+# — used when composing a value from another command's possibly-multi-line
+# output, BEFORE that value is stored via add_fact. Pure bash (no tr/sed
+# dependency): this must survive a PATH so bare it has neither, since the
+# whole point of this script is to still report something on such a host.
+oneline() {
+  local v="$1"
+  printf '%s' "${v//$'\n'/ }"
+}
+
+# Pipe-and-backslash-escaped, markdown-table-safe rendering of a value.
+# Apply exactly once per cell — at emit time only. Values passed to
+# add_fact should be plain (pre-collapsed with `oneline` if needed, but NOT
+# pre-escaped) since the emit loop is the single place this runs. Pure bash
+# parameter expansion — no tr/sed dependency, see `oneline` above.
+mdcell() {
+  local v="$1"
+  v="${v//$'\n'/ }"
+  v="${v//\\/\\\\}"
+  v="${v//|/\\|}"
+  printf '%s' "$v"
+}
+
+# Fill an empty/unset value with an explicit unmeasurable marker instead of
+# letting a blank cell reach the table.
+nonblank() {
+  if [ -n "${1:-}" ]; then
+    printf '%s' "$1"
   else
-    "$@"
+    printf 'unmeasurable: probe produced no output'
   fi
 }
 
-# One-line, pipe-escaped, markdown-table-safe rendering of a value.
-mdcell() {
-  printf '%s' "$1" | tr '\n' ' ' | sed 's/|/\\|/g'
-}
+PROBE_DATE="$(date -u +%Y-%m-%d 2>/dev/null || echo unmeasurable-date)"
 
 FACT_NAME=()
 FACT_VALUE=()
 FACT_EVIDENCE=()
+NOTES=()
 
 add_fact() {
   FACT_NAME+=("$1")
-  FACT_VALUE+=("$2")
-  FACT_EVIDENCE+=("$3")
+  FACT_VALUE+=("$(nonblank "$2")")
+  FACT_EVIDENCE+=("$(nonblank "$3"), ${PROBE_DATE}")
+}
+
+add_note() {
+  NOTES+=("$1")
 }
 
 # ---------------------------------------------------------------------------
@@ -101,10 +143,21 @@ if [ -n "$PROBE_TMP_DIR" ] && [ -d "$PROBE_TMP_DIR" ]; then
   : > "$dac_file" 2>/dev/null
   if [ -f "$dac_file" ]; then
     chmod 000 "$dac_file" 2>/dev/null
-    if cat "$dac_file" >/dev/null 2>&1; then
-      dac_result="NOT enforced — chmod 000 self-read SUCCEEDED (root, or DAC override active)"
+    chmod_rc=$?
+    mode_now=""
+    if have stat; then
+      mode_now="$(stat -c %a "$dac_file" 2>/dev/null || stat -f %Lp "$dac_file" 2>/dev/null || echo "")"
+    fi
+    if [ "$chmod_rc" -ne 0 ]; then
+      dac_result="unmeasurable: chmod 000 exited ${chmod_rc} — could not change the mode on this filesystem"
+    elif [ -n "$mode_now" ] && [ "$mode_now" != "0" ] && [ "$mode_now" != "000" ]; then
+      dac_result="unmeasurable: chmod 000 reported success but mode is still ${mode_now} on this filesystem (exfat/vfat/9p/virtiofs-style FS?)"
     else
-      dac_result="enforced — chmod 000 self-read FAILED (permission denied)"
+      if cat "$dac_file" >/dev/null 2>&1; then
+        dac_result="NOT enforced — chmod 000 self-read SUCCEEDED (see uid row: root ignores mode bits, or a DAC-override capability is active)"
+      else
+        dac_result="enforced — chmod 000 self-read FAILED (permission denied)"
+      fi
     fi
     chmod u+rw "$dac_file" 2>/dev/null || true
   else
@@ -114,7 +167,7 @@ else
   dac_result="unmeasurable: no writable temp dir under \$TMPDIR"
 fi
 add_fact "DAC / permission-bit enforcement" "$dac_result" \
-  "chmod 000 <file> then cat <file> as self, in a mktemp dir"
+  "chmod 000 <file>, verify mode via stat, then cat <file> as self, in a mktemp dir"
 
 # ---------------------------------------------------------------------------
 # CAP_LINUX_IMMUTABLE: chattr +i probe, cleaned up unconditionally
@@ -131,10 +184,12 @@ elif [ -n "$PROBE_TMP_DIR" ] && [ -d "$PROBE_TMP_DIR" ]; then
     if [ "$imm_rc" -eq 0 ]; then
       IMMUTABLE_TEST_FILE="$imm_file"
       imm_result="viable — chattr +i succeeded"
-      chattr -i "$imm_file" >/dev/null 2>&1 || true
-      IMMUTABLE_TEST_FILE=""
+      if chattr -i "$imm_file" >/dev/null 2>&1; then
+        IMMUTABLE_TEST_FILE=""
+      fi
+      # else: leave IMMUTABLE_TEST_FILE set so the EXIT trap retries cleanup.
     else
-      imm_result="not available — chattr +i failed: $(mdcell "$imm_err")"
+      imm_result="not available — chattr +i failed: $(oneline "$imm_err")"
     fi
   else
     imm_result="unmeasurable: could not create probe file under $PROBE_TMP_DIR"
@@ -146,7 +201,9 @@ add_fact "CAP_LINUX_IMMUTABLE" "$imm_result" \
   "chattr +i <file> in a mktemp dir, then chattr -i to clean up"
 
 # ---------------------------------------------------------------------------
-# Disk: free space on $HOME and $TMPDIR filesystems, quota tooling
+# Disk: free space on $HOME and $TMPDIR filesystems, quota tooling,
+# writable allowance (best-effort — quota may be enforced above the FS
+# without any local quota tool visibility).
 # ---------------------------------------------------------------------------
 
 disk_fact() {
@@ -159,11 +216,9 @@ disk_fact() {
 }
 
 home_disk="$(disk_fact "$HOME")"
-[ -n "$home_disk" ] || home_disk="unmeasurable: df produced no output"
 add_fact "Disk free (\$HOME fs)" "$home_disk" "df -Ph \"\$HOME\""
 
 tmp_disk="$(disk_fact "$TMPDIR")"
-[ -n "$tmp_disk" ] || tmp_disk="unmeasurable: df produced no output"
 add_fact "Disk free (\$TMPDIR fs)" "$tmp_disk" "df -Ph \"\$TMPDIR\""
 
 quota_tools=()
@@ -171,14 +226,36 @@ have quota && quota_tools+=("quota")
 have repquota && quota_tools+=("repquota")
 have xfs_quota && quota_tools+=("xfs_quota")
 if [ "${#quota_tools[@]}" -eq 0 ]; then
-  quota_result="absent (quota, repquota, xfs_quota not found)"
+  quota_bin_result="absent (quota, repquota, xfs_quota not found)"
 else
-  quota_result="present: ${quota_tools[*]}"
+  quota_bin_result="present: ${quota_tools[*]}"
 fi
-add_fact "Quota tooling" "$quota_result" "command -v quota / repquota / xfs_quota"
+add_fact "Quota binaries on PATH" "$quota_bin_result" \
+  "command -v quota / repquota / xfs_quota (binary presence only — does not imply the binary applies to this host's filesystems)"
+
+# Writable allowance: this is the fact that actually bit sessions (ENOSPC
+# stalls), and df total/avail does not measure it — a below-filesystem quota
+# can be enforced with no visible quota tool. Attempt `quota -s`; otherwise
+# say plainly that no per-user limit is visible via local tooling.
+if have quota; then
+  quota_out="$(bounded 5 quota -s 2>&1)"
+  quota_rc=$?
+  if [ "$quota_rc" -eq 0 ] && [ -n "$quota_out" ]; then
+    allowance_result="quota -s: $(oneline "$quota_out" | cut -c1-300)"
+  else
+    allowance_result="unmeasurable: quota -s exited ${quota_rc} with no usable output — no per-user limit visible via quota; allowance may still be enforced elsewhere (e.g. session sandbox, above the filesystem)"
+  fi
+else
+  allowance_result="unmeasurable: no quota tooling on PATH — no per-user write allowance visible locally; the \$HOME/\$TMPDIR df rows above are filesystem capacity, NOT a session allowance, which may be enforced below filesystem size with no local signal"
+fi
+add_fact "Writable allowance (session quota, distinct from FS capacity)" "$allowance_result" \
+  "quota -s, or explicit unmeasurable when no quota tool is present"
 
 # ---------------------------------------------------------------------------
-# O_DIRECT open behavior on $TMPDIR and $HOME's fs (python3 probe)
+# O_DIRECT behavior on $TMPDIR and $HOME's fs (python3 probe): open, AND an
+# unaligned write, since the repo's fault-injection fixtures (journal.rs)
+# branch on both — "open refused" and "unaligned write silently accepted"
+# both skip the fixture; only "unaligned write rejected" makes it expressible.
 # ---------------------------------------------------------------------------
 
 odirect_probe() {
@@ -200,13 +277,23 @@ try:
 except AttributeError:
     print("unmeasurable: os.O_DIRECT not exposed by this python3 build")
     sys.exit(0)
+fd = None
 try:
     fd = os.open(path, os.O_RDWR | os.O_CREAT | flag, 0o600)
-    os.close(fd)
-    print("open SUCCEEDS")
 except OSError as e:
-    print("open FAILS: errno=%d (%s)" % (e.errno, e.strerror))
+    print("open FAILS: errno=%d (%s) -> fault-injection fixture SKIPS here (can't even open)" % (e.errno, e.strerror))
+    sys.exit(0)
+try:
+    # Unaligned write: odd length, unaligned buffer — the shape the repo's
+    # fixtures rely on rejecting.
+    buf = b"x" * 513
+    try:
+        os.write(fd, buf)
+        print("open SUCCEEDS, unaligned write ACCEPTED -> fault-injection fixture SKIPS here (alignment unenforced)")
+    except OSError as e:
+        print("open SUCCEEDS, unaligned write REJECTED errno=%d (%s) -> fault-injection fixture IS expressible here" % (e.errno, e.strerror))
 finally:
+    os.close(fd)
     try:
         os.remove(path)
     except OSError:
@@ -215,15 +302,18 @@ PYEOF
 }
 
 odirect_tmp="$(odirect_probe "$PROBE_TMP_DIR")"
-add_fact "O_DIRECT open (\$TMPDIR fs)" "$(mdcell "$odirect_tmp")" \
-  "python3: os.open(path, O_RDWR|O_CREAT|O_DIRECT) in a mktemp dir under \$TMPDIR"
+add_fact "O_DIRECT open+unaligned-write (\$TMPDIR fs)" "$(oneline "$odirect_tmp")" \
+  "python3: open(O_RDWR|O_CREAT|O_DIRECT) then write a 513-byte unaligned buffer, in a mktemp dir under \$TMPDIR"
 
 odirect_home="$(odirect_probe "$PROBE_HOME_DIR")"
-add_fact "O_DIRECT open (\$HOME fs)" "$(mdcell "$odirect_home")" \
-  "python3: os.open(path, O_RDWR|O_CREAT|O_DIRECT) in a mktemp dir under \$HOME"
+add_fact "O_DIRECT open+unaligned-write (\$HOME fs)" "$(oneline "$odirect_home")" \
+  "python3: open(O_RDWR|O_CREAT|O_DIRECT) then write a 513-byte unaligned buffer, in a mktemp dir under \$HOME"
 
 # ---------------------------------------------------------------------------
-# Network posture: proxy env vars, HTTPS reachability (bounded, no error on fail)
+# Network posture: proxy env vars, HTTPS reachability (bounded, no error on
+# fail). Includes a real asset-path probe, not just a bare host, since the
+# fact that has actually cost sessions time is an asset-path 403 through an
+# agent proxy that still 200s/301s the bare host.
 # ---------------------------------------------------------------------------
 
 proxy_names=(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY ALL_PROXY all_proxy)
@@ -237,7 +327,7 @@ done
 if [ "${#proxy_set[@]}" -eq 0 ]; then
   proxy_result="none set"
 else
-  proxy_result="set: $(IFS=,; echo "${proxy_set[*]}") (values not printed — may carry embedded credentials)"
+  proxy_result="set: $(IFS=,; echo "${proxy_set[*]:-}") (values not printed — may carry embedded credentials)"
 fi
 add_fact "Proxy env vars" "$proxy_result" "checked ${#proxy_names[@]} conventional proxy var names"
 
@@ -268,8 +358,15 @@ add_fact "HTTPS reachability: api.github.com" "$gh_api" \
   "curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://api.github.com"
 
 gh_raw="$(https_probe https://raw.githubusercontent.com)"
-add_fact "HTTPS reachability: raw.githubusercontent.com" "$gh_raw" \
+add_fact "HTTPS reachability: raw.githubusercontent.com (bare host)" "$gh_raw" \
   "curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://raw.githubusercontent.com"
+
+# The real asset path CLAUDE.md names as the working fallback when the
+# release installer 403s — reproduces the fact that actually costs sessions
+# time, not just bare-host reachability.
+nomistakes_asset="$(https_probe https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh)"
+add_fact "HTTPS reachability: no-mistakes install.sh (real asset path)" "$nomistakes_asset" \
+  "curl -s -o /dev/null -w '%{http_code}' --max-time 5 https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh"
 
 # ---------------------------------------------------------------------------
 # Docker: presence, daemon reachability, storage driver, cgroup version,
@@ -280,12 +377,15 @@ if have docker; then
   docker_ver="$(bounded 3 docker --version 2>&1 | tr -d '\n')"
   docker_present="present ($docker_ver)"
 
-  info_raw="$(bounded 5 docker info --format '{{json .}}' 2>&1)"
+  # stdout and stderr captured separately: dockerd routinely writes health
+  # warnings to stderr on otherwise-healthy hosts, which must not poison the
+  # JSON parse of stdout.
+  info_out="$(bounded 5 docker info --format '{{json .}}' 2>/dev/null)"
   info_rc=$?
-  if [ "$info_rc" -eq 0 ]; then
+  if [ "$info_rc" -eq 0 ] && [ -n "$info_out" ]; then
     docker_daemon="reachable"
     if have python3; then
-      storage_driver="$(printf '%s' "$info_raw" | python3 -c '
+      storage_driver="$(printf '%s' "$info_out" | python3 -c '
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -293,7 +393,7 @@ try:
 except Exception as e:
     print("unmeasurable: json parse failed (%s)" % e)
 ' 2>/dev/null)"
-      cgroup_version="$(printf '%s' "$info_raw" | python3 -c '
+      cgroup_version="$(printf '%s' "$info_out" | python3 -c '
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -306,7 +406,8 @@ except Exception as e:
       cgroup_version="unmeasurable: python3 absent, cannot parse docker info JSON"
     fi
   else
-    docker_daemon="not reachable (docker info exited ${info_rc}: $(mdcell "$info_raw" | cut -c1-200))"
+    info_err="$(bounded 5 docker info --format '{{json .}}' 2>&1 >/dev/null)"
+    docker_daemon="not reachable (docker info exited ${info_rc}: $(oneline "$info_err" | cut -c1-200))"
     storage_driver="unmeasurable: daemon unreachable"
     cgroup_version="unmeasurable: daemon unreachable"
   fi
@@ -326,7 +427,7 @@ fi
 
 add_fact "Docker: presence / daemon / storage driver / cgroup / group" \
   "${docker_present}; daemon: ${docker_daemon}; storage driver: ${storage_driver}; cgroup: ${cgroup_version}; ${docker_group}" \
-  "docker --version; docker info --format '{{json .}}' (no pull, no run); id -nG"
+  "docker --version; docker info --format '{{json .}}' (stdout/stderr split, no pull, no run); id -nG"
 add_fact "Docker runtime lifecycle (pull/run/network/cleanup)" \
   "runtime lifecycle unprobed (use the docs/environments checklist)" \
   "deliberately not exercised at session start — session-start must stay cheap and offline-safe"
@@ -337,12 +438,11 @@ add_fact "Docker runtime lifecycle (pull/run/network/cleanup)" \
 
 if have claude; then
   claude_version="$(bounded 5 claude --version 2>&1 | tr -d '\n')"
-  [ -n "$claude_version" ] || claude_version="unmeasurable: claude --version produced no output"
 
   auth_raw="$(bounded 8 claude auth status --json 2>&1)"
   auth_rc=$?
   if [ "$auth_rc" -ne 0 ]; then
-    auth_summary="unmeasurable: claude auth status --json exited ${auth_rc} (may not exist on this CLI version)"
+    auth_summary="unmeasurable: claude auth status --json exited ${auth_rc} (may not exist on this CLI version, or timed out)"
   elif have python3; then
     auth_summary="$(printf '%s' "$auth_raw" | python3 -c '
 import json, sys
@@ -352,7 +452,6 @@ try:
 except Exception as e:
     print("unmeasurable: could not parse json (%s)" % e)
 ' 2>/dev/null)"
-    [ -n "$auth_summary" ] || auth_summary="unmeasurable: json parse produced no output"
   else
     auth_summary="unmeasurable: python3 absent, declining to hand-parse JSON that may carry tokens"
   fi
@@ -361,7 +460,7 @@ else
   auth_summary="unmeasurable: claude CLI absent"
 fi
 add_fact "claude CLI" "$claude_version" "command -v claude; claude --version"
-add_fact "claude auth status" "$(mdcell "$auth_summary")" \
+add_fact "claude auth status" "$(oneline "$auth_summary")" \
   "claude auth status --json, loggedIn+authMethod fields only — never tokens"
 
 # ---------------------------------------------------------------------------
@@ -372,15 +471,15 @@ path_tool_fact() {
   local tool="$1"
   if have "$tool"; then
     echo "$("$tool" --version 2>&1 | tr -d '\n') (on PATH)"
-  elif [ -x "$HOME/.cargo/bin/$tool" ]; then
-    echo "$("$HOME/.cargo/bin/$tool" --version 2>&1 | tr -d '\n') — found only at \$HOME/.cargo/bin, NOT on this shell's PATH; scripts must prefix PATH=\"\$HOME/.cargo/bin:\$PATH\""
+  elif [ -x "${HOME}/.cargo/bin/$tool" ]; then
+    echo "$("${HOME}/.cargo/bin/$tool" --version 2>&1 | tr -d '\n') — found only at \$HOME/.cargo/bin, NOT on this shell's PATH; scripts must prefix PATH=\"\$HOME/.cargo/bin:\$PATH\""
   else
     echo "absent (not on PATH, not at \$HOME/.cargo/bin)"
   fi
 }
 
-add_fact "cargo" "$(mdcell "$(path_tool_fact cargo)")" "command -v cargo; cargo --version; \$HOME/.cargo/bin/cargo fallback"
-add_fact "rustc" "$(mdcell "$(path_tool_fact rustc)")" "command -v rustc; rustc --version; \$HOME/.cargo/bin/rustc fallback"
+add_fact "cargo" "$(oneline "$(path_tool_fact cargo)")" "command -v cargo; cargo --version; \$HOME/.cargo/bin/cargo fallback"
+add_fact "rustc" "$(oneline "$(path_tool_fact rustc)")" "command -v rustc; rustc --version; \$HOME/.cargo/bin/rustc fallback"
 
 # ---------------------------------------------------------------------------
 # cores, kernel, container heuristic
@@ -398,12 +497,15 @@ add_fact "Kernel" "$kernel" "uname -r"
 
 if [ -e /.dockerenv ]; then
   dockerenv_evidence="/.dockerenv present"
+  is_docker_container=1
 else
   dockerenv_evidence="/.dockerenv absent"
+  is_docker_container=0
 fi
 if [ -r /proc/1/cgroup ]; then
   if grep -Eq 'docker|kubepods|containerd|lxc' /proc/1/cgroup 2>/dev/null; then
     cgroup_evidence="/proc/1/cgroup contains container markers (docker/kubepods/containerd/lxc)"
+    is_docker_container=1
   else
     cgroup_evidence="/proc/1/cgroup has no docker/kubepods/containerd/lxc markers"
   fi
@@ -414,25 +516,47 @@ add_fact "Container heuristic (evidence, not a verdict)" \
   "${dockerenv_evidence}; ${cgroup_evidence}" \
   "test -e /.dockerenv; grep -E 'docker|kubepods|containerd|lxc' /proc/1/cgroup"
 
+is_ci=0
+if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+  is_ci=1
+fi
+
 # ---------------------------------------------------------------------------
-# IS_SANDBOX and root: claude skip-flag refusal (src/backend/claude.rs docs)
+# IS_SANDBOX and uid — measured facts only. The claude.rs-documented root
+# skip-flag refusal is NOT re-derived here (it requires an actual claude
+# invocation to confirm on this host); it is reported as an unverified
+# imported note below the table, gated on uid==0 && claude present, never
+# printed as a "Measured value".
 # ---------------------------------------------------------------------------
 
 is_sandbox_val="${IS_SANDBOX:-<unset>}"
+add_fact "IS_SANDBOX env var" "IS_SANDBOX=${is_sandbox_val}" "\$IS_SANDBOX"
+
 if [ "$uid_num" = "0" ]; then
-  root_fact="uid 0 (root): claude --dangerously-skip-permissions is REFUSED under root/sudo (\"cannot be used with root/sudo privileges for security reasons\", exit 1) unless the spawning daemon's env sets IS_SANDBOX=1 — the adapter does not set this itself, per src/backend/claude.rs module docs. Current IS_SANDBOX=${is_sandbox_val}"
-else
-  root_fact="uid ${uid_num} (non-root): the root skip-flag refusal does not apply here. Current IS_SANDBOX=${is_sandbox_val}"
+  if have claude; then
+    add_note "uid 0 (root) with claude CLI present: src/backend/claude.rs module docs say \`claude --dangerously-skip-permissions\` is REFUSED under root/sudo (\"cannot be used with root/sudo privileges for security reasons\", exit 1) unless the spawning daemon's env sets IS_SANDBOX=1. NOT verified by this script this run (no claude invocation is made) — imported claim, re-check against src/backend/claude.rs and, if it matters for this session, confirm with a real turn."
+  else
+    add_note "uid 0 (root), claude CLI absent from PATH: cannot check the documented root skip-flag refusal on this host at all (imported claim from src/backend/claude.rs, unverifiable here without the CLI)."
+  fi
 fi
-add_fact "IS_SANDBOX / root skip-flag refusal" "$(mdcell "$root_fact")" \
-  "id -u; \$IS_SANDBOX; src/backend/claude.rs module docs (root constraint paragraph)"
 
 # ---------------------------------------------------------------------------
-# Emit: markdown table, then the paste-destination hint. Pure stdout.
+# Emit: dated header, markdown table, Notes section, then the paste-
+# destination hint. Pure stdout (Notes carries context that doesn't fit a
+# fact row, per the header contract — never silent extra noise).
 # ---------------------------------------------------------------------------
 
 hostname_val="$(hostname 2>/dev/null || uname -n 2>/dev/null || echo unknown-host)"
 
+if [ "$is_ci" -eq 1 ]; then
+  paste_target="github-runner"
+elif [ "$is_docker_container" -eq 1 ]; then
+  paste_target="claude-code-cloud"
+else
+  paste_target="$hostname_val"
+fi
+
+printf 'Facts measured %s on host "%s"\n\n' "$PROBE_DATE" "$hostname_val"
 printf '| Fact | Measured value | Evidence |\n'
 printf '|---|---|---|\n'
 i=0
@@ -444,4 +568,11 @@ while [ "$i" -lt "${#FACT_NAME[@]}" ]; do
   i=$((i + 1))
 done
 
-printf '\nPaste destination: docs/environments/%s.md\n' "$hostname_val"
+if [ "${#NOTES[@]}" -gt 0 ]; then
+  printf '\nNotes (imported context, NOT measured this run — verify before relying on):\n'
+  for n in "${NOTES[@]}"; do
+    printf -- '- %s\n' "$n"
+  done
+fi
+
+printf '\nPaste destination: docs/environments/%s.md\n' "$paste_target"


### PR DESCRIPTION
Sub-PR into the session branch. Lean loop ran in a dedicated worktree: Sonnet build → blind Opus critic (15 findings, 3 errors — fabricated-fact/honesty-invariant class, all closed) → fix + regression selftest + CLAUDE.md/environments-README wiring. Script verified twice on Cerberus: fail-soft on every probe, EXIT-trap cleanup verified, no writes outside mktemp dirs; facts cross-checked against docs/environments/cerberus.md with the two apparent disagreements run down and explained (xfs_quota tooling presence; bare-domain 301 vs asset-path 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxNQvdex4SSv8s8VW9tqdq