### PR TITLE
Fix resolve_data_dir fallback test isolation and --help precedence text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,9 @@ const HEALTH_TIMEOUT: Duration = Duration::from_secs(2);
     about = "sergeant-rs: local agent execution surface"
 )]
 struct Sgt {
-    /// Data directory (default: $SGT_DATA_DIR, then ~/.local/share/sergeant).
+    /// Data directory (default: $SGT_DATA_DIR, then the discovered estate's
+    /// .sergeant/data, then $XDG_DATA_HOME/sergeant, then
+    /// ~/.local/share/sergeant).
     #[arg(long, global = true)]
     data_dir: Option<PathBuf>,
     /// Emit machine-readable JSON instead of human text.

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -2334,13 +2334,18 @@ fn resolve_data_dir_falls_back_through_sgt_data_dir_then_xdg_then_home() {
     assert!(!home.path().join(".local").exists());
     drop(_reap);
 
-    // Absent SGT_DATA_DIR, `$XDG_DATA_HOME/sergeant` is next.
+    // Absent SGT_DATA_DIR, `$XDG_DATA_HOME/sergeant` is next. Run from a cwd
+    // outside any estate: an in-tree cwd would let step 3 (estate discovery,
+    // `resolve_data_dir`) resolve first and this fallback rung would never
+    // actually be exercised.
     let xdg2 = TempDir::new().expect("tempdir");
     let home2 = TempDir::new().expect("tempdir");
+    let cwd2 = TempDir::new().expect("tempdir");
     let resolved = xdg2.path().join("sergeant");
     let _reap = ReapOnDrop(resolved.clone());
     let output = Command::new(SGT)
         .args(["work", "list", "--json"])
+        .current_dir(cwd2.path())
         .env_remove("SGT_DATA_DIR")
         .env("XDG_DATA_HOME", xdg2.path())
         .env("HOME", home2.path())
@@ -2358,12 +2363,15 @@ fn resolve_data_dir_falls_back_through_sgt_data_dir_then_xdg_then_home() {
     assert!(!home2.path().join(".local").exists());
     drop(_reap);
 
-    // Absent both, `$HOME/.local/share/sergeant` is the last resort.
+    // Absent both, `$HOME/.local/share/sergeant` is the last resort. Same
+    // cwd-isolation reasoning as the XDG case above.
     let home3 = TempDir::new().expect("tempdir");
+    let cwd3 = TempDir::new().expect("tempdir");
     let resolved = home3.path().join(".local/share/sergeant");
     let _reap = ReapOnDrop(resolved.clone());
     let output = Command::new(SGT)
         .args(["work", "list", "--json"])
+        .current_dir(cwd3.path())
         .env_remove("SGT_DATA_DIR")
         .env_remove("XDG_DATA_HOME")
         .env("HOME", home3.path())


### PR DESCRIPTION
Closes #73. Dispatched as sergeant Work `01KZZ5KCFFYJNSMHG87G3CWRB8` (`implement`, 2/20 turns).

Pre-existing on `main` at `1929a90` — verified by running the test on the base commit before attributing it to any sprint change. The XDG/HOME sub-cases spawned `sgt` without an explicit cwd, so the child inherited the runner's cwd; in an `sgt init`ed checkout that cwd is itself an estate, so estate discovery (step 3 of 5) resolved before the rungs under test. Lands first so the suite is genuinely green for the rest of the sprint.

Also corrects `--data-dir`'s help text, which documented neither estate discovery nor XDG.

**Not changed:** the precedence order itself. Whether estate-before-XDG is right is parked for owner ruling in #73 — it makes an explicitly-set `XDG_DATA_HOME` inert.

Verified: passes from the estate cwd that exposed the bug, and still fails if the XDG branch is genuinely broken (non-vacuous).