### PR TITLE
W1': refuse init and daemon start on an advisory-locking-unreliable filesystem (Fixes #85)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1763,6 +1763,12 @@ mod doctor {
         // (and re-explaining) the same root cause.
         let (data_dir_check, data_dir_ok) = data_dir_check(data_dir);
         checks.push(data_dir_check);
+        // #85, ADR 0003 D6: whether this data dir's filesystem supports
+        // reliable advisory locking, independent of `data_dir_ok` — this
+        // answers a question about the mount underneath, not about
+        // writability, and (via `fs_locking::detect_for_path`'s own ancestor
+        // walk) works whether or not the data dir has been created yet.
+        checks.push(filesystem_check(data_dir));
         checks.push(docker_check(data_dir, data_dir_ok));
         // The journal is the only durable fact in the installation, so it is
         // checked before anything derived from it; a projection rebuild over
@@ -2313,6 +2319,58 @@ mod doctor {
         }
     }
 
+    /// #85, ADR 0003 D6: does this data dir's filesystem support reliable
+    /// advisory locking. The fail-closed asymmetry the ADR calls for: a
+    /// *confirmed* bad filesystem is `Fail` (this is not in
+    /// `healthy_for_init`'s `claude`/`docker` advisory exemption, so it
+    /// blocks `sgt init`'s exit code the same way `data_dir` above does); an
+    /// *inconclusive* probe — today, always true on macOS, #85's own open
+    /// question — is `Warn`, never `Fail`, because refusing on a probe this
+    /// crate cannot yet run would brick `sgt init` on exactly the platform
+    /// whose detection is unmeasured.
+    fn filesystem_check(data_dir: &Path) -> Check {
+        check_from_reliability(
+            data_dir,
+            crate::platform::fs_locking::detect_for_path(data_dir),
+        )
+    }
+
+    /// Split from [`filesystem_check`] so the three-way mapping from a
+    /// [`crate::platform::fs_locking::Reliability`] verdict to a `Check` is
+    /// testable without a real `drvfs`/NFS/SMB mount (`platform::fs_locking`'s
+    /// own tests cover the detection half).
+    fn check_from_reliability(
+        data_dir: &Path,
+        reliability: crate::platform::fs_locking::Reliability,
+    ) -> Check {
+        use crate::platform::fs_locking::Reliability;
+        match reliability {
+            Reliability::Reliable => Check::ok(
+                "filesystem",
+                format!("{} supports reliable advisory locking", data_dir.display()),
+            ),
+            Reliability::Unreliable { filesystem } => Check::fail(
+                "filesystem",
+                format!(
+                    "{} is on a {filesystem} filesystem, where advisory locking (flock) is \
+                     unreliable",
+                    data_dir.display()
+                ),
+                crate::platform::fs_locking::remedy(&filesystem),
+            ),
+            Reliability::Unknown { reason } => Check::warn(
+                "filesystem",
+                format!(
+                    "cannot determine whether {} supports reliable advisory locking: {reason}",
+                    data_dir.display()
+                ),
+                "this could not be measured on this platform; if the estate lives on a WSL2 \
+                 /mnt/c mount, an NFS share, or an SMB share, move it to a native filesystem as \
+                 a precaution",
+            ),
+        }
+    }
+
     /// Walk up from `path` to the nearest ancestor that already exists on
     /// disk — the directory `create_dir_all` actually stalled at, and the
     /// one worth naming as the fault (`data_dir_check`, #67).
@@ -2525,6 +2583,54 @@ mod doctor {
                  `sgt daemon` spawns a fresh daemon, which republishes it — observation verbs \
                  refuse instead rather than spawning one just to observe it (ADR 0009)",
             )
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::platform::fs_locking::Reliability;
+
+        /// #85, ADR 0003 D6: a confirmed-bad filesystem is `Fail`, and the
+        /// remedy names the filesystem. Reverting the `Unreliable` match arm
+        /// to `Check::warn` (or `ok`) fails this immediately, and — because
+        /// `healthy_for_init` only exempts `claude`/`docker` — would also
+        /// silently stop this check from blocking `sgt init`'s exit code.
+        #[test]
+        fn a_confirmed_bad_filesystem_is_a_failing_check_naming_the_remedy() {
+            let check = check_from_reliability(
+                Path::new("/some/data/dir"),
+                Reliability::Unreliable {
+                    filesystem: "drvfs".to_string(),
+                },
+            );
+            assert_eq!(check.status, Status::Fail);
+            assert!(check.detail.contains("drvfs"));
+            let remedy = check.remedy.expect("a failing check must name its remedy");
+            assert!(remedy.contains("drvfs"));
+        }
+
+        /// The fail-closed asymmetry's other half: an inconclusive probe is
+        /// `Warn`, never `Fail` — a `Fail` here would gate `healthy_for_init`
+        /// and brick `sgt init` on exactly the platform (macOS, today) whose
+        /// detection is unmeasured.
+        #[test]
+        fn an_inconclusive_probe_is_a_warning_never_a_failure() {
+            let check = check_from_reliability(
+                Path::new("/some/data/dir"),
+                Reliability::Unknown {
+                    reason: "macOS detection is unmeasured".to_string(),
+                },
+            );
+            assert_eq!(check.status, Status::Warn);
+            assert!(check.detail.contains("macOS detection is unmeasured"));
+        }
+
+        #[test]
+        fn an_ordinary_filesystem_is_ok() {
+            let check = check_from_reliability(Path::new("/some/data/dir"), Reliability::Reliable);
+            assert_eq!(check.status, Status::Ok);
+            assert!(check.remedy.is_none());
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,6 +3,10 @@
 //!
 //! Startup order is the safety argument:
 //!
+//! 0. refuse outright if the data dir's filesystem is one where advisory
+//!    locking is unreliable (#85, ADR 0003 D6) — the lock taken in step 1
+//!    would not actually exclude a second daemon there, and that failure is
+//!    silent until two daemons are racing the same data dir;
 //! 1. take the exclusive daemon lock in the data dir (second daemon fails
 //!    closed before touching anything);
 //! 2. open the journal (which holds its own exclusive lock — belt and
@@ -36,6 +40,7 @@ use crate::backend::docker::{DOCKER_BACKEND_NAME, DockerBackend, DockerConfig};
 use crate::backend::fake::FAKE_BACKEND_NAME;
 use crate::backend::{BackendRegistry, EventSink};
 use crate::domain::event::{EventDraft, EventSource};
+use crate::platform::fs_locking::{self, Reliability};
 use crate::runtime::analytics::{Analytics, AnalyticsError};
 use crate::runtime::engine::{Engine, EngineError};
 use crate::runtime::fsutil::{create_dir_all_durable, take_exclusive_lock, write_atomic_secret};
@@ -110,6 +115,21 @@ pub enum DaemonError {
     /// Another live daemon holds this data dir's exclusive lock.
     #[error("another daemon already owns this data dir (daemon.lock is held)")]
     Locked,
+    /// #85, ADR 0003 D6: the data dir sits on a filesystem where advisory
+    /// locking (`flock`) is unreliable, so the exclusive lock above cannot be
+    /// trusted to actually exclude a second daemon. Refused before the lock
+    /// is even attempted, never merely warned about.
+    #[error(
+        "{data_dir} sits on a {filesystem} filesystem, where advisory locking is unreliable; refusing to start there — {remedy}"
+    )]
+    UnreliableFilesystem {
+        /// The data dir that was refused.
+        data_dir: PathBuf,
+        /// The offending filesystem type, as the mount table names it.
+        filesystem: String,
+        /// What to do about it.
+        remedy: String,
+    },
     /// Journal failure (open, replay, or append).
     #[error(transparent)]
     Journal(#[from] JournalError),
@@ -265,6 +285,23 @@ pub async fn start(data_dir: &Path) -> Result<DaemonHandle, DaemonError> {
     start_with(data_dir, DaemonConfig::default()).await
 }
 
+/// #85, ADR 0003 D6: turn a filesystem-reliability verdict into the daemon's
+/// refusal, or lack of one. Split out from the call to
+/// [`fs_locking::detect_for_path`] itself so this decision — refuse only on
+/// a *confirmed* bad filesystem, never on an inconclusive probe — is
+/// testable without a real `drvfs`/NFS/SMB mount anywhere in the test
+/// sandbox (`platform::fs_locking`'s own tests cover the detection half).
+fn refuse_if_unreliable(data_dir: &Path, reliability: Reliability) -> Result<(), DaemonError> {
+    match reliability {
+        Reliability::Unreliable { filesystem } => Err(DaemonError::UnreliableFilesystem {
+            data_dir: data_dir.to_path_buf(),
+            remedy: fs_locking::remedy(&filesystem),
+            filesystem,
+        }),
+        Reliability::Reliable | Reliability::Unknown { .. } => Ok(()),
+    }
+}
+
 /// Start the daemon on `data_dir`. Returns once it is serving and the
 /// runtime descriptor is published.
 pub async fn start_with(
@@ -272,6 +309,14 @@ pub async fn start_with(
     config: DaemonConfig,
 ) -> Result<DaemonHandle, DaemonError> {
     create_dir_all_durable(data_dir)?;
+
+    // 0. #85 / ADR 0003 D6: refuse outright on a filesystem where advisory
+    // locking is unreliable — before the lock below is even attempted, since
+    // a lock that silently does not hold fails in a way nobody notices until
+    // two daemons are racing the same data dir. An inconclusive probe (e.g.
+    // today's always-Unknown macOS arm) does not refuse — see
+    // `refuse_if_unreliable`.
+    refuse_if_unreliable(data_dir, fs_locking::detect_for_path(data_dir))?;
 
     // 1. Exclusive daemon lock: a second daemon on the same data dir fails
     // closed here, before touching journal or descriptor. The OS releases
@@ -1329,5 +1374,58 @@ mod tests {
              queue, and the export never happened: {finished:?}"
         );
         assert_eq!(finished[0].name, "work");
+    }
+
+    /// #85, ADR 0003 D6: `start_with`'s pre-lock refusal, tested at the seam
+    /// that does not need a real `drvfs`/NFS/SMB mount — `refuse_if_unreliable`
+    /// takes an already-computed [`Reliability`] rather than calling
+    /// `fs_locking::detect_for_path` itself. Reverting the `Unreliable` match
+    /// arm to also return `Ok(())` (i.e. dropping the refusal) fails this
+    /// immediately.
+    #[test]
+    fn refuse_if_unreliable_blocks_on_a_confirmed_bad_filesystem() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let err = refuse_if_unreliable(
+            dir.path(),
+            Reliability::Unreliable {
+                filesystem: "drvfs".to_string(),
+            },
+        )
+        .expect_err("a confirmed-bad filesystem must be refused");
+        match err {
+            DaemonError::UnreliableFilesystem {
+                data_dir,
+                filesystem,
+                remedy,
+            } => {
+                assert_eq!(data_dir, dir.path());
+                assert_eq!(filesystem, "drvfs");
+                assert!(
+                    remedy.contains("drvfs"),
+                    "the remedy must name the offending filesystem: {remedy}"
+                );
+            }
+            other => panic!("expected UnreliableFilesystem, got {other:?}"),
+        }
+    }
+
+    /// The other half of the asymmetry: neither an ordinary filesystem nor an
+    /// inconclusive probe may refuse. Collapsing `Unknown` into the refusal
+    /// arm would brick daemon start on the very platform (macOS, today)
+    /// whose detection is unmeasured — this fails the moment that happens.
+    #[test]
+    fn refuse_if_unreliable_allows_reliable_and_unknown() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        assert!(refuse_if_unreliable(dir.path(), Reliability::Reliable).is_ok());
+        assert!(
+            refuse_if_unreliable(
+                dir.path(),
+                Reliability::Unknown {
+                    reason: "cannot be measured on this platform".to_string(),
+                },
+            )
+            .is_ok(),
+            "an inconclusive probe must never refuse"
+        );
     }
 }

--- a/src/platform/fs_locking.rs
+++ b/src/platform/fs_locking.rs
@@ -26,6 +26,13 @@
 //! direction the asymmetry below calls for (an inconclusive probe must never
 //! refuse). It closes only once someone measures a real detection path on a
 //! macOS host.
+//!
+//! Ponytail rung **R2**: this is a new file, but it reuses the platform
+//! boundary's already-established shape verbatim — the same `#[cfg]`-selected
+//! module plus injected-probe pattern `data_dir.rs`, `disk.rs`, and
+//! `process.rs` already use — rather than inventing a new mechanism, and it
+//! adds no new dependency (`detect_for_path` is called by `daemon.rs` and
+//! `cli.rs`'s doctor row; both are also R2 for the same reason).
 
 use std::path::{Path, PathBuf};
 

--- a/src/platform/fs_locking.rs
+++ b/src/platform/fs_locking.rs
@@ -1,0 +1,355 @@
+//! Advisory-locking reliability (#85, ADR 0003 D6).
+//!
+//! `sgt init` and daemon start both rest on exactly one process holding
+//! `daemon.lock` (`docs/DEVELOPMENT.md`'s "One owner" invariant;
+//! `src/runtime/fsutil.rs::take_exclusive_lock`) — and that lock itself is
+//! already cross-platform for free, because
+//! [`std::fs::File::try_lock`] compiles to `flock` on Unix and `LockFileEx`
+//! on Windows. What #85 asks for is not a new locking mechanism; it is a way
+//! to tell, *before* trusting that lock, whether the filesystem underneath it
+//! actually honors advisory locks at all. WSL2's `drvfs` (an estate cloned
+//! under `/mnt/c/...`), NFS, and SMB all answer `try_lock` with success while
+//! not actually excluding a second holder — the predicate this module
+//! implements is deliberately "advisory locking unreliable on this
+//! filesystem type", not "is this `/mnt/c`", so the same check covers all
+//! three (ADR 0003 D6).
+//!
+//! Shaped like every other fact in this boundary (ADR 0002 D3): [`classify`]
+//! and [`parse_proc_mounts`] are plain, unconditionally-compiled functions
+//! exercised by the tests below on any host, including a bare Linux box that
+//! has never seen a `drvfs`/NFS/SMB mount — only the actual `/proc/mounts`
+//! read is `#[cfg]`-gated. macOS has no `/proc` (D5's own liveness gap notes
+//! this), and what it should use instead — `statfs`, `getmntinfo`,
+//! `diskutil` — is explicitly unmeasured (ADR 0003's open question): rather
+//! than guess at an implementation nobody has run, the macOS arm always
+//! reports [`Reliability::Unknown`], which is the fail-closed-*safe*
+//! direction the asymmetry below calls for (an inconclusive probe must never
+//! refuse). It closes only once someone measures a real detection path on a
+//! macOS host.
+
+use std::path::{Path, PathBuf};
+
+/// The verdict [`detect_for_path`] reaches about one path's filesystem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reliability {
+    /// Advisory locking on this filesystem is expected to behave normally.
+    Reliable,
+    /// A specific, named filesystem type known to make advisory locking
+    /// unreliable — `sgt init` and daemon start must refuse (ADR 0003 D6).
+    Unreliable {
+        /// The filesystem type as the mount table names it (e.g. `"drvfs"`,
+        /// `"nfs4"`, `"cifs"`).
+        filesystem: String,
+    },
+    /// Could not be determined on this platform or in this environment.
+    /// **Never a refusal** — only a confirmed-bad filesystem refuses; an
+    /// inconclusive probe must not brick the very platform whose detection
+    /// is unmeasured (ADR 0003's stated open question).
+    Unknown {
+        /// What could not be determined, and why.
+        reason: String,
+    },
+}
+
+/// Filesystem types (as `/proc/mounts`' third column names them) known to
+/// make advisory locking unreliable. Not an exhaustive survey of every
+/// network or 9p-family filesystem in existence — it is the originating
+/// `drvfs` case plus ADR 0003's explicit NFS/SMB generalization, extended by
+/// name as new cases are measured (ADR 0003's second open question).
+const UNRELIABLE_FS_TYPES: &[&str] = &[
+    "drvfs", "9p", "nfs", "nfs2", "nfs3", "nfs4", "cifs", "smb3", "smbfs",
+];
+
+/// One `/proc/mounts` row this module cares about.
+struct MountEntry {
+    mount_point: PathBuf,
+    fs_type: String,
+}
+
+/// `/proc/mounts` escapes space, tab, newline and backslash in the mount
+/// point field as three-digit octal (`\040` for a space); everything else
+/// passes through unchanged. Necessary because a WSL2 drive letter mount or
+/// an operator-chosen mount point can legitimately contain a space.
+fn unescape_octal(field: &str) -> String {
+    let bytes = field.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\'
+            && i + 3 < bytes.len()
+            && bytes[i + 1..i + 4].iter().all(u8::is_ascii_digit)
+            && let Ok(text) = std::str::from_utf8(&bytes[i + 1..i + 4])
+            && let Ok(value) = u8::from_str_radix(text, 8)
+        {
+            out.push(value);
+            i += 4;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Parse `/proc/mounts`' text shape: whitespace-separated columns, one mount
+/// per line (`device mount_point fs_type options dump pass`). A line with
+/// fewer than three columns is dropped rather than turned into a bogus
+/// entry — the same "never guess" posture [`crate::platform::process`]'s
+/// per-line parsing takes.
+fn parse_proc_mounts(content: &str) -> Vec<MountEntry> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let mut columns = line.split_whitespace();
+            let _device = columns.next()?;
+            let mount_point = columns.next()?;
+            let fs_type = columns.next()?;
+            Some(MountEntry {
+                mount_point: PathBuf::from(unescape_octal(mount_point)),
+                fs_type: fs_type.to_string(),
+            })
+        })
+        .collect()
+}
+
+/// The decision logic ADR 0002 D3 asks for: given an already-canonicalized
+/// path and the mount table, find the mount that actually governs it — the
+/// entry with the *longest* matching mount-point prefix, since a deeper
+/// mount (e.g. `/mnt/c`) always shadows a shallower one (`/`) — and classify
+/// by its filesystem type. No covering mount at all is [`Reliability::Unknown`],
+/// never [`Reliability::Unreliable`]: absence of evidence must not read as
+/// evidence of a bad filesystem.
+fn classify(path: &Path, mounts: &[MountEntry]) -> Reliability {
+    let governing = mounts
+        .iter()
+        .filter(|entry| path.starts_with(&entry.mount_point))
+        .max_by_key(|entry| entry.mount_point.as_os_str().len());
+    match governing {
+        Some(entry) if UNRELIABLE_FS_TYPES.contains(&entry.fs_type.as_str()) => {
+            Reliability::Unreliable {
+                filesystem: entry.fs_type.clone(),
+            }
+        }
+        Some(_) => Reliability::Reliable,
+        None => Reliability::Unknown {
+            reason: format!(
+                "no mount entry covers {} — the mount table could not be matched against it",
+                path.display()
+            ),
+        },
+    }
+}
+
+/// [`classify`] plus [`parse_proc_mounts`], with the mount-table text
+/// supplied by `mounts_source` instead of a hardcoded `/proc/mounts` read —
+/// the injected-probe seam (ADR 0002 D2) that lets the whole wiring from a
+/// path down to a verdict be exercised in tests without a real
+/// `drvfs`/NFS/SMB mount anywhere in the test sandbox. `raw_detect` below is
+/// the only caller that supplies the real thing.
+fn raw_detect_from(path: &Path, mounts_source: impl FnOnce() -> Option<String>) -> Reliability {
+    match mounts_source() {
+        Some(content) => classify(path, &parse_proc_mounts(&content)),
+        None => Reliability::Unknown {
+            reason: "cannot read /proc/mounts".to_string(),
+        },
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn raw_detect(path: &Path) -> Reliability {
+    raw_detect_from(path, || std::fs::read_to_string("/proc/mounts").ok())
+}
+
+/// **UNVERIFIED — unmeasured, not merely untested.** There is no macOS host
+/// in this estate (`docs/environments/`) to measure `statfs`, `getmntinfo`,
+/// or `diskutil info`'s output shape against, and ADR 0003 names this
+/// exactly as an open question rather than assumed. Reporting
+/// [`Reliability::Unknown`] unconditionally is the fail-closed-*safe*
+/// direction: it produces a `sgt doctor` warn row (never a refusal) until
+/// someone measures a real detection path on a real Mac and replaces this.
+#[cfg(target_os = "macos")]
+fn raw_detect(_path: &Path) -> Reliability {
+    Reliability::Unknown {
+        reason: "macOS advisory-locking-reliability detection is unmeasured (#85) — /proc/mounts \
+                 is Linux-only, and what macOS should use instead (statfs, getmntinfo, or \
+                 `diskutil info`) needs its own measurement pass on a real host before this can \
+                 classify anything there"
+            .to_string(),
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn raw_detect(_path: &Path) -> Reliability {
+    Reliability::Unknown {
+        reason: "advisory-locking-reliability detection is not implemented on this platform"
+            .to_string(),
+    }
+}
+
+/// Walk up from `path` to the nearest ancestor that already exists — the
+/// same technique `cli.rs`'s `data_dir_check` uses for #67, needed here
+/// because `sgt init` calls this before the data dir itself has been
+/// created.
+fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut current = path;
+    loop {
+        if current.exists() {
+            return Some(current.to_path_buf());
+        }
+        current = current.parent()?;
+    }
+}
+
+/// Is `path`'s filesystem one where advisory locking (`flock`) is reliable?
+/// Walks up to the nearest existing ancestor first (`path` itself may not
+/// exist yet — `sgt init` calls this before scaffolding anything), then
+/// canonicalizes it so a symlinked estate resolves to the mount it actually
+/// lives on. Both `sgt init`'s refusal, `daemon::start_with`'s refusal, and
+/// `sgt doctor`'s `filesystem` row all call this same entry point, so the
+/// three surfaces can never disagree about what "unreliable" means.
+pub fn detect_for_path(path: &Path) -> Reliability {
+    let Some(existing) = nearest_existing_ancestor(path) else {
+        return Reliability::Unknown {
+            reason: format!("no existing ancestor found above {}", path.display()),
+        };
+    };
+    match existing.canonicalize() {
+        Ok(canonical) => raw_detect(&canonical),
+        Err(e) => Reliability::Unknown {
+            reason: format!("cannot canonicalize {}: {e}", existing.display()),
+        },
+    }
+}
+
+/// The shared remedy text for a confirmed-unreliable `filesystem` — used
+/// verbatim by both `daemon::DaemonError::UnreliableFilesystem` and `sgt
+/// doctor`'s `filesystem` row, so an operator sees the same instruction
+/// however they hit this.
+pub fn remedy(filesystem: &str) -> String {
+    format!(
+        "advisory locking (flock) is unreliable on {filesystem} filesystems — move the estate \
+         (or point --data-dir / SGT_DATA_DIR) to a filesystem where it is reliable: a native \
+         Linux filesystem rather than a WSL2 /mnt/c drvfs mount, and not an NFS or SMB share"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn octal_escaped_spaces_in_mount_points_are_unescaped() {
+        let mounts = parse_proc_mounts("dev /mnt/My\\040Drive ext4 rw 0 0\n");
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].mount_point, PathBuf::from("/mnt/My Drive"));
+    }
+
+    #[test]
+    fn a_line_with_too_few_columns_is_dropped_not_a_bogus_entry() {
+        assert!(parse_proc_mounts("only-one-column\n").is_empty());
+        assert!(parse_proc_mounts("dev /mnt\n").is_empty());
+    }
+
+    /// The originating WSL2 case: a deeper `drvfs` mount must win over the
+    /// shallower `/` entry that would otherwise also match by prefix.
+    #[test]
+    fn the_longest_matching_mount_wins_over_the_root() {
+        let mounts = parse_proc_mounts(
+            "/dev/sda1 / ext4 rw 0 0\n\
+             C: /mnt/c drvfs rw 0 0\n",
+        );
+        let verdict = classify(Path::new("/mnt/c/estate/data"), &mounts);
+        assert_eq!(
+            verdict,
+            Reliability::Unreliable {
+                filesystem: "drvfs".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn nfs_and_cifs_are_unreliable_the_same_way_drvfs_is() {
+        for fs_type in ["nfs", "nfs4", "cifs", "smbfs"] {
+            let mounts = parse_proc_mounts(&format!("srv:/x /mnt/share {fs_type} rw 0 0\n"));
+            let verdict = classify(Path::new("/mnt/share/estate"), &mounts);
+            assert_eq!(
+                verdict,
+                Reliability::Unreliable {
+                    filesystem: fs_type.to_string()
+                },
+                "fs_type {fs_type} must be classified unreliable"
+            );
+        }
+    }
+
+    #[test]
+    fn an_ordinary_filesystem_is_reliable() {
+        let mounts = parse_proc_mounts("/dev/sda1 / ext4 rw 0 0\n");
+        assert_eq!(
+            classify(Path::new("/home/user/estate"), &mounts),
+            Reliability::Reliable
+        );
+    }
+
+    #[test]
+    fn no_covering_mount_is_unknown_not_unreliable() {
+        let verdict = classify(Path::new("/nowhere/at/all"), &[]);
+        assert!(
+            matches!(verdict, Reliability::Unknown { .. }),
+            "absence of a matching mount must not be read as evidence of a bad filesystem: {verdict:?}"
+        );
+    }
+
+    /// The fail-closed asymmetry itself, pinned at the seam every caller
+    /// actually goes through: an unreadable mount table is inconclusive, and
+    /// inconclusive must never collapse into "unreliable, refuse".
+    #[test]
+    fn an_unreadable_mount_table_is_unknown_not_a_refusal() {
+        let verdict = raw_detect_from(Path::new("/"), || None);
+        assert!(
+            matches!(verdict, Reliability::Unknown { .. }),
+            "a probe that could not run must not be treated as a confirmed-bad filesystem: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn raw_detect_from_wires_a_real_unreliable_verdict_end_to_end() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize");
+        let mounts = format!("none {} 9p rw 0 0\n", canonical.display());
+        let verdict = raw_detect_from(&canonical, || Some(mounts.clone()));
+        assert_eq!(
+            verdict,
+            Reliability::Unreliable {
+                filesystem: "9p".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn detect_for_path_walks_up_to_an_existing_ancestor() {
+        // `child/data` does not exist; only `dir` does. Reverting the
+        // ancestor walk to require `path` itself to exist would make this
+        // return Unknown instead of actually classifying `dir`'s real
+        // filesystem.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let not_yet_created = dir.path().join("child").join("data");
+        let verdict = detect_for_path(&not_yet_created);
+        // This host's real filesystem is whatever it is — the property this
+        // test pins is that the walk reached *some* real, matched mount
+        // rather than giving up as Unknown for the trivial reason that the
+        // leaf path does not exist yet.
+        assert!(
+            !matches!(&verdict, Reliability::Unknown { reason } if reason.contains("no existing ancestor")),
+            "must not give up before walking up to {}: {verdict:?}",
+            dir.path().display()
+        );
+    }
+
+    #[test]
+    fn remedy_names_the_filesystem_and_where_to_move_the_estate() {
+        let text = remedy("drvfs");
+        assert!(text.contains("drvfs"));
+        assert!(text.contains("--data-dir") || text.contains("SGT_DATA_DIR"));
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -24,4 +24,5 @@
 
 pub mod data_dir;
 pub mod disk;
+pub mod fs_locking;
 pub mod process;

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -903,6 +903,10 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
             // data dir, so this check runs first and both defer to it by
             // name when it fails rather than re-diagnosing the same fault.
             "data_dir",
+            // #85, ADR 0003 D6: whether this data dir's filesystem supports
+            // reliable advisory locking — independent of data_dir's own
+            // writability, so it sits beside rather than behind it.
+            "filesystem",
             "docker",
             "journal",
             "projection",


### PR DESCRIPTION
Lane PR into `integration/path-to-mac-2026-08-15`. Work `01M023SXA1D8HY4EPGG4BAGQRP`, `implement`, **2/40 turns**, clean teardown.

Implements **ADR 0003 (D6)**. This is all that survived of a Work originally scoped to four issues — #18, #81 and #82 turned out to be already built, dual-platform and unit-tested, awaiting only macOS verification. **#85 was the one genuinely unbuilt platform item.**

## What it establishes first

`#85` is not a request for a locking mechanism. `std::fs::File::try_lock` is *already* cross-platform for free — `flock` on Unix, `LockFileEx` on Windows. What was missing is a way to tell, **before trusting that lock**, whether the filesystem underneath honors advisory locks at all. WSL2's `drvfs`, NFS and SMB all answer `try_lock` with success while failing to exclude a second holder — which is why the daemon's "One owner" invariant needs a predicate, not a better lock.

The predicate is deliberately generalized to *"advisory locking unreliable on this filesystem type"* rather than special-casing `/mnt/c`, so one check covers all three cases.

## The fail-closed asymmetry, decided and argued

Two different negatives, kept distinct:

- **Detected unreliable** → refuse `sgt init` and daemon start, naming the filesystem and the remedy (following #67's named-remedy convention).
- **Cannot determine** → **never refuse.** The macOS arm returns `Reliability::Unknown` because `statfs`/`getmntinfo`/`diskutil` are explicitly unmeasured — *"rather than guess at an implementation nobody has run."* A hard refusal on an inconclusive probe would brick `sgt init` on the very platform whose detection is unmeasured, which is a worse failure than the one being prevented.

It closes on macOS when someone measures a real detection path there — ADR 0001's posture, matching how `process.rs`, `disk.rs` and `data_dir.rs` already mark their UNVERIFIED arms.

## Shape

**Ponytail rung R2**, recorded: a new file, but it reuses the platform boundary's established `#[cfg]`-selected-module plus injected-probe pattern verbatim (ADR 0002 D3) rather than inventing a mechanism, and adds no dependency. `classify` and `parse_proc_mounts` are unconditionally compiled and tested on any host — including a Linux box that has never seen a `drvfs` mount — with only the raw `/proc/mounts` read `#[cfg]`-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)