### PR TITLE
Wave 2 / G3: the ADR 0002 platform boundary (#81, #82, #18 — none closed)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,7 +40,7 @@ A local agent execution daemon (`sgt`): durable Work items run staged workflows 
 - **Work state ≠ process state.** A Claude "session" is a durable conversation identity; the OS process exists per turn. Restart reconciliation (`src/runtime/recovery.rs`) resumes only on unambiguous evidence; ambiguity fails closed into `blocked` with a reason, never a guess.
 - **Adjacent-append crash windows** are this architecture's recurring hazard (LESSONS L6): any path appending two causally-linked events must tolerate the second one missing or write one compound event. Check for this class in review of any journal-touching change.
 
-Layout: single crate, lib + thin `main.rs` (`src/lib.rs` declares modules; integration tests need the lib target). `src/domain/` = types, `src/runtime/` = journal/projections/engine/recovery/router/analytics/graph, `src/backend/` = the §15 `Backend` trait + claude/fake/docker (docker runs `kind = "execute"` workflow stages; codex is a doc-stub per D6), `src/{api,cli,tui,web,daemon,telemetry,watch}.rs` = surfaces.
+Layout: single crate, lib + thin `main.rs` (`src/lib.rs` declares modules; integration tests need the lib target). `src/domain/` = types, `src/runtime/` = journal/projections/engine/recovery/router/analytics/graph, `src/backend/` = the §15 `Backend` trait + claude/fake/docker (docker runs `kind = "execute"` workflow stages; codex is a doc-stub per D6), `src/platform/` = the ADR 0002 platform boundary (`#[cfg]`-selected modules, not a trait — disk/data_dir/process facts, each with an UNVERIFIED macOS arm), `src/{api,cli,tui,web,daemon,telemetry,watch}.rs` = surfaces.
 
 ## Testing rules specific to this repo
 

--- a/docs/adr/0001-platform-targets-and-measurement-posture.md
+++ b/docs/adr/0001-platform-targets-and-measurement-posture.md
@@ -88,16 +88,20 @@ WSL2-as-real-Linux is what makes D1 cheap: no second process model, no
 native-Windows-specific signal or lockfile handling to build or keep green.
 
 D10's leave-alone posture has a consequence that must survive review, not
-just theory: the `cfg(not(unix))` stubs can still produce misleading
-runtime messages on a platform outside the measured set. Concretely,
-`free_space` in `src/backend/docker.rs:1308-1311` returns `None`
-unconditionally when not `cfg(unix)`, and `src/cli.rs:2029` and `2059`
-render that as "free space could not be measured on this platform" in
-`sgt doctor`'s disk-pressure check — a message that (per the comment at
-`src/cli.rs:2009-2014`, added for a related but distinct fix, #67) has
-already been flagged once as potentially misdirecting an operator. This
-gap is tracked separately as **issue #81** and is explicitly not fixed by
-this ADR or D10's decision to leave the stubs standing.
+just theory: platform-fact stubs can still produce misleading runtime
+messages on a platform outside the measured set. At the time of this
+interview, `free_space` in `src/backend/docker.rs:1308-1311` returned
+`None` unconditionally when not `cfg(unix)`; ADR 0002 has since moved that
+fact to `src/platform/disk.rs` and added an UNVERIFIED macOS arm, so today
+the unconditional `None` is confined to platforms outside both Linux and
+macOS. `src/cli.rs:2025` and `2055` render a `None` result as "free space
+could not be measured on this platform" in `sgt doctor`'s disk-pressure
+check — a message that (per the comment at `src/cli.rs:2005-2010`, added
+for a related but distinct fix, #67) has already been flagged once as
+potentially misdirecting an operator. This gap is tracked separately as
+**issue #81**, not closed by ADR 0002's macOS arm since it remains
+unmeasured on a real host, and was explicitly not fixed by this ADR or
+D10's decision to leave the stubs standing.
 
 ## Open questions
 

--- a/docs/adr/0003-durability-promise-and-storage-preconditions.md
+++ b/docs/adr/0003-durability-promise-and-storage-preconditions.md
@@ -32,20 +32,25 @@ therefore not "does the daemon survive" — nothing is supposed to guarantee
 that — but "after an abrupt daemon death, does work actually resume, or
 does it land in `blocked`?"
 
-That probe surfaces a known degradation on macOS today, and it must be
-recorded rather than left implicit: restart reconciliation gathers its
-liveness evidence from `/proc` (`src/backend/claude.rs`'s
-`session_liveness_excluding`, `src/backend/claude.rs:559-568` — "Linux-only
-by construction. Elsewhere the answer is `Unknowable`, not a guess"). With
-no `/proc` on macOS, every liveness check returns `Liveness::Unknowable`,
-and per the fail-closed contract restart reconciliation already applies
-("ambiguous states fail closed to blocked with evidence",
-`src/runtime/recovery.rs:76-77`), every *ambiguous* restart on macOS fails
-closed into `blocked` rather than resuming. This is tracked as **issue
-#18** — confirmed live in this repo as "/proc portability" (`GAUNTLET.md`
-line 1787, "P0 close-out... /proc portability #18"; `docs/gauntlet/contracts/N0.md`,
-"R-N0-5 — #18 (/proc portability): deferred to N5"). It is a real,
-already-known gap this ADR does not fix, only records.
+That probe surfaced a known degradation on macOS at the time of this
+interview: restart reconciliation gathered its liveness evidence from
+`/proc` alone (`src/backend/claude.rs`'s `session_liveness_excluding`), and
+with no `/proc` on macOS, every liveness check returned
+`Liveness::Unknowable`, so per the fail-closed contract restart
+reconciliation already applies ("ambiguous states fail closed to blocked
+with evidence", `src/runtime/recovery.rs:76-77`), every *ambiguous* restart
+on macOS failed closed into `blocked` rather than resuming. ADR 0002 has
+since moved this fact behind the platform boundary
+(`crate::platform::process::running_processes`,
+`session_liveness_excluding` at `src/backend/claude.rs:553-559`) and added a
+`ps`-based macOS arm, so a macOS restart is no longer *unconditionally*
+`Unknowable` — but that arm is marked **UNVERIFIED** (never run on a real
+macOS host), so the gap this paragraph records is narrowed, not closed.
+This is tracked as **issue #18** — confirmed live in this repo as "/proc
+portability" (`GAUNTLET.md` line 1787, "P0 close-out... /proc portability
+#18"; `docs/gauntlet/contracts/N0.md`, "R-N0-5 — #18 (/proc portability):
+deferred to N5"). It remains open until measured on a real macOS host, per
+ADR 0002's own UNVERIFIED marking.
 
 The interview record also corrects itself explicitly here: an earlier
 framing offered by the orchestrating session during the interview, that a
@@ -96,8 +101,9 @@ D5 is mostly a clarifying, non-code decision, but it fixes what "measured"
 in ADR 0001 has to actually mean for durability: a host isn't measured
 durable by observing that the daemon didn't crash, it's measured durable
 by observing that a killed daemon's work actually resumes. The known
-macOS `/proc`-liveness gap (#18) is a real, already-tracked cost of that
-standard, not a new one introduced here.
+macOS liveness gap (#18) — narrowed by ADR 0002's UNVERIFIED `ps`-based arm
+but not yet measured on a real host — is a real, already-tracked cost of
+that standard, not a new one introduced here.
 
 D6 implies work that **does not exist yet** in this codebase — there is no
 current check for advisory-locking-unreliable filesystems in `sgt init` or

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -483,7 +483,7 @@ struct LaunchConfig {
     permission_args: Vec<String>,
 }
 
-/// What a `/proc` scan can say about a conversation's per-turn process.
+/// What a process scan can say about a conversation's per-turn process.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Liveness {
     /// A running process carries this session id in its argv. Positive
@@ -492,13 +492,13 @@ pub enum Liveness {
     /// No running process carries this session id. Positive evidence that no
     /// turn of this conversation is running.
     Dead,
-    /// Liveness cannot be evidenced here (no `/proc`, or it is unreadable).
-    /// §25: the caller fails closed; it never assumes either direction.
+    /// Liveness cannot be evidenced here (this platform has no
+    /// process-listing mechanism, or reading it failed). §25: the caller
+    /// fails closed; it never assumes either direction.
     Unknowable(String),
 }
 
-/// Does this NUL-separated `/proc/<pid>/cmdline` belong to a turn of
-/// `session_id`?
+/// Does this process's argv belong to a turn of `session_id`?
 ///
 /// The rule is deliberately narrow: some argv element must be exactly
 /// `--session-id` or `--resume`, and the *next* element must be exactly the
@@ -510,14 +510,12 @@ pub enum Liveness {
 /// environment does) puts the id in *some* process's argv without any turn
 /// running, and the adapter then reported `NativeState::Running` with the
 /// evidence "pid N carries session id in argv". A quoted string is not a
-/// running turn. Tokenizing also makes the false positive structurally
-/// impossible rather than unlikely: a wrapper's whole command line is one
-/// argv element, so it can never *be* the id, only contain it.
-fn cmdline_names_session(cmdline: &[u8], session_id: &str) -> bool {
-    let mut argv = cmdline
-        .split(|byte| *byte == 0)
-        .filter(|arg| !arg.is_empty())
-        .map(String::from_utf8_lossy);
+/// running turn. Taking already-tokenized argv (never a joined command line)
+/// also makes the false positive structurally impossible rather than
+/// unlikely: a wrapper's whole command line is one argv element, so it can
+/// never *be* the id, only contain it.
+fn cmdline_names_session(argv: &[String], session_id: &str) -> bool {
+    let mut argv = argv.iter();
     while let Some(arg) = argv.next() {
         if (arg == "--session-id" || arg == "--resume")
             && argv.next().is_some_and(|value| value == session_id)
@@ -531,19 +529,15 @@ fn cmdline_names_session(cmdline: &[u8], session_id: &str) -> bool {
 /// Is a per-turn `claude` process for `session_id` still running?
 ///
 /// Every turn this adapter launches names its session in its own argv
-/// (`--session-id <uuid>` first, `--resume <uuid>` after), so scanning
-/// `/proc/<pid>/cmdline` for *that argv shape* is evidence about **this
-/// conversation** rather than about a pid — which matters precisely in the
-/// case that needs it: after a restart, when no in-memory record survives and
-/// a recorded pid (if anything had recorded one) could since have been
-/// recycled. What is matched is the flag-and-value pair
-/// ([`cmdline_names_session`]), not the id as a substring: the evidence this
-/// function returns is quoted verbatim into an execution-state claim, so it
-/// has to be about an execution.
-///
-/// Linux-only by construction. Elsewhere the answer is `Unknowable`, not a
-/// guess: an adapter that reported "exited" from the absence of a mechanism
-/// it does not have would be inventing execution state.
+/// (`--session-id <uuid>` first, `--resume <uuid>` after), so scanning every
+/// running process's argv for *that shape* ([`platform::process`]) is
+/// evidence about **this conversation** rather than about a pid — which
+/// matters precisely in the case that needs it: after a restart, when no
+/// in-memory record survives and a recorded pid (if anything had recorded
+/// one) could since have been recycled. What is matched is the
+/// flag-and-value pair ([`cmdline_names_session`]), not the id as a
+/// substring: the evidence this function returns is quoted verbatim into an
+/// execution-state claim, so it has to be about an execution.
 pub fn session_liveness(session_id: &str) -> Liveness {
     session_liveness_excluding(session_id, std::process::id())
 }
@@ -557,33 +551,36 @@ pub fn session_liveness(session_id: &str) -> Liveness {
 /// — excluding a bystander pid finds it, excluding the stand-in's own pid
 /// does not — which is the only way to pin a rule about "self" from outside.
 pub fn session_liveness_excluding(session_id: &str, skip_pid: u32) -> Liveness {
-    if !cfg!(target_os = "linux") {
+    session_liveness_among(
+        session_id,
+        skip_pid,
+        crate::platform::process::running_processes(),
+    )
+}
+
+/// [`session_liveness_excluding`]'s decision logic, taking the process scan
+/// as a parameter (ADR 0002 D3) instead of gathering it itself. Whatever
+/// platform gathered `processes` — or failed to, the `None` arm — this
+/// function's own behavior is identical and testable from any host: it is
+/// what proves the `Unknowable` fail-closed path a platform without any
+/// listing mechanism would take, without needing that platform to run it on.
+fn session_liveness_among(
+    session_id: &str,
+    skip_pid: u32,
+    processes: Option<Vec<crate::platform::process::ProcessArgv>>,
+) -> Liveness {
+    let Some(processes) = processes else {
         return Liveness::Unknowable(
-            "process liveness needs /proc; this platform has none".to_string(),
+            "process liveness needs a process-listing mechanism; none is available here"
+                .to_string(),
         );
-    }
-    let entries = match std::fs::read_dir("/proc") {
-        Ok(entries) => entries,
-        Err(e) => return Liveness::Unknowable(format!("/proc is unreadable: {e}")),
     };
-    for entry in entries.flatten() {
-        let Some(pid) = entry
-            .file_name()
-            .to_str()
-            .and_then(|name| name.parse::<u32>().ok())
-        else {
-            continue;
-        };
-        if pid == skip_pid {
+    for process in processes {
+        if process.pid == skip_pid {
             continue;
         }
-        // A vanished process between readdir and read is not evidence of
-        // anything; skip it. cmdline is NUL-separated argv.
-        let Ok(cmdline) = std::fs::read(entry.path().join("cmdline")) else {
-            continue;
-        };
-        if cmdline_names_session(&cmdline, session_id) {
-            return Liveness::Alive(pid);
+        if cmdline_names_session(&process.argv, session_id) {
+            return Liveness::Alive(process.pid);
         }
     }
     Liveness::Dead
@@ -2602,7 +2599,7 @@ mod tests {
     #[test]
     fn liveness_matches_turn_argv_and_not_a_quoted_session_id() {
         let session = "11111111-2222-4333-8444-555555555555";
-        let argv = |args: &[&str]| args.join("\0").into_bytes();
+        let argv = |args: &[&str]| args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
 
         for turn in [
             argv(&[
@@ -2620,8 +2617,7 @@ mod tests {
         ] {
             assert!(
                 cmdline_names_session(&turn, session),
-                "a real turn's argv must match: {:?}",
-                String::from_utf8_lossy(&turn)
+                "a real turn's argv must match: {turn:?}"
             );
         }
 
@@ -2644,10 +2640,49 @@ mod tests {
         ] {
             assert!(
                 !cmdline_names_session(&bystander, session),
-                "a quoted id is not a running turn: {:?}",
-                String::from_utf8_lossy(&bystander)
+                "a quoted id is not a running turn: {bystander:?}"
             );
         }
+    }
+
+    /// [`session_liveness_among`]'s own decision logic, injected-probe
+    /// tested per ADR 0002 D3: the `None` arm is the fail-closed path a
+    /// platform with no process-listing mechanism takes, exercised here
+    /// without needing such a platform to run it on.
+    #[test]
+    fn session_liveness_among_is_unknowable_with_no_process_listing() {
+        assert_eq!(
+            session_liveness_among("s", 0, None),
+            Liveness::Unknowable(
+                "process liveness needs a process-listing mechanism; none is available here"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn session_liveness_among_skips_the_excluded_pid() {
+        use crate::platform::process::ProcessArgv;
+        let session = "11111111-2222-4333-8444-555555555555";
+        let turn = ProcessArgv {
+            pid: 42,
+            argv: vec![
+                "claude".to_string(),
+                "-p".to_string(),
+                "--session-id".to_string(),
+                session.to_string(),
+            ],
+        };
+        assert_eq!(
+            session_liveness_among(session, 42, Some(vec![turn.clone()])),
+            Liveness::Dead,
+            "the excluded pid is not evidence about anyone else"
+        );
+        assert_eq!(
+            session_liveness_among(session, 0, Some(vec![turn])),
+            Liveness::Alive(42),
+            "an unexcluded pid whose argv matches is evidence of life"
+        );
     }
 
     /// `truncate` cuts on character boundaries. The inputs are CLI stderr and

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -1255,7 +1255,7 @@ pub struct DiskPressureReport {
 pub fn measure_disk_pressure(data_dir: &Path) -> DiskPressureReport {
     let data_dir_bytes = dir_size(data_dir);
     let blob_bytes = dir_size(&data_dir.join("blobs"));
-    let free_bytes = free_space(data_dir);
+    let free_bytes = crate::platform::disk::free_space(data_dir);
     DiskPressureReport {
         data_dir_bytes,
         blob_bytes,
@@ -1282,32 +1282,6 @@ fn dir_size(path: &Path) -> u64 {
         }
     }
     total
-}
-
-#[cfg(unix)]
-fn free_space(path: &Path) -> Option<u64> {
-    // `statvfs` is the portable POSIX call for this; sergeant is Linux-first
-    // (`docs/DEVELOPMENT.md`) and this crate otherwise reaches such facts through
-    // `std`, so a `df`-equivalent shell-out is used instead of adding a
-    // libc-binding dependency for one syscall — the same "smaller direct
-    // client" posture the module docs already take for Docker itself. `df`
-    // is present on every measured environment (`docs/environments/`).
-    let output = Command::new("df")
-        .args(["-k", "--output=avail"])
-        .arg(path)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let text = String::from_utf8_lossy(&output.stdout);
-    let last_line = text.lines().last()?.trim();
-    last_line.parse::<u64>().ok().map(|kb| kb * 1024)
-}
-
-#[cfg(not(unix))]
-fn free_space(_path: &Path) -> Option<u64> {
-    None
 }
 
 /// Build a doctor report: the cheap probe, the lifecycle round trip when the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -394,11 +394,15 @@ pub fn main() -> ExitCode {
 /// R-MVP1-12: filesystem-first, crossing git boundaries, bounded at `$HOME`.
 /// When one is found, the default is `<estate_root>/.sergeant/data` — the
 /// same path `sgt init` scaffolds a `.gitignore` entry for
-/// ([`crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR`]). This is a new
-/// fallback *rung*, not a replacement: only once no estate is found (or the
-/// current directory cannot even be read) does resolution fall through to
-/// the pre-estate default, `$XDG_DATA_HOME/sergeant` or
-/// `~/.local/share/sergeant`, unchanged.
+/// ([`crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR`]). This precedence —
+/// whether estate discovery should even come before the pre-estate fallback
+/// — is an owner ruling tracked separately in #80 and is not decided here.
+/// This is a new fallback *rung*, not a replacement: only once no estate is
+/// found (or the current directory cannot even be read) does resolution fall
+/// through to the pre-estate default, which is a platform fact
+/// ([`crate::platform::data_dir`], #82) — `$XDG_DATA_HOME/sergeant` or
+/// `~/.local/share/sergeant` on Linux, unchanged from before that boundary
+/// existed.
 fn resolve_data_dir(flag: Option<PathBuf>) -> Result<PathBuf, CliError> {
     if let Some(dir) = flag {
         return Ok(dir);
@@ -411,15 +415,7 @@ fn resolve_data_dir(flag: Option<PathBuf>) -> Result<PathBuf, CliError> {
     {
         return Ok(estate_root.join(crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR));
     }
-    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
-        return Ok(PathBuf::from(xdg).join("sergeant"));
-    }
-    match std::env::var_os("HOME") {
-        Some(home) => Ok(PathBuf::from(home).join(".local/share/sergeant")),
-        None => Err(CliError::new(
-            "cannot resolve data dir: set --data-dir, SGT_DATA_DIR, or HOME",
-        )),
-    }
+    crate::platform::data_dir::fallback_dir(|name| std::env::var_os(name)).map_err(CliError::new)
 }
 
 async fn dispatch(sgt: Sgt) -> Result<(), CliError> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -926,15 +926,11 @@ pub fn read_descriptor(data_dir: &Path) -> Result<Option<RuntimeDescriptor>, Dae
     Ok(Some(descriptor))
 }
 
-/// Whether a PID currently names a live process (Linux: `/proc/<pid>`;
-/// elsewhere this is unknowable without more machinery, so report alive —
-/// the fail-closed direction for spawn decisions).
+/// Whether a PID currently names a live process. Platform fact — see
+/// [`crate::platform::process::process_alive`] (#18) for the per-platform
+/// mechanism and its fail-closed posture elsewhere.
 pub fn pid_alive(pid: u32) -> bool {
-    if cfg!(target_os = "linux") {
-        Path::new(&format!("/proc/{pid}")).exists()
-    } else {
-        true
-    }
+    crate::platform::process::process_alive(pid)
 }
 
 /// Convenience: the descriptor path for a data dir.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod backend;
 pub mod cli;
 pub mod daemon;
 pub mod domain;
+pub mod platform;
 pub mod runtime;
 pub mod telemetry;
 pub mod tui;

--- a/src/platform/data_dir.rs
+++ b/src/platform/data_dir.rs
@@ -1,0 +1,128 @@
+//! The pre-estate data-dir fallback tail (#82).
+//!
+//! `cli.rs::resolve_data_dir`'s ladder is `--data-dir`, then
+//! `SGT_DATA_DIR`, then estate discovery — all three platform-neutral, and
+//! **their precedence is an owner ruling tracked separately in #80**, not
+//! something this module touches or re-litigates. Only the ladder's last
+//! rung — what to do once no estate is found at all — is a platform fact:
+//! freedesktop's `$XDG_DATA_HOME`/`~/.local/share` convention is a Linux
+//! thing, not a macOS one, whose own convention is
+//! `~/Library/Application Support`.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// One platform's fallback-tail convention, as data rather than as a second
+/// code path — the freedesktop and macOS tails differ only in *which*
+/// directories they name, not in the shape of "check an env var, else fall
+/// back to a fixed subdirectory of `$HOME`". Keeping that shape as one
+/// function over a `Convention` value (below) is what lets both platforms'
+/// conventions be exercised, unconditionally compiled, from any host (ADR
+/// 0002 D3) — there is nothing here a `#[cfg(target_os = "macos")]` split
+/// would gain.
+struct Convention {
+    /// The env var whose presence short-circuits straight to `$VAR/<suffix>`
+    /// — freedesktop's `XDG_DATA_HOME`. macOS has no equivalent env-var
+    /// override in its own convention.
+    env_override: Option<(&'static str, &'static str)>,
+    /// The fixed subdirectory of `$HOME` once no override applies.
+    home_suffix: &'static str,
+}
+
+// Both conventions are always compiled and always tested (ADR 0002 D3), but
+// only one is wired to `CURRENT` on any given host — the other is
+// production-dead there and only reachable through the tests below, which
+// is exactly the point: it lets a Linux host run macOS's decision logic.
+#[allow(dead_code)]
+const FREEDESKTOP: Convention = Convention {
+    env_override: Some(("XDG_DATA_HOME", "sergeant")),
+    home_suffix: ".local/share/sergeant",
+};
+
+#[allow(dead_code)]
+const MACOS: Convention = Convention {
+    env_override: None,
+    home_suffix: "Library/Application Support/sergeant",
+};
+
+#[cfg(target_os = "macos")]
+const CURRENT: &Convention = &MACOS;
+#[cfg(not(target_os = "macos"))]
+const CURRENT: &Convention = &FREEDESKTOP;
+
+/// Resolve one convention's fallback tail, reading env vars through `probe`
+/// (production passes [`std::env::var_os`] itself — same shape as
+/// `TtyWatch::watching`'s injected probe in `src/tui.rs`). A test can pass a
+/// canned lookup to exercise either convention, on any host, including the
+/// `HOME`-unset failure this ladder's last rung has always had to name.
+fn resolve(
+    convention: &Convention,
+    probe: impl Fn(&str) -> Option<OsString>,
+) -> Result<PathBuf, String> {
+    if let Some((var, suffix)) = convention.env_override
+        && let Some(value) = probe(var)
+    {
+        return Ok(PathBuf::from(value).join(suffix));
+    }
+    match probe("HOME") {
+        Some(home) => Ok(PathBuf::from(home).join(convention.home_suffix)),
+        None => Err("cannot resolve data dir: set --data-dir, SGT_DATA_DIR, or HOME".to_string()),
+    }
+}
+
+/// The fallback tail for whatever platform this binary is built for.
+///
+/// **The macOS arm is UNVERIFIED** — never executed on a real macOS host.
+/// Closes when measured there (#82), not when this lands.
+pub fn fallback_dir(probe: impl Fn(&str) -> Option<OsString>) -> Result<PathBuf, String> {
+    resolve(CURRENT, probe)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<OsString> {
+        move |name| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == name)
+                .map(|(_, v)| OsString::from(*v))
+        }
+    }
+
+    #[test]
+    fn freedesktop_prefers_xdg_data_home() {
+        let probe = env(&[("XDG_DATA_HOME", "/xdg"), ("HOME", "/home/x")]);
+        assert_eq!(
+            resolve(&FREEDESKTOP, probe).unwrap(),
+            PathBuf::from("/xdg/sergeant")
+        );
+    }
+
+    #[test]
+    fn freedesktop_falls_back_to_home_local_share() {
+        let probe = env(&[("HOME", "/home/x")]);
+        assert_eq!(
+            resolve(&FREEDESKTOP, probe).unwrap(),
+            PathBuf::from("/home/x/.local/share/sergeant")
+        );
+    }
+
+    #[test]
+    fn freedesktop_with_neither_var_errors() {
+        assert!(resolve(&FREEDESKTOP, env(&[])).is_err());
+    }
+
+    /// The macOS convention's own decision logic — exercised here, without a
+    /// macOS host, per ADR 0002 D3. Reverting `MACOS.home_suffix` to the
+    /// freedesktop path fails this immediately.
+    #[test]
+    fn macos_ignores_xdg_data_home_and_uses_application_support() {
+        let probe = env(&[("XDG_DATA_HOME", "/xdg"), ("HOME", "/Users/x")]);
+        assert_eq!(
+            resolve(&MACOS, probe).unwrap(),
+            PathBuf::from("/Users/x/Library/Application Support/sergeant")
+        );
+    }
+}

--- a/src/platform/disk.rs
+++ b/src/platform/disk.rs
@@ -1,0 +1,131 @@
+//! Free disk space (#81).
+//!
+//! `df` remains the mechanism — not a `libc`/`statvfs` binding. The module
+//! this fact used to live in (`src/backend/docker.rs`) explicitly declined
+//! that binding "for one syscall" in favor of the same shell-out posture the
+//! rest of this crate already takes for external facts (`kill` for signals,
+//! `docker` itself for the container adapter); `df` is present on every
+//! measured environment. #81 asks whether that tradeoff still holds now that
+//! the shell-out has a *measured* portability cost (GNU's `--output` extension
+//! failing outright on BSD/macOS `df`), not just a theoretical one. It still
+//! holds: the fix below is a second, POSIX-portable invocation shape
+//! (`df -k <path>`, no `--output`) plus positional column parsing, which adds
+//! no dependency and keeps every platform on the same "shell out to a
+//! coreutil" idiom as the rest of the crate. The cost this trades in is the
+//! brittleness `--output` was chosen to avoid — a wrapped or reformatted `df`
+//! table would defeat [`parse_bsd_avail_kb`] — accepted here because it is
+//! the only POSIX-portable option, it is covered by an injected-probe test
+//! that pins the exact BSD column shape, and a parse failure degrades to
+//! `None` (`doctor`'s already-honest "could not be measured"), never a wrong
+//! number.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Bytes of free space at `path`, or `None` if it cannot be measured —
+/// `sgt doctor`'s disk-pressure check degrades to "could not be measured" in
+/// that case (`src/cli.rs`'s `disk_pressure_check`).
+pub fn free_space(path: &Path) -> Option<u64> {
+    let kb = raw_avail_kb(path)?;
+    Some(kb * 1024)
+}
+
+/// GNU coreutils' shape: `df -k --output=avail <path>` prints exactly one
+/// column, so the answer is whatever numeric text the last non-empty line
+/// holds. Unchanged from this fact's pre-boundary form — Linux behavior does
+/// not move.
+fn parse_gnu_avail_kb(stdout: &str) -> Option<u64> {
+    stdout.lines().last()?.trim().parse().ok()
+}
+
+/// BSD/macOS `df` has no `--output`; `df -k <path>` prints a header row and
+/// one data row (`Filesystem 1024-blocks Used Available Capacity Mounted on`
+/// on macOS's own `df`), so the `Available` column has to be found by
+/// position rather than assumed. This is the "decision logic" ADR 0002 D3
+/// asks for: pure, unconditionally compiled, exercised by
+/// [`bsd_shape_parses_positionally`] below without a macOS host in sight.
+fn parse_bsd_avail_kb(stdout: &str) -> Option<u64> {
+    let mut lines = stdout.lines();
+    let header = lines.next()?;
+    let idx = header
+        .split_whitespace()
+        .position(|col| col.eq_ignore_ascii_case("available"))?;
+    let data = lines.next()?;
+    data.split_whitespace().nth(idx)?.parse().ok()
+}
+
+/// The raw fact: `df`'s stdout for `path`, parsed by whichever shape it
+/// turns out to hold. Trying the single-column GNU shape first and falling
+/// back to BSD's positional shape is safe in both directions — GNU's output
+/// has no header row an "Available" search could latch onto, and BSD's data
+/// row is never itself a bare integer — so this does not need a
+/// `#[cfg(target_os = ...)]` split at the parsing layer, only at the
+/// invocation layer below.
+fn parse_avail_kb(stdout: &str) -> Option<u64> {
+    parse_gnu_avail_kb(stdout).or_else(|| parse_bsd_avail_kb(stdout))
+}
+
+#[cfg(target_os = "linux")]
+fn raw_avail_kb(path: &Path) -> Option<u64> {
+    let output = Command::new("df")
+        .args(["-k", "--output=avail"])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_avail_kb(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// **UNVERIFIED** — never executed against a real macOS `df`. `--output` is
+/// a GNU extension BSD/macOS `df` does not have (#81's finding), so this
+/// drops it and leans on [`parse_bsd_avail_kb`] instead.
+#[cfg(target_os = "macos")]
+fn raw_avail_kb(path: &Path) -> Option<u64> {
+    let output = Command::new("df").arg("-k").arg(path).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_avail_kb(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn raw_avail_kb(_path: &Path) -> Option<u64> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gnu_shape_parses_the_single_column() {
+        assert_eq!(parse_avail_kb("Avail\n1048576\n"), Some(1048576));
+        // `--output=avail` alone, no header, is what production actually
+        // sends through this path.
+        assert_eq!(parse_avail_kb("1048576\n"), Some(1048576));
+    }
+
+    /// Pins [`parse_bsd_avail_kb`]'s column lookup — the decision logic a
+    /// macOS host would exercise for real, run here on whatever host is
+    /// building this crate (ADR 0002 D3). Reverting the `position` search to
+    /// a fixed index fails this the moment a column shifts.
+    #[test]
+    fn bsd_shape_parses_positionally() {
+        let stdout = "Filesystem 1024-blocks Used Available Capacity Mounted on\n\
+                       /dev/disk3s1 976490568 400000000 500000000 45% /\n";
+        assert_eq!(parse_avail_kb(stdout), Some(500_000_000));
+    }
+
+    #[test]
+    fn missing_available_column_is_none_not_a_wrong_number() {
+        let stdout = "Filesystem Used Capacity Mounted on\n/dev/disk3s1 400000000 45% /\n";
+        assert_eq!(parse_avail_kb(stdout), None);
+    }
+
+    #[test]
+    fn empty_output_is_none() {
+        assert_eq!(parse_avail_kb(""), None);
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,0 +1,27 @@
+//! The platform boundary (ADR 0002): a standard API over `#[cfg]`-selected
+//! modules, not a trait. Platform is a compile-time fact — nobody selects one
+//! at runtime the way `--backend` selects a [`crate::backend::Backend`] impl
+//! — so this module buys none of the dispatch a `Platform` trait would, and
+//! none of its category errors (a `WindowsPlatform` instantiated on a Linux
+//! host) either. See the ADR for the full argument and its precedents
+//! (`Reducer` as a plain fn pointer; `TtyWatch::watching` in `src/tui.rs`).
+//!
+//! Each fact below follows the same shape (ADR 0002 D3): the decision logic
+//! is a plain function, unconditionally compiled and unit-tested from
+//! whatever host happens to be building this crate, and only the raw
+//! syscall/shell-out underneath it is `#[cfg]`-gated per platform. That is
+//! what makes a macOS arm's *logic* reviewable — and its fail-closed path
+//! exercisable — from a Linux box, even though the macOS arm's actual `df`/
+//! `ps`/`kill` invocation cannot be.
+//!
+//! The measured targets are Linux and macOS (ADR 0001 D1; WSL2 counts as
+//! Linux underneath, so it needs no third arm). **Every macOS-specific arm in
+//! this module is marked UNVERIFIED**: there is no macOS host in this estate
+//! yet (`docs/environments/`), and `docs/DEVELOPMENT.md`'s rule is
+//! measured-not-assumed. Those arms close their tracking issue (#81, #82,
+//! #18) only once someone runs the suite on a real macOS host and records it
+//! there — not when this module lands.
+
+pub mod data_dir;
+pub mod disk;
+pub mod process;

--- a/src/platform/process.rs
+++ b/src/platform/process.rs
@@ -1,0 +1,137 @@
+//! Process liveness (#18).
+//!
+//! Two distinct facts live here, both platform-dependent, kept separate
+//! because they answer different questions and fail closed in opposite
+//! directions:
+//!
+//! - [`running_processes`] backs `backend::claude`'s per-turn liveness scan.
+//!   It is identity-verified evidence about a *specific conversation's turn*
+//!   (argv carries the session id), and failing to gather it means
+//!   `Liveness::Unknowable` — the engine then fails a resume closed rather
+//!   than guess (§25).
+//! - [`process_alive`] backs `daemon.rs`'s spawn/wait/stop paths. It answers
+//!   the coarser "does this pid exist at all", with no identity check, and
+//!   failing to gather it means *assume alive* — the fail-closed direction
+//!   for "should I spawn a second daemon over this one" is the opposite of
+//!   the one above.
+//!
+//! Both are Linux-only via `/proc` today; both get a macOS arm here, and
+//! **both macOS arms are UNVERIFIED** — never executed on a real macOS host.
+//! They close #18 when someone measures them there, not when this lands.
+
+/// One running process a liveness scan can see: its pid, and — wherever the
+/// platform can produce it — its argv, already tokenized into separate
+/// arguments (never a single joined command line: see
+/// `backend::claude::cmdline_names_session`'s doc for why a joined line is
+/// exactly the false-positive shape this fact must not produce).
+#[derive(Debug, Clone)]
+pub struct ProcessArgv {
+    pub pid: u32,
+    pub argv: Vec<String>,
+}
+
+/// Enumerate running processes' pid + argv, or `None` if this platform has
+/// no mechanism to gather it at all (never true on a measured platform
+/// today — Linux via `/proc`, macOS via `ps` — but the caller's fail-closed
+/// path exists for exactly this case). A transient failure reading one
+/// process's own details (it exited between being listed and being read)
+/// just drops that one entry, unchanged from this fact's pre-boundary
+/// Linux-only form.
+pub fn running_processes() -> Option<Vec<ProcessArgv>> {
+    raw_running_processes()
+}
+
+/// Whether a pid currently names a live process — no identity check, just
+/// existence. Elsewhere unknowable without more machinery, this reports
+/// alive: the fail-closed direction for the spawn/wait decisions that call
+/// it (never conclude a daemon is gone, and double-spawn over it, on a
+/// platform this cannot evidence).
+pub fn process_alive(pid: u32) -> bool {
+    raw_process_alive(pid)
+}
+
+#[cfg(target_os = "linux")]
+fn raw_running_processes() -> Option<Vec<ProcessArgv>> {
+    let entries = std::fs::read_dir("/proc").ok()?;
+    let mut processes = Vec::new();
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Ok(cmdline) = std::fs::read(entry.path().join("cmdline")) else {
+            continue;
+        };
+        let argv = cmdline
+            .split(|byte| *byte == 0)
+            .filter(|arg| !arg.is_empty())
+            .map(|arg| String::from_utf8_lossy(arg).into_owned())
+            .collect();
+        processes.push(ProcessArgv { pid, argv });
+    }
+    Some(processes)
+}
+
+#[cfg(target_os = "linux")]
+fn raw_process_alive(pid: u32) -> bool {
+    std::path::Path::new(&format!("/proc/{pid}")).exists()
+}
+
+/// **UNVERIFIED** — never executed against a real macOS host. There is no
+/// `/proc` to scan; `ps -axo pid=,command=` lists every process with its pid
+/// and full command line in one shot, tokenized here on whitespace. That
+/// tokenization is the one place this arm is weaker than Linux's byte-exact
+/// NUL-split argv: a quoted argument containing a space would defeat it. The
+/// launch grammar this fact is actually matched against — `--session-id
+/// <uuid>` / `--resume <uuid>`, see `backend::claude::cmdline_names_session`
+/// — never quotes, so this is judged sufficient for the fact this function
+/// serves, not offered as a general argv parser.
+#[cfg(target_os = "macos")]
+fn raw_running_processes() -> Option<Vec<ProcessArgv>> {
+    let output = std::process::Command::new("ps")
+        .args(["-axo", "pid=,command="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut processes = Vec::new();
+    for line in text.lines() {
+        let mut tokens = line.split_whitespace();
+        let Some(pid) = tokens.next().and_then(|token| token.parse::<u32>().ok()) else {
+            continue;
+        };
+        processes.push(ProcessArgv {
+            pid,
+            argv: tokens.map(str::to_string).collect(),
+        });
+    }
+    Some(processes)
+}
+
+/// **UNVERIFIED** — never executed against a real macOS host. `kill -0`
+/// signals nothing; a zero exit means the pid exists and this user may
+/// signal it. Shells to the same `kill` binary `cli.rs`'s graceful-stop path
+/// already invokes for SIGTERM, so this adds no new external dependency.
+#[cfg(target_os = "macos")]
+fn raw_process_alive(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn raw_running_processes() -> Option<Vec<ProcessArgv>> {
+    None
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn raw_process_alive(_pid: u32) -> bool {
+    true
+}


### PR DESCRIPTION
Work `01M00K9N9TYQDZ9JX7AMR5HWA0` (`implement`, 2/25 turns), plus the gate's doc-refresh commit.

**`Refs #81`, `Refs #82`, `Refs #18` — deliberately no `Fixes`.** These are portability issues. They close when measured on a real macOS host, not when the code is written on Linux (ADR 0001's "measured" posture).

## What landed

`src/platform/` — a standard API over `#[cfg]`-selected modules, **no trait**, exactly as ADR 0002 D2 rules: platform is a compile-time fact, so a `Platform` trait would buy dispatch nobody exercises and admit category errors that cannot occur. Three facts moved behind it:

- **`disk::free_space`** (#81) — Linux keeps `df -k --output=avail` byte-for-byte; a positional BSD arm is added since `--output` is a GNU extension.
- **`data_dir::fallback_dir`** (#82) — only the pre-estate *tail* moved. The flag / `SGT_DATA_DIR` / estate-discovery precedence above it is untouched and remains an owner ruling in #80.
- **`process::running_processes` / `process_alive`** (#18) — the `/proc` argv scan and existence check. macOS gets `ps`-based enumeration preserving the `--session-id`/`--resume` argv identity match, and `kill -0`.

D3 is honored where it matters most: `session_liveness_among` takes the process scan **as a parameter**, so the decision logic — including the `Unknowable` fail-closed path a platform with no listing mechanism would take — is exercisable from Linux.

Every macOS arm carries a literal **UNVERIFIED** marker. The Work type-checked them against real `x86_64-apple-darwin` std via `rustc --target`, and said plainly that a full `cargo check` was impossible because transitive `ring` needs an Apple toolchain — the same constraint G4 hit independently, and why its CI lane uses a real `macos-latest` runner.

## Known gap, deliberately left to a follow-up Work

The macOS `ps` **parsing** sits inside `#[cfg(target_os = "macos")]`. That is decision logic, not a raw shell-out, so per D3 it should be liftable and testable from any host — `platform::disk` does exactly that with its BSD parser. It is also the arm whose own doc concedes whitespace tokenization is weaker than Linux's NUL-split argv, so "cannot run here" and "cannot test here" compound.

The orchestrating session initially fixed this by hand. That was the wrong call — authoring, not orchestrating — and the commit was withdrawn. It is being dispatched as its own Work so it gets a `tdd` stage, a `30-review` stage, and the gate, rather than one review by the session that wrote it. A trap for whoever takes it: a naive unconditional extraction is dead code on Linux and `clippy -D warnings` rejects it, because unlike `disk` there is no Linux caller funnelling through the parser.

## The gate's own contribution

`04e9b64` refreshed ADR 0001/0003 and DEVELOPMENT.md for the boundary's existence — annotating rather than rewriting ("at the time of this interview…", then what changed since), refreshing stale line numbers, adding `src/platform/` to the layout map, and explicitly keeping #81 open because the macOS arm remains unmeasured.

## Verification

Full suite 12 suites / 0 failures; `fmt` and `clippy -D warnings` clean; no orphan daemons, no leaked containers. Shipping gate **passed**.

Linux behavior is unchanged throughout — this is a refactor plus unverified macOS arms, not a behavior change.