### PR TITLE
§5.4: the estate manifest gains authority over its own data_dir (Refs #80, Fixes #64)

### DIFF
--- a/GAUNTLET.md
+++ b/GAUNTLET.md
@@ -40,7 +40,7 @@ rationale. The proposal is the idea as it stood in that moment, not a how-to.
 | B2 | M6 adjudication | Dashboard auth delivers the bearer token in the `sgt web` URL query string (shoulder-surf/history exposure on a shared machine) | Accepted at R1 for the P0: the listener is loopback-only and the token already travels in the printed URL by design; the API refuses query tokens on non-GET/HEAD (CSRF bound), and `/ui` sits behind the same `require_bearer` gate as `/v1`. Post-P0 alternative recorded per the M6 contract: exchange the URL token once for an `HttpOnly; SameSite=Strict` cookie handoff. Trigger: any non-loopback binding or multi-user host. |
 | B3 | P0 final gate | `ClaudeBackend::stop` joins the turn's evidence-archive thread while API handlers hold the core lock, so a concurrent request waits out one transcript flush during a cancel/retry of an in-flight Claude turn | Orchestrator ruling at the final gate (three review rounds converged here): STOP's evidence promise (round-2 fix — the archive is durable before STOP returns) is kept; the lock-hold is rare-path and bounded by one local-disk write; the real fix is a §15 trait-shape change (`stop` returning a join token the caller awaits after releasing the core guard) — R7 machinery, not invented at gate-time without panel coverage. `block_in_place` (d82a6e2) keeps the executor healthy meanwhile; trade-off documented on `stop` itself (d20554d). Trigger: any measured multi-client stall, or the first §15 trait revision for other reasons. **CLOSED at N3**: the trigger fired exactly as registered — §14.3's `prepare`/`launch` split is the first §15 trait revision, and B3's own prescribed fix ("`stop` returning a join token the caller awaits after releasing the core guard") is what landed. `stop`/`interrupt` return a `Completion`; the engine collects them into a `Deferred`; `api::crank` drains it after dropping the guard. `block_in_place` removed. Pinned by `tests/m2_daemon_api.rs` t10 — a stalled evidence archive with an independent read answering in ~2 ms — and revert-probed (holding the guard across the drain fails the test in 1 s). Issue #14 closed. |
 | B4 | R-MVP1-10 (blocked exit-door invariant) build | A `pending → blocked` landing from a real start failure (a materialize permission fault, or `reconcile_crashed_start`'s crash-window block) has no working `retry` door: `begin_retry` requires `run.current_stage()` (`engine.rs`), and no stage is ever entered before `settle_materialize` fails or a crashed start is swept — `KIND_WORKFLOW_BOUND`/`KIND_STAGE_ENTERED` land together with `KIND_WORK_STARTED` in one group-committed guard hold, all *after* a successful materialize, so this is not a narrow timing window but the whole category. `retry` fails closed with `EngineError::NoRun` (404, `"no_run"`) — safe, structured, non-corrupting, never silently wrong — but not an open door. The real, working exit is `cancel` (`blocked → canceled`), proven instead. | Reopening it properly needs the full `StartPlan` (workflow resolution, routing, per-stage bindings) re-derivable from the journal alone, and today it is not: `origin.cwd` — needed to re-run `Workspace::discover` — is never persisted (`engine.rs`'s own `reconcile_crashed_start` comment says so), and guessing at a substitute `cwd` would silently re-plan against the wrong estate, which CLAUDE.md's fail-closed doctrine forbids. The honest fix is persisting enough of the submit-time plan to redo it — a bind-path change (`engine.rs`, `SurfacePlan`/`KIND_SURFACE_MATERIALIZING`'s payload) outside this ruling's own file scope (`projection.rs`/`recovery.rs`/`surface.rs`/`api.rs` views). Trigger: any MVP that needs `retry` to reopen a `pending`-origin block — the natural home is wherever the submit-time plan next gets a durable record (R-MVP1-1/R-MVP1-4's `workflow.bound` widening is adjacent territory). Pinned as *expected, safe* behavior by `tests/m2_daemon_api.rs`'s `r_mvp1_10_pending_to_blocked_from_a_real_materialize_fault_exits_via_cancel` (revert-probed: removing the `NoRun`→404 mapping or the `no_run` code fails it). |
-| B5 | MVP-3 fixer pass, invariants finding MVP3-C4 | `docs/gauntlet/notes/estate-manifest-design-2026-08-11.md`'s `[estate]` shape lists `data_dir` defaulting `.sergeant/data`, but R-MVP1-1 ruled only `surfaces_dir`; `data_dir` was never implemented (`EstateSection` is `deny_unknown_fields` with no such field; `resolve_data_dir` hardcodes the estate-relative default and reads no manifest field at all). A hand-written `[estate] data_dir = "..."` following the design note literally fails closed with a parse refusal instead of overriding anything. | Not implemented in the fixer pass: this is new engine/config surface (an estate-level override of where the daemon's own data dir lives), R-NS-4 territory that wants explicit ratification, not a silent addition riding in on a bug-fix pass. Design doc corrected in place ([v3] note) so it no longer misdescribes shipped behavior. Trigger: any MVP that actually needs a non-default, manifest-declared data dir (today's only override is `--data-dir`/`SGT_DATA_DIR`, both already covered by R-MVP1-12's discovery-boundary rules). |
+| B5 | MVP-3 fixer pass, invariants finding MVP3-C4 | `docs/gauntlet/notes/estate-manifest-design-2026-08-11.md`'s `[estate]` shape lists `data_dir` defaulting `.sergeant/data`, but R-MVP1-1 ruled only `surfaces_dir`; `data_dir` was never implemented (`EstateSection` is `deny_unknown_fields` with no such field; `resolve_data_dir` hardcodes the estate-relative default and reads no manifest field at all). A hand-written `[estate] data_dir = "..."` following the design note literally fails closed with a parse refusal instead of overriding anything. | Not implemented in the fixer pass: this is new engine/config surface (an estate-level override of where the daemon's own data dir lives), R-NS-4 territory that wants explicit ratification, not a silent addition riding in on a bug-fix pass. Design doc corrected in place ([v3] note) so it no longer misdescribes shipped behavior. Trigger: any MVP that actually needs a non-default, manifest-declared data dir (today's only override is `--data-dir`/`SGT_DATA_DIR`, both already covered by R-MVP1-12's discovery-boundary rules). **CLOSED, ADR 0008(b)** (see the ledger entry below): the trigger fired — ADR 0008 ratified `[estate] data_dir` explicitly (R-NS-4's "explicit ratification, not a silent addition"), and it is now implemented, mirroring `surfaces_dir`'s shape exactly as this row anticipated. |
 | B6 | MVP-3 fixer pass, invariants finding MVP3-C5 | `sgt run --turns`/`--ceiling-secs` (commit 78e5da9) adds a per-Work `EnvelopeRequest{turn_cap, ceiling_secs}` the engine reads via `effective_turn_cap`/`effective_turn_ceiling` — genuinely new engine surface (submit-time envelope override) that R-MVP1-7 specified as daemon-wide only (`with_turn_cap`/`SGT_TURN_CAP`), and MVP-3's own bucketing plan does not list it. Counting integrity is intact (not a bypass: `check_turn_envelope` still gates on the effective values, `turns_spawned` stays journal-derived, submit rejects `turn_cap==0`/`ceiling_secs==0`) — the gap is process, not safety. | Shipped code kept as-is (it works, and reverting a MVP-3-milestone feature inside a fixer pass is a bigger unilateral move than registering it); registered here instead per R-NS-4 discipline, for owner ratification at the next adjudication rather than silently standing unregistered. Trigger: MVP-3's own adjudication — fold into the milestone's deviation record or explicitly ratify there. |
 | B7 | MVP-5 F2 execution-surface re-triage (`docs/icm/retriage-2026-08-11.md`, `load-project` verdict notes) | `sergeant-setup`'s `30-project-interview` stage duplicates `load-project`'s registration job wholesale (same "complete project definition... previewed... written only after confirmation" shape) instead of delegating to it — the retriage itself flags this as "a duplication defect, not a clean stage-boundary split," and it stood unresolved when the F2 pass executed the surrounding CLI-SURFACE verdicts around it. | Fixing it means editing `sergeant-setup`'s own package to delegate its interview stage to `load-project` instead of reimplementing it — a `.sergeant/workflows/` content edit outside the MVP-5 fixer pass's file scope (docs/`AGENTS.md`/`skills/` only). Trigger: any pass that next touches either `sergeant-setup` or `load-project`'s own package. |
 | B8 | MVP-5 Lane F1 dispositions, content-honesty CH-1 (fixer pass, 2026-08-13) | 17 `agents-invariant` units (BU-1033..1048's codebase-design vocabulary/deepening rules, BU-1064's domain-modeling CONTEXT.md file-role rule) have no live skill package to land in — only frozen upstream evidence under `reference/sergeant-upstream/.claude/skills/`, which `docs/DEVELOPMENT.md` forbids treating as live content. `docs/icm/agents-invariant-dispositions.md` previously (and wrongly) claimed both were already-published `.sergeant/workflows/` packages; corrected to `not-adopted` this pass, and the two live packages that named a "grilling/domain-modeling" pair (`triage/40-grill-if-underspecified`, `wayfinder/00-name-destination`) were corrected to name `grilling` alone rather than invent the second invocation. | Promoting either skill is new content, not a dispositioning correction — this fixer pass's job was to stop asserting they exist, not to build them. Trigger: an owner decision to actually promote `codebase-design` and/or `domain-modeling` as `skills/` packages (nearest precedent: `deepen-module` already cites `codebase-design`'s upstream `DEEPENING.md` directly, without a `skill:` indirection — see `00-classify-dependencies/CONTEXT.md`). |
@@ -48,6 +48,66 @@ rationale. The proposal is the idea as it stood in that moment, not a how-to.
 ---
 
 ## Ledger entries
+
+### ADR 0008 — 2026-08-14, manifest authority over its own state location: (b) implemented, (a) pinned unchanged, (c) re-ruled and #64 closed without code
+
+**Mission outcome: shipped.** Implements proposal §5.4 / ADR 0008, a Work
+dispatched off FOUNDATION-1's ruling (below). Three parts, one ruling, per
+the ADR:
+
+**(a) Estate-first precedence — untouched, pinned.** `resolve_data_dir`'s
+rung order (`--data-dir`, `SGT_DATA_DIR`, estate discovery, pre-estate
+platform fallback) is unchanged; already pinned by
+`tests/m8_estate_cli.rs`'s `explicit_data_dir_and_env_still_win_over_a_discovered_estate`
+and `no_estate_anywhere_falls_back_to_the_pre_estate_default_unchanged`, both
+re-run green with no edits needed.
+
+**(b) `[estate] data_dir` added, closing B5.** `Workspace` gains a
+`data_dir: Option<PathBuf>` field, parsed and resolved identically to
+`surfaces_dir` (relative declarations join onto the manifest's own
+directory; absolute ones pass through) — same shape, deliberately, per the
+ADR's "do not invent a second convention." `resolve_data_dir` consults it
+via the new `Workspace::estate_root_and_data_dir` (disk-free structural
+parse, so a data-dir lookup never fails on a declared repository missing
+from disk) only once an estate has already been found, narrowing the
+`<estate_root>/.sergeant/data` default exactly as `surfaces_dir` narrows the
+daemon's own. **Precedence rung — a recommendation, not an owner ruling
+(proposal §8.7 named this explicitly undecided):** `SGT_DATA_DIR` and
+`--data-dir` still outrank a manifest-declared `data_dir`; the manifest is
+consulted only inside the estate-discovery rung. Argument for: `--data-dir`
+and `SGT_DATA_DIR` are positioned as unconditional operator overrides that
+already skip estate discovery entirely, and `data_dir` is the daemon's
+single-owner boundary (journal, blob store, lock) — a bigger blast radius
+than `surfaces_dir`'s per-submission narrowing, so letting a checked-out
+manifest silently redirect an operator's own env-set override is the more
+surprising failure mode. Argument against, carried honestly: `surfaces_dir`
+already establishes manifest-over-env as this codebase's actual precedent
+(`workspace.surfaces_dir` always wins over the daemon's `SGT_SURFACES_DIR`-set
+default once a submission has a workspace), and ADR 0008(b)'s own framing —
+"the manifest should be authority for both or neither" — pulls toward
+manifest-over-`SGT_DATA_DIR`, not below it. Pinned by
+`sgt_data_dir_env_var_still_outranks_a_manifest_declared_data_dir` so a
+future change cannot flip this silently; open for adjudication.
+
+**(c) #64 re-ruled, not implemented — closed on the ADR's reasoning.** No
+code was written for #64's filed `XDG_STATE_HOME` flip. The cost is carried
+rather than softened, per the ADR: surfaces under `.sergeant/data/surfaces/`
+do sit inside the sergeant-rs checkout when sergeant operates on itself,
+invisible today only because that path is gitignored and the engine's
+refusal checks the target repo rather than the outer one — re-ruling accepts
+that permanently. Closed via commit trailer (`Fixes #64`), reasoning
+recorded here and in the commit body, not softened into a silent close.
+
+**Verification.** `manifest_data_dir_overrides_the_estate_local_default`
+revert-probed: reverting only the `src/cli.rs` change (keeping the domain
+parsing) reproduces the old hardcoded default and fails the test, confirming
+it actually exercises the fix rather than passing vacuously. Full suite
+green (`cargo test`); one throughput test
+(`t12_submission_throughput_has_an_automated_floor`) flaked under host load
+in a full-suite run and passed clean in isolation — unrelated to this
+change (the submit path this Work touches, `resolve_data_dir`, runs once at
+CLI startup, never inside the daemon's hot submit path this test measures).
+`cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` clean.
 
 ### FOUNDATION-1 — 2026-08-14, a proposal graded instead of an implementation: validated with findings
 

--- a/docs/adr/0008-manifest-authority-over-storage-paths.md
+++ b/docs/adr/0008-manifest-authority-over-storage-paths.md
@@ -96,8 +96,9 @@ ADR 0006 establishes, not more.
 ## Consequences
 
 The manifest gains a new `[estate] data_dir` field, mirroring
-`surfaces_dir`'s shape — not yet implemented by this ADR, which records
-the decision rather than the code.
+`surfaces_dir`'s shape. Implemented; see GAUNTLET.md's "ADR 0008" ledger
+entry for the shipped shape, the precedence rung it chose, and
+verification.
 
 #64 closes on this ruling rather than on the implementation it originally
 proposed; the self-hosting contradiction it named stays real and is now an
@@ -116,5 +117,7 @@ The precedence and override behavior of a manifest-declared `data_dir`
 relative to `--data-dir` and `SGT_DATA_DIR` — whether it slots in at the
 same rung as estate discovery currently does, or somewhere else in the
 existing five-rung order — is not specified beyond "the manifest should be
-authority for both or neither"; the exact rung it occupies is
-implementation work this ADR does not perform.
+authority for both or neither." The implementation picked a rung
+(`SGT_DATA_DIR`/`--data-dir` still outrank a manifest `data_dir`) as a
+recommendation, not an owner ruling — argued and left open for
+adjudication in GAUNTLET.md's "ADR 0008" ledger entry.

--- a/docs/gauntlet/notes/estate-manifest-design-2026-08-11.md
+++ b/docs/gauntlet/notes/estate-manifest-design-2026-08-11.md
@@ -9,18 +9,15 @@ dispositions; the owner's decisions stand except one ESCALATED fork.
 
 Extends the estate root's `sergeant.toml` (reuse the discovered config
 file, R1): `[estate]` (name, `data_dir` defaulting `.sergeant/data`),
-**[v3] `data_dir` was never carried into implementation and this line is
-stale.** R-MVP1-1 (the MVP-1 contract's own ruling on `[estate]`) named
-only `surfaces_dir`; `EstateSection` (`workspace.rs`) is
-`deny_unknown_fields` over `name`/`default_backend`/`default_workflow`/
-`surfaces_dir`, and `resolve_data_dir` (`cli.rs`) hardcodes
-`estate_root.join(DEFAULT_ESTATE_DATA_DIR)` reading no manifest field at
-all — so a hand-written `[estate] data_dir = "..."` following this line
-literally fails closed with a `deny_unknown_fields` parse refusal rather
-than overriding anything. Flagged, not implemented, at the MVP-3 fixer
-pass (invariants finding MVP3-C4; GAUNTLET.md backlog entry B5):
-per-Work-item scope, this is R-NS-4 new engine/config surface and wants
-its own ratification, not a silent addition inside a bug-fix pass.
+**[v3] `data_dir` was never carried into implementation and this line was
+stale** as of the MVP-3 fixer pass (invariants finding MVP3-C4; GAUNTLET.md
+backlog entry B5): flagged rather than implemented there, since it was
+R-NS-4 new engine/config surface wanting its own ratification, not a
+silent addition inside a bug-fix pass. **[v4] Ratified and implemented**:
+ADR 0008(b) added `[estate] data_dir` to `EstateSection`, resolved
+identically to `surfaces_dir`; see GAUNTLET.md's B5 row and its "ADR
+0008" ledger entry for the shipped shape and the still-open precedence
+question against `--data-dir`/`SGT_DATA_DIR`.
 `[[profile]]` (existing; **[v2]** array-of-tables per `workspace.rs:179`,
 unchanged here — the earlier `[profile.*]` shorthand was wrong),
 `[[repo]]` entries, `[group.<name>]` tables.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -392,17 +392,22 @@ pub fn main() -> ExitCode {
 /// unconditional precedence — then (U-R2, MVP-3's estate-resolved default) an
 /// estate discovered by walking upward from the current directory, mirroring
 /// R-MVP1-12: filesystem-first, crossing git boundaries, bounded at `$HOME`.
-/// When one is found, the default is `<estate_root>/.sergeant/data` — the
-/// same path `sgt init` scaffolds a `.gitignore` entry for
-/// ([`crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR`]). This precedence —
-/// whether estate discovery should even come before the pre-estate fallback
-/// — is an owner ruling tracked separately in #80 and is not decided here.
-/// This is a new fallback *rung*, not a replacement: only once no estate is
-/// found (or the current directory cannot even be read) does resolution fall
-/// through to the pre-estate default, which is a platform fact
-/// ([`crate::platform::data_dir`], #82) — `$XDG_DATA_HOME/sergeant` or
-/// `~/.local/share/sergeant` on Linux, unchanged from before that boundary
-/// existed.
+/// When one is found, the default is the manifest's own `[estate] data_dir`
+/// if it declares one (ADR 0008(b)), else `<estate_root>/.sergeant/data` —
+/// the same path `sgt init` scaffolds a `.gitignore` entry for
+/// ([`crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR`]). Both `data_dir`
+/// and the hardcoded default sit *below* the flag and `SGT_DATA_DIR`: ADR
+/// 0008(a) upholds estate-first precedence over the pre-estate platform
+/// fallback unchanged, and does not touch the flag/env rungs above it — a
+/// manifest declaration is consulted only once estate discovery has already
+/// won that race, narrowing what it would otherwise default to, exactly as
+/// `surfaces_dir` narrows the daemon's own default rather than outranking an
+/// explicit override. This is a new fallback *rung*, not a replacement: only
+/// once no estate is found (or the current directory cannot even be read)
+/// does resolution fall through to the pre-estate default, which is a
+/// platform fact ([`crate::platform::data_dir`], #82) — `$XDG_DATA_HOME/sergeant`
+/// or `~/.local/share/sergeant` on Linux, unchanged from before that
+/// boundary existed.
 fn resolve_data_dir(flag: Option<PathBuf>) -> Result<PathBuf, CliError> {
     if let Some(dir) = flag {
         return Ok(dir);
@@ -411,9 +416,12 @@ fn resolve_data_dir(flag: Option<PathBuf>) -> Result<PathBuf, CliError> {
         return Ok(PathBuf::from(dir));
     }
     if let Ok(cwd) = std::env::current_dir()
-        && let Some(estate_root) = crate::domain::workspace::Workspace::estate_root(&cwd, None)?
+        && let Some((estate_root, data_dir)) =
+            crate::domain::workspace::Workspace::estate_root_and_data_dir(&cwd, None)?
     {
-        return Ok(estate_root.join(crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR));
+        return Ok(data_dir.unwrap_or_else(|| {
+            estate_root.join(crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR)
+        }));
     }
     crate::platform::data_dir::fallback_dir(|name| std::env::var_os(name)).map_err(CliError::new)
 }

--- a/src/domain/workspace.rs
+++ b/src/domain/workspace.rs
@@ -202,6 +202,16 @@ pub struct Workspace {
     /// `<data_dir>/surfaces`) in force — this field only ever narrows it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub surfaces_dir: Option<PathBuf>,
+    /// `[estate] data_dir` (ADR 0008(b)): resolved the same way as
+    /// `surfaces_dir` above — an absolute path, relative declarations
+    /// joined onto `root`. Consulted only by `src/cli.rs`'s
+    /// `resolve_data_dir`, and only once an estate has already been
+    /// discovered (it narrows what that discovery would otherwise default
+    /// to, `<estate_root>/.sergeant/data`); it does not affect
+    /// `--data-dir`/`SGT_DATA_DIR`, which both still short-circuit before an
+    /// estate is ever looked for (ADR 0008(a), unchanged).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_dir: Option<PathBuf>,
     /// Per-repository instruction policy (R-MVP1-4), keyed by repository
     /// name. A name absent from this map (including every repository in the
     /// zero-config single-repo fallback) resolves to
@@ -398,6 +408,10 @@ struct EstateSection {
     /// when not absolute.
     #[serde(default)]
     surfaces_dir: Option<PathBuf>,
+    /// ADR 0008(b): `data_dir` override, resolved the same way as
+    /// `surfaces_dir` above.
+    #[serde(default)]
+    data_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -530,6 +544,7 @@ impl Workspace {
                 profiles: Vec::new(),
                 config_path: None,
                 surfaces_dir: None,
+                data_dir: None,
                 repository_policy: BTreeMap::new(),
                 groups: BTreeMap::new(),
                 repository_origin: BTreeMap::new(),
@@ -871,7 +886,8 @@ impl Workspace {
             );
         }
 
-        let (name, default_backend, default_workflow, surfaces_dir) = match parsed.estate {
+        let (name, default_backend, default_workflow, surfaces_dir, data_dir) = match parsed.estate
+        {
             Some(estate) => (
                 estate.name,
                 estate.default_backend,
@@ -879,8 +895,11 @@ impl Workspace {
                 estate
                     .surfaces_dir
                     .map(|d| if d.is_absolute() { d } else { root.join(d) }),
+                estate
+                    .data_dir
+                    .map(|d| if d.is_absolute() { d } else { root.join(d) }),
             ),
-            None => (repo_name(&root), None, None, None),
+            None => (repo_name(&root), None, None, None, None),
         };
 
         Ok(Self {
@@ -892,6 +911,7 @@ impl Workspace {
             profiles: parsed.profile,
             config_path: Some(config_path.to_path_buf()),
             surfaces_dir,
+            data_dir,
             repository_policy,
             groups,
             repository_origin,
@@ -991,7 +1011,8 @@ impl Workspace {
             );
         }
 
-        let (name, default_backend, default_workflow, surfaces_dir) = match parsed.estate {
+        let (name, default_backend, default_workflow, surfaces_dir, data_dir) = match parsed.estate
+        {
             Some(estate) => (
                 estate.name,
                 estate.default_backend,
@@ -999,8 +1020,11 @@ impl Workspace {
                 estate
                     .surfaces_dir
                     .map(|d| if d.is_absolute() { d } else { root.join(d) }),
+                estate
+                    .data_dir
+                    .map(|d| if d.is_absolute() { d } else { root.join(d) }),
             ),
-            None => (repo_name(&root), None, None, None),
+            None => (repo_name(&root), None, None, None, None),
         };
 
         Ok(Self {
@@ -1012,6 +1036,7 @@ impl Workspace {
             profiles: parsed.profile,
             config_path: Some(config_path.to_path_buf()),
             surfaces_dir,
+            data_dir,
             repository_policy,
             groups,
             repository_origin,
@@ -1054,6 +1079,26 @@ impl Workspace {
     ) -> Result<Option<PathBuf>, WorkspaceError> {
         Ok(Self::find_estate_upward(start, data_dir)?
             .and_then(|config| config.parent().map(Path::to_path_buf)))
+    }
+
+    /// [`Self::estate_root`]'s sibling for `src/cli.rs`'s `resolve_data_dir`
+    /// (ADR 0008(b)): the discovered estate root together with its
+    /// manifest's `[estate] data_dir` override, if any — resolved via
+    /// [`Self::from_config_structural`] (disk-free, no per-repo git
+    /// resolution) so a data-dir lookup never fails on a declared repository
+    /// that happens not to exist on disk yet. `None` when no estate is
+    /// found; `Some((root, None))` when one is found but declares no
+    /// override, leaving the caller's own default in force exactly as
+    /// `surfaces_dir` does.
+    pub fn estate_root_and_data_dir(
+        start: &Path,
+        data_dir_scope: Option<&Path>,
+    ) -> Result<Option<(PathBuf, Option<PathBuf>)>, WorkspaceError> {
+        let Some(config_path) = Self::find_estate_upward(start, data_dir_scope)? else {
+            return Ok(None);
+        };
+        let workspace = Self::from_config_structural(&config_path)?;
+        Ok(Some((workspace.root, workspace.data_dir)))
     }
 
     /// Restrict the workspace to the named repositories (the submit request's
@@ -1271,6 +1316,7 @@ mod tests {
             profiles: Vec::new(),
             config_path: None,
             surfaces_dir: None,
+            data_dir: None,
             repository_policy: BTreeMap::new(),
             groups: BTreeMap::new(),
             repository_origin: BTreeMap::new(),
@@ -1589,6 +1635,46 @@ mod tests {
         )
         .expect("no surfaces_dir parses");
         assert_eq!(workspace.surfaces_dir, None);
+    }
+
+    // ---- ADR 0008(b): `[estate] data_dir` ---------------------------------
+
+    /// `data_dir` parses and resolves exactly like `surfaces_dir` above —
+    /// same shape, deliberately, per ADR 0008(b)'s "do not invent a second
+    /// convention".
+    #[test]
+    fn estate_data_dir_resolves_relative_and_keeps_absolute() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+        init_repo(root);
+
+        let workspace = parse(
+            root,
+            "[estate]\nname = \"w\"\ndata_dir = \"../elsewhere-data\"\n\n\
+             [[repo]]\nname = \"solo\"\npath = \".\"\n",
+        )
+        .expect("relative data_dir parses");
+        assert_eq!(workspace.data_dir, Some(root.join("../elsewhere-data")));
+
+        let absolute = dir.path().join("abs-data");
+        let workspace = parse(
+            root,
+            &format!(
+                "[estate]\nname = \"w\"\ndata_dir = {:?}\n\n[[repo]]\nname = \"solo\"\npath = \".\"\n",
+                absolute.to_string_lossy()
+            ),
+        )
+        .expect("absolute data_dir parses");
+        assert_eq!(workspace.data_dir, Some(absolute));
+
+        // Unset stays `None` — `resolve_data_dir`'s own default is left in
+        // force.
+        let workspace = parse(
+            root,
+            "[estate]\nname = \"w\"\n\n[[repo]]\nname = \"solo\"\npath = \".\"\n",
+        )
+        .expect("no data_dir parses");
+        assert_eq!(workspace.data_dir, None);
     }
 
     // ---- R-MVP1-12: estate discovery past inner `.git` --------------------

--- a/src/domain/workspace.rs
+++ b/src/domain/workspace.rs
@@ -1083,13 +1083,22 @@ impl Workspace {
 
     /// [`Self::estate_root`]'s sibling for `src/cli.rs`'s `resolve_data_dir`
     /// (ADR 0008(b)): the discovered estate root together with its
-    /// manifest's `[estate] data_dir` override, if any — resolved via
-    /// [`Self::from_config_structural`] (disk-free, no per-repo git
-    /// resolution) so a data-dir lookup never fails on a declared repository
-    /// that happens not to exist on disk yet. `None` when no estate is
-    /// found; `Some((root, None))` when one is found but declares no
-    /// override, leaving the caller's own default in force exactly as
+    /// manifest's `[estate] data_dir` override, if any. `None` when no
+    /// estate is found; `Some((root, None))` when one is found but declares
+    /// no override, leaving the caller's own default in force exactly as
     /// `surfaces_dir` does.
+    ///
+    /// Deliberately **not** [`Self::from_config_structural`]:
+    /// `resolve_data_dir` runs at the top of every `dispatch`, ahead of
+    /// every command including `sgt doctor`, whose entire job is diagnosing
+    /// a broken manifest gracefully. A structural defect elsewhere in the
+    /// file — a duplicate profile, an unknown group member, an invalid
+    /// permission mode — has nothing to do with `data_dir` and must not
+    /// stop `doctor` from ever running. This reads only the one field it
+    /// needs, at the same tolerance [`estate_table_check`] already applies
+    /// to find the file in the first place: valid TOML syntax and no
+    /// legacy vocabulary are required, everything else about the manifest's
+    /// shape is not.
     pub fn estate_root_and_data_dir(
         start: &Path,
         data_dir_scope: Option<&Path>,
@@ -1097,8 +1106,12 @@ impl Workspace {
         let Some(config_path) = Self::find_estate_upward(start, data_dir_scope)? else {
             return Ok(None);
         };
-        let workspace = Self::from_config_structural(&config_path)?;
-        Ok(Some((workspace.root, workspace.data_dir)))
+        let root = config_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let data_dir = estate_data_dir_override(&config_path, &root)?;
+        Ok(Some((root, data_dir)))
     }
 
     /// Restrict the workspace to the named repositories (the submit request's
@@ -1168,6 +1181,43 @@ fn estate_table_check(config_path: &Path) -> Result<bool, WorkspaceError> {
     Ok(value
         .as_table()
         .is_some_and(|table| table.contains_key("estate")))
+}
+
+/// [`estate_table_check`]'s sibling for `data_dir` (ADR 0008(b)): the
+/// `[estate] data_dir` string, if any, resolved onto `root` exactly as
+/// [`Workspace::from_config_impl_structural`] resolves it — relative joins
+/// on, absolute passes through — but reached the same tolerant way
+/// `estate_table_check` finds the `[estate]` table itself: a raw TOML
+/// value, not a deserialize into [`WorkspaceFile`]. This is what lets
+/// [`Workspace::estate_root_and_data_dir`] read `data_dir` without also
+/// demanding the rest of the manifest — repos, profiles, groups — be
+/// structurally valid. Unreadable (permission, race) answers `None`, the
+/// same "indistinguishable from no file here" tolerance `estate_table_check`
+/// applies; by the time this runs, [`Workspace::find_estate_upward`] has
+/// already required the file to parse as TOML and carry no legacy
+/// vocabulary, so those two failure modes are not re-checked here.
+fn estate_data_dir_override(
+    config_path: &Path,
+    root: &Path,
+) -> Result<Option<PathBuf>, WorkspaceError> {
+    let Ok(text) = std::fs::read_to_string(config_path) else {
+        return Ok(None);
+    };
+    let file = config_path.display().to_string();
+    let value: toml::Value =
+        toml::from_str(&text).map_err(|source| WorkspaceError::Malformed { path: file, source })?;
+    Ok(value
+        .get("estate")
+        .and_then(|estate| estate.get("data_dir"))
+        .and_then(|data_dir| data_dir.as_str())
+        .map(PathBuf::from)
+        .map(|data_dir| {
+            if data_dir.is_absolute() {
+                data_dir
+            } else {
+                root.join(data_dir)
+            }
+        }))
 }
 
 #[cfg(test)]
@@ -1675,6 +1725,47 @@ mod tests {
         )
         .expect("no data_dir parses");
         assert_eq!(workspace.data_dir, None);
+    }
+
+    /// `resolve_data_dir` (`src/cli.rs`) calls
+    /// [`Workspace::estate_root_and_data_dir`] at the top of every command
+    /// dispatch, including `sgt doctor` — whose entire purpose is to
+    /// diagnose a broken manifest. A structural defect unrelated to
+    /// `data_dir` (here, a duplicate profile name — the same manifest both
+    /// [`Workspace::from_config`] and [`Workspace::from_config_structural`]
+    /// refuse) must not stop `data_dir` from being found, or `doctor` could
+    /// never run against the very manifest it exists to diagnose.
+    #[test]
+    fn estate_data_dir_is_found_even_when_the_rest_of_the_manifest_is_structurally_broken() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+        init_repo(root);
+        let config_path = root.join(WORKSPACE_FILE);
+        std::fs::write(
+            &config_path,
+            "[estate]\nname = \"w\"\ndata_dir = \"custom-data\"\n\n\
+             [[repo]]\nname = \"solo\"\npath = \".\"\n\n\
+             [[profile]]\nname = \"same\"\nbackend = \"fake\"\n\n\
+             [[profile]]\nname = \"same\"\nbackend = \"fake\"\n",
+        )
+        .expect("sergeant.toml");
+
+        // Both strict resolvers refuse this manifest outright.
+        assert!(Workspace::from_config(&config_path).is_err());
+        assert!(matches!(
+            Workspace::from_config_structural(&config_path),
+            Err(WorkspaceError::DuplicateProfile { .. })
+        ));
+
+        // But locating the estate and its `data_dir` override does not.
+        let (found_root, data_dir) = Workspace::estate_root_and_data_dir(root, None)
+            .expect("an unrelated structural defect must not fail data-dir lookup")
+            .expect("an estate is found");
+        assert_eq!(
+            std::fs::canonicalize(&found_root).ok(),
+            std::fs::canonicalize(root).ok()
+        );
+        assert_eq!(data_dir, Some(root.join("custom-data")));
     }
 
     // ---- R-MVP1-12: estate discovery past inner `.git` --------------------

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -4155,6 +4155,7 @@ mod tests {
                 profiles: Vec::new(),
                 config_path: None,
                 surfaces_dir: None,
+                data_dir: None,
                 repository_policy: std::collections::BTreeMap::new(),
                 groups: std::collections::BTreeMap::new(),
                 repository_origin: std::collections::BTreeMap::new(),

--- a/tests/m8_estate_cli.rs
+++ b/tests/m8_estate_cli.rs
@@ -779,6 +779,94 @@ fn no_estate_anywhere_falls_back_to_the_pre_estate_default_unchanged() {
     assert_eq!(reported, xdg.join("sergeant"));
 }
 
+/// Append `data_dir = "<value>"` to the `[estate]` table `sgt init` already
+/// scaffolded — a direct manifest edit (mirroring how the domain-level
+/// `surfaces_dir` tests write TOML by hand) rather than going through a CLI
+/// verb, since `sgt init` itself has no flag for this key.
+fn declare_manifest_data_dir(root: &Path, value: &str) {
+    let manifest_path = root.join("sergeant.toml");
+    let manifest = std::fs::read_to_string(&manifest_path).expect("read manifest");
+    assert!(
+        manifest.contains("[estate]"),
+        "expected an already-scaffolded [estate] table, got:\n{manifest}"
+    );
+    let updated = manifest.replacen(
+        "[estate]\n",
+        &format!("[estate]\ndata_dir = {value:?}\n"),
+        1,
+    );
+    std::fs::write(&manifest_path, updated).expect("write manifest");
+}
+
+/// guard-map (ADR 0008(b)): with no `--data-dir`/`SGT_DATA_DIR`, a manifest
+/// declaring `[estate] data_dir` is honored instead of the hardcoded
+/// `<estate_root>/.sergeant/data` default — the whole point of the ADR
+/// (the manifest is authority for repos, groups, profiles and
+/// `surfaces_dir`; this closes the same-shaped gap for its own state).
+/// Mutation this kills: `resolve_data_dir` finding the estate and still
+/// hardcoding `DEFAULT_ESTATE_DATA_DIR` regardless of what the manifest
+/// says — reverting the `cli.rs` change alone (leaving the domain parsing in
+/// place) reproduces exactly that and fails this test.
+#[test]
+fn manifest_data_dir_overrides_the_estate_local_default() {
+    let estate = tempfile::TempDir::new().expect("tempdir");
+    run(
+        estate.path(),
+        Some(&estate.path().join("init-scratch-data-dir")),
+        &[],
+        &["init"],
+    )
+    .assert_ok("init");
+    declare_manifest_data_dir(estate.path(), "custom-durable-state");
+
+    let expected = std::fs::canonicalize(estate.path())
+        .expect("canonical estate root")
+        .join("custom-durable-state");
+
+    let result = run(estate.path(), None, &[], &["--json", "doctor"]);
+    let reported = PathBuf::from(result.json()["data_dir"].as_str().expect("data_dir"));
+    let reported = std::fs::canonicalize(&reported).unwrap_or(reported);
+    assert_eq!(
+        reported, expected,
+        "a manifest-declared data_dir must be honored, not the hardcoded .sergeant/data default"
+    );
+}
+
+/// guard-map (ADR 0008(b), §8.7's open precedence question, resolved here):
+/// `SGT_DATA_DIR` still outranks a manifest-declared `data_dir` — the
+/// recommendation this Work is making, not an owner ruling (see the
+/// commit/PR summary for the argument and its counterargument). Pinned so a
+/// future change cannot silently flip which one wins without this test
+/// naming the flip. Mutation this kills: reordering `resolve_data_dir` so
+/// the estate walk (and the manifest `data_dir` it may carry) is consulted
+/// before `SGT_DATA_DIR`.
+#[test]
+fn sgt_data_dir_env_var_still_outranks_a_manifest_declared_data_dir() {
+    let estate = tempfile::TempDir::new().expect("tempdir");
+    run(
+        estate.path(),
+        Some(&estate.path().join("init-scratch-data-dir")),
+        &[],
+        &["init"],
+    )
+    .assert_ok("init");
+    declare_manifest_data_dir(estate.path(), "manifest-declared-data-dir");
+
+    let explicit_env = estate.path().join("explicit-env-dir");
+    let result = run(
+        estate.path(),
+        None,
+        &[("SGT_DATA_DIR", explicit_env.to_str().expect("utf8"))],
+        &["--json", "doctor"],
+    );
+    let reported = PathBuf::from(result.json()["data_dir"].as_str().expect("data_dir"));
+    assert_eq!(
+        std::fs::canonicalize(&reported).unwrap_or(reported),
+        std::fs::canonicalize(&explicit_env).unwrap_or(explicit_env),
+        "SGT_DATA_DIR must still win over a manifest-declared data_dir"
+    );
+}
+
 // -------------------------------------------- work transcript / output pointer
 
 /// A minimal two-stage workflow — the same shape `m5_projections.rs` uses —

--- a/tests/m8_estate_cli.rs
+++ b/tests/m8_estate_cli.rs
@@ -867,6 +867,59 @@ fn sgt_data_dir_env_var_still_outranks_a_manifest_declared_data_dir() {
     );
 }
 
+/// guard-map (regression): `resolve_data_dir` runs at the top of every
+/// `dispatch`, ahead of every command including `sgt doctor` — whose entire
+/// job is diagnosing a broken installation, up to and including a broken
+/// manifest. Finding a manifest's `data_dir` must not itself demand the
+/// rest of the manifest — here, two profiles sharing a name, a defect
+/// `sgt doctor` has nothing to do with — be structurally valid, or `doctor`
+/// could never run against the one manifest it most needs to. Mutation this
+/// kills: resolving `data_dir` via the full structural validator (duplicate
+/// repos/profiles, invalid permission modes, unknown group members all
+/// refuse) instead of a lookup scoped to `data_dir` alone — that would make
+/// `doctor` (and every other command) crash before ever running, on stderr,
+/// instead of producing its own JSON report.
+#[test]
+fn a_structurally_broken_manifest_does_not_stop_doctor_from_running() {
+    let estate = tempfile::TempDir::new().expect("tempdir");
+    run(
+        estate.path(),
+        Some(&estate.path().join("init-scratch-data-dir")),
+        &[],
+        &["init"],
+    )
+    .assert_ok("init");
+    declare_manifest_data_dir(estate.path(), "custom-durable-state");
+    let manifest_path = estate.path().join("sergeant.toml");
+    let mut manifest = std::fs::read_to_string(&manifest_path).expect("read manifest");
+    manifest.push_str(
+        "\n[[profile]]\nname = \"same\"\nbackend = \"fake\"\n\n\
+         [[profile]]\nname = \"same\"\nbackend = \"fake\"\n",
+    );
+    std::fs::write(&manifest_path, manifest).expect("write manifest");
+
+    let result = run(estate.path(), None, &[], &["--json", "doctor"]);
+    // `json()` itself asserts stdout parses as JSON — a pre-doctor crash on
+    // the duplicate profile would instead put a plain error string on
+    // stderr and leave stdout empty. Reaching doctor's own report (whatever
+    // its `healthy` verdict, which depends on the unrelated claude/docker
+    // harness rows) is the thing under test, so only structure is checked.
+    let report = result.json();
+    assert!(
+        report["checks"].is_array(),
+        "doctor must still produce its own report: {report}"
+    );
+    let expected_data_dir = std::fs::canonicalize(estate.path())
+        .expect("canonical estate root")
+        .join("custom-durable-state");
+    let reported = PathBuf::from(report["data_dir"].as_str().expect("data_dir"));
+    assert_eq!(
+        std::fs::canonicalize(&reported).unwrap_or(reported),
+        expected_data_dir,
+        "the manifest's data_dir must still be honored despite the unrelated profile defect"
+    );
+}
+
 // -------------------------------------------- work transcript / output pointer
 
 /// A minimal two-stage workflow — the same shape `m5_projections.rs` uses —


### PR DESCRIPTION
Proposal §5.4, ADR 0008. Work `01M0154XDA5WDNPYAW50JD8CKY` (`implement`, 2/20 turns), plus the gate's doc refresh.

`Refs #80` — #80 carries the broader data-dir identity contract and stays open. `Fixes #64` — re-ruled, not implemented.

## What landed

`resolve_data_dir` walked up to *find* `sergeant.toml` and then ignored its contents, hardcoding `estate_root.join(DEFAULT_ESTATE_DATA_DIR)` — while `[estate] surfaces_dir` was already honored. The manifest was authority for repos, groups, profiles and `surfaces_dir`, but not for where its own durable state lives.

`[estate] data_dir` is now parsed and resolved exactly like `surfaces_dir` (relative joins onto the manifest's directory, absolute passes through), consulted inside the estate-discovery rung.

## The precedence rung — adjudicated, not assumed

Proposal §8.7 recorded that manifest-vs-environment precedence was **undecided**, and the brief told the Work to choose, implement, argue both sides, and treat it as a recommendation rather than a ruling. It did.

**Its choice, accepted:** `--data-dir` and `SGT_DATA_DIR` outrank a manifest `data_dir`.

Its argument: both are positioned as unconditional operator overrides, and `data_dir` is the daemon's single-owner boundary — journal, blob store, lock — a far larger blast radius than `surfaces_dir`'s per-submission narrowing.

Its counter-argument, carried honestly: `surfaces_dir`'s actual precedent in this codebase is manifest-over-env, and "authority for both or neither" pulls the other way.

**Adjudication.** The counter-argument's premise was verified — `[estate] surfaces_dir` really does outrank `SGT_SURFACES_DIR` — so this is a knowing asymmetry, not an oversight. Accepted anyway, because the two keys differ in blast radius: every test rig isolates through `SGT_DATA_DIR`, and if a manifest could outrank it, a suite run inside an estate would be silently redirected onto the real journal and lock. That is the same silent-override hazard this round exists to remove, and it is a correctness problem rather than a preference.

Pinned by a test named for the behavior, so a future change cannot flip it quietly.

## The bug its own review caught

The first cut routed the lookup through `from_config_structural` — the full manifest validator. A duplicate profile name *anywhere* in `sergeant.toml` would then crash **every command, including `sgt doctor`**, whose entire job is diagnosing a broken manifest. The fix reads only `[estate] data_dir` as a raw TOML value, with the same tolerance already used to locate the file.

Verified by reverting: fails with `DuplicateProfile` as predicted, passes once restored. An end-to-end test (`a_structurally_broken_manifest_does_not_stop_doctor_from_running`) now pins the user-facing guarantee, not just the domain parse.

## #64 re-ruled, with its cost stated

No code written for the `XDG_STATE_HOME` flip. The self-hosting contradiction #64 named **stays real and is recorded rather than softened**: surfaces under `.sergeant/data/surfaces/` do sit inside the sergeant-rs checkout when sergeant operates on itself, invisible today only because that path is gitignored and the engine's refusal checks the *target* repo rather than the outer one. Re-ruling accepts that permanently.

## Verification

L7 confirmed independently by neutering the manifest read: the feature test fails with *"a manifest-declared data_dir must be honored, not the hardcoded .sergeant/data default"*.

Worth recording that my **first** L7 attempt was a false pass — I `sed`'d for `pub fn estate_data_dir_override` when the function is private, so nothing changed and the test passed against unmodified code. Caught by checking why the revert produced no diff.

Full suite 12 suites / 0 failures; `fmt` and `clippy -D warnings` clean. Shipping gate **passed**; its doc commit refreshed ADR 0008 and the design notes for the shipped key.
