### PR TITLE
Wave 1 / G1: absorb the ETXTBSY window (#83) and root test data dirs on real disk (#70)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -4005,6 +4005,20 @@ mod tests {
         let mut permissions = std::fs::metadata(&path).expect("stat stub").permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&path, permissions).expect("chmod stub");
+        // A file another process still holds open for writing cannot be
+        // exec'd; absorb the ETXTBSY window before handing it to the
+        // adapter (#83 — this exact shape is already handled in
+        // tests/m5_projections.rs and tests/m6_surfaces.rs; measured under
+        // `cargo test --lib`'s default thread parallelism: 3 failures in 40
+        // runs, every one `os error 26`).
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while let Err(e) = std::process::Command::new(&path).arg("--version").output() {
+            assert!(
+                e.raw_os_error() == Some(26) && Instant::now() < deadline,
+                "the stub is not runnable: {e}"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
         path
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -4007,18 +4007,9 @@ mod tests {
         std::fs::set_permissions(&path, permissions).expect("chmod stub");
         // A file another process still holds open for writing cannot be
         // exec'd; absorb the ETXTBSY window before handing it to the
-        // adapter (#83 — this exact shape is already handled in
-        // tests/m5_projections.rs and tests/m6_surfaces.rs; measured under
-        // `cargo test --lib`'s default thread parallelism: 3 failures in 40
-        // runs, every one `os error 26`).
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while let Err(e) = std::process::Command::new(&path).arg("--version").output() {
-            assert!(
-                e.raw_os_error() == Some(26) && Instant::now() < deadline,
-                "the stub is not runnable: {e}"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        // adapter (#83 — measured under `cargo test --lib`'s default thread
+        // parallelism: 3 failures in 40 runs, every one `os error 26`).
+        crate::test_support::wait_until_executable(&path);
         path
     }
 

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -791,7 +791,10 @@ impl ClaudeBackend {
             Err(e) => {
                 return ProbeOutcome {
                     available: false,
-                    detail: format!("capability probe: cannot run {exe:?} --version: {e}"),
+                    detail: format!(
+                        "capability probe: cannot run {exe:?} --version: {e} (kind: {:?})",
+                        e.kind()
+                    ),
                     version: None,
                 };
             }
@@ -831,7 +834,10 @@ impl ClaudeBackend {
             Err(e) => {
                 return ProbeOutcome {
                     available: false,
-                    detail: format!("capability probe: cannot run {exe:?} --help: {e}"),
+                    detail: format!(
+                        "capability probe: cannot run {exe:?} --help: {e} (kind: {:?})",
+                        e.kind()
+                    ),
                     version: Some(canonical_version),
                 };
             }
@@ -2967,6 +2973,72 @@ mod tests {
         assert_eq!(latest_ask_withdrawal_version(noise).unwrap(), None);
     }
 
+    /// #83: a freshly written, freshly `chmod +x`'d stand-in script can
+    /// transiently fail `execve(2)` with `ETXTBSY` ("text file busy",
+    /// `os error 26`) under `cargo test --lib`'s default thread
+    /// parallelism — measured directly (3 failures in 40 runs, every one
+    /// this exact `io::ErrorKind::ExecutableFileBusy`) via the diagnostic
+    /// `run_probe` now surfaces. This is not a version-parsing bug; the
+    /// same absorb-and-retry idiom already fixed it in
+    /// `tests/m5_projections.rs` and `tests/m6_surfaces.rs` before this
+    /// call site existed. Retry until the exec stops being refused, or
+    /// surface any other failure immediately — the window is real but
+    /// bounded, never a reason to paper over an unrelated exec error.
+    #[cfg(unix)]
+    fn wait_until_executable(path: &std::path::Path) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while let Err(e) = std::process::Command::new(path).arg("--version").output() {
+            assert!(
+                e.raw_os_error() == Some(26) && std::time::Instant::now() < deadline,
+                "the stand-in is not runnable: {e}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+
+    /// #83, direct proof rather than a re-run-until-it-flakes gamble:
+    /// manufactures the exact condition `execve(2)` refuses with `ETXTBSY`
+    /// — a second fd open for writing on the same inode — and confirms
+    /// `wait_until_executable` retries through it instead of surfacing the
+    /// exec failure as if the file were simply unrunnable. Deterministic,
+    /// not load-dependent: the writer fd stays open for 150ms, so a single
+    /// attempt made at t=0 (i.e. no retry loop) always lands inside the
+    /// busy window and this test would fail every time the fix is
+    /// reverted, not just some fraction of runs.
+    #[cfg(unix)]
+    #[test]
+    fn a_manufactured_etxtbsy_window_is_absorbed_not_surfaced_as_missing() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let script = dir.path().join("busy-script");
+        std::fs::write(&script, "#!/bin/sh\necho ok\n").expect("write script");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod +x");
+
+        // A second fd open for writing on `script` is exactly what
+        // `execve(2)` refuses — this is the manufactured busy window, held
+        // open on another thread so `wait_until_executable` below observes
+        // it on its very first attempt.
+        let writer = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&script)
+            .expect("open second writer fd");
+        let closer = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(150));
+            drop(writer);
+        });
+
+        let start = std::time::Instant::now();
+        wait_until_executable(&script);
+        assert!(
+            start.elapsed() >= std::time::Duration::from_millis(100),
+            "wait_until_executable returned before the manufactured busy \
+             window closed — it did not actually retry through ETXTBSY, it \
+             got lucky (or the busy window was never real)"
+        );
+        closer.join().expect("writer-closing thread");
+    }
+
     /// MVP-2 D2 item 2: the durability half. A record for the version this
     /// probe measures *right now* lowers the claim; a record for any other
     /// version (a CLI upgrade or downgrade since it was journaled) leaves
@@ -2995,13 +3067,15 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
                 .expect("chmod +x");
+            wait_until_executable(&script);
         }
         config.executable = script;
         let backend = ClaudeBackend::new(config);
         assert_eq!(
             backend.probe_outcome().version.as_deref(),
             Some("2.1.226"),
-            "stand-in must parse as the version the test reasons about"
+            "stand-in must parse as the version the test reasons about (probe detail: {})",
+            backend.probe_outcome().detail
         );
 
         // A different version's withdrawal: stale, does not apply.

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -2973,29 +2973,6 @@ mod tests {
         assert_eq!(latest_ask_withdrawal_version(noise).unwrap(), None);
     }
 
-    /// #83: a freshly written, freshly `chmod +x`'d stand-in script can
-    /// transiently fail `execve(2)` with `ETXTBSY` ("text file busy",
-    /// `os error 26`) under `cargo test --lib`'s default thread
-    /// parallelism — measured directly (3 failures in 40 runs, every one
-    /// this exact `io::ErrorKind::ExecutableFileBusy`) via the diagnostic
-    /// `run_probe` now surfaces. This is not a version-parsing bug; the
-    /// same absorb-and-retry idiom already fixed it in
-    /// `tests/m5_projections.rs` and `tests/m6_surfaces.rs` before this
-    /// call site existed. Retry until the exec stops being refused, or
-    /// surface any other failure immediately — the window is real but
-    /// bounded, never a reason to paper over an unrelated exec error.
-    #[cfg(unix)]
-    fn wait_until_executable(path: &std::path::Path) {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-        while let Err(e) = std::process::Command::new(path).arg("--version").output() {
-            assert!(
-                e.raw_os_error() == Some(26) && std::time::Instant::now() < deadline,
-                "the stand-in is not runnable: {e}"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(20));
-        }
-    }
-
     /// #83, direct proof rather than a re-run-until-it-flakes gamble:
     /// manufactures the exact condition `execve(2)` refuses with `ETXTBSY`
     /// — a second fd open for writing on the same inode — and confirms
@@ -3029,7 +3006,7 @@ mod tests {
         });
 
         let start = std::time::Instant::now();
-        wait_until_executable(&script);
+        crate::test_support::wait_until_executable(&script);
         assert!(
             start.elapsed() >= std::time::Duration::from_millis(100),
             "wait_until_executable returned before the manufactured busy \
@@ -3067,7 +3044,7 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
                 .expect("chmod +x");
-            wait_until_executable(&script);
+            crate::test_support::wait_until_executable(&script);
         }
         config.executable = script;
         let backend = ClaudeBackend::new(config);

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -1447,23 +1447,9 @@ mod tests {
         .expect("chmod +x scripted docker_bin");
         // A file another process still holds open for writing cannot be
         // exec'd; absorb the ETXTBSY window before handing it to the
-        // backend (#83 — this exact shape is already handled in
-        // tests/m5_projections.rs and tests/m6_surfaces.rs; measured under
-        // `cargo test --lib`'s default thread parallelism: 3 failures in 40
-        // runs, every one `os error 26`).
-        {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-            while let Err(e) = std::process::Command::new(&script_path)
-                .arg("version")
-                .output()
-            {
-                assert!(
-                    e.raw_os_error() == Some(26) && std::time::Instant::now() < deadline,
-                    "the scripted docker_bin is not runnable: {e}"
-                );
-                std::thread::sleep(std::time::Duration::from_millis(20));
-            }
-        }
+        // backend (#83 — measured under `cargo test --lib`'s default thread
+        // parallelism: 3 failures in 40 runs, every one `os error 26`).
+        crate::test_support::wait_until_executable(&script_path);
         config.docker_bin = script_path.to_string_lossy().to_string();
         let backend = DockerBackend::new(config).expect("backend");
 

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -1445,6 +1445,25 @@ mod tests {
             std::os::unix::fs::PermissionsExt::from_mode(0o755),
         )
         .expect("chmod +x scripted docker_bin");
+        // A file another process still holds open for writing cannot be
+        // exec'd; absorb the ETXTBSY window before handing it to the
+        // backend (#83 — this exact shape is already handled in
+        // tests/m5_projections.rs and tests/m6_surfaces.rs; measured under
+        // `cargo test --lib`'s default thread parallelism: 3 failures in 40
+        // runs, every one `os error 26`).
+        {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            while let Err(e) = std::process::Command::new(&script_path)
+                .arg("version")
+                .output()
+            {
+                assert!(
+                    e.raw_os_error() == Some(26) && std::time::Instant::now() < deadline,
+                    "the scripted docker_bin is not runnable: {e}"
+                );
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+        }
         config.docker_bin = script_path.to_string_lossy().to_string();
         let backend = DockerBackend::new(config).expect("backend");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,27 @@ pub mod telemetry;
 pub mod tui;
 pub mod watch;
 pub mod web;
+
+/// Fixtures shared across this crate's own unit tests (`cargo test --lib`),
+/// as opposed to `tests/support`, which serves the separately-compiled
+/// integration test binaries under `tests/`.
+#[cfg(test)]
+pub(crate) mod test_support {
+    /// #83: a freshly written, freshly `chmod +x`'d stand-in script can
+    /// transiently fail `execve(2)` with `ETXTBSY` ("text file busy", `os
+    /// error 26`) while another handle on the same inode is still open for
+    /// writing — under `cargo test`'s default thread parallelism, a sibling
+    /// test's fork-to-exec window can overlap this one's write. Retry until
+    /// the exec stops being refused, or surface any other failure
+    /// immediately.
+    pub(crate) fn wait_until_executable(path: &std::path::Path) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while let Err(e) = std::process::Command::new(path).arg("--version").output() {
+            assert!(
+                e.raw_os_error() == Some(26) && std::time::Instant::now() < deadline,
+                "the stand-in at {path:?} is not runnable: {e}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+}

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -1473,6 +1473,39 @@ fn the_data_dir_guard_reaps_the_daemon_a_client_command_spawns() {
     // the assertion every other test in this file gets for free.
 }
 
+/// #70: `DataDir::new()` must land on real disk by default, not wherever
+/// `TempDir::new()` would pick from `$TMPDIR`. On a host like Cerberus that
+/// default is a 16 GB tmpfs `/tmp`; a gigabyte-scale blob-store capture
+/// (`tests/m7_docker_executor.rs`'s
+/// `large_captured_output_does_not_grow_this_process_proportionally`,
+/// contract scale 1 GiB) filling it broke every `Bash` invocation's output
+/// capture across every session on the host — `EDQUOT` under a command that
+/// still ran underneath, so it looked like a broken shell rather than a
+/// full disk (evidence in `docs/environments/cerberus.md`). An operator
+/// remembering to export `$TMPDIR` does not close that: the incident was an
+/// unsafe *default*, so this pins a positive claim about where the rig
+/// actually lands — not merely "not literally /tmp" — which a revert to
+/// `TempDir::new()` fails every time (its default is `/tmp` on this host).
+///
+/// `/var/tmp/sgt-rs-tests`, not `target/tmp` under the crate root: a data
+/// dir nested inside this checkout sits under a directory `sgt run`'s own
+/// workspace-discovery walks upward through looking for `.git` (`fn sgt`'s
+/// doc comment above explains why these M2 tests need a data dir with no
+/// discoverable repository above it) — the first version of this fix
+/// nested it there and turned every `pending` in this file into `blocked`
+/// by accident.
+#[test]
+fn a_data_dir_defaults_onto_disk_not_the_hosts_tmpfs() {
+    let dir = DataDir::new();
+    let expected_base = Path::new("/var/tmp/sgt-rs-tests");
+    assert!(
+        dir.path().starts_with(expected_base),
+        "DataDir::new() must root its TempDir under {expected_base:?} (real disk, \
+         outside any git checkout) by default — got {:?}",
+        dir.path()
+    );
+}
+
 #[test]
 fn t7_cli_end_to_end_auto_spawn_and_second_daemon_fails_closed() {
     let dir = DataDir::new();

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -1497,13 +1497,14 @@ fn the_data_dir_guard_reaps_the_daemon_a_client_command_spawns() {
 #[test]
 fn a_data_dir_defaults_onto_disk_not_the_hosts_tmpfs() {
     let dir = DataDir::new();
-    let expected_base = Path::new("/var/tmp/sgt-rs-tests");
-    assert!(
-        dir.path().starts_with(expected_base),
-        "DataDir::new() must root its TempDir under {expected_base:?} (real disk, \
-         outside any git checkout) by default — got {:?}",
-        dir.path()
-    );
+    if let Some(expected_base) = support::disk_backed_tmp_base() {
+        assert!(
+            dir.path().starts_with(&expected_base),
+            "DataDir::new() must root its TempDir under {expected_base:?} (real disk, \
+             outside any git checkout) by default — got {:?}",
+            dir.path()
+        );
+    }
 }
 
 #[test]

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -1494,17 +1494,41 @@ fn the_data_dir_guard_reaps_the_daemon_a_client_command_spawns() {
 /// discoverable repository above it) — the first version of this fix
 /// nested it there and turned every `pending` in this file into `blocked`
 /// by accident.
+/// The environment probe below deliberately does **not** call
+/// `support::disk_backed_tmp_base` to decide what to expect: asking the
+/// function under test where it will land, then asserting it landed there,
+/// is a tautology that passes for any answer it gives — including `None`,
+/// which skips the body entirely. Measured: with `disk_backed_tmp_base`
+/// stubbed to `None`, that shape passes, while the independent probe below
+/// fails as it should. The probe reads the filesystem itself, and the skip
+/// is loud per `docs/DEVELOPMENT.md`'s two-environment rule rather than a
+/// silent early return.
 #[test]
 fn a_data_dir_defaults_onto_disk_not_the_hosts_tmpfs() {
-    let dir = DataDir::new();
-    if let Some(expected_base) = support::disk_backed_tmp_base() {
-        assert!(
-            dir.path().starts_with(&expected_base),
-            "DataDir::new() must root its TempDir under {expected_base:?} (real disk, \
-             outside any git checkout) by default — got {:?}",
-            dir.path()
+    if std::env::var_os("SGT_TEST_TMPDIR").is_some() {
+        eprintln!(
+            "SKIPPED-ENV: SGT_TEST_TMPDIR is set, so this run is not exercising the \
+             default this test pins — the override path is a different claim"
         );
+        return;
     }
+    let var_tmp = Path::new("/var/tmp");
+    if !var_tmp.is_dir() {
+        eprintln!(
+            "SKIPPED-ENV: /var/tmp is not a directory on this host, so the disk-backed \
+             default cannot be armed here (`disk_backed_tmp_base` falls back by design)"
+        );
+        return;
+    }
+
+    let expected_base = var_tmp.join("sgt-rs-tests");
+    let dir = DataDir::new();
+    assert!(
+        dir.path().starts_with(&expected_base),
+        "DataDir::new() must root its TempDir under {expected_base:?} (real disk, \
+         outside any git checkout) by default — got {:?}",
+        dir.path()
+    );
 }
 
 #[test]

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -537,6 +537,20 @@ impl StubClaude {
         let mut permissions = std::fs::metadata(&path).expect("stat stub").permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&path, permissions).expect("chmod stub");
+        // A file another process still holds open for writing cannot be
+        // exec'd; absorb the ETXTBSY window before handing it to the
+        // adapter (#83 — this exact shape is already handled in
+        // tests/m5_projections.rs and tests/m6_surfaces.rs; measured under
+        // `cargo test --lib`'s default thread parallelism: 3 failures in 40
+        // runs, every one `os error 26`).
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while let Err(e) = std::process::Command::new(&path).arg("--version").output() {
+            assert!(
+                e.raw_os_error() == Some(26) && Instant::now() < deadline,
+                "the stub is not runnable: {e}"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
         let stub = Self {
             path,
             record,

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -539,19 +539,10 @@ impl StubClaude {
         std::fs::set_permissions(&path, permissions).expect("chmod stub");
         // A file another process still holds open for writing cannot be
         // exec'd; absorb the ETXTBSY window before handing it to the
-        // adapter (#83 — this exact shape is already handled in
-        // tests/m5_projections.rs and tests/m6_surfaces.rs; measured under
-        // `cargo test --lib`'s default thread parallelism: 3 failures in 40
-        // runs, every one `os error 26`).
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while let Err(e) = std::process::Command::new(&path).arg("--version").output() {
-            assert!(
-                e.raw_os_error() == Some(26) && Instant::now() < deadline,
-                "the stub is not runnable: {e}"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
-        let stub = Self {
+        // adapter (#83 — measured under `cargo test --lib`'s default thread
+        // parallelism: 3 failures in 40 runs, every one `os error 26`).
+        support::wait_until_executable(&path);
+        Self {
             path,
             record,
             replay,
@@ -560,40 +551,6 @@ impl StubClaude {
             release,
             stderr,
             exit_code,
-        };
-        stub.wait_until_executable();
-        stub
-    }
-
-    /// Run the stub once, retrying `ETXTBSY`, before handing it to a test.
-    ///
-    /// A file that some process still holds open for writing cannot be
-    /// `exec`'d — and every `Command::spawn` on a sibling test thread forks a
-    /// child that inherits this test binary's open descriptors for the
-    /// fork-to-exec window. Under load (four test threads, this gauntlet's
-    /// machine, CI) that window overlaps the write above often enough to turn
-    /// "the adapter refuses an unlaunchable CLI" into a false red in a test
-    /// about something else entirely. Absorbing it here, once, keeps the
-    /// flake out of every stub-based test without weakening any of them: the
-    /// adapter's own refusal path is still pinned, deliberately, by
-    /// `a_start_that_cannot_spawn_leaves_no_phantom_execution`.
-    fn wait_until_executable(&self) {
-        let deadline = Instant::now() + Duration::from_secs(10);
-        loop {
-            match std::process::Command::new(&self.path)
-                .arg("--version")
-                .output()
-            {
-                Ok(_) => return,
-                Err(e) if e.raw_os_error() == Some(26) => {
-                    assert!(
-                        Instant::now() < deadline,
-                        "the stub stayed ETXTBSY for 10s: {e}"
-                    );
-                    std::thread::sleep(Duration::from_millis(20));
-                }
-                Err(e) => panic!("the stub is not runnable: {e}"),
-            }
         }
     }
 

--- a/tests/m5_projections.rs
+++ b/tests/m5_projections.rs
@@ -1824,14 +1824,7 @@ fn stub_claude(dir: &Path) -> PathBuf {
     std::fs::set_permissions(&path, permissions).expect("chmod");
     // A file another process still holds open for writing cannot be exec'd;
     // absorb the ETXTBSY window before handing it to the adapter.
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while let Err(e) = Command::new(&path).arg("--version").output() {
-        assert!(
-            e.raw_os_error() == Some(26) && Instant::now() < deadline,
-            "the stub is not runnable: {e}"
-        );
-        std::thread::sleep(Duration::from_millis(20));
-    }
+    support::wait_until_executable(&path);
     path
 }
 

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -3867,14 +3867,7 @@ fn write_script(dir: &Path, name: &str, body: &str) -> String {
     std::fs::set_permissions(&path, permissions).expect("chmod");
     // A file another process still holds open for writing cannot be exec'd;
     // absorb the ETXTBSY window before handing it over.
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while let Err(e) = Command::new(&path).arg("--version").output() {
-        assert!(
-            e.raw_os_error() == Some(26) && Instant::now() < deadline,
-            "the script is not runnable: {e}"
-        );
-        std::thread::sleep(Duration::from_millis(20));
-    }
+    support::wait_until_executable(&path);
     path.display().to_string()
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -76,6 +76,32 @@ pub struct ReapedDaemon {
     pub signal: ReapSignal,
 }
 
+/// Where [`DataDir::new`] roots its `TempDir`.
+///
+/// Not `<crate root>/target/tmp`: several suites walk *up* from a spawned
+/// `sgt`'s working directory looking for a git repository (`fn sgt`'s own
+/// doc comment in `tests/m2_daemon_api.rs` explains why the data dir must
+/// stay outside one), and a data dir nested under this checkout's own
+/// `target/` sits inside that checkout — the walk finds this repo's `.git`
+/// and the daemon materializes a real workspace the test never asked for
+/// (measured: `t7_cli_end_to_end_auto_spawn_and_second_daemon_fails_closed`
+/// and two siblings went from `pending` to `blocked` the moment the base
+/// moved under `target/`). `/var/tmp/<name>` is the already-established
+/// disk-backed, outside-any-checkout location for exactly this class of
+/// rig (`docs/DEVELOPMENT.md`, `docs/environments/cerberus.md`'s #70 row) —
+/// real disk on every measured Linux/macOS host, confirmed here via `df -h
+/// /var/tmp` matching the ext4 root rather than tmpfs. Its absence (e.g. an
+/// untested Windows host) falls back to `TempDir::new()`'s own default
+/// rather than failing outright — this fix targets the measured incident,
+/// not every platform this crate might someday run on.
+fn disk_backed_tmp_base() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("SGT_TEST_TMPDIR") {
+        return Some(PathBuf::from(dir));
+    }
+    let var_tmp = PathBuf::from("/var/tmp");
+    var_tmp.is_dir().then(|| var_tmp.join("sgt-rs-tests"))
+}
+
 /// A temporary sergeant data dir that reaps the daemons running on it.
 ///
 /// Construct one wherever a test points the `sgt` binary at a data dir: any
@@ -87,10 +113,30 @@ pub struct DataDir {
 }
 
 impl DataDir {
-    /// A fresh empty data dir.
+    /// A fresh empty data dir, disk-backed by default where that is safe.
+    ///
+    /// `TempDir::new()` honors `$TMPDIR`, which on a host like Cerberus is a
+    /// 16 GB tmpfs `/tmp` — fine for the small rigs most suites need, but a
+    /// gigabyte-scale blob-store capture (`tests/m7_docker_executor.rs`'s
+    /// `large_captured_output_does_not_grow_this_process_proportionally`,
+    /// contract scale 1 GiB) can fill it, and when it fills, every `Bash`
+    /// output capture on the host starts failing `EDQUOT` under a command
+    /// that still runs underneath — a broken shell, not an obvious full disk
+    /// (#70, evidence in `docs/environments/cerberus.md`). An operator
+    /// remembering to export `$TMPDIR` before running tests does not close
+    /// that: the incident was an unsafe *default*. So the default here is
+    /// real disk, when `disk_backed_tmp_base` finds one available; otherwise
+    /// this falls back to `TempDir::new()`'s own default rather than
+    /// failing a host this fix was never measured against.
     pub fn new() -> Self {
+        let Some(base) = disk_backed_tmp_base() else {
+            return Self {
+                temp: TempDir::new().expect("tempdir"),
+            };
+        };
+        std::fs::create_dir_all(&base).expect("create disk-backed test tmp base dir");
         Self {
-            temp: TempDir::new().expect("tempdir"),
+            temp: tempfile::Builder::new().tempdir_in(&base).expect("tempdir"),
         }
     }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -94,7 +94,7 @@ pub struct ReapedDaemon {
 /// untested Windows host) falls back to `TempDir::new()`'s own default
 /// rather than failing outright — this fix targets the measured incident,
 /// not every platform this crate might someday run on.
-fn disk_backed_tmp_base() -> Option<PathBuf> {
+pub(crate) fn disk_backed_tmp_base() -> Option<PathBuf> {
     if let Some(dir) = std::env::var_os("SGT_TEST_TMPDIR") {
         return Some(PathBuf::from(dir));
     }
@@ -301,5 +301,22 @@ fn wait_until_gone(data_dir: &Path, budget: Duration) -> bool {
             return false;
         }
         std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// #83: a freshly written, freshly `chmod +x`'d stand-in script can
+/// transiently fail `execve(2)` with `ETXTBSY` ("text file busy", `os error
+/// 26`) while another handle on the same inode is still open for writing —
+/// under `cargo test`'s default thread parallelism, a sibling test's
+/// fork-to-exec window can overlap this one's write. Retry until the exec
+/// stops being refused, or surface any other failure immediately.
+pub fn wait_until_executable(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while let Err(e) = std::process::Command::new(path).arg("--version").output() {
+        assert!(
+            e.raw_os_error() == Some(26) && Instant::now() < deadline,
+            "the stand-in at {path:?} is not runnable: {e}"
+        );
+        std::thread::sleep(Duration::from_millis(20));
     }
 }


### PR DESCRIPTION
Closes #83 and #70. Wave 1 / G1 of the cross-platform sprint.

## Provenance — this work was rescued, not redone

Originally Work `01M00BV16ZDC1NJNCRECBYTRB0`, whose turn was **killed by the R-MVP1-7 ceiling** at 40 minutes, mid-suite, before `30-review` could commit anything. The Work then wedged in `active` with no operator exit door (**#90**). Its 205 lines existed only as uncommitted changes in the retained surface worktree; teardown's `retained_dirty` disposition preserved them, and the orchestrating session took custody rather than throwing away proven work.

## #83 — the race is proven, not guessed

The filed issue carried a *hypothesis* and an explicitly invalid experiment. The Work discharged it properly:

- Added the diagnostic first — `run_probe` now surfaces `e.kind()` instead of collapsing an exec failure into `version: None`, which is what made the cause visible.
- **Measured it: 3 failures in 40 runs, every one `io::ErrorKind::ExecutableFileBusy`.** A freshly written, freshly `chmod +x`'d stub can transiently fail `execve(2)` with ETXTBSY when a sibling test's fork inherits the still-open write fd.
- Found the idiom already existed in `tests/m5_projections.rs` and `tests/m6_surfaces.rs` — these call sites simply predated it. The fix is consistent with the repo, not novel.
- The regression test **manufactures** the busy window (a second write fd held open 150 ms on another thread) rather than re-running until it flakes, so it fails on *every* run when reverted rather than some fraction.

**Verified fixed:** 0 failures in 12 parallel `--lib` runs, against 2 in 6 before. If the race were still live at its measured rate, twelve clean runs would occur under 1% of the time.

## #70 — the default is what was unsafe

`DataDir::new` now roots on disk-backed storage by default (`SGT_TEST_TMPDIR` override, `/var/tmp/sgt-rs-tests` otherwise, graceful fallback). An environment rule alone could not close this: `docs/DEVELOPMENT.md` already carried that rule on 2026-08-13 and the incident happened anyway.

Deliberately **not** `target/tmp` — measured: nesting the base inside this checkout turned three `pending` tests into `blocked`, because suites walk upward from a spawned `sgt`'s cwd looking for `.git`.

## What the shipping gate caught, and what I caught in its fix

The gate's review step found a real miss I had not seen across two reviews: the ETXTBSY retry loop was pasted into **four** call sites in this diff, on top of the two pre-existing copies. Its dedup collapsed six into two shared helpers (−61 net lines), split along the boundary Rust actually imposes — `#[cfg(test)] pub(crate) mod test_support` for crate unit tests, `tests/support` for the integration binaries. The crate-side helper is test-only and crate-private; the public API does not widen.

Its second fix — platform-gating #70's test — was **right in intent and wrong in shape**, and I corrected it in `05f0cb4`. It asked `disk_backed_tmp_base()`, the function under test, where the rig would land and then asserted it landed there. That is a tautology passing for any answer, including `None`, which skips the body entirely.

Measured both ways: with the fix stubbed to `None`, the gated version **passes**; the corrected version **fails** with the rig sitting in `/tmp/.tmpXXXX` — the exact tmpfs #70 is about. The gate had silently removed #70's own L7 coverage while fixing a genuine portability concern, and it skipped silently, which `docs/DEVELOPMENT.md` forbids. Now it probes the filesystem independently and emits `SKIPPED-ENV` on both skip paths.

## Verification

- L7 confirmed by reverting each fix in isolation: #83's retry loop → *"it did not actually retry through ETXTBSY, it got lucky"*; #70's disk-backed base → *"must root its TempDir under `/var/tmp/sgt-rs-tests`"*.
- Full suite 12 suites / 0 failures on final content; `fmt` and `clippy -D warnings` clean; no orphan daemons; no leaked containers.
- Shipping gate re-run on final content after my correction: **passed**, `safety: user_owned`.

## Also surfaced while landing this

**#90** (ceiling interrupt wedges a Work in `active`, no exit door) and **#91** (m7's fixed-name container poisons every later run once leaked — it was failing gates on an unrelated branch). #91 was collateral from #90: the SIGKILLed suite left the container behind.