### PR TITLE
doctor: collapse the unwritable-parent EPERM into one named remedy row

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1645,12 +1645,18 @@ mod doctor {
 
     /// Run every check against `data_dir`.
     pub async fn run(data_dir: &Path) -> Report {
-        let mut checks = vec![
-            git_check(),
-            claude_check(data_dir),
-            docker_check(data_dir),
-            data_dir_check(data_dir),
-        ];
+        let mut checks = vec![git_check(), claude_check(data_dir)];
+        // #67: the data dir's own existence and writability is checked
+        // before anything that lives *inside* it — the docker adapter's
+        // blob store and disk-pressure's `df` call both fail the instant
+        // the data dir cannot be created, and running them first surfaced
+        // that single fault as two unrelated-looking downstream symptoms.
+        // Threading `data_dir_ok` down mirrors `journal_ok` below: the
+        // checks that depend on it decline by name instead of re-deriving
+        // (and re-explaining) the same root cause.
+        let (data_dir_check, data_dir_ok) = data_dir_check(data_dir);
+        checks.push(data_dir_check);
+        checks.push(docker_check(data_dir, data_dir_ok));
         // The journal is the only durable fact in the installation, so it is
         // checked before anything derived from it; a projection rebuild over
         // an unreadable journal would report the journal's fault under the
@@ -1665,7 +1671,7 @@ mod doctor {
         // after everything above regardless of their outcome — knowing "is
         // this installation about to run out of disk" does not depend on the
         // daemon, the journal, or Docker being reachable.
-        checks.push(disk_pressure_check(data_dir));
+        checks.push(disk_pressure_check(data_dir, data_dir_ok));
         Report {
             data_dir: data_dir.to_path_buf(),
             checks,
@@ -1932,7 +1938,20 @@ mod doctor {
     /// healthy either way. This row exists so an operator can tell *why* an
     /// execute submission would be refused before trying one, with real
     /// evidence rather than a ping's optimism.
-    fn docker_check(data_dir: &Path) -> Check {
+    fn docker_check(data_dir: &Path, data_dir_ok: bool) -> Check {
+        // #67: `DockerBackend::new` opens a blob store under `data_dir` and
+        // fails with the same EPERM the `data_dir` check above already
+        // named and gave a remedy for — re-running it here would just print
+        // that fault a second time under a different, more confusing name
+        // ("could not initialize the Docker adapter") without adding
+        // information.
+        if !data_dir_ok {
+            return Check::warn(
+                "docker",
+                "not attempted: the data dir is not writable",
+                "fix the data_dir check above first",
+            );
+        }
         let backend = match DockerBackend::new(DockerConfig::new(data_dir)) {
             Ok(backend) => backend,
             Err(e) => {
@@ -1984,7 +2003,20 @@ mod doctor {
     /// exists independent of any execute stage ever running), folded into
     /// this module because Docker-captured stdout/stderr is the evidence
     /// class most likely to grow it fast (§16.9, §22.8).
-    fn disk_pressure_check(data_dir: &Path) -> Check {
+    fn disk_pressure_check(data_dir: &Path, data_dir_ok: bool) -> Check {
+        // #67: when the data dir does not exist, `df` on it fails ENOENT and
+        // `free_space` reports `None` — which this check used to print as
+        // "free space could not be measured on this platform", a claim
+        // that's simply false (the platform is fine; the path is missing)
+        // and misdirects an operator away from the real, already-named
+        // fault above.
+        if !data_dir_ok {
+            return Check::warn(
+                "disk_pressure",
+                "not attempted: the data dir is not writable",
+                "fix the data_dir check above first",
+            );
+        }
         let report = docker::measure_disk_pressure(data_dir);
         let detail = format!(
             "data dir {} ({} blobs), {}",
@@ -2046,35 +2078,103 @@ mod doctor {
         }
     }
 
-    /// §31: the data dir exists and this user can write it.
+    /// §31/#67: the data dir exists and this user can write it — checked
+    /// before anything that lives *inside* it (`docker_check`,
+    /// `disk_pressure_check`), so the boolean this returns lets both decline
+    /// instead of re-diagnosing the same fault under a more confusing name.
     ///
     /// Probed by actually creating and removing a file. Permission *bits* are
     /// not the question — read-only mounts, full disks and SELinux all answer
     /// "writable" by inspection and "no" in practice.
-    fn data_dir_check(data_dir: &Path) -> Check {
-        let remedy = format!(
+    ///
+    /// #67: when `create_dir_all` fails, the leaf path named in the raw io
+    /// error is often not the directory an operator actually needs to fix —
+    /// it never got created, so the error is really about wherever the walk
+    /// stalled. Walking up to the nearest ancestor that *does* exist and
+    /// probing that instead turns "permission denied" on a path that was
+    /// never created into one remedy row naming the actual offending parent.
+    fn data_dir_check(data_dir: &Path) -> (Check, bool) {
+        let generic_remedy = format!(
             "create {} and make it writable by this user (or point --data-dir / SGT_DATA_DIR \
              somewhere that is)",
             data_dir.display()
         );
         if let Err(e) = std::fs::create_dir_all(data_dir) {
-            return Check::fail(
-                "data_dir",
-                format!("cannot create {}: {e}", data_dir.display()),
-                remedy,
+            if let Some(ancestor) = nearest_existing_ancestor(data_dir)
+                && !probe_writable(&ancestor)
+            {
+                return (
+                    Check::fail(
+                        "data_dir",
+                        format!(
+                            "{} does not exist and cannot be created: its nearest existing \
+                             parent, {}, is not writable by this user ({e})",
+                            data_dir.display(),
+                            ancestor.display()
+                        ),
+                        format!(
+                            "make {} writable by this user — e.g. `chmod u+w {}` — or point \
+                             --data-dir / SGT_DATA_DIR at a location under a writable parent",
+                            ancestor.display(),
+                            ancestor.display()
+                        ),
+                    ),
+                    false,
+                );
+            }
+            return (
+                Check::fail(
+                    "data_dir",
+                    format!("cannot create {}: {e}", data_dir.display()),
+                    generic_remedy,
+                ),
+                false,
             );
         }
         let probe = data_dir.join(".doctor-write-probe");
         match std::fs::write(&probe, b"doctor") {
             Ok(()) => {
                 let _ = std::fs::remove_file(&probe);
-                Check::ok("data_dir", format!("{} is writable", data_dir.display()))
+                (
+                    Check::ok("data_dir", format!("{} is writable", data_dir.display())),
+                    true,
+                )
             }
-            Err(e) => Check::fail(
-                "data_dir",
-                format!("cannot write inside {}: {e}", data_dir.display()),
-                remedy,
+            Err(e) => (
+                Check::fail(
+                    "data_dir",
+                    format!("cannot write inside {}: {e}", data_dir.display()),
+                    generic_remedy,
+                ),
+                false,
             ),
+        }
+    }
+
+    /// Walk up from `path` to the nearest ancestor that already exists on
+    /// disk — the directory `create_dir_all` actually stalled at, and the
+    /// one worth naming as the fault (`data_dir_check`, #67).
+    fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
+        let mut current = path;
+        loop {
+            if current.exists() {
+                return Some(current.to_path_buf());
+            }
+            current = current.parent()?;
+        }
+    }
+
+    /// Same real-write probe `data_dir_check` uses on the data dir itself,
+    /// reused on an ancestor directory: permission bits are not the
+    /// question, actually creating and removing a file is.
+    fn probe_writable(dir: &Path) -> bool {
+        let probe = dir.join(format!(".sgt-doctor-writable-probe-{}", std::process::id()));
+        match std::fs::write(&probe, b"doctor") {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&probe);
+                true
+            }
+            Err(_) => false,
         }
     }
 

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -1177,8 +1177,12 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
         vec![
             "git",
             "claude",
-            "docker",
+            // #67: data_dir is checked before docker — the docker adapter's
+            // blob store and disk_pressure's `df` call both live inside the
+            // data dir, so this check runs first and both defer to it by
+            // name when it fails rather than re-diagnosing the same fault.
             "data_dir",
+            "docker",
             "journal",
             "projection",
             "daemon",
@@ -1728,6 +1732,122 @@ fn t3e_doctor_estate_check_names_file_and_line_on_a_malformed_manifest() {
     assert!(
         detail.to_lowercase().contains("line"),
         "the parse error must carry a line number, not just \"invalid\": {detail}"
+    );
+}
+
+/// #67: an unwritable *parent* of the data dir used to produce two
+/// confusing, apparently-independent downstream symptoms — `docker` failing
+/// to open its blob store under the data dir (EPERM) and `disk_pressure`'s
+/// `df` call failing because the data dir never got created (ENOENT,
+/// misreported as "could not be measured on this platform", which isn't
+/// even true — the platform can measure free space fine). Both are the same
+/// root cause. This drives `sgt doctor` against a data dir whose parent is
+/// stripped of write permission and requires that fault collapse into one
+/// `data_dir` FAIL row naming the actual offending parent directory, with
+/// `docker` and `disk_pressure` declining rather than re-diagnosing it under
+/// their own, more confusing names.
+///
+/// guard-map: reverting the fix restores the old check order (`docker`
+/// before `data_dir`) and the un-consolidated `docker`/`disk_pressure`
+/// bodies — this fails on the reverted code because `data_dir`'s detail
+/// never names the parent directory and `docker`/`disk_pressure` print
+/// their own confusing messages instead of deferring.
+#[test]
+fn t3f_doctor_names_an_unwritable_parent_as_one_remedy_row() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin = TempDir::new().expect("tempdir");
+    let claude = stub_claude(bin.path());
+    let docker = stub_docker(bin.path());
+
+    let parent = TempDir::new().expect("tempdir");
+    // The data dir itself must not exist yet — `create_dir_all` has to walk
+    // up past it and find this unwritable directory stalling the walk.
+    let data_dir = parent.path().join("child").join("data");
+
+    std::fs::set_permissions(parent.path(), std::fs::Permissions::from_mode(0o555))
+        .expect("chmod parent read+exec only");
+    struct RestorePerms(PathBuf);
+    impl Drop for RestorePerms {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o755));
+        }
+    }
+    let _restore = RestorePerms(parent.path().to_path_buf());
+
+    // Environment probe (docs/DEVELOPMENT.md's testing rules): the root dev
+    // container silently ignores permission-bit restrictions, so this
+    // fixture cannot be armed there — skip loudly rather than assert
+    // something that cannot hold in that environment.
+    if std::fs::create_dir(parent.path().join("probe")).is_ok() {
+        eprintln!(
+            "SKIPPED-ENV: permission bits are not enforced on this host (root container \
+             shape) — the unwritable-parent fault cannot be armed here"
+        );
+        return;
+    }
+
+    let (code, stdout, _) = doctor(
+        &data_dir,
+        &[("SGT_CLAUDE_BIN", &claude), ("SGT_DOCKER_BIN", &docker)],
+        false,
+    );
+    assert_ne!(
+        code,
+        Some(0),
+        "an unwritable parent must exit nonzero:\n{stdout}"
+    );
+
+    let (_, json, _) = doctor(
+        &data_dir,
+        &[("SGT_CLAUDE_BIN", &claude), ("SGT_DOCKER_BIN", &docker)],
+        true,
+    );
+    let report: Value = serde_json::from_str(&json).expect("doctor --json is json");
+
+    let parent_str = parent.path().display().to_string();
+
+    let data_dir_check = named_check(&report, "data_dir");
+    assert_eq!(data_dir_check["status"], "fail", "{data_dir_check}");
+    let detail = data_dir_check["detail"].as_str().expect("detail");
+    assert!(
+        detail.contains(&parent_str),
+        "the data_dir check must name the actual offending parent directory, not just the \
+         data dir it could not create: {detail}"
+    );
+    let remedy = data_dir_check["remedy"].as_str().expect("remedy");
+    assert!(
+        remedy.contains(&parent_str),
+        "the remedy must point at the parent directory to fix, not a generic instruction: \
+         {remedy}"
+    );
+
+    // The two downstream co-failures decline instead of re-diagnosing the
+    // same fault under their own, more confusing names.
+    let docker_check = named_check(&report, "docker");
+    assert_ne!(
+        docker_check["status"], "ok",
+        "docker cannot succeed when the data dir it opens a blob store under does not exist: \
+         {docker_check}"
+    );
+    assert!(
+        !docker_check["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("could not initialize the Docker adapter"),
+        "docker must defer to the data_dir check above rather than re-diagnosing the same \
+         EPERM under its own name: {docker_check}"
+    );
+
+    let disk_pressure_check = named_check(&report, "disk_pressure");
+    assert_ne!(disk_pressure_check["status"], "ok", "{disk_pressure_check}");
+    assert!(
+        !disk_pressure_check["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("could not be measured on this platform"),
+        "disk_pressure must not claim the platform can't measure free space when the real \
+         cause is the parent directory data_dir already named: {disk_pressure_check}"
     );
 }
 


### PR DESCRIPTION
Closes #67. Dispatched as sergeant Work `01KZZ4KTZGJ022M8TQKF9BKP6J` (`implement`, 2/20 turns).

Fixed as **reframed by the 2026-08-13 grooming comment**, not as the original body describes — that framing (docker EPERM + unmeasurable disk_pressure on a plain fresh data dir) is non-repro. Both symptoms share one precondition: an unwritable *parent* of the data dir.

`data_dir_check` now runs before `docker_check`, walks up to the nearest existing ancestor when `create_dir_all` fails, and names that ancestor with a concrete remedy. `docker` and `disk_pressure` take the resulting bool and decline by name rather than re-diagnosing — deliberately mirroring the existing `journal_ok -> projection_check` pattern rather than inventing a second idiom.

Also kills a false claim: `disk_pressure` used to print "free space could not be measured on this platform" when the platform is fine and the path is simply missing.

Test probe-gates with a loud `SKIPPED-ENV` under root, per DEVELOPMENT.md's two-environment rule — permission-bit fixtures pass vacuously in the root dev container.

Verified: reverting `cli.rs` alone fails the new test, reproducing issue #67's reported string verbatim.