### PR TITLE
Wave 2 / G4: bash 3.2 script floor (#86) and tiered cross-platform CI (#87)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+# ADR 0004 (D9): this is the cheap per-push tier — Linux fmt/clippy/test plus
+# a macOS lane, run on every push so wall-clock stays low (matrix jobs run
+# concurrently, so cost is max(job) not sum(job)). The full real-suite matrix
+# across all measured targets (ADR 0001 D1) runs only on PR-to-main, nightly,
+# and release — see matrix.yml.
 on:
   # `on: [push, pull_request]` ran this battery twice for every push to a PR
   # branch — same commit, same result, twice the wait. Pushes are checked on
@@ -31,3 +36,46 @@ jobs:
 
       - name: cargo test
         run: cargo test
+
+  shellcheck:
+    # ADR 0004 (D7): hygiene, not a version gate — shellcheck has no bash-3.2
+    # target mode, so it cannot enforce the scripts/ floor. The macos-check
+    # job below only runs `cargo check` (type-check, no test execution), so
+    # it does NOT exercise scripts/demo.sh; the real enforcement of the
+    # bash-3.2 floor is matrix.yml's full-suite `cargo test` on macos-latest
+    # (via tests/m6_surfaces.rs t4's scripts/demo.sh subprocess), which runs
+    # on PR-to-main, nightly, and release — not on every push. Gated at
+    # --severity=error only: a 2026-08-14 sweep of all 25 scripts/**/*.sh
+    # found the tree clean at that threshold but carrying ~84 pre-existing
+    # warning/note/style findings (mostly SC2154 false positives from the
+    # perf harness's `perf_mark VAR` return-by-name convention, plus SC2034
+    # on intentionally-external vars). Triaging those individually is out of
+    # scope here; this still gives every future change a real,
+    # currently-clean gate against actual shell bugs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck (errors only — see comment above for the warning backlog)
+        run: find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=error
+
+  macos-check:
+    # ADR 0004 (D9) / ADR 0002 (D2): the macOS module is `#[cfg]`-selected and
+    # not compiled at all on Linux, so breaking it is invisible locally — this
+    # is the compensating lane, run per push. `cargo check` on an actual
+    # macos-latest runner rather than a literal Linux->macOS cross-compile:
+    # the `duckdb` dependency's `bundled` feature compiles DuckDB's C++ from
+    # source via its own build script, which needs a real Apple toolchain
+    # (cross-compiling that from Linux needs an osxcross-style Apple SDK
+    # extraction that hosted runners don't carry). Since this repo is public,
+    # a real macos-latest runner is free and unmetered (ADR 0004 D9), so it's
+    # both cheaper and more faithful than fighting a cross C++ toolchain.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo check
+        run: cargo check --all-targets

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,0 +1,89 @@
+# The full-suite tier (ADR 0004, D9). ci.yml's per-push tier is cheap by
+# design (Linux fmt/clippy/test + a macOS `cargo check`); this workflow is
+# what actually runs the real test suite on every measured target (ADR 0001,
+# D1) and only on the events where the wall-clock cost is worth paying:
+# PR-to-main, nightly, and a published release. This repo is public, so
+# macOS/Windows runner minutes are free and unmetered (ADR 0004, D9) — the
+# constraint here is wall-clock, and matrix jobs run concurrently, so this
+# tier costs max(job), not sum(job).
+#
+# Targets covered: Linux and macOS, both as real `cargo test` runs. Windows
+# is measured only via WSL2, never natively (ADR 0001, D1) — wiring a WSL2
+# lane needs its own toolchain bootstrap inside the WSL guest and a caching
+# strategy that crosses the WSL/host filesystem boundary (Swatinem/rust-cache
+# runs on the Windows host and cannot see a cache rooted inside the WSL VM),
+# neither of which this change attempts to get right unverified. Left as
+# follow-up scope rather than shipped half-working — see the PR/commit note.
+#
+# Every job publishes ADR 0001's D8 "measured" skip count: the number of
+# `SKIPPED-ENV` probe-gated skips (docs/DEVELOPMENT.md's two-environment
+# rule) a run hit on that host, via `cargo test -- --nocapture` (plain
+# `cargo test` swallows stdout/stderr for passing tests, which is where
+# `SKIPPED-ENV` lines live). This is the count; it does not by itself make a
+# target "measured" under ADR 0001 — that also needs `scripts/probe-env.sh`'s
+# output recorded in `docs/environments/<host>.md`, a documentation step this
+# workflow does not do for the runner's own transient host.
+name: matrix
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Nightly, ahead of coverage.yml's weekly Monday 06:17 UTC run so the two
+    # heavy lanes don't contend for the same runner pool.
+    - cron: "30 5 * * *"
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Cancel a superseded PR run's still-queued/running matrix instead of letting
+# it burn its full ~10-60 min wall-clock (2 OSes, cold DuckDB build): wall
+# clock, not runner cost, is this repo's real CI constraint (ADR 0004, D9).
+# Scoped to pull_request only — a scheduled nightly run and a release run
+# must never cancel each other or a concurrent PR run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  full-suite:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    # Cold DuckDB C++ build (~500 TUs, ~10 min) plus the real suites; wide
+    # margin on purpose, matching coverage.yml's posture for the same build.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # macOS's plain `bash` here resolves to the system-frozen 3.2.57 (ADR
+      # 0004, D7) — GitHub's macos-latest image does not preinstall a newer
+      # Homebrew bash ahead of it on PATH. `cargo test` includes
+      # tests/m6_surfaces.rs t4, which spawns `scripts/demo.sh` via
+      # `Command::new("bash")`, so this job's test run is what ADR 0004 means
+      # by "a macOS CI job actually running /bin/bash is the real
+      # enforcement" of the scripts/ bash-3.2 floor from #86 — no separate
+      # step needed.
+      - name: cargo test (full suite)
+        run: cargo test -- --nocapture 2>&1 | tee test-output.log
+
+      - name: publish skip count (ADR 0001 D8 measured bar)
+        if: always()
+        run: |
+          # `grep -o` exits 1 on zero matches, which under Actions' default
+          # `bash -eo pipefail` would abort this step on the fully-measured,
+          # all-green case (0 skips) instead of publishing "0 skips" — the
+          # `|| count=0` catches exactly that, and only that, case.
+          count=$(grep -o 'SKIPPED-ENV' test-output.log | wc -l | tr -d ' ') || count=0
+          {
+            echo "## Skip count — ${{ matrix.os }}"
+            echo "$count SKIPPED-ENV probe-gated skips this run (docs/DEVELOPMENT.md's two-environment rule)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/adr/0004-cross-platform-development-constraints.md
+++ b/docs/adr/0004-cross-platform-development-constraints.md
@@ -27,11 +27,12 @@ scripts, not bash syntax, and don't count against the bash floor. There is
 exactly **one** bash-4.3+ dependency in the whole tree: `local -n` at
 `scripts/perf/common.sh:56`, a nameref that bash 3.2 does not support —
 this matches the interview's own figure exactly, down to the file and
-line. The interview also decided to wire `shellcheck` into CI: it is
+line. The interview also decided to wire `shellcheck` into CI: it was
 already installed on Cerberus (confirmed present at `/usr/bin/shellcheck`,
-version 0.11.0, on this host) but is currently absent from
-`.github/workflows/` (only `ci.yml` and `coverage.yml` exist there today,
-neither runs shellcheck).
+version 0.11.0, on this host) but at the time of this interview was
+absent from `.github/workflows/` (only `ci.yml` and `coverage.yml`
+existed there then, neither ran shellcheck) — since wired in, see D9's
+consequence below.
 
 **CI shape (D9).** This repo is public, and standard GitHub-hosted
 runners — including macOS and Windows — are free and unmetered for public
@@ -68,26 +69,31 @@ on, not a considered-and-rejected alternative in its own right.
 
 ## Consequences
 
-D7's practical consequence is that `scripts/perf/common.sh:56`'s `local -n`
-site is now a known, named incompatibility with the macOS-shipped bash —
-this ADR does not fix it (scope limits below), only records it as the one
-site that needs attention before a perf script can be measured to work
-under macOS's bash. Wiring `shellcheck` into CI is hygiene on top of that,
+D7's practical consequence was that `scripts/perf/common.sh:56`'s `local -n`
+site was a known, named incompatibility with the macOS-shipped bash — this
+ADR did not fix it itself (scope limits below), only recorded it as the one
+site needing attention before a perf script could be measured to work under
+macOS's bash. It has since been fixed (#86): `perf_mark` now hands its
+result back via `printf -v`, a bash-3.1 builtin, instead of the bash-4.3+
+`local -n` nameref. Wiring `shellcheck` into CI is hygiene on top of that,
 not a version gate in itself: per the interview's own framing, a macOS CI
 job actually running `/bin/bash` is the real enforcement of bash 3.2
 compatibility; `shellcheck` catches shell bugs and portability smells
 independent of that specific version floor.
 
-D9's consequence is that the compensating cross `cargo check` lane named
-in ADR 0002 has a concrete home — the per-push CI job — but is not yet
-implemented; `.github/workflows/ci.yml` today runs only a single
-`ubuntu-latest` job (`fmt`/`clippy`/`test`) with no macOS target check and
-no separate PR-to-main/nightly/release matrix tier. This ADR records the
-decided shape; building it — the macOS `cargo check` lane, the
-PR-to-main/nightly/release matrix tier, and `shellcheck` wiring — is
-separate, not-yet-filed implementation work, not something this ADR does.
+D9's consequence was that the compensating cross `cargo check` lane named
+in ADR 0002 had a concrete home — the per-push CI job — but was not yet
+implemented at the time of this interview: `.github/workflows/ci.yml` then
+ran only a single `ubuntu-latest` job (`fmt`/`clippy`/`test`) with no macOS
+target check and no separate PR-to-main/nightly/release matrix tier. This
+ADR recorded the decided shape; building it was filed and shipped as #87:
+`ci.yml` now also runs a `macos-latest` `cargo check` job and a
+`--severity=error` `shellcheck` job on every push, and `.github/workflows/matrix.yml`
+runs the full `cargo test` suite on Linux and macOS on PR-to-main, nightly,
+and release, publishing each run's ADR 0001 D8 `SKIPPED-ENV` count.
 
 ## Open questions
 
 None identified in the interview record beyond the implementation gap
-already named above as a consequence, not an unresolved decision.
+named above as a consequence — since closed by #86 and #87 — which was
+never an unresolved decision in its own right.

--- a/scripts/perf/common.sh
+++ b/scripts/perf/common.sh
@@ -52,17 +52,23 @@ perf_now_ns() {
 }
 
 # perf_mark VAR — assign "now" in ns to VAR without forking a subshell.
+# bash 3.2 (macOS's frozen system bash) has no `local -n` nameref (4.3+), so
+# the value is handed back via `printf -v` instead — also fork-free, and
+# (like the nameref) assigns straight into the caller's variable, local or
+# global. Namespaced locals below so this never shadows the caller's own
+# variable when $1 happens to be a short name like "t" or "sec".
 perf_mark() {
-  local -n __perf_mark_out=$1
-  local t=${EPOCHREALTIME:-}
-  if [ -n "$t" ]; then
-    t=${t/,/.}
-    local sec=${t%.*} frac=${t#*.}
-    while [ ${#frac} -lt 9 ]; do frac="${frac}0"; done
-    __perf_mark_out="${sec}${frac:0:9}"
+  local __perf_mark_t=${EPOCHREALTIME:-}
+  local __perf_mark_val
+  if [ -n "$__perf_mark_t" ]; then
+    __perf_mark_t=${__perf_mark_t/,/.}
+    local __perf_mark_sec=${__perf_mark_t%.*} __perf_mark_frac=${__perf_mark_t#*.}
+    while [ ${#__perf_mark_frac} -lt 9 ]; do __perf_mark_frac="${__perf_mark_frac}0"; done
+    __perf_mark_val="${__perf_mark_sec}${__perf_mark_frac:0:9}"
   else
-    __perf_mark_out="$(date +%s%N)"
+    __perf_mark_val="$(date +%s%N)"
   fi
+  printf -v "$1" '%s' "$__perf_mark_val"
 }
 
 perf_die() { printf '\033[31mperf: %s\033[0m\n' "$*" >&2; exit 1; }


### PR DESCRIPTION
Closes #86 and #87. Work `01M00KAN2FSVP0QQ1JP7B9GNC7` (`implement`, 2/20 turns), plus the gate's doc refresh.

## #86 — bash 3.2 floor

`perf_mark`'s `local -n` nameref (bash 4.3+) replaced with `printf -v` — a bash-3.1 builtin, equally fork-free, assigning into the caller's variable either way. macOS ships bash 3.2.57, frozen for licensing reasons.

The rewrite also namespaces every local, closing a latent bug: the nameref version declared `local t` and `local sec` beside `local -n __perf_mark_out=$1`, so `perf_mark t` would have resolved into the function's own `t` rather than the caller's. Verified independently — monotonic 19-digit values, and both `perf_mark t` and `perf_mark sec` now work.

## #87 — tiered CI

**Per push** (`ci.yml`): existing Linux `fmt`/`clippy`/`test`, plus shellcheck at `--severity=error` and a `macos-latest` `cargo check`.

**Full suite** (`matrix.yml`): real `cargo test` on Linux and macOS, on PR-to-main, nightly and release only. Publishes ADR 0001 D8's **skip count** per host via `--nocapture`, since plain `cargo test` swallows the stdout `SKIPPED-ENV` lines live in. `cancel-in-progress` scoped to `pull_request` so nightly and release never cancel each other.

### The Work corrected the brief, and was right

The dispatch specified a Linux→macOS cross `cargo check`. It used a real `macos-latest` runner instead: `duckdb`'s `bundled` feature builds C++ in its build script and needs a genuine Apple toolchain, which hosted runners cannot cross-target without an osxcross SDK extraction. Since the repo is public, the real runner is free, unmetered, and strictly more faithful. G3 hit the same constraint independently via `ring`.

### Claims verified rather than accepted

- `m6_surfaces.rs:2073` does spawn `scripts/demo.sh` via `Command::new("bash")` — so that macOS job really is where #86's floor is enforced, not shellcheck, which has no version-target mode.
- shellcheck is clean at `--severity=error` across all 25 scripts; the lower-severity backlog is **84**, matching its "~84" exactly.
- All three workflow files parse.

It also declined to ship a half-working WSL2 lane, explaining that `Swatinem/rust-cache` runs on the Windows host and cannot see a cache inside the WSL VM. Left as follow-up rather than shipped broken.

## Rescued, not redone

This Work reached `completed` having committed **nothing** — the actor ended its turn waiting for a background-completion callback that a headless `claude -p` turn does not have. Its output, including an **untracked** `matrix.yml` a `git diff`-based rescue would have silently dropped, sat in the retained worktree. Filed as **#94**.

## Found while reviewing

**#95** — the perf harness has no working nanosecond clock on macOS: `EPOCHREALTIME` is bash 5.0+ so the fast path never fires on 3.2.57, and the fallback `date +%s%N` is GNU-only so BSD `date` emits a literal `N`. Pre-existing, not #86's doing, but it means "the scripts run on macOS" would be syntactically true and semantically false. Reasoned, not measured — to verify on the MacBook.

**#91 gained a second trigger** — two *concurrent* suite runs collide over the fixed container name, no leak required. Observed when this branch's gate raced a dispatched Work's suite. That is a hard constraint on #87's matrix and on dogfooding.

## Verification

Full suite 12 suites / 0 failures with m7 included; `fmt` and `clippy -D warnings` clean; no orphan daemons, no leaked containers. Shipping gate **passed**; its `f2b4b56` refreshed ADR 0004's consequences now that both decisions are shipped.