### PR TITLE
W3: harness hygiene — #108's marker leak, #113's rig reaper, #95's clock guard

### DIFF
--- a/scripts/perf/common-selftest.sh
+++ b/scripts/perf/common-selftest.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# common-selftest.sh — regression coverage for #95: `perf_now_ns` and
+# `perf_mark` in common.sh must fail loudly when neither clock branch works,
+# rather than feed a malformed value (macOS's BSD `date +%s%N` prints the
+# epoch seconds followed by a literal "N", e.g. "1786728341N") into
+# arithmetic. This estate has no macOS host, so the real failure mode
+# (`EPOCHREALTIME` unset because bash is 3.2, `date` lacking `%N`) is
+# reproduced here on Linux by unsetting `EPOCHREALTIME` — which forces the
+# same fallback branch macOS always takes — and shadowing `date` with a
+# BSD-shaped stub on `PATH`.
+#
+# R-S0-12 "code is code": common.sh's clock functions changed executable
+# behavior and need a test that fails when the fix is reverted (LESSONS L7).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON="$SCRIPT_DIR/common.sh"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/perf-common-selftest.XXXXXX")"
+FAIL=0
+
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAIL=1
+}
+pass() {
+  echo "PASS: $1"
+}
+
+# A BSD/macOS-shaped `date`: honors every flag common.sh actually uses
+# (`+%s%N`, plus whatever else a caller passes) except `%N`, which it passes
+# through literally — exactly what real BSD date does, because it has no
+# idea what `%N` means. Delegates everything else to the *real* date
+# binary, resolved to an absolute path now, before this stub goes on
+# `PATH` — otherwise the fallback line would exec itself.
+mk_bsd_date_stub() {
+  local dir="$1" real_date
+  real_date="$(command -v date)"
+  mkdir -p "$dir"
+  cat >"$dir/date" <<EOF
+#!/bin/sh
+case "\$1" in
+  +%s%N) printf '%sN\n' "\$($real_date +%s)" ;;
+  *) exec "$real_date" "\$@" ;;
+esac
+EOF
+  chmod +x "$dir/date"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1 (baseline): on this host, with EPOCHREALTIME available, perf_now_ns
+# and perf_mark must still work exactly as before — the guard must not
+# false-positive on the fast path.
+# ---------------------------------------------------------------------------
+out="$(bash -c '
+  set -u
+  source "'"$COMMON"'"
+  perf_now_ns
+' 2>"$WORK/baseline.err")"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "baseline (EPOCHREALTIME present): expected exit 0, got $rc: $(cat "$WORK/baseline.err")"
+elif ! [[ "$out" =~ ^[0-9]+$ ]]; then
+  fail "baseline (EPOCHREALTIME present): expected a plain integer, got '$out'"
+else
+  pass "baseline (EPOCHREALTIME present): perf_now_ns returns a plain integer"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2 (#95 regression, perf_now_ns): EPOCHREALTIME unset + BSD-shaped
+# `date` must make perf_now_ns fail loudly — nonzero exit, a stderr message
+# naming the cause — never a value containing a stray "N".
+# ---------------------------------------------------------------------------
+stub="$WORK/bsd-date"
+mk_bsd_date_stub "$stub"
+out="$(PATH="$stub:$PATH" bash -c '
+  set -u
+  unset EPOCHREALTIME
+  source "'"$COMMON"'"
+  perf_now_ns
+' 2>"$WORK/t2.err")"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  fail "#95 (perf_now_ns, no working clock): expected nonzero exit, got 0 (output: '$out')"
+elif [[ "$out" == *N* ]]; then
+  fail "#95 (perf_now_ns, no working clock): malformed value leaked to stdout: '$out'"
+elif ! grep -qF 'no working nanosecond clock' "$WORK/t2.err"; then
+  fail "#95 (perf_now_ns, no working clock): stderr did not name the cause: $(cat "$WORK/t2.err")"
+else
+  pass "#95 (perf_now_ns, no working clock): fails loudly instead of emitting a malformed value"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3 (#95 regression, perf_mark): same fault, through the fork-free
+# nameref-style helper every scenario actually calls.
+# ---------------------------------------------------------------------------
+out="$(PATH="$stub:$PATH" bash -c '
+  set -u
+  unset EPOCHREALTIME
+  source "'"$COMMON"'"
+  perf_mark t0
+  printf "%s" "$t0"
+' 2>"$WORK/t3.err")"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  fail "#95 (perf_mark, no working clock): expected nonzero exit, got 0 (t0='$out')"
+elif [[ "$out" == *N* ]]; then
+  fail "#95 (perf_mark, no working clock): malformed value leaked into the marked variable: '$out'"
+elif ! grep -qF 'no working nanosecond clock' "$WORK/t3.err"; then
+  fail "#95 (perf_mark, no working clock): stderr did not name the cause: $(cat "$WORK/t3.err")"
+else
+  pass "#95 (perf_mark, no working clock): fails loudly instead of emitting a malformed value"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: EPOCHREALTIME unset but a GNU-shaped `date` (this host's real
+# fallback shape) must still work — the guard must accept a genuinely
+# numeric fallback, not just reject everything once EPOCHREALTIME is gone.
+# ---------------------------------------------------------------------------
+out="$(bash -c '
+  set -u
+  unset EPOCHREALTIME
+  source "'"$COMMON"'"
+  perf_now_ns
+' 2>"$WORK/t4.err")"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "GNU date fallback: expected exit 0, got $rc: $(cat "$WORK/t4.err")"
+elif ! [[ "$out" =~ ^[0-9]+$ ]]; then
+  fail "GNU date fallback: expected a plain integer, got '$out'"
+else
+  pass "GNU date fallback: perf_now_ns still works when EPOCHREALTIME is unset but date supports %N"
+fi
+
+echo
+if [ "$FAIL" -ne 0 ]; then
+  echo "common-selftest: FAILURES ABOVE"
+  exit 1
+fi
+echo "common-selftest: all checks passed"
+exit 0

--- a/scripts/perf/common-selftest.sh
+++ b/scripts/perf/common-selftest.sh
@@ -11,6 +11,12 @@
 #
 # R-S0-12 "code is code": common.sh's clock functions changed executable
 # behavior and need a test that fails when the fix is reverted (LESSONS L7).
+#
+# Ponytail rung R2 (new file, existing pattern): this is a new file, but it
+# reuses scripts/coverage/selftest.sh's already-established shape verbatim —
+# a standalone bash self-test wired into `cargo test` via a subprocess check
+# (see tests/m6_surfaces.rs's the_coverage_harness_grades_its_own_accounting)
+# rather than a new harness invented for this one guard.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/perf/common.sh
+++ b/scripts/perf/common.sh
@@ -47,8 +47,28 @@ perf_now_ns() {
     while [ ${#frac} -lt 9 ]; do frac="${frac}0"; done
     printf '%s%s\n' "$sec" "${frac:0:9}"
   else
-    date +%s%N
+    local ns
+    ns="$(date +%s%N)"
+    perf_require_numeric_ns "$ns"
+    printf '%s\n' "$ns"
   fi
+}
+
+# #95: `date +%s%N` is a GNU coreutils extension — BSD/macOS `date` (the only
+# path bash 3.2's macOS ever reaches, since EPOCHREALTIME needs bash 5.0)
+# silently emits the epoch seconds followed by a literal `N`, e.g.
+# "1786728341N". Fed straight into arithmetic that would be a silently wrong
+# measurement, not a crash — worse for a perf harness than refusing to run.
+# This is the one guard in scope here; which working clock macOS gets
+# instead (perl -MTime::HiRes, python3 time.time_ns() with its fork cost
+# measured, or documented millisecond resolution) is an open parameter left
+# for the platform that can actually time the candidates.
+perf_require_numeric_ns() {
+  case "$1" in
+    ''|*[!0-9]*)
+      perf_die "no working nanosecond clock: \$EPOCHREALTIME is unset (needs bash 5.0+; macOS ships 3.2.57) and 'date +%s%N' returned non-numeric '$1' (%N is a GNU coreutils extension BSD/macOS date does not implement). See issue #95 for the clock this platform still needs."
+      ;;
+  esac
 }
 
 # perf_mark VAR — assign "now" in ns to VAR without forking a subshell.
@@ -67,6 +87,7 @@ perf_mark() {
     __perf_mark_val="${__perf_mark_sec}${__perf_mark_frac:0:9}"
   else
     __perf_mark_val="$(date +%s%N)"
+    perf_require_numeric_ns "$__perf_mark_val"
   fi
   printf -v "$1" '%s' "$__perf_mark_val"
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -482,6 +482,11 @@ async fn test_hold_wait(path: String, deadman: Duration, poll: Duration) -> Resu
     // involved), so `Drop` runs every time and an RAII guard is sufficient;
     // relying on the caller to remember cleanup only covers whichever path
     // that particular caller happens to exercise.
+    //
+    // Ponytail rung R2: reuses the RAII-guard-on-Drop idiom this crate
+    // already relies on elsewhere for exactly this shape of problem
+    // (tests/support/mod.rs's DataDir reaps its daemons the same way) rather
+    // than inventing a new cleanup mechanism for one call site.
     struct ReadyMarker(String);
     impl Drop for ReadyMarker {
         fn drop(&mut self) {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -476,6 +476,19 @@ async fn test_hold_wait(path: String, deadman: Duration, poll: Duration) -> Resu
     // falls through to the same bounded wait/timeout rather than a distinct
     // error variant.
     let _ = std::fs::write(&ready, b"");
+    // #108: this marker must not outlive the wait on *either* exit — the
+    // happy path (release path appears) or the dead-man path (it never
+    // does). Both are ordinary returns from this `async fn` (no signal is
+    // involved), so `Drop` runs every time and an RAII guard is sufficient;
+    // relying on the caller to remember cleanup only covers whichever path
+    // that particular caller happens to exercise.
+    struct ReadyMarker(String);
+    impl Drop for ReadyMarker {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+    let _ready_marker = ReadyMarker(ready);
     let deadline = Instant::now() + deadman;
     loop {
         if std::path::Path::new(&path).exists() {
@@ -802,12 +815,52 @@ mod tests {
         .await;
 
         releaser.await.expect("releaser task must not panic");
+        // The `.ready` marker is `test_hold_wait`'s own artifact — its RAII
+        // guard removes it on this return, so only the release path this
+        // test itself created needs cleaning up here (#108).
         let _ = std::fs::remove_file(&path);
-        let _ = std::fs::remove_file(format!("{path}.ready"));
 
         assert!(
             result.is_ok(),
             "the hold must resolve Ok(()) once the release path appears: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hold_wait_removes_its_ready_marker_even_when_the_deadman_fires() {
+        // #108: the dead-man branch's premise is that the release path never
+        // appears, so this is exactly the path a plain `let _ =
+        // std::fs::remove_file` in the *test* body cannot cover — cleanup
+        // has to live in `test_hold_wait` itself. Revert the RAII guard and
+        // this fails: the `.ready` marker survives the timeout.
+        let path = std::env::temp_dir()
+            .join(format!(
+                "sgt-watch-test-hold-deadman-cleanup-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ))
+            .to_string_lossy()
+            .into_owned();
+        let ready = format!("{path}.ready");
+        // Guard against a stale file from a previous failed run confusing
+        // this assertion.
+        let _ = std::fs::remove_file(&ready);
+
+        let result = test_hold_wait(
+            path.clone(),
+            Duration::from_millis(60),
+            Duration::from_millis(5),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(WatchError::TestHoldTimedOut { .. })),
+            "expected the dead-man timeout, got {result:?}"
+        );
+        assert!(
+            !std::path::Path::new(&ready).exists(),
+            "the .ready marker at {ready:?} must not survive the dead-man branch \
+             (#108: it leaked one such file per suite run into tmpfs /tmp)"
         );
     }
 

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -3387,6 +3387,135 @@ fn the_coverage_harness_grades_its_own_accounting() {
     );
 }
 
+// ---------------------------------------------------- rig-reaper self-test
+
+/// #113: eight `TempDir`-shaped rigs, 1.7 GB, left behind by suite runs that
+/// got `SIGKILL`ed mid-run — `Drop` never runs for those, so the fix is a
+/// reaper that runs at the start of the *next* run rather than another
+/// destructor. `support::reap_orphaned_rigs` is what does that sweep; this
+/// grades it directly rather than trusting a mechanism nothing exercises.
+#[test]
+fn the_rig_reaper_removes_only_orphans_whose_owner_process_is_actually_dead() {
+    let base = TempDir::new().expect("scratch base for the reaper test");
+    let base = base.path();
+
+    // An orphan: its marker names a pid this test can prove is dead, because
+    // it spawned and `wait()`ed on it itself — no ambiguity about whether
+    // the process table still holds it.
+    let mut dead = Command::new("true")
+        .spawn()
+        .expect("spawn a short-lived process");
+    let dead_pid = dead.id();
+    dead.wait()
+        .expect("wait for the short-lived process to exit");
+    let orphan = base.join("orphan-rig");
+    std::fs::create_dir_all(&orphan).expect("create fake orphaned rig");
+    std::fs::write(
+        orphan.join(support::RIG_OWNER_PID_FILE),
+        dead_pid.to_string(),
+    )
+    .expect("write dead owner-pid marker");
+
+    // A live rig: its marker names this very test process, which is alive
+    // for the whole test — reaping it would be exactly the "eats a live
+    // run's state" defect the issue calls out as worse than the leak.
+    let live = base.join("live-rig");
+    std::fs::create_dir_all(&live).expect("create fake live rig");
+    std::fs::write(
+        live.join(support::RIG_OWNER_PID_FILE),
+        std::process::id().to_string(),
+    )
+    .expect("write live owner-pid marker");
+
+    // A pre-#113 rig: no marker at all. Left alone rather than guessed
+    // about.
+    let unmarked = base.join("unmarked-rig");
+    std::fs::create_dir_all(&unmarked).expect("create fake unmarked rig");
+
+    let reaped = support::reap_orphaned_rigs(base);
+
+    assert_eq!(
+        reaped,
+        vec![orphan.clone()],
+        "exactly the dead-owner rig must be reaped"
+    );
+    assert!(!orphan.exists(), "the orphaned rig must be gone");
+    assert!(
+        live.exists(),
+        "a rig with a live owner must survive the sweep"
+    );
+    assert!(unmarked.exists(), "an unmarked rig must survive the sweep");
+}
+
+/// The same sweep, exercised through `DataDir::new()` itself rather than the
+/// bare function — proving the wiring, not just the mechanism. Runs against
+/// the real disk-backed base (or its `SGT_TEST_TMPDIR` override) because
+/// that is what every suite's `DataDir::new()` actually sweeps; the planted
+/// orphan's pid is independently proven dead the same way as above, so this
+/// is safe to run alongside any other suite sharing that base.
+#[test]
+fn data_dir_new_reaps_an_orphaned_rig_left_by_a_prior_killed_run() {
+    let Some(base) = support::disk_backed_tmp_base() else {
+        eprintln!("SKIPPED-ENV: no disk-backed tmp base on this host");
+        return;
+    };
+    std::fs::create_dir_all(&base).expect("create disk-backed test tmp base dir");
+
+    let mut dead = Command::new("true")
+        .spawn()
+        .expect("spawn a short-lived process");
+    let dead_pid = dead.id();
+    dead.wait()
+        .expect("wait for the short-lived process to exit");
+    let orphan = base.join(format!("sgt-rs-tests-orphan-pin-{}", std::process::id()));
+    std::fs::create_dir_all(&orphan).expect("create fake orphaned rig");
+    std::fs::write(
+        orphan.join(support::RIG_OWNER_PID_FILE),
+        dead_pid.to_string(),
+    )
+    .expect("write dead owner-pid marker");
+
+    let _data_dir = DataDir::new();
+
+    assert!(
+        !orphan.exists(),
+        "DataDir::new() must reap an orphaned rig left under its base at start"
+    );
+}
+
+// -------------------------------------------------- perf clock guard pin
+
+/// #95: `scripts/perf/common.sh`'s `perf_now_ns`/`perf_mark` must fail
+/// loudly when neither clock branch works (macOS: `EPOCHREALTIME` needs
+/// bash 5.0+, BSD `date` has no `%N`), instead of feeding a value like
+/// `"1786728341N"` into arithmetic. Picking the replacement clock is out of
+/// scope (needs real macOS timing); this only pins the guard, exercised on
+/// Linux by forcing the fallback branch (`scripts/perf/common-selftest.sh`'s
+/// own header explains the reproduction). Same pattern as the coverage
+/// harness self-test above: a shell script outside the gate is a script
+/// whose checks are claims, and this suite already owns `scripts/`.
+#[test]
+fn the_perf_clock_guard_fails_loudly_instead_of_a_malformed_timestamp() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = root.join("scripts/perf/common-selftest.sh");
+    assert!(
+        script.exists(),
+        "scripts/perf/common-selftest.sh must exist"
+    );
+
+    let output = Command::new("bash")
+        .arg(&script)
+        .current_dir(&root)
+        .output()
+        .expect("run scripts/perf/common-selftest.sh");
+    assert!(
+        output.status.success(),
+        "the perf clock guard's selftest must pass\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 // ------------------------------------------------------- spawned-daemon rig
 
 /// How the rig's own daemon ended, and what the kernel said about it.

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -102,6 +102,66 @@ pub(crate) fn disk_backed_tmp_base() -> Option<PathBuf> {
     var_tmp.is_dir().then(|| var_tmp.join("sgt-rs-tests"))
 }
 
+/// Marker `[DataDir::new]` writes into every rig it creates, naming the pid
+/// of the process that owns it.
+///
+/// #113: a suite process that gets `SIGKILL`ed mid-run (the R-MVP1-7
+/// ceiling, or the harness killing a backgrounded `cargo test`) never runs
+/// `Drop` — no destructor of any kind reaches a rig left behind that way, so
+/// this marker plus [`reap_orphaned_rigs`] is the mechanism that does,
+/// checked at the start of the *next* run rather than relied on from the
+/// dead one.
+pub(crate) const RIG_OWNER_PID_FILE: &str = ".owner-pid";
+
+fn write_owner_pid(dir: &Path) {
+    let _ = std::fs::write(dir.join(RIG_OWNER_PID_FILE), std::process::id().to_string());
+}
+
+fn pid_is_alive(pid: u32) -> bool {
+    Path::new("/proc").join(pid.to_string()).is_dir()
+}
+
+/// Reap rig directories directly under `base` whose owning process is no
+/// longer alive, returning the paths removed.
+///
+/// This is the start-of-run reaper #113 asks for, not another `Drop` guard —
+/// `Drop` is structurally incapable of running for a `SIGKILL`ed process, so
+/// the only cleanup that survives the way these processes actually die is
+/// one that runs when the *next* run starts. [`DataDir::new`] calls this
+/// before creating its own rig, so it sweeps up whatever the last run left.
+///
+/// A directory with no readable [`RIG_OWNER_PID_FILE`] marker (predates this
+/// fix, or is mid-write) is left alone rather than guessed about, and so is
+/// one whose marker names a pid still present in `/proc` — that second check
+/// is what makes this safe to call from a suite running concurrently with
+/// others sharing the same base directory: reaping a live run's state would
+/// be a worse defect than the leak this closes.
+pub(crate) fn reap_orphaned_rigs(base: &Path) -> Vec<PathBuf> {
+    let mut reaped = Vec::new();
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return reaped;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Ok(contents) = std::fs::read_to_string(path.join(RIG_OWNER_PID_FILE)) else {
+            continue;
+        };
+        let Ok(pid) = contents.trim().parse::<u32>() else {
+            continue;
+        };
+        if pid_is_alive(pid) {
+            continue;
+        }
+        if std::fs::remove_dir_all(&path).is_ok() {
+            reaped.push(path);
+        }
+    }
+    reaped
+}
+
 /// A temporary sergeant data dir that reaps the daemons running on it.
 ///
 /// Construct one wherever a test points the `sgt` binary at a data dir: any
@@ -135,9 +195,13 @@ impl DataDir {
             };
         };
         std::fs::create_dir_all(&base).expect("create disk-backed test tmp base dir");
-        Self {
-            temp: tempfile::Builder::new().tempdir_in(&base).expect("tempdir"),
-        }
+        // #113: sweep up whatever a prior, SIGKILLed run left behind before
+        // adding this run's own rig — the only cleanup point that survives
+        // how those processes actually die.
+        reap_orphaned_rigs(&base);
+        let temp = tempfile::Builder::new().tempdir_in(&base).expect("tempdir");
+        write_owner_pid(temp.path());
+        Self { temp }
     }
 
     /// The path to hand to `--data-dir`.

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -136,6 +136,14 @@ fn pid_is_alive(pid: u32) -> bool {
 /// is what makes this safe to call from a suite running concurrently with
 /// others sharing the same base directory: reaping a live run's state would
 /// be a worse defect than the leak this closes.
+///
+/// Ponytail rung **R7** (new machinery): R2 (reuse `DataDir`'s existing
+/// `Drop`-based daemon reaper) fails outright — `Drop` cannot run for a
+/// `SIGKILL`ed process, which is the whole premise of #113. R4 (a bare
+/// `/proc` liveness check) is necessary but not sufficient alone; it supplies
+/// no reap-at-start trigger without the marker file pairing it to a rig. R5
+/// doesn't apply — this stays dependency-free per the module doc above. The
+/// marker-plus-scan pair is the minimum that works.
 pub(crate) fn reap_orphaned_rigs(base: &Path) -> Vec<PathBuf> {
     let mut reaped = Vec::new();
     let Ok(entries) = std::fs::read_dir(base) else {


### PR DESCRIPTION
Lane PR into `integration/path-to-mac-2026-08-15`. Work `01M0213N9BNG9J3XHZ016BHG2A`, `implement`, **2/40 turns**, clean teardown. Three separately-labeled items, per the owner's ruling that they are different mechanisms.

## Fixes #108 — the `.ready` marker leak

Guard-shaped cleanup, not a reaper. The distinction was established by reading the code rather than reasoning about it: `test_hold_wait` returns an ordinary `Err(WatchError::TestHoldTimedOut)` and the dead-man test is a plain `#[tokio::test]` that awaits, asserts and returns. **No signal is involved**, so `Drop` runs — which is why `LESSONS.md` L21's prescription (cleanup in the code under test or an RAII guard) is sufficient here.

An earlier draft of the sprint plan claimed the opposite and would have shipped a reaper as this issue's fix, leaving the actual leak unfixed while reporting #108 closed.

## Fixes #113 — the rig reaper

The leak `Drop` genuinely cannot reach: `TempDir`-shaped rigs left by suite runs killed mid-flight by a ceiling interrupt or by the harness. Start-of-run reaping in `tests/support/mod.rs`, extending the existing `DataDir` daemon reaper to cover rigs — start-of-run is load-bearing, because it is the only cleanup that survives the way these processes actually die.

## Refs #95 — the guard only, deliberately

`scripts/perf/common.sh` now fails **loudly** rather than emitting a malformed number. On macOS both clock branches fail — `EPOCHREALTIME` is bash 5.0+ and macOS ships 3.2.57; `%N` is a GNU extension, so BSD `date` emits `1786728341N`. That non-numeric value was being fed into a harness that does arithmetic on it: not a crash, a silently wrong measurement, which is worse.

**The clock choice is deliberately not made here** — picking between `perl -MTime::HiRes`, `python3 time.time_ns()` and millisecond resolution needs timing on real macOS hardware. `Refs`, not `Fixes`.

`scripts/perf/common-selftest.sh` is new: it exercises the guard from Linux by forcing the fallback branch, so the fix is testable here rather than only on the platform it targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)