### PR TITLE
Bug sprint 2026-08-14: five issues (#71, #67, #26, #11, #73) via sergeant Work items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 repos/
 .sergeant.toml.lock
 sergeant.toml.validate-*
+sergeant.toml

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ sgt analytics blocked_time_per_work  # answer one of them
 sgt doctor
 ```
 
-Checks git, the `claude` CLI (presence and version gate), Docker (capability probe), the data directory, the journal (full validating replay), the analytics projection, the daemon, the effective permission mode each declared profile launches with, (inside an estate) the estate manifest's own health, and disk pressure inside the data directory — in that order, so a fault is reported under the right name. Every failing check names its remedy; `sgt doctor` does **not** auto-spawn a daemon (every other command does), because it's diagnosing the installation, not priming it.
+Checks git, the `claude` CLI (presence and version gate), the data directory, Docker (capability probe), the journal (full validating replay), the analytics projection, the daemon, the effective permission mode each declared profile launches with, (inside an estate) the estate manifest's own health, and disk pressure inside the data directory — in that order, so a fault is reported under the right name; an unwritable data directory makes Docker and disk pressure decline with a pointer back to the `data_dir` row instead of re-diagnosing the same fault under their own name. Every failing check names its remedy; `sgt doctor` does **not** auto-spawn a daemon (every other command does), because it's diagnosing the installation, not priming it.
 
 **Manage the estate** — the directory declaring the repositories and groups a work item can target with `--repo`/`--group`:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,9 @@ const HEALTH_TIMEOUT: Duration = Duration::from_secs(2);
     about = "sergeant-rs: local agent execution surface"
 )]
 struct Sgt {
-    /// Data directory (default: $SGT_DATA_DIR, then ~/.local/share/sergeant).
+    /// Data directory (default: $SGT_DATA_DIR, then the discovered estate's
+    /// .sergeant/data, then $XDG_DATA_HOME/sergeant, then
+    /// ~/.local/share/sergeant).
     #[arg(long, global = true)]
     data_dir: Option<PathBuf>,
     /// Emit machine-readable JSON instead of human text.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1645,12 +1645,18 @@ mod doctor {
 
     /// Run every check against `data_dir`.
     pub async fn run(data_dir: &Path) -> Report {
-        let mut checks = vec![
-            git_check(),
-            claude_check(data_dir),
-            docker_check(data_dir),
-            data_dir_check(data_dir),
-        ];
+        let mut checks = vec![git_check(), claude_check(data_dir)];
+        // #67: the data dir's own existence and writability is checked
+        // before anything that lives *inside* it — the docker adapter's
+        // blob store and disk-pressure's `df` call both fail the instant
+        // the data dir cannot be created, and running them first surfaced
+        // that single fault as two unrelated-looking downstream symptoms.
+        // Threading `data_dir_ok` down mirrors `journal_ok` below: the
+        // checks that depend on it decline by name instead of re-deriving
+        // (and re-explaining) the same root cause.
+        let (data_dir_check, data_dir_ok) = data_dir_check(data_dir);
+        checks.push(data_dir_check);
+        checks.push(docker_check(data_dir, data_dir_ok));
         // The journal is the only durable fact in the installation, so it is
         // checked before anything derived from it; a projection rebuild over
         // an unreadable journal would report the journal's fault under the
@@ -1665,7 +1671,7 @@ mod doctor {
         // after everything above regardless of their outcome — knowing "is
         // this installation about to run out of disk" does not depend on the
         // daemon, the journal, or Docker being reachable.
-        checks.push(disk_pressure_check(data_dir));
+        checks.push(disk_pressure_check(data_dir, data_dir_ok));
         Report {
             data_dir: data_dir.to_path_buf(),
             checks,
@@ -1932,7 +1938,20 @@ mod doctor {
     /// healthy either way. This row exists so an operator can tell *why* an
     /// execute submission would be refused before trying one, with real
     /// evidence rather than a ping's optimism.
-    fn docker_check(data_dir: &Path) -> Check {
+    fn docker_check(data_dir: &Path, data_dir_ok: bool) -> Check {
+        // #67: `DockerBackend::new` opens a blob store under `data_dir` and
+        // fails with the same EPERM the `data_dir` check above already
+        // named and gave a remedy for — re-running it here would just print
+        // that fault a second time under a different, more confusing name
+        // ("could not initialize the Docker adapter") without adding
+        // information.
+        if !data_dir_ok {
+            return Check::warn(
+                "docker",
+                "not attempted: the data dir is not writable",
+                "fix the data_dir check above first",
+            );
+        }
         let backend = match DockerBackend::new(DockerConfig::new(data_dir)) {
             Ok(backend) => backend,
             Err(e) => {
@@ -1984,7 +2003,20 @@ mod doctor {
     /// exists independent of any execute stage ever running), folded into
     /// this module because Docker-captured stdout/stderr is the evidence
     /// class most likely to grow it fast (§16.9, §22.8).
-    fn disk_pressure_check(data_dir: &Path) -> Check {
+    fn disk_pressure_check(data_dir: &Path, data_dir_ok: bool) -> Check {
+        // #67: when the data dir does not exist, `df` on it fails ENOENT and
+        // `free_space` reports `None` — which this check used to print as
+        // "free space could not be measured on this platform", a claim
+        // that's simply false (the platform is fine; the path is missing)
+        // and misdirects an operator away from the real, already-named
+        // fault above.
+        if !data_dir_ok {
+            return Check::warn(
+                "disk_pressure",
+                "not attempted: the data dir is not writable",
+                "fix the data_dir check above first",
+            );
+        }
         let report = docker::measure_disk_pressure(data_dir);
         let detail = format!(
             "data dir {} ({} blobs), {}",
@@ -2046,35 +2078,103 @@ mod doctor {
         }
     }
 
-    /// §31: the data dir exists and this user can write it.
+    /// §31/#67: the data dir exists and this user can write it — checked
+    /// before anything that lives *inside* it (`docker_check`,
+    /// `disk_pressure_check`), so the boolean this returns lets both decline
+    /// instead of re-diagnosing the same fault under a more confusing name.
     ///
     /// Probed by actually creating and removing a file. Permission *bits* are
     /// not the question — read-only mounts, full disks and SELinux all answer
     /// "writable" by inspection and "no" in practice.
-    fn data_dir_check(data_dir: &Path) -> Check {
-        let remedy = format!(
+    ///
+    /// #67: when `create_dir_all` fails, the leaf path named in the raw io
+    /// error is often not the directory an operator actually needs to fix —
+    /// it never got created, so the error is really about wherever the walk
+    /// stalled. Walking up to the nearest ancestor that *does* exist and
+    /// probing that instead turns "permission denied" on a path that was
+    /// never created into one remedy row naming the actual offending parent.
+    fn data_dir_check(data_dir: &Path) -> (Check, bool) {
+        let generic_remedy = format!(
             "create {} and make it writable by this user (or point --data-dir / SGT_DATA_DIR \
              somewhere that is)",
             data_dir.display()
         );
         if let Err(e) = std::fs::create_dir_all(data_dir) {
-            return Check::fail(
-                "data_dir",
-                format!("cannot create {}: {e}", data_dir.display()),
-                remedy,
+            if let Some(ancestor) = nearest_existing_ancestor(data_dir)
+                && !probe_writable(&ancestor)
+            {
+                return (
+                    Check::fail(
+                        "data_dir",
+                        format!(
+                            "{} does not exist and cannot be created: its nearest existing \
+                             parent, {}, is not writable by this user ({e})",
+                            data_dir.display(),
+                            ancestor.display()
+                        ),
+                        format!(
+                            "make {} writable by this user — e.g. `chmod u+w {}` — or point \
+                             --data-dir / SGT_DATA_DIR at a location under a writable parent",
+                            ancestor.display(),
+                            ancestor.display()
+                        ),
+                    ),
+                    false,
+                );
+            }
+            return (
+                Check::fail(
+                    "data_dir",
+                    format!("cannot create {}: {e}", data_dir.display()),
+                    generic_remedy,
+                ),
+                false,
             );
         }
         let probe = data_dir.join(".doctor-write-probe");
         match std::fs::write(&probe, b"doctor") {
             Ok(()) => {
                 let _ = std::fs::remove_file(&probe);
-                Check::ok("data_dir", format!("{} is writable", data_dir.display()))
+                (
+                    Check::ok("data_dir", format!("{} is writable", data_dir.display())),
+                    true,
+                )
             }
-            Err(e) => Check::fail(
-                "data_dir",
-                format!("cannot write inside {}: {e}", data_dir.display()),
-                remedy,
+            Err(e) => (
+                Check::fail(
+                    "data_dir",
+                    format!("cannot write inside {}: {e}", data_dir.display()),
+                    generic_remedy,
+                ),
+                false,
             ),
+        }
+    }
+
+    /// Walk up from `path` to the nearest ancestor that already exists on
+    /// disk — the directory `create_dir_all` actually stalled at, and the
+    /// one worth naming as the fault (`data_dir_check`, #67).
+    fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
+        let mut current = path;
+        loop {
+            if current.exists() {
+                return Some(current.to_path_buf());
+            }
+            current = current.parent()?;
+        }
+    }
+
+    /// Same real-write probe `data_dir_check` uses on the data dir itself,
+    /// reused on an ancestor directory: permission bits are not the
+    /// question, actually creating and removing a file is.
+    fn probe_writable(dir: &Path) -> bool {
+        let probe = dir.join(format!(".sgt-doctor-writable-probe-{}", std::process::id()));
+        match std::fs::write(&probe, b"doctor") {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&probe);
+                true
+            }
+            Err(_) => false,
         }
     }
 

--- a/src/domain/manifest.rs
+++ b/src/domain/manifest.rs
@@ -54,19 +54,25 @@ use crate::runtime::fsutil::{create_dir_all_durable, take_exclusive_lock, write_
 use crate::runtime::git::{git_clone, git_succeeds};
 
 /// The `.gitignore` entries `sgt init` maintains (task's own naming): the
-/// estate-local data dir, the populated repository mounts, and this
-/// module's own scratch files. None belong in the estate's own history —
-/// `.sergeant/data` is machine-local runtime state (journal, blobs,
-/// projections), `repos/` is populated clones of *other* repositories' own
-/// histories, `.sergeant.toml.lock` is [`ManifestLock`]'s advisory-lock
-/// marker (never removed by design — see its own doc comment — so it
-/// outlives every edit and would otherwise sit untracked at the estate root
-/// forever), and `sergeant.toml.validate-*` is [`validate`]'s throwaway
-/// probe file, removed on the happy path but left behind if the process
-/// dies mid-validate (MVP-3 invariants finding MVP3-C3).
+/// estate-local data dir, the populated repository mounts, the manifest
+/// itself, and this module's own scratch files. None belong in the estate's
+/// own history — `.sergeant/data` is machine-local runtime state (journal,
+/// blobs, projections), `repos/` is populated clones of *other*
+/// repositories' own histories, `sergeant.toml` is [`WORKSPACE_FILE`] itself
+/// and is per-installation by design (#71: `sgt init` is what generates it,
+/// so a colleague's own checkout can never carry the same one — leaving it
+/// untracked left every subsequent `git status` in a clone-is-distro
+/// checkout showing `?? sergeant.toml` forever), `.sergeant.toml.lock` is
+/// [`ManifestLock`]'s advisory-lock marker (never removed by design — see
+/// its own doc comment — so it outlives every edit and would otherwise sit
+/// untracked at the estate root forever), and `sergeant.toml.validate-*` is
+/// [`validate`]'s throwaway probe file, removed on the happy path but left
+/// behind if the process dies mid-validate (MVP-3 invariants finding
+/// MVP3-C3).
 const GITIGNORE_ENTRIES: &[&str] = &[
     ".sergeant/data",
     "repos/",
+    "sergeant.toml",
     ".sergeant.toml.lock",
     "sergeant.toml.validate-*",
 ];
@@ -831,7 +837,11 @@ mod tests {
     /// reports nothing changed. Mutation this kills: dropping the
     /// `doc.contains_key("estate")` guard (always inserting a fresh table)
     /// or the `have.contains(entry)` guard in `ensure_gitignore` (always
-    /// appending) — both would corrupt or duplicate on a second run.
+    /// appending) — both would corrupt or duplicate on a second run. Also
+    /// pins #71: `sergeant.toml` itself must be one of the scaffolded
+    /// entries (it is per-installation, so a colleague's clone-is-distro
+    /// checkout must never show it as permanent untracked noise), and a
+    /// second run must not re-append it either.
     #[test]
     fn init_is_idempotent_on_a_second_run() {
         let dir = tempfile::TempDir::new().expect("tempdir");
@@ -848,6 +858,12 @@ mod tests {
             std::fs::read_to_string(root.join(WORKSPACE_FILE)).expect("read manifest");
         let gitignore_after_first =
             std::fs::read_to_string(root.join(".gitignore")).expect("read gitignore");
+        assert!(
+            gitignore_after_first
+                .lines()
+                .any(|l| l.trim() == "sergeant.toml"),
+            "a fresh init must gitignore the per-installation manifest itself (#71), got {gitignore_after_first:?}"
+        );
 
         let second = init_estate(root, Some("different-name")).expect("second init");
         assert!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -714,7 +714,15 @@ where
     let mut outcome: Result<Exit, TuiError> = Ok(Exit::Requested);
     'session: {
         if let Err(e) = terminal.draw(|frame| draw(frame, app)) {
-            outcome = Err(terminal_error(e));
+            // Same rule as the in-loop draw below: a write that fails because
+            // the pty already hung up is `TerminalGone`, not a reported
+            // error — this is the one draw site a hangup landing before the
+            // event loop starts would otherwise slip past.
+            outcome = if tty.hung_up() {
+                Ok(Exit::TerminalGone)
+            } else {
+                Err(terminal_error(e))
+            };
             break 'session;
         }
         loop {
@@ -1969,6 +1977,122 @@ mod tests {
             Exit::TerminalGone,
             "the loop must name the hangup, so `run` knows there is nobody to \
              report to"
+        );
+    }
+
+    /// A backend whose `draw` always fails, wrapping a real `TestBackend` for
+    /// every other call. `TestBackend` itself cannot fail a draw (its error
+    /// type is `Infallible`), so a hangup landing on the very first,
+    /// pre-loop draw — the gap issue #26's grooming narrowed the report
+    /// to — is otherwise unreachable from a test.
+    struct FailingBackend(ratatui::backend::TestBackend);
+
+    impl ratatui::backend::Backend for FailingBackend {
+        type Error = std::io::Error;
+
+        fn draw<'a, I>(&mut self, _content: I) -> std::io::Result<()>
+        where
+            I: Iterator<Item = (u16, u16, &'a ratatui::buffer::Cell)>,
+        {
+            Err(std::io::Error::from(std::io::ErrorKind::BrokenPipe))
+        }
+
+        fn hide_cursor(&mut self) -> std::io::Result<()> {
+            self.0.hide_cursor().unwrap();
+            Ok(())
+        }
+
+        fn show_cursor(&mut self) -> std::io::Result<()> {
+            self.0.show_cursor().unwrap();
+            Ok(())
+        }
+
+        fn get_cursor_position(&mut self) -> std::io::Result<ratatui::layout::Position> {
+            Ok(self.0.get_cursor_position().unwrap())
+        }
+
+        fn set_cursor_position<P: Into<ratatui::layout::Position>>(
+            &mut self,
+            position: P,
+        ) -> std::io::Result<()> {
+            self.0.set_cursor_position(position).unwrap();
+            Ok(())
+        }
+
+        fn clear(&mut self) -> std::io::Result<()> {
+            self.0.clear().unwrap();
+            Ok(())
+        }
+
+        fn clear_region(&mut self, clear_type: ratatui::backend::ClearType) -> std::io::Result<()> {
+            self.0.clear_region(clear_type).unwrap();
+            Ok(())
+        }
+
+        fn size(&self) -> std::io::Result<ratatui::layout::Size> {
+            Ok(self.0.size().unwrap())
+        }
+
+        fn window_size(&mut self) -> std::io::Result<ratatui::backend::WindowSize> {
+            Ok(self.0.window_size().unwrap())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.0.flush().unwrap();
+            Ok(())
+        }
+    }
+
+    /// A hangup landing on the pre-loop draw — before the event loop's
+    /// `select!` (and its own hung-up check) is ever reached — still exits
+    /// as `TerminalGone`, not as a reported error.
+    ///
+    /// Issue #26, as narrowed by its 2026-08-13 grooming comment: the reader
+    /// thread and `TtyWatch::install` now both arm synchronously before this
+    /// draw, closing the original 1-2 second startup window, but this one
+    /// call site still lacked the `tty.hung_up()` check every later draw
+    /// (line ~774) and the watch arm (line ~765) both consult. Without the
+    /// fix this test's `terminal.draw` failure is reported as a `TuiError`
+    /// instead of recognized as `Exit::TerminalGone`.
+    #[tokio::test]
+    async fn a_hangup_at_the_pre_loop_draw_exits_cleanly() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let _quiet = SIGNALS_QUIET.lock().await;
+        static PRESENT: AtomicBool = AtomicBool::new(true);
+        fn probe() -> bool {
+            PRESENT.load(Ordering::SeqCst)
+        }
+
+        PRESENT.store(true, Ordering::SeqCst);
+        let watch = TtyWatch::watching(probe);
+        // The terminal is already gone by the time the very first draw runs.
+        PRESENT.store(false, Ordering::SeqCst);
+        let probes = TerminalProbes {
+            watch,
+            tick: Box::new(|| ReaderTick::Idle),
+        };
+
+        let mut terminal =
+            ratatui::Terminal::new(FailingBackend(ratatui::backend::TestBackend::new(80, 24)))
+                .expect("a test terminal");
+        let mut app = App::new();
+        let client = ApiClient::new("http://127.0.0.1:1", "token").expect("client");
+
+        let exit = tokio::time::timeout(
+            Duration::from_secs(20),
+            event_loop(&mut terminal, &mut app, &client, probes),
+        )
+        .await
+        .expect("a pre-loop hangup must not hang the session");
+        assert_eq!(
+            exit.expect(
+                "a hangup discovered on the pre-loop draw is not a failure — \
+                 there is nobody left to report one to"
+            ),
+            Exit::TerminalGone,
+            "the pre-loop draw must consult the same hung-up check every \
+             later draw site does"
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -470,6 +470,27 @@ fn footer_line(app: &App) -> Paragraph<'_> {
     ]))
 }
 
+/// Render `text` into a fixed-width fleet column: space-padded if it fits,
+/// truncated with a trailing `…` if it does not.
+///
+/// Padding alone (`{:<width$}`) only ever *adds* space — it never removes it,
+/// so a value longer than `width` overruns into the next column and the
+/// visual gap between them disappears (e.g. a long stage label running into
+/// the backend column). Truncating to `width` keeps every column exactly
+/// `width` cells wide regardless of content, so the next column always
+/// starts where its padding says it should.
+fn column(text: &str, width: usize) -> String {
+    let len = text.chars().count();
+    if len <= width {
+        format!("{text:<width$}")
+    } else if width == 0 {
+        String::new()
+    } else {
+        let head: String = text.chars().take(width - 1).collect();
+        format!("{head}…")
+    }
+}
+
 fn draw_fleet(frame: &mut Frame, app: &App, area: Rect) {
     let block = Block::bordered().title(format!("fleet — {} work", app.rows.len()));
     if app.rows.is_empty() {
@@ -484,10 +505,10 @@ fn draw_fleet(frame: &mut Frame, app: &App, area: Rect) {
         .iter()
         .map(|row| {
             ListItem::new(Line::from(vec![
-                Span::raw(format!("{:<28}", row.id)),
-                Span::styled(format!("{:<12}", row.state), state_style(&row.state)),
-                Span::raw(format!("{:<26}", row.stage)),
-                Span::raw(format!("{:<10}", row.backend)),
+                Span::raw(column(&row.id, 28)),
+                Span::styled(column(&row.state, 12), state_style(&row.state)),
+                Span::raw(column(&row.stage, 26)),
+                Span::raw(column(&row.backend, 10)),
                 Span::raw(row.intent.clone()),
             ]))
         })
@@ -1473,6 +1494,74 @@ mod tests {
 
         // A body with no `works` array at all is an empty fleet, not a panic.
         assert!(fleet_rows(&json!({})).is_empty());
+    }
+
+    /// A stage value that overruns its column's padding is truncated, so the
+    /// backend column still starts exactly where the stage column's width
+    /// says it should — instead of the two columns running together.
+    ///
+    /// Issue #11: `draw_fleet` pads each cell with `format!("{:<N}")`, which
+    /// only ever *adds* space and never removes it, so a stage longer than
+    /// its 26-column width overruns into the backend column and the gap
+    /// between them disappears (`docs/img/tui-fleet.png` shows exactly this:
+    /// `needs_inputfake` with no separator). The existing fleet-row test
+    /// above asserts field *content* via substrings, which cannot see this —
+    /// a substring check passes whether or not the columns are padded to
+    /// width at all. This test instead asserts on column position: it finds
+    /// the fixed-width stage field on the rendered screen and checks the
+    /// backend field starts exactly 26 columns after it, not wherever the
+    /// stage text happened to end.
+    #[test]
+    fn an_overlong_stage_is_truncated_so_the_backend_column_still_starts_on_time() {
+        let mut app = App::new();
+        app.rows = vec![WorkRow {
+            id: "rowid1".to_string(),
+            state: "needs_input".to_string(),
+            // Well past the 26-column stage width.
+            stage: "10-implement 2/2 · running a very long stage label indeed".to_string(),
+            backend: "fake".to_string(),
+            intent: "an intent".to_string(),
+        }];
+
+        let screen = screen_text(&app);
+        let line = screen
+            .lines()
+            .find(|line| line.contains("rowid1"))
+            .expect("the fleet row is on screen");
+
+        let id_start = line.find("rowid1").expect("already checked it's there");
+        let after_id: Vec<char> = line[id_start..].chars().collect();
+        assert!(
+            after_id.len() >= 28 + 12 + 26 + 10,
+            "the row must be wide enough to hold every column: {line}"
+        );
+
+        let stage_field: String = after_id[28 + 12..28 + 12 + 26].iter().collect();
+        let backend_field: String = after_id[28 + 12 + 26..28 + 12 + 26 + 10].iter().collect();
+
+        assert_eq!(
+            stage_field.chars().count(),
+            26,
+            "the stage column is exactly 26 cells wide regardless of content: \
+             {line}"
+        );
+        assert!(
+            stage_field.ends_with('…'),
+            "a stage longer than the column must be truncated with an \
+             ellipsis, not overrun the column: {stage_field:?} in {line}"
+        );
+        assert!(
+            !stage_field.contains("running a very long"),
+            "the full stage text must not survive into the fixed-width \
+             column: {stage_field:?}"
+        );
+        assert!(
+            backend_field.trim_start().starts_with("fake"),
+            "the backend column must start exactly where the stage column's \
+             padding says it should, not wherever the untruncated stage text \
+             happened to end: stage={stage_field:?} backend={backend_field:?} \
+             in {line}"
+        );
     }
 
     /// Liveness is durable state, not a message.

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -2334,13 +2334,18 @@ fn resolve_data_dir_falls_back_through_sgt_data_dir_then_xdg_then_home() {
     assert!(!home.path().join(".local").exists());
     drop(_reap);
 
-    // Absent SGT_DATA_DIR, `$XDG_DATA_HOME/sergeant` is next.
+    // Absent SGT_DATA_DIR, `$XDG_DATA_HOME/sergeant` is next. Run from a cwd
+    // outside any estate: an in-tree cwd would let step 3 (estate discovery,
+    // `resolve_data_dir`) resolve first and this fallback rung would never
+    // actually be exercised.
     let xdg2 = TempDir::new().expect("tempdir");
     let home2 = TempDir::new().expect("tempdir");
+    let cwd2 = TempDir::new().expect("tempdir");
     let resolved = xdg2.path().join("sergeant");
     let _reap = ReapOnDrop(resolved.clone());
     let output = Command::new(SGT)
         .args(["work", "list", "--json"])
+        .current_dir(cwd2.path())
         .env_remove("SGT_DATA_DIR")
         .env("XDG_DATA_HOME", xdg2.path())
         .env("HOME", home2.path())
@@ -2358,12 +2363,15 @@ fn resolve_data_dir_falls_back_through_sgt_data_dir_then_xdg_then_home() {
     assert!(!home2.path().join(".local").exists());
     drop(_reap);
 
-    // Absent both, `$HOME/.local/share/sergeant` is the last resort.
+    // Absent both, `$HOME/.local/share/sergeant` is the last resort. Same
+    // cwd-isolation reasoning as the XDG case above.
     let home3 = TempDir::new().expect("tempdir");
+    let cwd3 = TempDir::new().expect("tempdir");
     let resolved = home3.path().join(".local/share/sergeant");
     let _reap = ReapOnDrop(resolved.clone());
     let output = Command::new(SGT)
         .args(["work", "list", "--json"])
+        .current_dir(cwd3.path())
         .env_remove("SGT_DATA_DIR")
         .env_remove("XDG_DATA_HOME")
         .env("HOME", home3.path())

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -1177,8 +1177,12 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
         vec![
             "git",
             "claude",
-            "docker",
+            // #67: data_dir is checked before docker — the docker adapter's
+            // blob store and disk_pressure's `df` call both live inside the
+            // data dir, so this check runs first and both defer to it by
+            // name when it fails rather than re-diagnosing the same fault.
             "data_dir",
+            "docker",
             "journal",
             "projection",
             "daemon",
@@ -1728,6 +1732,122 @@ fn t3e_doctor_estate_check_names_file_and_line_on_a_malformed_manifest() {
     assert!(
         detail.to_lowercase().contains("line"),
         "the parse error must carry a line number, not just \"invalid\": {detail}"
+    );
+}
+
+/// #67: an unwritable *parent* of the data dir used to produce two
+/// confusing, apparently-independent downstream symptoms — `docker` failing
+/// to open its blob store under the data dir (EPERM) and `disk_pressure`'s
+/// `df` call failing because the data dir never got created (ENOENT,
+/// misreported as "could not be measured on this platform", which isn't
+/// even true — the platform can measure free space fine). Both are the same
+/// root cause. This drives `sgt doctor` against a data dir whose parent is
+/// stripped of write permission and requires that fault collapse into one
+/// `data_dir` FAIL row naming the actual offending parent directory, with
+/// `docker` and `disk_pressure` declining rather than re-diagnosing it under
+/// their own, more confusing names.
+///
+/// guard-map: reverting the fix restores the old check order (`docker`
+/// before `data_dir`) and the un-consolidated `docker`/`disk_pressure`
+/// bodies — this fails on the reverted code because `data_dir`'s detail
+/// never names the parent directory and `docker`/`disk_pressure` print
+/// their own confusing messages instead of deferring.
+#[test]
+fn t3f_doctor_names_an_unwritable_parent_as_one_remedy_row() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin = TempDir::new().expect("tempdir");
+    let claude = stub_claude(bin.path());
+    let docker = stub_docker(bin.path());
+
+    let parent = TempDir::new().expect("tempdir");
+    // The data dir itself must not exist yet — `create_dir_all` has to walk
+    // up past it and find this unwritable directory stalling the walk.
+    let data_dir = parent.path().join("child").join("data");
+
+    std::fs::set_permissions(parent.path(), std::fs::Permissions::from_mode(0o555))
+        .expect("chmod parent read+exec only");
+    struct RestorePerms(PathBuf);
+    impl Drop for RestorePerms {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o755));
+        }
+    }
+    let _restore = RestorePerms(parent.path().to_path_buf());
+
+    // Environment probe (docs/DEVELOPMENT.md's testing rules): the root dev
+    // container silently ignores permission-bit restrictions, so this
+    // fixture cannot be armed there — skip loudly rather than assert
+    // something that cannot hold in that environment.
+    if std::fs::create_dir(parent.path().join("probe")).is_ok() {
+        eprintln!(
+            "SKIPPED-ENV: permission bits are not enforced on this host (root container \
+             shape) — the unwritable-parent fault cannot be armed here"
+        );
+        return;
+    }
+
+    let (code, stdout, _) = doctor(
+        &data_dir,
+        &[("SGT_CLAUDE_BIN", &claude), ("SGT_DOCKER_BIN", &docker)],
+        false,
+    );
+    assert_ne!(
+        code,
+        Some(0),
+        "an unwritable parent must exit nonzero:\n{stdout}"
+    );
+
+    let (_, json, _) = doctor(
+        &data_dir,
+        &[("SGT_CLAUDE_BIN", &claude), ("SGT_DOCKER_BIN", &docker)],
+        true,
+    );
+    let report: Value = serde_json::from_str(&json).expect("doctor --json is json");
+
+    let parent_str = parent.path().display().to_string();
+
+    let data_dir_check = named_check(&report, "data_dir");
+    assert_eq!(data_dir_check["status"], "fail", "{data_dir_check}");
+    let detail = data_dir_check["detail"].as_str().expect("detail");
+    assert!(
+        detail.contains(&parent_str),
+        "the data_dir check must name the actual offending parent directory, not just the \
+         data dir it could not create: {detail}"
+    );
+    let remedy = data_dir_check["remedy"].as_str().expect("remedy");
+    assert!(
+        remedy.contains(&parent_str),
+        "the remedy must point at the parent directory to fix, not a generic instruction: \
+         {remedy}"
+    );
+
+    // The two downstream co-failures decline instead of re-diagnosing the
+    // same fault under their own, more confusing names.
+    let docker_check = named_check(&report, "docker");
+    assert_ne!(
+        docker_check["status"], "ok",
+        "docker cannot succeed when the data dir it opens a blob store under does not exist: \
+         {docker_check}"
+    );
+    assert!(
+        !docker_check["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("could not initialize the Docker adapter"),
+        "docker must defer to the data_dir check above rather than re-diagnosing the same \
+         EPERM under its own name: {docker_check}"
+    );
+
+    let disk_pressure_check = named_check(&report, "disk_pressure");
+    assert_ne!(disk_pressure_check["status"], "ok", "{disk_pressure_check}");
+    assert!(
+        !disk_pressure_check["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("could not be measured on this platform"),
+        "disk_pressure must not claim the platform can't measure free space when the real \
+         cause is the parent directory data_dir already named: {disk_pressure_check}"
     );
 }
 


### PR DESCRIPTION
First bug sprint run end-to-end through `sgt` with the owner supplying the intent. Four dispatched Work items on the `implement` workflow, all reviewed and independently verified by this session before landing.

## What landed

| PR | Issue(s) | Summary |
|---|---|---|
| #74 | #73 | m2's `resolve_data_dir` fallback test isolates its child's cwd; `--data-dir` help text states the real precedence |
| #75 | #71 | `sgt init` gitignores the per-installation manifest |
| #76 | #26, #11 | TUI: hangup guard on the pre-loop draw; fleet columns truncate with an ellipsis |
| #77 | #67 | doctor collapses the unwritable-parent EPERM into one named remedy row |

Plus two commits outside those PRs: applying #71's new entry to this checkout's tracked `.gitignore` (see below), and the pipeline's own `document`-step fix correcting README's now-stale description of doctor's check order.

## Verification

Every fix carries a test that I confirmed fails when **only its production code** is reverted — checked by hand, not taken on the worker's word:

- **#71** — removing the `GITIGNORE_ENTRIES` line fails the extended idempotency test.
- **#67** — restoring the original `cli.rs` fails the new test and reproduces the issue's reported string verbatim: `could not initialize the Docker adapter: docker adapter blob store: blob io error: Permission denied (os error 13)`.
- **#26** — reverting the pre-loop guard fails its test.
- **#11** — reverting the `column()` call fails its test, printing the `…indeedfake` run-together from `docs/img/tui-fleet.png`.
- **#73** — passes from the estate cwd that exposed the bug, and still fails if the XDG branch is genuinely broken, so the isolation is not vacuous.

Full suite green on the combined result (257 lib + all integration suites, 0 failures, 4 opt-in ignored), run twice. `fmt` and `clippy -D warnings` clean. Shipping gate: **passed** (run `01KZZ7TJBN9ECCVQCM766V1239`, `--skip push,pr,ci`), custody recovered via `axi sync --recover`. No orphaned daemons after the suite.

## Envelope actually spent

| Work | Issue(s) | Turns | Ceiling |
|---|---|---|---|
| `01KZZ5KCFFYJNSMHG87G3CWRB8` | #73 | 2 | 20 turns / 2400s per turn |
| `01KZZ4K8MYRPEPY6ATXZ4N9TMA` | #71 | 2 | 20 / 2400s |
| `01KZZ4MEE1STJPPR9G7THQ3606` | #26, #11 | 2 | 20 / 2400s |
| `01KZZ4KTZGJ022M8TQKF9BKP6J` | #67 | 2 | 20 / 2400s |

**8 turns total against an 80-turn cap.** No Work raised `needs_input`; none was retried, extended, or cancelled. I widened the envelope from the `DEFAULT_TURN_CAP` of 12 / 15-minute default because each surface is a fresh worktree facing a cold DuckDB build before its first test — a 15-minute per-turn ceiling would have killed a turn mid-compile. In the event, nothing came close to either bound.

## Two things that need your judgment

1. **#73's precedence question is parked, not answered.** `resolve_data_dir` tries estate discovery *before* `XDG_DATA_HOME`, which makes an explicitly-set `XDG_DATA_HOME` inert inside any estate. That looks intended per U-R2, but nothing pins it as a ruling, so the Work was explicitly fenced off from touching the order. It only fixed the test's isolation and the help text. Worth an explicit ruling. (Corroboration: README already documented the full precedence correctly — `--help` was the stale one.)

2. **#78 filed for the stale screenshot.** `docs/img/tui-fleet.png` is embedded in README as the "TUI — fleet" illustration and predates the #11 fix, so it is now a picture of a bug we fixed. Regenerating it needs a real TUI run, which the gate correctly called outside a documentation pass.

## Notes on the run

- **`.gitignore` needed a second step to actually deliver #71.** The code change governs what `sgt init` *writes*; it does not retroactively edit an estate whose init already ran. Without re-running init here, this repo would still have shown `?? sergeant.toml` while shipping the fix. Committing the tracked result also means a fresh clone is clean before init ever runs.
- **Issue #60 was live for this run** and neutralized deliberately: the daemon was spawned from a shell carrying `~/.cargo/bin`, and I verified the toolchain in `/proc/<pid>/environ` rather than assuming it. Without that, every worker's `cargo` invocation would have failed and — per #60's own history — likely been self-misdiagnosed as a permissions fault.
- **Submit-time preflight earned its keep.** The first `sgt run` was refused with `422: profile "sonnet" launches backend "claude", but this work routed to "fake" (global_default)` — caught before a single turn was spent.
- `TMPDIR` was pointed at disk-backed `/var/tmp` for all gate runs, since concurrent suites hitting m7's 2×256 MiB captures on the 16 GB tmpfs is the #70 shape that broke this host on 08-13.

Issues #71, #67, #26, #11 and #73 close on merge via their commit trailers.