### PR TITLE
W4: retention scope, retained/reap verbs, transcript timestamps (Fixes #96, Refs #109)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -63,7 +63,7 @@ use crate::runtime::projection::{
 };
 use crate::runtime::surface::{
     BindingDisposition, KIND_SURFACE_MATERIALIZED, KIND_SURFACE_MATERIALIZING,
-    KIND_SURFACE_TORN_DOWN,
+    KIND_SURFACE_TORN_DOWN, reap, retained_bindings,
 };
 
 /// API revision served by this build (`GET /v1/system`, runtime descriptor).
@@ -394,6 +394,8 @@ pub fn router(state: ApiState) -> Router {
         .route("/work/{id}/input", post(work_input))
         .route("/work/{id}/retry", post(work_retry))
         .route("/work/{id}/extend", post(work_extend))
+        .route("/work/{id}/reap", post(reap_work))
+        .route("/retained", get(list_retained))
         .route("/admission/pause", post(pause_admission))
         .route("/graph/work/{id}", get(work_graph))
         .route("/analytics", get(analytics_index))
@@ -2282,6 +2284,146 @@ async fn work_extend(
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct ReapRequest {
+    command_id: String,
+    /// Must be `true`, or the request is refused (#109: reap has no undo,
+    /// so intent is never guessed).
+    #[serde(default)]
+    confirm: bool,
+}
+
+/// `POST /v1/work/{id}/reap` — #109's dispose verb: permanently discard
+/// whatever `RetainedDirty` bindings still hold for this Work's teardown
+/// (`crate::runtime::surface::reap`'s own doc has the full contract — the
+/// captured patch, or the submodule/capture-failure fallback directory;
+/// never the retained branch, which stays outside anything this verb can
+/// reach).
+///
+/// Refuses without `{"confirm": true}` in the body: unlike `cancel`/
+/// `retry`/`extend`, there is no journaled state this can safely undo by
+/// resubmitting a different command, so a bare or malformed body is
+/// ambiguity, not an implicit yes (`AGENTS.md`'s fail-closed rule). An
+/// operator reviews `GET /v1/retained` first — that is the read half of
+/// this same pair — then re-sends with confirmation.
+async fn reap_work(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    body: Result<Json<ReapRequest>, JsonRejection>,
+) -> Response {
+    let req = match parse_body(body) {
+        Ok(r) => r,
+        Err(resp) => return *resp,
+    };
+    if let Err(resp) = parse_command_id(&req.command_id) {
+        return *resp;
+    }
+    let mut core = CoreGuard::acquire(&state.core).await;
+    if let Some(resp) = replay_command(&core, &req.command_id) {
+        return resp;
+    }
+    if !req.confirm {
+        let result = error_body(
+            "confirmation_required",
+            "reap destroys retained dirty state with no undo; review GET /v1/retained for \
+             this work, then resend with \"confirm\": true",
+        );
+        return record_and_respond(
+            &mut core,
+            &req.command_id,
+            "work.reap",
+            Some(&id),
+            StatusCode::BAD_REQUEST,
+            result,
+        );
+    }
+    let Some(work) = core.registry.state().works.get(&id).cloned() else {
+        let result = error_body("work_not_found", format!("no work with id {id}"));
+        return record_and_respond(
+            &mut core,
+            &req.command_id,
+            "work.reap",
+            None,
+            StatusCode::NOT_FOUND,
+            result,
+        );
+    };
+    let run = resolve_run(&core, &work, core.registry.state().run_view(&id));
+    let bound = run.and_then(|r| match (r.surface.clone(), r.teardown.clone()) {
+        (Some(surface), Some(teardown)) => Some((surface, teardown)),
+        _ => None,
+    });
+    let Some((surface, teardown)) = bound else {
+        let result = error_body(
+            "nothing_to_reap",
+            format!("work {id} has no recorded teardown to reap"),
+        );
+        return record_and_respond(
+            &mut core,
+            &req.command_id,
+            "work.reap",
+            Some(&id),
+            StatusCode::NOT_FOUND,
+            result,
+        );
+    };
+    // §22.6 tradeoff, same disclosure as `work_transcript`'s: this runs git
+    // and filesystem calls (potentially a real, if small, worktree removal)
+    // while the core guard is held, queueing every other guarded request for
+    // its duration. Reap is rare and explicit, never on a hot path, so this
+    // is accepted rather than plumbed through the async effect system the
+    // way `teardown` itself is.
+    let report = blocking_sync(|| reap(&surface, &teardown));
+    let result = json!({"report": report});
+    record_and_respond(
+        &mut core,
+        &req.command_id,
+        "work.reap",
+        Some(&id),
+        StatusCode::OK,
+        result,
+    )
+}
+
+/// `GET /v1/retained` — #109's inspect verb: every repository binding any
+/// terminal Work's teardown left something on disk for, across the whole
+/// estate — a captured patch, the submodule/capture-failure fallback
+/// directory, or a `RetainedError`. Correct retention is otherwise
+/// indistinguishable from a leak (#109); this is the read side of that
+/// pair, `POST /v1/work/{id}/reap` the write side.
+///
+/// Same `resolve_run` journal-replay fallback `fleet_body`/`work_view`
+/// already rely on for an evicted terminal work — and the same accepted
+/// tradeoff `work_transcript` discloses: a terminal work not already in the
+/// bounded cache costs a full journal replay under the guard. Inspecting
+/// retained state is an occasional, operator-driven action, not a hot path.
+async fn list_retained(State(state): State<ApiState>) -> Response {
+    let core = CoreGuard::acquire(&state.core).await;
+    let registry = core.registry.state();
+    let entries: Vec<Value> = registry
+        .works
+        .values()
+        .filter_map(|work| {
+            let run = resolve_run(&core, work, registry.run_view(&work.id))?;
+            let teardown = run.teardown?;
+            Some((work.id.clone(), retained_bindings(&teardown)))
+        })
+        .flat_map(|(work_id, bindings)| {
+            bindings.into_iter().map(move |b| {
+                json!({
+                    "work_id": work_id,
+                    "repository": b.repository,
+                    "path": b.path,
+                    "disposition": b.reason,
+                    "detail": b.detail,
+                    "bytes": b.bytes,
+                })
+            })
+        })
+        .collect();
+    Json(json!({"retained": entries})).into_response()
+}
+
 /// Catch the analytical projection up to the journal, then hand it to `f`.
 ///
 /// The projection is folded lazily, at read time, rather than on every
@@ -2909,6 +3051,26 @@ impl ApiClient {
             &json!({
                 "command_id": ulid::Ulid::generate().to_string(),
                 "input": input,
+            }),
+        )
+        .await
+    }
+
+    /// `GET /v1/retained` — #109's inspect verb: every repository binding
+    /// any terminal Work's teardown left something on disk for, estate-wide.
+    pub async fn retained(&self) -> Result<Value, ClientError> {
+        self.get("/v1/retained").await
+    }
+
+    /// `POST /v1/work/{id}/reap` with a fresh command id (§26) — #109's
+    /// dispose verb. `confirm` must be `true` or the daemon refuses (fail
+    /// closed: reap has no undo).
+    pub async fn reap(&self, id: &str, confirm: bool) -> Result<Value, ClientError> {
+        self.post(
+            &format!("/v1/work/{id}/reap"),
+            &json!({
+                "command_id": ulid::Ulid::generate().to_string(),
+                "confirm": confirm,
             }),
         )
         .await

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -355,6 +355,29 @@ enum WorkCommand {
         /// Work id whose conversation to decode.
         id: String,
     },
+    /// #109's inspect verb: every repository binding any terminal work's
+    /// teardown left something on disk for — a captured dirty-state patch,
+    /// or, in the submodule/capture-failure fallback, the whole worktree
+    /// directory — with why and how large. Read-only: never mutates daemon
+    /// state, and never destroys anything by itself. `sgt work reap`
+    /// disposes of what this names.
+    Retained,
+    /// #109's dispose verb: permanently discard a work's retained dirty
+    /// state (the captured patch, or — the submodule/capture-failure
+    /// fallback — the worktree directory itself). Never touches the
+    /// retained *branch*: teardown's branch-retention guarantee is
+    /// unconditional (§11) and this verb has no path that reaches it.
+    /// Refuses without `--yes`: instead of guessing intent, it prints
+    /// exactly what `--yes` would destroy (`sgt work retained`'s own view,
+    /// scoped to this work) and stops there.
+    Reap {
+        /// Work id whose retained dirty state to reap.
+        id: String,
+        /// Actually perform the deletion. Without it, this only previews
+        /// what would be destroyed.
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 /// CLI error: a message for stderr and a nonzero exit.
@@ -677,6 +700,49 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             }
             Ok(())
         }
+        Command::Work {
+            command: WorkCommand::Reap { id, yes },
+        } => {
+            // #109's dispose verb mutates durable state (it deletes retained
+            // artifacts and journals the outcome), so it joins
+            // `cancel`/`retry`/`extend`'s bucket rather than the read-only
+            // `work list`/`show`/`transcript`/`retained` one.
+            let client = ensure_daemon(&data_dir).await?;
+            if !yes {
+                let retained = client.retained().await?;
+                let mine: Vec<&Value> = retained["retained"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter(|r| r["work_id"].as_str() == Some(id.as_str()))
+                    .collect();
+                if sgt.json {
+                    print_json(&json!({"would_reap": mine}));
+                } else if mine.is_empty() {
+                    println!("nothing retained for {id}");
+                } else {
+                    println!("--yes would permanently discard:");
+                    for r in &mine {
+                        println!(
+                            "  {}  {}  {}  {}",
+                            r["repository"].as_str().unwrap_or("?"),
+                            r["disposition"].as_str().unwrap_or("?"),
+                            doctor::human_bytes(r["bytes"].as_u64().unwrap_or(0)),
+                            r["path"].as_str().unwrap_or("?"),
+                        );
+                    }
+                    println!("re-run with --yes to actually reap this");
+                }
+                return Ok(());
+            }
+            let result = client.reap(&id, true).await?;
+            if sgt.json {
+                print_json(&result);
+            } else {
+                print_reap_report(&result);
+            }
+            Ok(())
+        }
         Command::Work { command } => {
             let client = observe_connect(&data_dir).await?;
             match command {
@@ -765,6 +831,18 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                     }
                     Ok(())
                 }
+                WorkCommand::Retained => {
+                    let result = client.retained().await?;
+                    if sgt.json {
+                        print_json(&result);
+                    } else {
+                        print_retained(&result);
+                    }
+                    Ok(())
+                }
+                // Handled by the dedicated `ensure_daemon` arm above, since
+                // reap mutates durable state — never reachable here.
+                WorkCommand::Reap { .. } => unreachable!("reap is matched before this arm"),
             }
         }
         Command::Analytics { name } => {
@@ -1092,12 +1170,31 @@ fn print_graph(result: &Value) {
 /// its own journaled event) is called out, since it is lower-fidelity than
 /// the rest — never presented as if it were an ordinary completed turn.
 fn print_transcript(result: &Value) {
+    print!("{}", render_transcript(result));
+}
+
+/// #96: the journal timestamps every conversation event
+/// (`transcript_turns`'s `"ts"` field, read straight off `event.timestamp`);
+/// the human rendering used to drop it, so an operator reading assistant text
+/// with no wall-clock anchor mistook "recent-looking" for "recent" and missed
+/// a turn that had already been ceiling-interrupted two minutes earlier (#90).
+///
+/// Prints the RFC3339 timestamp the journal already carries, verbatim — no
+/// elapsed-time arithmetic against "now": that would be *deriving* a fact
+/// this surface has no business computing, not reading one the journal
+/// already recorded. `--json` (`transcript_turns`) already carries the same
+/// field per entry, so only this rendering needed the fix.
+///
+/// Factored out from `print_transcript` (matching `watch::render_human`'s
+/// split) so the rendering is a pure function a test can pin without a
+/// daemon.
+fn render_transcript(result: &Value) -> String {
     let empty = Vec::new();
     let turns = result["turns"].as_array().unwrap_or(&empty);
     if turns.is_empty() {
-        println!("no conversation recorded for this work");
-        return;
+        return "no conversation recorded for this work\n".to_string();
     }
+    let mut out = String::new();
     for turn in turns {
         let label = match turn["role"].as_str().unwrap_or("?") {
             "user" => "User",
@@ -1110,9 +1207,70 @@ fn print_transcript(result: &Value) {
         } else {
             ""
         };
-        println!("{label}{recovered}:");
-        println!("{}", turn["text"].as_str().unwrap_or(""));
-        println!();
+        let ts = turn["ts"].as_str().unwrap_or("?");
+        out.push_str(&format!("[{ts}] {label}{recovered}:\n"));
+        out.push_str(turn["text"].as_str().unwrap_or(""));
+        out.push_str("\n\n");
+    }
+    out
+}
+
+/// #109's inspect verb (`GET /v1/retained`, `sgt work retained`): every
+/// repository binding some terminal work's teardown left something on disk
+/// for, with a running total so "how much disk is this actually costing me"
+/// is answerable at a glance — the question #109 itself was filed over.
+fn print_retained(result: &Value) {
+    let empty = Vec::new();
+    let entries = result["retained"].as_array().unwrap_or(&empty);
+    if entries.is_empty() {
+        println!("nothing retained");
+        return;
+    }
+    let mut total = 0u64;
+    for entry in entries {
+        let bytes = entry["bytes"].as_u64().unwrap_or(0);
+        total += bytes;
+        println!(
+            "{}  {}  {}  {}  {}",
+            entry["work_id"].as_str().unwrap_or("?"),
+            entry["repository"].as_str().unwrap_or("?"),
+            entry["disposition"].as_str().unwrap_or("?"),
+            doctor::human_bytes(bytes),
+            entry["path"].as_str().unwrap_or("?"),
+        );
+    }
+    println!("total: {}", doctor::human_bytes(total));
+}
+
+/// #109's dispose verb's own result (`POST /v1/work/{id}/reap`, `sgt work
+/// reap --yes`): what actually happened to each binding, not just that the
+/// call succeeded.
+fn print_reap_report(result: &Value) {
+    let empty = Vec::new();
+    let bindings = result["report"]["bindings"].as_array().unwrap_or(&empty);
+    if bindings.is_empty() {
+        println!("nothing to reap");
+        return;
+    }
+    for binding in bindings {
+        let outcome = &binding["outcome"];
+        let repository = binding["repository"].as_str().unwrap_or("?");
+        match outcome["outcome"].as_str() {
+            Some("reaped") => println!(
+                "{repository}: reaped {}",
+                doctor::human_bytes(outcome["bytes"].as_u64().unwrap_or(0)),
+            ),
+            Some("nothing_retained") => println!("{repository}: nothing retained"),
+            Some("skipped") => println!(
+                "{repository}: skipped — {}",
+                outcome["reason"].as_str().unwrap_or("?"),
+            ),
+            Some("failed") => println!(
+                "{repository}: failed — {}",
+                outcome["detail"].as_str().unwrap_or("?"),
+            ),
+            _ => println!("{repository}: {outcome}"),
+        }
     }
 }
 
@@ -2230,8 +2388,10 @@ mod doctor {
 
     /// Render a byte count the way an operator reading a terminal wants it,
     /// not the raw integer `disk_pressure_check`'s JSON already carries
-    /// losslessly.
-    fn human_bytes(bytes: u64) -> String {
+    /// losslessly. `pub(super)`: `sgt work retained`/`sgt work reap` (#109)
+    /// reuse this rather than a second byte formatter — one declaration,
+    /// one resolution.
+    pub(super) fn human_bytes(bytes: u64) -> String {
         const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB"];
         let mut value = bytes as f64;
         let mut unit = 0;
@@ -2632,5 +2792,76 @@ mod doctor {
             assert_eq!(check.status, Status::Ok);
             assert!(check.remedy.is_none());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #96: a human-rendered transcript must show *when* each turn
+    /// happened, not just what it said — the exact gap that let a
+    /// ceiling-interrupted turn (#90) read as still in progress.
+    /// Reverting `render_transcript` to drop the `[{ts}]` prefix passes
+    /// every other assertion here and fails only this one.
+    #[test]
+    fn render_transcript_prints_each_turns_timestamp() {
+        let result = json!({
+            "turns": [
+                {
+                    "seq": 1,
+                    "ts": "2026-08-14T15:24:00.000Z",
+                    "role": "user",
+                    "text": "let's wait for both background runs to complete",
+                    "source": "event",
+                },
+                {
+                    "seq": 2,
+                    "ts": "2026-08-14T15:26:55.874Z",
+                    "role": "assistant",
+                    "text": "still waiting",
+                    "source": "event",
+                },
+            ],
+        });
+        let rendered = render_transcript(&result);
+        assert!(
+            rendered.contains("[2026-08-14T15:24:00.000Z] User:"),
+            "missing user timestamp: {rendered}"
+        );
+        assert!(
+            rendered.contains("[2026-08-14T15:26:55.874Z] Assistant:"),
+            "missing assistant timestamp: {rendered}"
+        );
+    }
+
+    /// A turn recovered from the interrupted raw archive still needs its
+    /// timestamp — that is the exact turn #90's transcript misdiagnosis
+    /// involved (a `blob_decode` entry from a ceiling-interrupted turn).
+    #[test]
+    fn render_transcript_timestamps_a_recovered_turn_too() {
+        let result = json!({
+            "turns": [{
+                "seq": 3,
+                "ts": "2026-08-14T15:26:55.874Z",
+                "role": "assistant",
+                "text": "partial output before the cut",
+                "source": "blob_decode",
+                "interrupted": true,
+            }],
+        });
+        let rendered = render_transcript(&result);
+        assert!(
+            rendered.contains(
+                "[2026-08-14T15:26:55.874Z] Assistant (recovered from the interrupted turn's raw archive):"
+            ),
+            "missing recovered-turn timestamp: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_transcript_reports_no_conversation_without_a_timestamp_line() {
+        let rendered = render_transcript(&json!({"turns": []}));
+        assert_eq!(rendered, "no conversation recorded for this work\n");
     }
 }

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -4987,6 +4987,7 @@ mod tests {
             } else {
                 BindingDisposition::RetainedDirty {
                     changes: "M solo/wip.rs".to_string(),
+                    patch: None,
                 }
             };
             TeardownReport {

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -207,16 +207,43 @@ impl WorkSurface {
     }
 }
 
+/// Where #109's captured dirty-state patch was written, and how large it
+/// is — enough for an operator (or `sgt work reap`) to reason about what is
+/// actually on disk without re-reading it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PatchInfo {
+    /// The patch file's path, under the surface root (sibling to the
+    /// worktree it replaced — `remove_surface_root`'s own fail-closed
+    /// `remove_dir` is what keeps the root alive once this is the only
+    /// thing left inside it).
+    pub path: PathBuf,
+    /// The patch file's size in bytes.
+    pub bytes: u64,
+}
+
 /// What happened to one binding at teardown.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "disposition", rename_all = "snake_case")]
 pub enum BindingDisposition {
     /// The worktree was clean and has been removed.
     Removed,
-    /// The worktree had uncommitted or untracked changes: retained, recorded.
+    /// The worktree had uncommitted or untracked changes: the dirty state
+    /// is retained, never the directory it happened to live in (#109, owner
+    /// ruling R4: *"The journal is the real artifact. Let's keep the disk
+    /// clean."*).
     RetainedDirty {
         /// `git status --porcelain` output, as evidence.
         changes: String,
+        /// Where the dirty state was captured as a patch, once the worktree
+        /// directory itself was reclaimed (see [`retain_dirty`]). `None`
+        /// means the capture could not be trusted — a submodule-bearing
+        /// worktree, or a git failure partway through — so teardown fell
+        /// back to retaining the whole directory, exactly as it did before
+        /// #109. `#[serde(default)]` so every binding journaled before this
+        /// field existed deserializes as that same fallback, which is
+        /// honest: those really did retain the whole directory.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        patch: Option<PatchInfo>,
     },
     /// The worktree path was already gone: recorded, not treated as success.
     Missing,
@@ -710,6 +737,229 @@ pub fn teardown(surface: &WorkSurface) -> TeardownReport {
     }
 }
 
+/// One binding a Work's teardown left something on disk for — #109's
+/// inspect verb (`sgt work retained`): what is retained, why, and how
+/// large. Never includes `Removed`/`Missing` bindings, since there is
+/// nothing there for an operator to act on.
+#[derive(Debug, Clone, Serialize)]
+pub struct RetainedBinding {
+    /// Repository name.
+    pub repository: String,
+    /// Where the retained content actually lives: the patch file when
+    /// [`retain_dirty`] captured one, otherwise the worktree directory
+    /// itself (the submodule/capture-failure fallback, or a
+    /// `RetainedError`).
+    pub path: PathBuf,
+    /// `retained_dirty` or `retained_error` — the same bare-tag spelling
+    /// `sgt work show`'s output pointer already uses, so a client never has
+    /// to reconcile two vocabularies for the same fact.
+    pub reason: &'static str,
+    /// The evidence teardown recorded: `git status --porcelain` output for
+    /// `retained_dirty`, Git's own diagnostic for `retained_error`.
+    pub detail: String,
+    /// Size in bytes: exact for a captured patch, best-effort
+    /// ([`directory_size`]) for a still-retained directory.
+    pub bytes: u64,
+}
+
+/// #109's inspect verb, the pure decode: every binding in `teardown` that
+/// still holds disk past a clean removal. A live filesystem read
+/// ([`directory_size`]) for the directory-fallback case, not a size cached
+/// at teardown time — so this always reports what is *actually* on disk
+/// right now, including after a partial `sgt work reap` or an out-of-band
+/// change, rather than trusting a number that can go stale the moment
+/// anything else touches the path.
+pub fn retained_bindings(teardown: &TeardownReport) -> Vec<RetainedBinding> {
+    teardown
+        .bindings
+        .iter()
+        .filter_map(|b| match &b.disposition {
+            BindingDisposition::RetainedDirty {
+                changes,
+                patch: Some(info),
+            } => {
+                // Live check, not the size journaled at teardown time: a
+                // `sgt work reap` since then (or anything else that removed
+                // the file) must not keep showing up here — the same
+                // "report what is actually on disk right now" rule
+                // `directory_size`'s callers below already follow.
+                if !info.path.is_file() {
+                    return None;
+                }
+                Some(RetainedBinding {
+                    repository: b.repository.clone(),
+                    path: info.path.clone(),
+                    reason: "retained_dirty",
+                    detail: changes.clone(),
+                    bytes: info.bytes,
+                })
+            }
+            BindingDisposition::RetainedDirty {
+                changes,
+                patch: None,
+            } => {
+                if !b.worktree_path.exists() {
+                    return None;
+                }
+                Some(RetainedBinding {
+                    repository: b.repository.clone(),
+                    path: b.worktree_path.clone(),
+                    reason: "retained_dirty",
+                    detail: changes.clone(),
+                    bytes: directory_size(&b.worktree_path),
+                })
+            }
+            BindingDisposition::RetainedError { detail } => {
+                if !b.worktree_path.exists() {
+                    return None;
+                }
+                Some(RetainedBinding {
+                    repository: b.repository.clone(),
+                    path: b.worktree_path.clone(),
+                    reason: "retained_error",
+                    detail: detail.clone(),
+                    bytes: directory_size(&b.worktree_path),
+                })
+            }
+            BindingDisposition::Removed | BindingDisposition::Missing => None,
+        })
+        .collect()
+}
+
+/// What happened when [`reap`] tried to dispose of one binding's retained
+/// state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ReapOutcome {
+    /// The retained state was permanently discarded.
+    Reaped {
+        /// What was freed.
+        bytes: u64,
+    },
+    /// Nothing was retained for this binding (`Removed`/`Missing`, or an
+    /// earlier reap already cleared it) — a no-op, not a failure.
+    NothingRetained,
+    /// Left alone, on purpose: `RetainedError` means teardown could not
+    /// even establish that this worktree was clean (`git status` itself
+    /// failed), so there is no evidence a forced removal here would be
+    /// discarding only what teardown already knows about, rather than real
+    /// uncommitted work nothing ever captured. Ambiguity fails closed
+    /// (`AGENTS.md`) — resolve the underlying git error and let teardown
+    /// re-run instead.
+    Skipped {
+        /// Why this binding was left alone.
+        reason: String,
+    },
+    /// The reap attempt itself failed (git or the filesystem refused).
+    Failed {
+        /// The underlying diagnostic.
+        detail: String,
+    },
+}
+
+/// One binding's [`reap`] outcome.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BindingReap {
+    /// Repository name.
+    pub repository: String,
+    /// What happened.
+    pub outcome: ReapOutcome,
+}
+
+/// [`reap`]'s outcome for a whole Work.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReapReport {
+    /// Work whose retained state was reaped.
+    pub work_id: String,
+    /// Per-binding outcomes.
+    pub bindings: Vec<BindingReap>,
+}
+
+/// #109's dispose verb: permanently discard whatever `RetainedDirty`
+/// bindings still hold for this Work — the captured patch, or, in the
+/// submodule/capture-failure fallback, the worktree directory itself.
+///
+/// A deliberate, explicit, human-invoked action, never run on its own:
+/// `AGENTS.md`'s guardrail puts preserved state (a retained branch, a
+/// journal, a Work record) outside anything standing authorization may
+/// destroy, and this is how a human destroys the *dirty-state* half of it
+/// on purpose, once they have decided they no longer need it (typically
+/// after reading it via [`retained_bindings`]). It never touches the
+/// retained *branch* — teardown's branch-retention guarantee is
+/// unconditional (§11) and this function has no path that reaches it.
+///
+/// Scoped to `RetainedDirty` only, matching [`ReapOutcome::Skipped`]'s
+/// reasoning: a `RetainedError` binding has no evidence backing a forced
+/// removal, so it is reported, not touched.
+pub fn reap(surface: &WorkSurface, teardown: &TeardownReport) -> ReapReport {
+    let bindings = teardown
+        .bindings
+        .iter()
+        .map(|b| BindingReap {
+            repository: b.repository.clone(),
+            outcome: reap_binding(surface, b),
+        })
+        .collect();
+    remove_surface_root(&surface.root);
+    ReapReport {
+        work_id: teardown.work_id.clone(),
+        bindings,
+    }
+}
+
+fn reap_binding(surface: &WorkSurface, binding: &BindingTeardown) -> ReapOutcome {
+    match &binding.disposition {
+        BindingDisposition::RetainedDirty {
+            patch: Some(info), ..
+        } => match std::fs::remove_file(&info.path) {
+            Ok(()) => ReapOutcome::Reaped { bytes: info.bytes },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReapOutcome::NothingRetained,
+            Err(e) => ReapOutcome::Failed {
+                detail: e.to_string(),
+            },
+        },
+        BindingDisposition::RetainedDirty { patch: None, .. } => {
+            if !binding.worktree_path.exists() {
+                return ReapOutcome::NothingRetained;
+            }
+            // The directory is still a real, registered git worktree (that
+            // is exactly why it was never removed at teardown) — going
+            // through git rather than a raw recursive delete keeps the
+            // source repository's own worktree registry consistent, the
+            // same as every other removal this module ever does.
+            let Some(source) = surface
+                .bindings
+                .iter()
+                .find(|b| b.repository == binding.repository)
+                .map(|b| b.source_path.clone())
+            else {
+                return ReapOutcome::Failed {
+                    detail: "no surface binding recorded for this repository; cannot resolve \
+                             which source repository's worktree registry to update"
+                        .to_string(),
+                };
+            };
+            let bytes = directory_size(&binding.worktree_path);
+            let path = binding.worktree_path.display().to_string();
+            match with_repository(&source, || {
+                git(&source, &["worktree", "remove", "--force", &path])
+            }) {
+                Ok(_) => ReapOutcome::Reaped { bytes },
+                Err(e) => ReapOutcome::Failed {
+                    detail: e.to_string(),
+                },
+            }
+        }
+        BindingDisposition::RetainedError { detail } => ReapOutcome::Skipped {
+            reason: format!(
+                "teardown could not establish this worktree was clean ({detail}); resolve the \
+                 underlying git error and retry teardown instead of reaping"
+            ),
+        },
+        BindingDisposition::Removed | BindingDisposition::Missing => ReapOutcome::NothingRetained,
+    }
+}
+
 /// Remove the per-work surface root, but only once nothing is left inside it.
 ///
 /// `remove_dir` *is* the whole guard, and deliberately so: it refuses a
@@ -750,6 +1000,110 @@ fn prune_stale_worktrees(source: &Path) {
     let _ = git(source, &["worktree", "prune"]);
 }
 
+/// #109 (R4): retention preserves the dirty *state*, never the whole
+/// directory it happened to live in — `target/` and every other gitignored
+/// artifact must never be in scope (owner ruling, plan v2 R4/R12: *"The
+/// journal is the real artifact. Let's keep the disk clean."*). Measured
+/// motivation: three `retained_dirty` surfaces held 30 GB, essentially all
+/// of it gitignored `target/` (#109).
+///
+/// `git add -A` (respects `.gitignore`, so `target/` is never staged) plus
+/// `git diff --cached --binary` captures every tracked modification *and*
+/// every untracked-but-wanted file in one patch — the same trick that
+/// answers the issue's hard case, an untracked file worth keeping beside
+/// untracked build output that is not. A `git bundle` was considered and
+/// rejected: its advantage is self-contained branch history, and teardown
+/// already keeps that for free by never deleting the branch (§11) — a
+/// bundle would only duplicate it. A `git stash` was rejected too: it lives
+/// in the *source* repository's own reflog, subject to that repository's
+/// own housekeeping, rather than travelling with the surface the way a file
+/// under the surface root does.
+///
+/// Fails closed onto the pre-#109 behavior — the whole worktree directory
+/// left in place, nothing removed — whenever the capture cannot be fully
+/// trusted: a worktree that declares submodules (a nested repository's own
+/// uncommitted content never appears in the parent's `git add -A`, only its
+/// commit pointer does, so a patch here could silently under-capture it),
+/// or any git/io failure along the way. Only once the patch is durably on
+/// disk does this remove the worktree, and only with `--force` — safe here
+/// specifically because everything `git status --porcelain` just reported
+/// has already been captured.
+fn retain_dirty(binding: &RepositoryBinding, changes: String) -> BindingDisposition {
+    if binding.worktree_path.join(".gitmodules").exists() {
+        return BindingDisposition::RetainedDirty {
+            changes,
+            patch: None,
+        };
+    }
+    let Some(patch) = capture_dirty_patch(binding) else {
+        return BindingDisposition::RetainedDirty {
+            changes,
+            patch: None,
+        };
+    };
+    let path = binding.worktree_path.display().to_string();
+    // Whether or not the removal below succeeds, the patch is already
+    // durable, so nothing captured can be lost. A removal failure just means
+    // the directory did not get reclaimed this round — the next teardown
+    // retry, or `sgt work reap`, tries again (idempotent, same as every
+    // other disposition here).
+    let _ = git(
+        &binding.source_path,
+        &["worktree", "remove", "--force", &path],
+    );
+    BindingDisposition::RetainedDirty {
+        changes,
+        patch: Some(patch),
+    }
+}
+
+/// Stage everything `.gitignore` does not exclude (`git add -A`), diff it
+/// against `HEAD` (`git diff --cached --binary`), and write the result
+/// durably under the surface root, sibling to the worktree it is about to
+/// replace. `None` on any failure — a caller that gets `None` back must not
+/// remove anything, since nothing was actually captured.
+fn capture_dirty_patch(binding: &RepositoryBinding) -> Option<PatchInfo> {
+    git(&binding.worktree_path, &["add", "-A"]).ok()?;
+    let diff = git(&binding.worktree_path, &["diff", "--cached", "--binary"]).ok()?;
+    // Defensive: the caller already confirmed `git status --porcelain` was
+    // non-empty, so an empty diff here means something about the capture
+    // did not actually see what made the worktree dirty — fail closed
+    // rather than reclaim a directory whose content was never written down.
+    if diff.is_empty() {
+        return None;
+    }
+    let path = binding
+        .worktree_path
+        .parent()?
+        .join(format!("{}.dirty.patch", binding.repository));
+    crate::runtime::fsutil::write_atomic(&path, diff.as_bytes()).ok()?;
+    Some(PatchInfo {
+        path,
+        bytes: diff.len() as u64,
+    })
+}
+
+/// Best-effort recursive size of everything under `path`, in bytes — disk-
+/// usage evidence for an operator (`sgt work retained`), not an accounting
+/// system. Errors partway (permissions, a vanished entry mid-walk) are
+/// swallowed: a size that is merely a lower bound because of one unreadable
+/// subtree is more useful than refusing to answer at all.
+pub fn directory_size(path: &Path) -> u64 {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if !metadata.is_dir() {
+        return metadata.len();
+    }
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return metadata.len();
+    };
+    entries
+        .flatten()
+        .map(|entry| directory_size(&entry.path()))
+        .sum()
+}
+
 fn teardown_binding(binding: &RepositoryBinding) -> (BindingDisposition, Option<String>) {
     with_repository(&binding.source_path, || teardown_binding_locked(binding))
 }
@@ -773,7 +1127,7 @@ fn teardown_binding_locked(binding: &RepositoryBinding) -> (BindingDisposition, 
     }
     match git(&binding.worktree_path, &["status", "--porcelain"]) {
         Ok(changes) if !changes.is_empty() => {
-            return (BindingDisposition::RetainedDirty { changes }, final_sha);
+            return (retain_dirty(binding, changes), final_sha);
         }
         Ok(_) => {}
         Err(e) => {
@@ -1082,26 +1436,43 @@ mod tests {
 
     /// §12 makes retry the one door back out of failed, blocked and waiting,
     /// and retry re-attaches the worktrees teardown removed. A worktree that
-    /// teardown *retained* (dirty, so fail-closed left it alone) and that
-    /// was then deleted out of band is the case nothing else prunes: git
-    /// still has it registered, and without a prune every `worktree add` at
-    /// that path fails for good, wedging retry permanently.
+    /// teardown *retained whole* (fail-closed left it alone) and that was
+    /// then deleted out of band is the case nothing else prunes: git still
+    /// has it registered, and without a prune every `worktree add` at that
+    /// path fails for good, wedging retry permanently.
+    ///
+    /// #109 narrows how often the whole directory is what is retained — an
+    /// ordinary dirty worktree now gets its state captured as a patch and
+    /// the directory itself reclaimed via a real `git worktree remove`,
+    /// which never leaves this staleness behind in the first place. The
+    /// submodule fallback is the case that still can: `retain_dirty` leaves
+    /// the directory (and its git registration) untouched, so this test
+    /// exercises that path to keep covering the recovery this docstring
+    /// describes.
     #[test]
     fn a_worktree_deleted_after_a_dirty_teardown_can_still_be_rematerialized() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
-        let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01STALE", std::slice::from_ref(&spec)).expect("materialize");
+        let inner = repo(&dir.path().join("inner"));
+        let outer = repo(&dir.path().join("outer"));
+        declare_submodule(&outer.path, &inner.path, "vendored");
+
+        let surface = materialize(data.path(), "01STALE", std::slice::from_ref(&outer))
+            .expect("materialize a repository with a submodule");
         let worktree = surface.bindings[0].worktree_path.clone();
 
-        // Uncommitted work: teardown retains it, and therefore never prunes.
+        // Uncommitted work: teardown retains it whole, and therefore never
+        // prunes.
         std::fs::write(worktree.join("half-done.rs"), "fn main() {}\n").expect("dirty");
         let report = teardown(&surface);
         assert!(matches!(
             report.bindings[0].disposition,
-            BindingDisposition::RetainedDirty { .. }
+            BindingDisposition::RetainedDirty { patch: None, .. }
         ));
+        assert!(
+            worktree.exists(),
+            "the submodule fallback keeps the whole directory"
+        );
 
         // ...and then it is deleted by something that is not sergeant.
         std::fs::remove_dir_all(&worktree).expect("delete out of band");
@@ -1272,19 +1643,31 @@ mod tests {
         );
 
         // A retained worktree keeps its root: teardown fails closed, and the
-        // root is where the retained thing lives.
+        // root is where the retained *state* lives. #109: not the whole
+        // directory — that gets reclaimed once its dirty state is captured
+        // as a patch, which is exactly what keeps the root non-empty.
         let dirty_spec = repo(&dir.path().join("dirty"));
         let dirty = materialize(data.path(), "01DIRTY", std::slice::from_ref(&dirty_spec))
             .expect("materialize dirty");
         std::fs::write(dirty.bindings[0].worktree_path.join("wip.rs"), "//\n").expect("dirty");
         let report = teardown(&dirty);
-        assert!(matches!(
-            report.bindings[0].disposition,
-            BindingDisposition::RetainedDirty { .. }
-        ));
+        let BindingDisposition::RetainedDirty { patch, .. } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected RetainedDirty: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        let patch = patch
+            .as_ref()
+            .expect("an ordinary (non-submodule) dirty worktree must capture a patch");
         assert!(
-            dirty.root.is_dir() && dirty.bindings[0].worktree_path.is_dir(),
-            "uncommitted work is never removed, and neither is the root holding it"
+            dirty.root.is_dir() && patch.path.is_file(),
+            "the dirty state is retained as a patch under the root, not the whole directory"
+        );
+        assert!(
+            !dirty.bindings[0].worktree_path.exists(),
+            "#109: the reclaimed worktree directory itself must be gone"
         );
     }
 
@@ -1560,10 +1943,28 @@ mod tests {
         assert!(
             matches!(
                 &report.bindings[0].disposition,
-                BindingDisposition::RetainedDirty { changes } if changes.contains("vendored")
+                BindingDisposition::RetainedDirty { changes, .. } if changes.contains("vendored")
             ),
             "must be retained as dirty (not silently force-removed): {:?}",
             report.bindings[0].disposition
+        );
+        // #109: a submodule-bearing worktree is the fallback case teardown
+        // still retains the *whole directory* for, because `git add -A` in
+        // the superproject cannot see the submodule's own uncommitted
+        // content — only its commit pointer. `patch` staying `None` is what
+        // proves the capture path was skipped rather than silently
+        // under-capturing it.
+        let BindingDisposition::RetainedDirty { patch, .. } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected RetainedDirty: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        assert!(
+            patch.is_none(),
+            "a submodule-bearing worktree must fall back to whole-directory retention, \
+             not a patch that cannot see inside the submodule: {patch:?}"
         );
         assert!(
             worktree.exists() && worktree.join("vendored").join("actors-work.txt").is_file(),
@@ -1921,5 +2322,207 @@ mod tests {
             attach(data.path(), "01EMPTY", "01TARGET", &[]),
             Err(SurfaceError::NoRepositories)
         ));
+    }
+
+    // ------------------------------------------------------------- #109
+
+    /// The retention-scope clause itself, pinned end to end: a dirty
+    /// worktree with a genuinely wanted untracked file *and* gitignored
+    /// build output produces a patch that captures the former and excludes
+    /// the latter, and the (potentially huge) directory is gone afterward.
+    /// Reverting `retain_dirty`/`capture_dirty_patch` back to "leave the
+    /// whole directory" fails the `!worktree.exists()` assertion; reverting
+    /// to "stage everything, ignoring .gitignore" would fail the
+    /// `!patch_text.contains("compiled output")` assertion instead.
+    #[test]
+    fn teardown_captures_an_untracked_wanted_file_and_excludes_gitignored_build_output() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface =
+            materialize(data.path(), "01SCOPE", std::slice::from_ref(&spec)).expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        std::fs::write(worktree.join(".gitignore"), "target/\n").expect(".gitignore");
+        git_as_test_identity(&worktree, &["add", ".gitignore"]);
+        git_as_test_identity(&worktree, &["commit", "-m", "ignore target/"]);
+
+        // A file worth keeping, never `git add`ed — exactly #109's "hard
+        // case".
+        std::fs::write(worktree.join("new-module.rs"), "fn wanted() {}\n").expect("untracked");
+        // Gitignored build output, large in spirit — #109's whole point is
+        // that this must never end up retained.
+        std::fs::create_dir_all(worktree.join("target")).expect("target dir");
+        std::fs::write(worktree.join("target").join("big.bin"), "compiled output")
+            .expect("build artifact");
+
+        let report = teardown(&surface);
+        let BindingDisposition::RetainedDirty { patch, .. } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected RetainedDirty: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        let patch = patch.as_ref().expect("must capture a patch");
+        assert!(
+            !worktree.exists(),
+            "the directory — target/ included — must be gone, not just the tracked bits"
+        );
+
+        let patch_text = std::fs::read_to_string(&patch.path).expect("read captured patch");
+        assert!(
+            patch_text.contains("new-module.rs") && patch_text.contains("fn wanted()"),
+            "the untracked-but-wanted file must be captured: {patch_text}"
+        );
+        assert!(
+            !patch_text.contains("target/big.bin") && !patch_text.contains("compiled output"),
+            "gitignored build output must never enter the patch: {patch_text}"
+        );
+        assert_eq!(
+            patch.bytes,
+            patch_text.len() as u64,
+            "the recorded size must match what was actually written"
+        );
+    }
+
+    /// [`retained_bindings`] (`sgt work retained`'s inspect verb): a
+    /// captured patch reports its exact known size; a `RetainedError`
+    /// binding — no patch, since nothing was ever captured for it — is
+    /// still surfaced, with a live directory-size measurement rather than a
+    /// stale or absent one.
+    #[test]
+    fn retained_bindings_reports_a_captured_patch_and_a_retained_error_directory() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface = materialize(data.path(), "01INSPECT", std::slice::from_ref(&spec))
+            .expect("materialize");
+        std::fs::write(surface.bindings[0].worktree_path.join("wip.rs"), "//\n").expect("dirty");
+        let report = teardown(&surface);
+
+        let error_binding = BindingTeardown {
+            repository: "other".to_string(),
+            worktree_path: dir.path().join("some-other-worktree"),
+            work_branch: "sergeant/01INSPECT".to_string(),
+            final_sha: None,
+            disposition: BindingDisposition::RetainedError {
+                detail: "fatal: could not read status".to_string(),
+            },
+        };
+        std::fs::create_dir_all(&error_binding.worktree_path).expect("stand-in directory");
+        std::fs::write(error_binding.worktree_path.join("evidence.txt"), "12345").expect("file");
+
+        let mut combined = report.clone();
+        combined.bindings.push(error_binding);
+
+        let retained = retained_bindings(&combined);
+        assert_eq!(
+            retained.len(),
+            2,
+            "both bindings hold something: {retained:?}"
+        );
+
+        let BindingDisposition::RetainedDirty {
+            patch: Some(expected),
+            ..
+        } = &combined.bindings[0].disposition
+        else {
+            panic!(
+                "expected a captured patch: {:?}",
+                combined.bindings[0].disposition
+            );
+        };
+        let dirty = retained
+            .iter()
+            .find(|r| r.repository == "solo")
+            .expect("the captured-patch binding");
+        assert_eq!(dirty.reason, "retained_dirty");
+        assert!(dirty.bytes > 0);
+        assert_eq!(dirty.path, expected.path);
+        assert_eq!(dirty.bytes, expected.bytes);
+
+        let errored = retained
+            .iter()
+            .find(|r| r.repository == "other")
+            .expect("the RetainedError binding");
+        assert_eq!(errored.reason, "retained_error");
+        assert_eq!(
+            errored.bytes, 5,
+            "directory_size must measure the stand-in file"
+        );
+    }
+
+    /// [`reap`]: a captured patch is deleted and its exact size is reported
+    /// freed; a `RetainedError` binding is left alone (no evidence backs a
+    /// forced removal), and a `RetainedDirty` binding with no patch
+    /// (submodule fallback) is force-removed through git rather than a raw
+    /// delete, keeping the source repository's own worktree registry
+    /// truthful.
+    #[test]
+    fn reap_deletes_a_captured_patch_and_leaves_a_retained_error_binding_alone() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface =
+            materialize(data.path(), "01REAP", std::slice::from_ref(&spec)).expect("materialize");
+        std::fs::write(surface.bindings[0].worktree_path.join("wip.rs"), "//\n").expect("dirty");
+        let mut report = teardown(&surface);
+        let BindingDisposition::RetainedDirty {
+            patch: Some(before),
+            ..
+        } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected a captured patch: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        let patch_path = before.path.clone();
+        let expected_bytes = before.bytes;
+        assert!(patch_path.is_file(), "the patch must exist before reaping");
+
+        report.bindings.push(BindingTeardown {
+            repository: "other".to_string(),
+            worktree_path: dir.path().join("untouched"),
+            work_branch: "sergeant/01REAP".to_string(),
+            final_sha: None,
+            disposition: BindingDisposition::RetainedError {
+                detail: "fatal: could not read status".to_string(),
+            },
+        });
+
+        let reaped = reap(&surface, &report);
+        assert_eq!(reaped.work_id, "01REAP");
+
+        let solo = reaped
+            .bindings
+            .iter()
+            .find(|b| b.repository == "solo")
+            .expect("solo's reap outcome");
+        assert_eq!(
+            solo.outcome,
+            ReapOutcome::Reaped {
+                bytes: expected_bytes
+            }
+        );
+        assert!(!patch_path.exists(), "the patch must actually be deleted");
+
+        let other = reaped
+            .bindings
+            .iter()
+            .find(|b| b.repository == "other")
+            .expect("other's reap outcome");
+        assert!(
+            matches!(&other.outcome, ReapOutcome::Skipped { .. }),
+            "a RetainedError binding must be left alone: {:?}",
+            other.outcome
+        );
+
+        // Nothing left in the root once the only retained artifact is gone.
+        assert!(
+            !surface.root.exists(),
+            "reaping the last retained artifact must let the root go too"
+        );
     }
 }

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -2333,9 +2333,128 @@ async fn a_dirty_worktree_is_retained_and_recorded_at_teardown() {
             .contains("half-done.rs"),
         "the evidence must name what was found: {report}"
     );
+    // #109: the dirty *state* survives teardown, never the directory it
+    // happened to live in — the worktree itself is reclaimed once its
+    // content is captured as a patch.
     assert!(
-        worktree.join("half-done.rs").is_file(),
-        "a dirty worktree must survive teardown"
+        !worktree.exists(),
+        "#109: the reclaimed worktree directory must be gone"
+    );
+    let patch_path = PathBuf::from(
+        report["bindings"][0]["patch"]["path"]
+            .as_str()
+            .expect("a captured patch path"),
+    );
+    let patch_text = std::fs::read_to_string(&patch_path).expect("read the captured patch");
+    assert!(
+        patch_text.contains("half-done.rs") && patch_text.contains("fn main()"),
+        "the captured patch must hold what the dirty worktree actually had: {patch_text}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// #109's inspect and dispose verbs, end to end through the real API: a
+/// dirty worktree's teardown shows up in `GET /v1/retained`; `POST
+/// /v1/work/{id}/reap` refuses without confirmation and destroys the
+/// captured patch once confirmed; and the entry is gone from `/v1/retained`
+/// afterward. Reverting either handler (dropping the confirm gate, or
+/// `surface::reap` itself) fails a different assertion here.
+#[tokio::test]
+async fn retained_lists_a_dirty_teardown_and_reap_disposes_of_it_only_when_confirmed() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let repo = repos.path().join("solo");
+    init_repo(&repo);
+    write_two_stage_workflow(&repo);
+
+    let (registry, _fake) = one_fake([FakeStep::hang()]);
+    let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
+    let client = http();
+    let (_, body) = submit(
+        &client,
+        &handle,
+        &repo,
+        "leaves a mess for #109",
+        json!({"workflow": "tiny"}),
+    )
+    .await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    let worktree = PathBuf::from(
+        body["surface"]["bindings"][0]["worktree_path"]
+            .as_str()
+            .expect("worktree"),
+    );
+    std::fs::write(worktree.join("half-done.rs"), "fn main() {}\n").expect("dirty the worktree");
+
+    let (status, _) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/cancel"),
+        json!({"command_id": ulid()}),
+    )
+    .await;
+    assert_eq!(status, 200);
+
+    // The inspect verb finds it.
+    let retained = get(&client, &handle, "/v1/retained").await;
+    let entries = retained["retained"].as_array().expect("retained array");
+    let entry = entries
+        .iter()
+        .find(|e| e["work_id"] == work_id)
+        .expect("the dirty binding is listed");
+    assert_eq!(entry["repository"], "solo");
+    assert_eq!(entry["disposition"], "retained_dirty");
+    let bytes = entry["bytes"].as_u64().expect("bytes");
+    assert!(bytes > 0, "a real patch has a nonzero size: {entry}");
+    let patch_path = PathBuf::from(entry["path"].as_str().expect("patch path"));
+    assert!(
+        patch_path.is_file(),
+        "the patch the inspect verb names must actually exist"
+    );
+
+    // Reap refuses without confirmation, and destroys nothing.
+    let (status, body) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/reap"),
+        json!({"command_id": ulid()}),
+    )
+    .await;
+    assert_eq!(status, 400, "{body}");
+    assert!(
+        patch_path.is_file(),
+        "an unconfirmed reap must not touch anything"
+    );
+
+    // Confirmed, it actually reaps.
+    let (status, body) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/reap"),
+        json!({"command_id": ulid(), "confirm": true}),
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(
+        body["report"]["bindings"][0]["outcome"]["outcome"], "reaped",
+        "{body}"
+    );
+    assert_eq!(
+        body["report"]["bindings"][0]["outcome"]["bytes"], bytes,
+        "the freed size must match what was actually there: {body}"
+    );
+    assert!(!patch_path.exists(), "reap must actually delete the patch");
+
+    // And it is gone from the inspect view.
+    let retained_after = get(&client, &handle, "/v1/retained").await;
+    assert!(
+        retained_after["retained"]
+            .as_array()
+            .expect("retained array")
+            .iter()
+            .all(|e| e["work_id"] != work_id),
+        "a reaped binding must not still be listed: {retained_after}"
     );
 
     handle.shutdown().await;
@@ -2416,9 +2535,11 @@ async fn a_stranded_completion_is_not_reported_as_plain_completed() {
         body["output"]["repositories"][0]["disposition"], "retained_dirty",
         "{body}"
     );
+    // #109: the dirty state survives teardown as a captured patch, not the
+    // worktree directory itself.
     assert!(
-        worktree.join("half-done.rs").is_file(),
-        "a dirty worktree must survive teardown: {body}"
+        !worktree.exists(),
+        "#109: the reclaimed worktree directory must be gone: {body}"
     );
 
     // The one thing an operator reads first must not say plain `completed`.

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -3997,9 +3997,22 @@ fn a4_a_swept_surface_that_cannot_be_removed_is_retained_named_and_not_re_swept(
         "…with git's own evidence for why: {}",
         torn[0]["report"]
     );
+    // #109: recovery's sweep goes through the same `teardown` this
+    // repository's ordinary path does, so the dirty *state* survives as a
+    // captured patch, never the worktree directory it was found in.
     assert!(
-        worktree.join("half-done.txt").is_file(),
-        "recovery must never delete uncommitted work it found on disk"
+        !worktree.exists(),
+        "#109: the reclaimed worktree directory must be gone"
+    );
+    let patch_path = PathBuf::from(
+        torn[0]["report"]["bindings"][0]["patch"]["path"]
+            .as_str()
+            .expect("a captured patch path"),
+    );
+    let patch_text = std::fs::read_to_string(&patch_path).expect("read the captured patch");
+    assert!(
+        patch_text.contains("half-done.txt") && patch_text.contains("not committed anywhere"),
+        "recovery must never actually lose uncommitted work it found on disk: {patch_text}"
     );
     assert!(
         surface.root.is_dir(),

--- a/tests/m7_docker_executor.rs
+++ b/tests/m7_docker_executor.rs
@@ -1476,6 +1476,14 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
     assert_no_containers_for_work(&work_id);
 }
 
+/// Looks for `validated.txt` as a plain file (a clean worktree, or a
+/// `RetainedError`/submodule-fallback directory still standing whole), or —
+/// #109's retention-scope change — inside a captured `*.dirty.patch`: an
+/// uncommitted execute-stage artifact is exactly the "dirty state" R4 says
+/// teardown retains as a patch rather than the whole directory, so the
+/// evidence this test is proving survives teardown now travels in that
+/// form. Either way the evidence handed to the following actor was not
+/// lost, which is the actual N4/§21.5 claim this test pins.
 fn walk_for_marker(dir: &Path) -> bool {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return false;
@@ -1488,8 +1496,15 @@ fn walk_for_marker(dir: &Path) -> bool {
             }
         } else if path.file_name().and_then(|n| n.to_str()) == Some("validated.txt")
             && let Ok(content) = std::fs::read_to_string(&path)
+            && content.trim() == "container-produced-evidence"
         {
-            return content.trim() == "container-produced-evidence";
+            return true;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("patch")
+            && let Ok(content) = std::fs::read_to_string(&path)
+            && content.contains("validated.txt")
+            && content.contains("container-produced-evidence")
+        {
+            return true;
         }
     }
     false

--- a/tests/m8_estate_cli.rs
+++ b/tests/m8_estate_cli.rs
@@ -1075,6 +1075,123 @@ fn work_transcript_and_output_pointer_are_reachable_from_the_real_cli() {
     data_dir.reap();
 }
 
+/// guard-map: `sgt work retained` and `sgt work reap` (#109), reachable end
+/// to end through the real CLI/daemon. `sgt work reap <id>` without `--yes`
+/// previews and destroys nothing; `--yes` actually disposes of the captured
+/// patch a dirty teardown left behind, and the entry drops out of `sgt work
+/// retained` afterward.
+#[test]
+fn work_retained_and_reap_are_reachable_from_the_real_cli() {
+    let data_dir = DataDir::new();
+    let repo = tempfile::TempDir::new().expect("tempdir");
+    init_repo(repo.path());
+    write_two_stage_workflow(repo.path());
+
+    // `hang` keeps the first stage in flight so the worktree can be dirtied
+    // before anything tears it down — the env reaches the auto-spawned
+    // daemon this `run` call spawns, the same way `SGT_FAKE_SCRIPT` reaches
+    // it in the §39 walkthrough.
+    let submitted = run(
+        repo.path(),
+        Some(data_dir.path()),
+        &[("SGT_FAKE_SCRIPT", "hang")],
+        &[
+            "--json",
+            "run",
+            "--workflow",
+            "tiny",
+            "leaves a mess for #109",
+        ],
+    );
+    submitted.assert_ok("run");
+    let work_id = submitted.json()["work"]["id"]
+        .as_str()
+        .expect("work id")
+        .to_string();
+    let worktree = PathBuf::from(
+        submitted.json()["surface"]["bindings"][0]["worktree_path"]
+            .as_str()
+            .expect("worktree"),
+    );
+    std::fs::write(worktree.join("half-done.rs"), "fn main() {}\n").expect("dirty the worktree");
+
+    run(
+        repo.path(),
+        Some(data_dir.path()),
+        &[],
+        &["cancel", &work_id],
+    )
+    .assert_ok("cancel");
+    wait_for_state(repo.path(), data_dir.path(), &work_id, "canceled");
+
+    // `sgt work retained` names it.
+    let retained = run(
+        repo.path(),
+        Some(data_dir.path()),
+        &[],
+        &["--json", "work", "retained"],
+    );
+    retained.assert_ok("work retained");
+    let entries = retained.json()["retained"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let entry = entries
+        .iter()
+        .find(|e| e["work_id"] == work_id)
+        .unwrap_or_else(|| panic!("the dirty binding must be listed: {:?}", retained.json()));
+    assert_eq!(entry["disposition"], "retained_dirty");
+    let patch_path = PathBuf::from(entry["path"].as_str().expect("patch path"));
+    assert!(patch_path.is_file(), "the named patch must actually exist");
+
+    // Without `--yes`, reap previews and destroys nothing.
+    let preview = run(
+        repo.path(),
+        Some(data_dir.path()),
+        &[],
+        &["work", "reap", &work_id],
+    );
+    preview.assert_ok("work reap (preview)");
+    assert!(
+        preview.stdout.contains("--yes"),
+        "an unconfirmed reap must point at --yes: {}",
+        preview.stdout
+    );
+    assert!(patch_path.is_file(), "a preview must not touch anything");
+
+    // `--yes` actually disposes of it.
+    let reaped = run(
+        repo.path(),
+        Some(data_dir.path()),
+        &[],
+        &["work", "reap", &work_id, "--yes"],
+    );
+    reaped.assert_ok("work reap --yes");
+    assert!(
+        !patch_path.exists(),
+        "reap --yes must actually delete the patch"
+    );
+
+    let retained_after = run(
+        repo.path(),
+        Some(data_dir.path()),
+        &[],
+        &["--json", "work", "retained"],
+    );
+    retained_after.assert_ok("work retained (after reap)");
+    assert!(
+        retained_after.json()["retained"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .all(|e| e["work_id"] != work_id),
+        "a reaped binding must not still be listed: {:?}",
+        retained_after.json()
+    );
+
+    data_dir.reap();
+}
+
 // -------------------------------------------------- envelope / daemon stop
 
 /// guard-map: `sgt run --turns N --ceiling-secs S` (checkpoint-friction


### PR DESCRIPTION
Lane PR into `integration/path-to-mac-2026-08-15`. Work `01M0265B4VXYEWA93AWDMWNV64`, `implement`, **2/40 turns**, clean teardown. The sprint's largest diff: 1,297 insertions across 8 files.

## Refs #109 — deliberately narrowed, and it says so

Implements the owner's ruling: teardown retains the dirty **state** as a patch, **not the directory**, and `target/` is never in scope. *"The journal is the real artifact. Let's keep the disk clean."* Plus the inspect and reap verbs, fail-closed about what they destroy.

The arithmetic behind it: three `retained_dirty` surfaces held **30 GB**, essentially all of it gitignored build artifacts. That was 3 Works against 28 dispatched in one night — roughly 280 GB had they all torn down dirty, in the one dimension sergeant exists to make large. `LESSONS.md` **L22**.

**`Refs`, not `Fixes`, on purpose.** #109's own later comment reframes the top-level item as *"write the disk-footprint contract"* — what a Work may write and where, who owns each artifact at each Work state, who may reclaim it — with the verbs as its enforcement surface rather than the fix. **That contract is not in this sprint.** #109 does not fully close on this Work's output, and closing it would misrepresent what shipped. An earlier draft of the plan narrowed this silently; its own review caught that.

## Fixes #96 — transcript timestamps

`sgt work transcript` rendered turns without the timestamps the journal already holds, so "recent-looking" and "recent" were trivially conflated — which produced a wrong liveness claim the owner caught from a raw event. Not cosmetic: a surface telling an operator something false about whether work is progressing, in a system whose core invariant is that work state is not process state.

A rendering change only — `NORTH-STAR.md`'s *"a surface adds usability, never functionality."* The fact was always in the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)