### PR TITLE
W7: make #113's rig reaper platform-correct before it reaches a Mac (Refs #113, #18)

### DIFF
--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -3487,6 +3487,42 @@ fn data_dir_new_reaps_an_orphaned_rig_left_by_a_prior_killed_run() {
     );
 }
 
+/// W7 (#113 platform-correctness fixer): `pid_is_alive` must decide macOS
+/// liveness through the platform boundary's own, already-cfg-gated
+/// `process_alive` (`src/platform/process.rs`), not a bare, unguarded
+/// `/proc` read. The bug this pins: `Path::new("/proc").join(pid.to_string())
+/// .is_dir()` with no `cfg` guard is `false` for *every* pid on a host with
+/// no `/proc` at all — macOS — so the reaper would delete the rig of a run
+/// that is still using it, on exactly the platform this sprint exists to
+/// reach.
+///
+/// This can't be pinned by running the suite here: this host *has* `/proc`,
+/// so the old bare read and the fixed `process_alive` delegation answer
+/// identically for any real pid on Linux (the sibling test above already
+/// exercises that shared behavior). What differs only on a platform this
+/// suite cannot run on is not observable by any assertion over live
+/// process state — so, same shape as `t5` above pinning `tui.rs`'s client
+/// boundary via a source scan rather than a runtime probe, this pins the
+/// *wiring*: revert `pid_is_alive` back to the bare `/proc` read (verified
+/// in a disposable `/var/tmp` worktree per L7) and this fails, because the
+/// source no longer names `process_alive`.
+#[test]
+fn the_reaper_liveness_check_goes_through_the_platform_boundary_not_a_bare_proc_read() {
+    let source = read_test_support_source();
+    assert!(
+        source.contains("platform::process::process_alive"),
+        "tests/support/mod.rs's pid_is_alive must delegate to \
+         sergeant_rs::platform::process::process_alive (src/platform/process.rs), \
+         whose macOS arm is cfg-gated — a bare, unguarded `/proc` read reports \
+         every pid dead on a platform with no `/proc`"
+    );
+}
+
+fn read_test_support_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/support/mod.rs");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"))
+}
+
 // -------------------------------------------------- perf clock guard pin
 
 /// #95: `scripts/perf/common.sh`'s `perf_now_ns`/`perf_mark` must fail

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -3504,18 +3504,49 @@ fn data_dir_new_reaps_an_orphaned_rig_left_by_a_prior_killed_run() {
 /// process state — so, same shape as `t5` above pinning `tui.rs`'s client
 /// boundary via a source scan rather than a runtime probe, this pins the
 /// *wiring*: revert `pid_is_alive` back to the bare `/proc` read (verified
-/// in a disposable `/var/tmp` worktree per L7) and this fails, because the
-/// source no longer names `process_alive`.
+/// in a disposable `/var/tmp` worktree per L7) and this fails.
+///
+/// Scoped to the function *body*, not the whole file: an earlier version of
+/// this test scanned the full source, which made it pass against a reverted
+/// body anyway, because `pid_is_alive`'s own doc comment (this file,
+/// `tests/support/mod.rs`) names `platform::process::process_alive` in a
+/// rustdoc link — a revert that leaves that comment in place, which is what
+/// a real revert of just the function body does, left the substring in the
+/// file and the test green. Caught by actually reverting in a disposable
+/// `/var/tmp` worktree per L7, not by inspection.
 #[test]
 fn the_reaper_liveness_check_goes_through_the_platform_boundary_not_a_bare_proc_read() {
     let source = read_test_support_source();
+    let body = pid_is_alive_body(&source);
     assert!(
-        source.contains("platform::process::process_alive"),
+        body.contains("process_alive"),
         "tests/support/mod.rs's pid_is_alive must delegate to \
          sergeant_rs::platform::process::process_alive (src/platform/process.rs), \
          whose macOS arm is cfg-gated — a bare, unguarded `/proc` read reports \
-         every pid dead on a platform with no `/proc`"
+         every pid dead on a platform with no `/proc`. Body was: {body:?}"
     );
+    assert!(
+        !body.contains("/proc"),
+        "tests/support/mod.rs's pid_is_alive must not read /proc directly — that bare \
+         read is the bug this test pins. Body was: {body:?}"
+    );
+}
+
+/// The braces-delimited body of `fn pid_is_alive(pid: u32) -> bool { ... }`,
+/// so the assertions above scan only the implementation and not any doc
+/// comment above it (see the test's own doc comment for why that distinction
+/// is load-bearing). Assumes a body with no nested braces, true of both the
+/// delegating form and the bare-`/proc`-read form this test must catch.
+fn pid_is_alive_body(source: &str) -> &str {
+    let sig = "fn pid_is_alive(pid: u32) -> bool {";
+    let start = source
+        .find(sig)
+        .unwrap_or_else(|| panic!("tests/support/mod.rs must declare `{sig}`"));
+    let after_sig = &source[start + sig.len()..];
+    let end = after_sig
+        .find('}')
+        .expect("pid_is_alive's body must close with a `}`");
+    &after_sig[..end]
 }
 
 fn read_test_support_source() -> String {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -117,8 +117,39 @@ fn write_owner_pid(dir: &Path) {
     let _ = std::fs::write(dir.join(RIG_OWNER_PID_FILE), std::process::id().to_string());
 }
 
+/// Whether `pid` is currently a live process, decided the same
+/// platform-correct way the product itself decides it — never a bare
+/// `/proc` read.
+///
+/// **W7 (#113 platform-correctness fixer).** This function used to read
+/// `Path::new("/proc").join(pid.to_string()).is_dir()` directly, with no
+/// `cfg` guard at all. macOS has no `/proc`, so on macOS that check is
+/// `false` for *every* pid, including live ones, and
+/// [`reap_orphaned_rigs`] would then delete the rig of a run that is still
+/// using it — exactly the "reaping a live run's state would be a worse
+/// defect than the leak this closes" failure that function's own doc
+/// comment calls out.
+///
+/// Ponytail rung **R1** (reuse existing machinery, not a new one):
+/// [`platform::process::process_alive`](sergeant_rs::platform::process::process_alive)
+/// (`src/platform/process.rs`) already solves this identical fact behind
+/// the ADR 0002 platform boundary — `#[cfg(target_os = "linux")]` reads
+/// `/proc` exactly as this function used to, `#[cfg(target_os = "macos")]`
+/// shells to `kill -0` (marked **UNVERIFIED** there — never run on a real
+/// macOS host; verified by running `src/platform/process.rs`'s suite, and
+/// this reaper's own suite, on one), and it is `pub`, so this integration
+/// test can reach it directly. Its own fail-closed direction — assume
+/// alive, never conclude a pid is gone, on a platform this cannot evidence
+/// — is exactly the direction this reaper needs, for free. **R7 (a second,
+/// locally `cfg`-gated copy) was considered and rejected**: duplicating the
+/// macOS arm here would be a second UNVERIFIED implementation to keep in
+/// sync with `process.rs`'s own — the reinvention this sprint's own review
+/// exists to catch (`LESSONS.md` L18; this is the third instance of it in
+/// this sprint alone). The module doc's "dependency-free" pledge above is
+/// about spending this crate's *external* dependency budget; reusing this
+/// crate's own already-public platform module is not that.
 fn pid_is_alive(pid: u32) -> bool {
-    Path::new("/proc").join(pid.to_string()).is_dir()
+    sergeant_rs::platform::process::process_alive(pid)
 }
 
 /// Reap rig directories directly under `base` whose owning process is no


### PR DESCRIPTION
Lane PR into `integration/path-to-mac-2026-08-15`. Work `01M029JKSZY9TCMAD51423W8J5`, **2/40 turns**. `Refs #113`, `Refs #18` — closes neither.

## The defect, found by the orchestrator reviewing W3's own output

W3's #113 fix added a start-of-run rig reaper whose liveness probe was unconditionally `/proc`-based, with no `cfg` guard:

```rust
fn pid_is_alive(pid: u32) -> bool { Path::new("/proc").join(pid.to_string()).is_dir() }
```

macOS has no `/proc`, so on macOS that returns `false` for **every** pid — including live ones — and the reaper then deletes the rig of a run still using it. Its own doc comment names that outcome: *"reaping a live run's state would be a worse defect than the leak this closes."*

A sprint whose entire purpose is reaching a MacBook was about to ship a test helper that **destroys live test state on exactly that platform**, while closing #113 with a `Fixes` trailer.

## The fix

Reuses `sergeant_rs::platform::process::process_alive` — the ADR 0002 boundary's existing, already-`cfg`-gated implementation (`/proc` on Linux, `kill -0` on macOS, marked UNVERIFIED) — rather than duplicating the pattern. Its fail-closed direction, *assume alive and never conclude a pid is gone on a platform it cannot evidence*, is exactly what a reaper needs, for free.

Note the second commit: **"Make W7's reaper-wiring pinning test actually fail on revert."** The Work revert-probed its own new test, found it vacuous, and fixed it — **L7** applied to itself without being asked.

## The pattern this belongs to

Third instance of **L18** in one sprint: `src/platform/` already carried #18/#81/#82; #94 was already fixed; and now the correct liveness probe already existed two modules away. L18's trigger was sharpened this sprint for *planning*; this instance argues it needs a sibling for *implementation* — **before writing a platform-dependent helper, check whether the platform module already has it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)