### PR TITLE
§5.3: the actor runtime contract (Refs #94, Refs #60)

### DIFF
--- a/docs/adr/0007-actor-runtime-contract.md
+++ b/docs/adr/0007-actor-runtime-contract.md
@@ -69,10 +69,12 @@ exactly as it did twice on 2026-08-14.
 
 ## Consequences
 
-This is a product change that does not exist yet in this codebase. The ADR
-records the two-part contract; it does not implement the context-
-composition addition in (a) or the closing-stage guard in (b). Both remain
-separate, not-yet-filed implementation work against issue #94.
+Implemented. (a) is `EXECUTION_MODEL_CONTRACT` in
+`src/backend/claude.rs`, composed ahead of the intent and the stage's
+CONTEXT.md on every headless turn's launch. (b) is `stranded_completion`
+and `reported_state` in `src/api.rs`, which report `completed_dirty`
+instead of plain `completed` when a closing stage's branch never actually
+advanced, surfaced through `sgt work show`/`work list`/`watch` and the TUI.
 
 Recording the orchestrator's own fault in the second #94 occurrence is
 itself a consequence worth stating plainly: this decision is not only

--- a/src/api.rs
+++ b/src/api.rs
@@ -1481,6 +1481,54 @@ fn disposition_tag(disposition: &BindingDisposition) -> &'static str {
     }
 }
 
+/// ADR 0007(b): a closing stage that declares a commit as its durable
+/// outcome must not be reported as plain `completed` when the branch never
+/// advanced and the worktree was left dirty — the safety net for when an
+/// actor guesses wrong about its own runtime model anyway
+/// (`docs/adr/0007-actor-runtime-contract.md`). The engine still learns
+/// nothing about what a commit *is* (NORTH-STAR: "the engine learns no
+/// output vocabulary; only the pointer is core"): this reads two facts the
+/// pointer already computes — a binding's teardown disposition, and whether
+/// its finalize commit ever moved past the surface's own base SHA — rather
+/// than asking any workflow what it meant to do.
+fn stranded_completion(work: &Work, run: &WorkRun) -> bool {
+    if work.state != WorkState::Completed {
+        return false;
+    }
+    let Some(teardown) = run.teardown.as_ref() else {
+        return false;
+    };
+    let Some(surface) = run.surface.as_ref() else {
+        return false;
+    };
+    teardown.bindings.iter().any(|binding| {
+        let never_advanced = surface
+            .bindings
+            .iter()
+            .find(|b| b.repository == binding.repository)
+            .is_some_and(|b| binding.final_sha.as_deref() == Some(b.base_sha.as_str()));
+        never_advanced
+            && matches!(
+                binding.disposition,
+                BindingDisposition::RetainedDirty { .. }
+            )
+    })
+}
+
+/// The `state` `work list`/`work show` report: verbatim for every ordinary
+/// case, but not plain `completed` when [`stranded_completion`] holds. The
+/// persisted [`WorkState`] this is derived from is untouched — the run is
+/// genuinely terminal, neither blocked nor failed — so retry, cancel, and
+/// every other state-machine consumer still see `Completed`; only the
+/// string an operator reads first changes.
+fn reported_state(work: &Work, run: Option<&WorkRun>) -> &'static str {
+    if run.is_some_and(|r| stranded_completion(work, r)) {
+        "completed_dirty"
+    } else {
+        work.state.as_str()
+    }
+}
+
 /// The full view of a work: the §10 record, plus the orthogonal run
 /// coordinates the M3 contract asks `work show` to include — current stage,
 /// surface, and execution state. They are siblings of `work`, not fields
@@ -1491,8 +1539,19 @@ fn work_view(core: &Core, engine: &Engine, work_id: &str) -> Value {
     let work = registry.works.get(work_id);
     let cached_run = registry.run_view(work_id);
     let run = work.and_then(|w| resolve_run(core, w, cached_run));
+    // ADR 0007(b): the persisted `Work` serializes with its true `state`
+    // (`Completed`) intact; only this view's own `state` key is overridden,
+    // so a work still in flight and every non-stranded completion look
+    // exactly as before.
+    let work_json = work.map(|w| {
+        let mut value = serde_json::to_value(w).unwrap_or(Value::Null);
+        if let Some(object) = value.as_object_mut() {
+            object.insert("state".to_string(), json!(reported_state(w, run.as_ref())));
+        }
+        value
+    });
     json!({
-        "work": work,
+        "work": work_json,
         "stage": run.as_ref().and_then(run_stage_view),
         "surface": run.as_ref().and_then(|r| r.surface.clone()),
         "execution": run.as_ref().and_then(|r| r.execution.clone()),
@@ -1567,16 +1626,34 @@ fn fleet_body(core: &Core, engine: &Engine) -> Value {
         .works
         .values()
         .map(|work| {
-            let run = registry.run_view(&work.id);
+                // `registry.run_view` alone only reaches the bounded
+                // in-memory cache (`TERMINAL_RUN_CACHE_CAPACITY`); once a
+                // terminal run ages out of it, `resolve_run`'s journal-
+                // replay fallback is what `work_view` already relies on to
+                // keep `sgt work show` correct for the identical work. This
+                // row must use the same fallback, or an evicted work's
+                // `state` here would silently fall back to plain
+                // `completed` (ADR 0007(b)) while `work show` still says
+                // `completed_dirty` for it.
+            let run = resolve_run(core, work, registry.run_view(&work.id));
             let mut row = serde_json::to_value(work).unwrap_or(Value::Null);
             if let Some(object) = row.as_object_mut() {
+                // ADR 0007(b): `sgt work list` is where an operator looks
+                // first, and its plain `state` column must not read
+                // `completed` for a closing stage that never actually
+                // advanced the branch and left the worktree dirty.
+                object.insert(
+                    "state".to_string(),
+                    json!(reported_state(work, run.as_ref())),
+                );
                 object.insert(
                     "stage".to_string(),
-                    run.and_then(run_stage_view).unwrap_or(Value::Null),
+                    run.as_ref().and_then(run_stage_view).unwrap_or(Value::Null),
                 );
                 object.insert(
                     "resolved_backend".to_string(),
-                    run.and_then(|r| r.backend.clone())
+                    run.as_ref()
+                        .and_then(|r| r.backend.clone())
                         .map_or(Value::Null, Value::String),
                 );
                 // MVP-3's envelope-visibility item, folded onto the fleet
@@ -1585,7 +1662,7 @@ fn fleet_body(core: &Core, engine: &Engine) -> Value {
                 // turns-spent/cap/ceiling `sgt work show` does, no second
                 // request per work required.
                 let default_run = WorkRun::default();
-                let run_ref = run.unwrap_or(&default_run);
+                let run_ref = run.as_ref().unwrap_or(&default_run);
                 object.insert(
                     "envelope".to_string(),
                     json!({
@@ -4244,6 +4321,139 @@ mod tests {
         assert_eq!(
             decode_partial_assistant_text(archive.as_bytes()),
             "first second"
+        );
+    }
+
+    /// ADR 0007(b) hardening found in review of the feature's first cut:
+    /// `fleet_body` originally read a work's run straight out of
+    /// `registry.run_view`'s *bounded* terminal-run cache, with no fallback
+    /// once an entry aged out — the exact silent-revert gap `work_view`'s
+    /// own `resolve_run` call already closes for `sgt work show`. Left
+    /// unfixed, `sgt work list` would report plain `completed` for a
+    /// stranded completion the moment its run fell out of the cache, while
+    /// `sgt work show` for the identical id still said `completed_dirty`.
+    ///
+    /// Cheap at the unit level, the same way `projection.rs`'s own
+    /// `the_terminal_run_cache_itself_stays_bounded_under_churn_beyond_its_
+    /// capacity` is: journal commits directly against a bare `Core`, no
+    /// HTTP, no daemon.
+    #[test]
+    fn a_stranded_completion_survives_terminal_run_cache_eviction() {
+        use crate::runtime::testing;
+
+        fn surface(work_id: &str) -> Value {
+            json!({"surface": {
+                "work_id": work_id,
+                "root": "/data/surfaces/x",
+                "bindings": [{
+                    "repository": "solo",
+                    "source_path": "/repos/solo",
+                    "base_branch": "main",
+                    "base_sha": "0".repeat(40),
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "head_sha": "0".repeat(40),
+                }],
+            }})
+        }
+
+        fn stranded_teardown(work_id: &str) -> Value {
+            json!({"report": {
+                "work_id": work_id,
+                "clean": false,
+                "bindings": [{
+                    "repository": "solo",
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "disposition": "retained_dirty",
+                    "changes": " M half-done.rs",
+                    // Never advanced past the base SHA `surface` recorded.
+                    "final_sha": "0".repeat(40),
+                }],
+            }})
+        }
+
+        fn ordinary_teardown(work_id: &str) -> Value {
+            json!({"report": {
+                "work_id": work_id,
+                "clean": true,
+                "bindings": [{
+                    "repository": "solo",
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "disposition": "removed",
+                }],
+            }})
+        }
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+
+        let stranded_id = "01STRANDED0000000001";
+        testing::submit(&mut core, stranded_id, "declares a commit, never makes one");
+        testing::commit(
+            &mut core,
+            stranded_id,
+            KIND_SURFACE_MATERIALIZED,
+            surface(stranded_id),
+        );
+        testing::commit(&mut core, stranded_id, KIND_WORK_COMPLETED, json!({}));
+        testing::commit(
+            &mut core,
+            stranded_id,
+            KIND_SURFACE_TORN_DOWN,
+            stranded_teardown(stranded_id),
+        );
+
+        // Churn ordinary completions past the terminal-run cache's own bound
+        // (`projection.rs`'s `TERMINAL_RUN_CACHE_CAPACITY`, 512) so the
+        // stranded work above — submitted first, so it is the oldest —
+        // actually ages out of it.
+        for i in 0..600 {
+            let id = format!("01CACHECHURN{i:06}");
+            testing::submit(&mut core, &id, "cache churn");
+            testing::commit(&mut core, &id, KIND_SURFACE_MATERIALIZED, surface(&id));
+            testing::commit(&mut core, &id, KIND_WORK_COMPLETED, json!({}));
+            testing::commit(
+                &mut core,
+                &id,
+                KIND_SURFACE_TORN_DOWN,
+                ordinary_teardown(&id),
+            );
+        }
+
+        assert!(
+            core.registry.state().run_view(stranded_id).is_none(),
+            "the stranded work's run must actually have aged out of the \
+             bounded cache for this test to prove anything"
+        );
+
+        let backends = BackendRegistry::new().with(Arc::new(
+            crate::backend::fake::FakeBackend::new(crate::backend::fake::FAKE_BACKEND_NAME),
+        ));
+        let engine = Engine::new(
+            Arc::new(backends),
+            Some(crate::backend::fake::FAKE_BACKEND_NAME.to_string()),
+            dir.path(),
+        );
+
+        // `fleet_body` is what `sgt work list` actually serves. Before this
+        // fix it read the run straight out of the bounded cache and had no
+        // fallback once an entry aged out, so it would silently report
+        // plain `completed` here — exactly what `sgt work show` (`work_view`,
+        // via `resolve_run`) never does for the same work.
+        let fleet = fleet_body(&core, &engine);
+        let row = fleet["works"]
+            .as_array()
+            .expect("works")
+            .iter()
+            .find(|w| w["id"] == stranded_id)
+            .expect("the evicted work is still listed");
+        assert_eq!(
+            row["state"], "completed_dirty",
+            "an evicted stranded completion must not silently revert to plain \
+             completed in `sgt work list` just because its run cache entry \
+             aged out: {row}"
         );
     }
 }

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -165,6 +165,27 @@ pub const CLAUDE_BIN_ENV: &str = "SGT_CLAUDE_BIN";
 /// (measured on 2.1.226 — see [`actor_question`]).
 pub const POST_TURN_SUMMARY_SUBTYPE: &str = "post_turn_summary";
 
+/// ADR 0007(a): the execution-model half of the actor runtime contract.
+/// Stated here, at the same composition step that builds the stage's first
+/// turn (`ClaudeAdapter::launch`), alongside — but never asserting — the
+/// environment guarantee ADR 0006 will eventually compose at this same
+/// seam; that half does not exist yet (#60) and is out of scope here.
+///
+/// This is *why* #94 happened twice on 2026-08-14: a headless `claude -p`
+/// turn is one process that runs to completion and exits. There is no
+/// notification, callback, or wakeup when something it backgrounded finishes
+/// after the turn ends — the actor considered exactly that mechanism,
+/// correctly ruled it inapplicable, and then acted as though it existed
+/// anyway, because nothing had ever told it otherwise. Composed into every
+/// stage's first turn rather than left to a dispatch brief to restate.
+pub const EXECUTION_MODEL_CONTRACT: &str = "\
+Execution model: this is a headless turn. You get one turn and no callbacks \
+— nothing wakes you when a command you backgrounded finishes after you end \
+your turn. If a command might take a while, run it in the foreground with \
+an adequate timeout and wait for it to finish before ending your turn. Do \
+not background a long-running command and end your turn expecting a \
+notification to resume you; none will come.";
+
 /// The actor's question from one `post_turn_summary` line, when it asked one.
 ///
 /// **Measured, 2.1.226** (`docs/gauntlet/notes/n3-claude-ask-measurement.md`),
@@ -1588,9 +1609,15 @@ impl Backend for ClaudeBackend {
                 },
             );
         }
-        // §12: procedure is data — intent plus the stage's CONTEXT.md,
-        // verbatim, uninterpreted.
-        let prompt = format!("{}\n\n{}", request.intent, request.context);
+        // ADR 0007(a) precedes both: sergeant's own execution-model
+        // statement, not stage content, so it is never subject to §12's
+        // "verbatim, uninterpreted" rule the way intent and CONTEXT.md are.
+        // §12 itself: procedure is data — intent plus the stage's
+        // CONTEXT.md, verbatim, uninterpreted.
+        let prompt = format!(
+            "{EXECUTION_MODEL_CONTRACT}\n\n{}\n\n{}",
+            request.intent, request.context
+        );
         if let Err(e) = self.spawn_turn(&request.execution_id, prompt) {
             // A failed launch must not leave a phantom execution that
             // OBSERVE would misread as an interrupted-but-resumable turn.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1627,6 +1627,25 @@ mod tests {
     }
 
     #[test]
+    fn adr_0007b_completed_dirty_is_not_painted_like_ordinary_in_flight_work() {
+        // Review of the first cut found `completed_dirty` fell through to
+        // the default arm and was painted the same Cyan as ordinary
+        // in-flight work — indistinguishable from a run still running, in
+        // the one place an operator scans a whole fleet at a glance.
+        assert_eq!(
+            state_style("completed_dirty").fg,
+            Some(Color::Yellow),
+            "a stranded completion needs a second look, so it belongs with \
+             needs_input/waiting, not the default Cyan in-flight bucket"
+        );
+        assert_ne!(
+            state_style("completed_dirty").fg,
+            state_style("active").fg,
+            "must be visually distinct from ordinary in-flight work"
+        );
+    }
+
+    #[test]
     fn only_state_bearing_events_ask_for_a_refresh() {
         let mut app = App::new();
         assert!(app.observe(&json!({"seq": 7, "kind": "work.completed"})));

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -439,7 +439,10 @@ fn field(value: &Value, key: &str) -> String {
 fn state_style(state: &str) -> Style {
     let color = match state {
         "completed" => Color::Green,
-        "needs_input" | "waiting" => Color::Yellow,
+        // ADR 0007(b): a stranded completion is terminal, not a plain
+        // success — group it with the other "needs a look" states rather
+        // than the default Cyan bucket ordinary in-flight work falls into.
+        "needs_input" | "waiting" | "completed_dirty" => Color::Yellow,
         "failed" | "blocked" | "canceled" => Color::Red,
         _ => Color::Cyan,
     };

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -540,6 +540,29 @@ mod tests {
     }
 
     #[test]
+    fn adr_0007b_completed_dirty_classifies_as_completed_and_is_terminal() {
+        // ADR 0007(b) review fix: before this, `classify` only recognized
+        // plain `completed`, so a stranded completion's snapshot state
+        // fell into `None` ("not watched") and a scoped `--follow` watcher
+        // would never see it as terminal — it would hang forever
+        // (`classify_snapshot` feeds `snapshot["work"]["state"]` straight
+        // into this function).
+        assert_eq!(
+            WatchState::classify("completed_dirty"),
+            Some(WatchState::Completed),
+            "a stranded completion must classify into the same watch \
+             bucket as an ordinary completed run"
+        );
+        assert!(
+            WatchState::classify("completed_dirty")
+                .expect("classifies")
+                .is_terminal(),
+            "a scoped --follow watcher must exit on completed_dirty, not \
+             hang waiting for a notice that will never come"
+        );
+    }
+
+    #[test]
     fn only_completed_and_canceled_are_terminal_for_scoped_follow() {
         for (state, terminal) in [
             (WatchState::NeedsInput, false),

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -89,7 +89,13 @@ impl WatchState {
             "blocked" => Some(Self::Blocked),
             "waiting" => Some(Self::Waiting),
             "failed" => Some(Self::Failed),
-            "completed" => Some(Self::Completed),
+            // ADR 0007(b): a stranded completion is still terminal — the
+            // Work is done, not blocked or failed — so it belongs in the
+            // same watch bucket as an ordinary `completed`. `watch` forwards
+            // the snapshot verbatim (`emit`, below), so the notice an
+            // operator sees still reads `completed_dirty`; only whether the
+            // loop notices and exits changes here.
+            "completed" | "completed_dirty" => Some(Self::Completed),
             "canceled" => Some(Self::Canceled),
             _ => None,
         }

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -2341,6 +2341,129 @@ async fn a_dirty_worktree_is_retained_and_recorded_at_teardown() {
     handle.shutdown().await;
 }
 
+/// ADR 0007(b): a closing stage that declares a commit as its durable
+/// outcome must not be reported as plain `completed` when the branch never
+/// advanced and the worktree was left dirty — the safety net for when an
+/// actor guesses wrong about its own runtime model anyway (independent of
+/// ADR 0007(a), which is what a headless turn's own first-turn prompt
+/// states).
+///
+/// Reproduces the real shape: a stage parks in `waiting` (so its worktree is
+/// never torn down), the test dirties that worktree exactly the way an
+/// actor stranding mid-command would, and the run is then driven to a
+/// normal `StageCompleted` signal for every remaining stage — the fake
+/// backend never runs `git commit`, so the branch never advances past its
+/// base SHA either. The engine still learns nothing about what a commit
+/// *is*: the check only ever compares a teardown disposition and a SHA the
+/// pointer already computed (`docs/adr/0007-actor-runtime-contract.md`).
+#[tokio::test]
+async fn a_stranded_completion_is_not_reported_as_plain_completed() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let repo = repos.path().join("solo");
+    init_repo(&repo);
+    write_two_stage_workflow(&repo);
+
+    let (registry, _fake) = one_fake([
+        FakeStep::waiting("needs a second look"),
+        FakeStep::complete_with("first done"),
+        FakeStep::complete_with("second done"),
+    ]);
+    let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
+    let client = http();
+
+    let (_, body) = submit(
+        &client,
+        &handle,
+        &repo,
+        "declares a commit, never makes one",
+        json!({"workflow": "tiny"}),
+    )
+    .await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    assert_eq!(
+        body["work"]["state"], "waiting",
+        "the first script step parks the run without tearing anything down: {body}"
+    );
+    let worktree = PathBuf::from(
+        body["surface"]["bindings"][0]["worktree_path"]
+            .as_str()
+            .expect("worktree"),
+    );
+
+    // The stage's own actor would have run `git commit` here; it strands
+    // instead, exactly the shape #94 produced twice on 2026-08-14.
+    std::fs::write(worktree.join("half-done.rs"), "fn main() {}\n").expect("dirty the worktree");
+
+    // Retry re-enters the stage (waiting -> active is legal), and the
+    // scripted run then completes every remaining stage normally: the fake
+    // backend signals `StageCompleted` twice in a row and never touches
+    // git, so this one HTTP call drives the whole run to `completed` and
+    // through teardown.
+    let (status, body) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/retry"),
+        json!({"command_id": ulid()}),
+    )
+    .await;
+    assert_eq!(status, 200, "retry rejected: {body}");
+
+    // The pointer's own facts prove the shape: the branch never advanced
+    // past its base SHA, and the worktree it left behind is still dirty.
+    assert_eq!(body["teardown"]["clean"], false, "{body}");
+    assert_eq!(
+        body["output"]["repositories"][0]["disposition"], "retained_dirty",
+        "{body}"
+    );
+    assert!(
+        worktree.join("half-done.rs").is_file(),
+        "a dirty worktree must survive teardown: {body}"
+    );
+
+    // The one thing an operator reads first must not say plain `completed`.
+    assert_ne!(
+        body["work"]["state"], "completed",
+        "a closing stage that declared a commit but never advanced the \
+         branch, leaving the worktree dirty, must not be reported as plain \
+         success: {body}"
+    );
+    assert_eq!(
+        body["work"]["state"], "completed_dirty",
+        "the honest label the pointer already supports: {body}"
+    );
+
+    // The same fact must be visible from `sgt work list` — the place an
+    // operator looks first, per the ADR's own framing of the problem — not
+    // only from `work show`'s fuller record.
+    let list = get(&client, &handle, "/v1/work").await;
+    let row = list["works"]
+        .as_array()
+        .expect("works")
+        .iter()
+        .find(|w| w["id"] == work_id)
+        .expect("the work is listed");
+    assert_ne!(row["state"], "completed", "{list}");
+    assert_eq!(row["state"], "completed_dirty", "{list}");
+
+    // The persisted lifecycle state is untouched: this run is genuinely
+    // terminal (retry refuses it, exactly as any other `completed` work),
+    // never blocked or failed. Only the reported label changed.
+    let (status, _) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/retry"),
+        json!({"command_id": ulid()}),
+    )
+    .await;
+    assert_eq!(
+        status, 409,
+        "a stranded completion is still `Completed` underneath — terminal, not retryable"
+    );
+
+    handle.shutdown().await;
+}
+
 /// A multi-repository submission where a later repository cannot be
 /// materialized: the earlier ones already have a real branch and worktree in
 /// the user's own checkouts. Those are rolled back and the report is

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -2312,13 +2312,6 @@ fn adr_0007a_the_first_turn_states_the_execution_model() {
         first.stdin
     );
     assert!(
-        EXECUTION_MODEL_CONTRACT.contains("one turn")
-            && EXECUTION_MODEL_CONTRACT.contains("no callbacks")
-            && EXECUTION_MODEL_CONTRACT.contains("foreground"),
-        "the statement must actually say what #94 needed said: one turn, \
-         no callbacks, run long commands in the foreground: {EXECUTION_MODEL_CONTRACT:?}"
-    );
-    assert!(
         first.stdin.ends_with("the intent||the stage context"),
         "the intent and CONTEXT.md must still reach the actor, verbatim, \
          after the execution model: {:?}",

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -59,8 +59,8 @@ use tempfile::TempDir;
 
 use sergeant_rs::api::Core;
 use sergeant_rs::backend::claude::{
-    CLAUDE_BACKEND_NAME, ClaudeBackend, ClaudeConfig, PinVerdict, preflight_model_pin,
-    verify_model_pin,
+    CLAUDE_BACKEND_NAME, ClaudeBackend, ClaudeConfig, EXECUTION_MODEL_CONTRACT, PinVerdict,
+    preflight_model_pin, verify_model_pin,
 };
 use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend, FakeStep};
 use sergeant_rs::backend::{
@@ -2257,8 +2257,10 @@ fn d2_the_launch_grammar_is_session_pinned_then_resumed() {
         "adapter config env is applied"
     );
     assert_eq!(
-        first.stdin, "the intent||the stage context",
-        "§12: intent plus the stage's CONTEXT.md, verbatim, on stdin"
+        first.stdin,
+        format!("{EXECUTION_MODEL_CONTRACT}||the intent||the stage context"),
+        "ADR 0007(a) precedes it, then §12: intent plus the stage's \
+         CONTEXT.md, verbatim, on stdin"
     );
 
     let second = &launches[1];
@@ -2278,6 +2280,50 @@ fn d2_the_launch_grammar_is_session_pinned_then_resumed() {
         second.argv
     );
     assert_eq!(second.stdin, "second turn");
+}
+
+/// ADR 0007(a): whatever composes an actor's context states what wakes it.
+/// A headless turn is one process that runs to completion and exits — there
+/// is no callback when a backgrounded command finishes after the turn ends
+/// — and #94 happened twice on 2026-08-14 because nothing told the actor
+/// that. This pins that the statement actually reaches the actor, on the
+/// stage's very first turn, ahead of the intent and the stage's own
+/// CONTEXT.md.
+#[test]
+fn adr_0007a_the_first_turn_states_the_execution_model() {
+    let dir = TempDir::new().expect("tempdir");
+    let cwd = TempDir::new().expect("tempdir");
+    let stub = StubClaude::passing(dir.path());
+    let mut config = ClaudeConfig::new(dir.path());
+    config.executable = stub.path.clone();
+    let backend = ClaudeBackend::new(config);
+
+    let mut request = start_request("e-execmodel", cwd.path(), "the intent", None);
+    request.context = "the stage context".to_string();
+    let handle = backend.start(&request).expect("start");
+    wait_settled(&backend, &handle, Duration::from_secs(10));
+
+    let launches = stub.wait_for_launches(1);
+    let first = &launches[0];
+    let stdin_lines: Vec<&str> = first.stdin.split('|').collect();
+    assert_eq!(
+        stdin_lines[0], EXECUTION_MODEL_CONTRACT,
+        "the execution model must precede the intent, not follow or replace it: {:?}",
+        first.stdin
+    );
+    assert!(
+        EXECUTION_MODEL_CONTRACT.contains("one turn")
+            && EXECUTION_MODEL_CONTRACT.contains("no callbacks")
+            && EXECUTION_MODEL_CONTRACT.contains("foreground"),
+        "the statement must actually say what #94 needed said: one turn, \
+         no callbacks, run long commands in the foreground: {EXECUTION_MODEL_CONTRACT:?}"
+    );
+    assert!(
+        first.stdin.ends_with("the intent||the stage context"),
+        "the intent and CONTEXT.md must still reach the actor, verbatim, \
+         after the execution model: {:?}",
+        first.stdin
+    );
 }
 
 /// MVP-2 D2 item 1 (the `--setting-sources` de-leak), pinned against the

--- a/tests/m7_docker_executor.rs
+++ b/tests/m7_docker_executor.rs
@@ -1426,7 +1426,17 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
             .json()
             .await
             .expect("json");
-        if polled["work"]["state"] == "completed" || polled["work"]["state"] == "blocked" {
+        // ADR 0007(b): this test's "20-close" stage is a bare fake actor
+        // that signals completion without ever running `git commit` — it
+        // exists to prove the execute stage's artifact reaches a following
+        // actor through the worktree, not to exercise a real closing
+        // stage's commit procedure. So the branch never advances and the
+        // container's `validated.txt` is left dirty, and the honest label
+        // for that is `completed_dirty`, not plain `completed`.
+        if polled["work"]["state"] == "completed"
+            || polled["work"]["state"] == "completed_dirty"
+            || polled["work"]["state"] == "blocked"
+        {
             last = polled;
             break;
         }
@@ -1438,8 +1448,10 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
     }
 
     assert_eq!(
-        last["work"]["state"], "completed",
-        "the mixed workflow must complete end to end: {last}"
+        last["work"]["state"], "completed_dirty",
+        "the mixed workflow completes end to end, but its stub closing stage \
+         never commits the execute stage's artifact, so it must not be \
+         reported as plain success (ADR 0007(b)): {last}"
     );
 
     // §12: sergeant never interprets the container's output — but the


### PR DESCRIPTION
Proposal §5.3, ADR 0007. Work `01M014NN1W1S38X3RVCPQ3YJBP` (`implement`, 2/20 turns), plus two gate fixes.

`Refs #94`, `Refs #60` — neither closes. #94 closes when the environment guarantee lands with the passthrough; #60 closes with the passthrough itself.

## Part (a) — the execution model is now stated, not guessed

Every headless turn's first prompt is preceded by sergeant's own statement: one turn, no callbacks, run long commands in the foreground. Composed at `ClaudeAdapter::launch` — deliberately the same seam ADR 0006's environment guarantee will use, so the two halves compose rather than collide, and a brief author never restates it.

This is what #94 was missing both times. The second transcript is the clearest evidence: the actor considered a wakeup mechanism, correctly ruled it inapplicable, then concluded *"I'll simply wait for the background task notification instead."* That is correct reasoning from premises nobody supplied.

## Part (b) — `completed` can no longer mean "committed nothing"

A closing stage that declares a commit but leaves the branch at its base SHA with a dirty worktree now reads `completed_dirty` in both `sgt work show` and `sgt work list`.

**The engine still learns nothing about commits.** `stranded_completion` reads only the pointer's own data — the teardown binding's `final_sha` compared against the surface binding's `base_sha`, plus the disposition. `Work.state` remains `Completed`; only the string an operator reads first changes. That keeps NORTH-STAR's "the engine learns no output vocabulary; only the pointer is core" intact, which the brief flagged as the trap to avoid.

## What the Work's own review caught

Introducing a new reported state left three places still speaking the old one:

- `sgt watch` didn't recognise `completed_dirty` as terminal, so `--follow` would have hung forever on a stranded completion.
- The TUI coloured it the same Cyan as ordinary in-flight work.
- `sgt work list` read a work's run only from the bounded terminal-run cache with no journal-replay fallback — so a stranded completion's row would silently revert to plain `completed` once its run aged out, while `sgt work show` for the same work still said `completed_dirty`. Two surfaces disagreeing about one fact, visible only after cache eviction.

That third one would have passed every test that runs immediately after a Work finishes.

## What the shipping gate caught

Two findings, both `auto-fix`, both taken:

- **`redundant-content-assertion`** — a test asserted substrings of the Rust constant itself rather than anything delivered through the interface, when the preceding assertions already proved `first.stdin` starts with that constant verbatim. A test mirroring its implementation.
- **`adr-consequences-stale`** — ADR 0007 still read "does not exist yet… not-yet-filed implementation work" while this branch implemented both halves.

That second one is the **second time tonight** the gate caught ADR staleness (ADR 0008 earlier). Both times the drift was identical, and neither the Work nor the orchestrating session applied the repo's own refresh-on-ship convention unprompted. That is a gap in how the briefs are written, not a one-off — subsequent briefs carry it explicitly.

## Verification

Full suite 12 suites / 0 failures; `fmt` and `clippy -D warnings` clean. Shipping gate **passed**.

The boundary claim was verified rather than accepted: `stranded_completion`'s inputs are only `run.teardown` and `run.surface`, and its doc states the invariant directly — *"every other state-machine consumer still sees `Completed`; only the string an operator reads first changes."*
