### PR TITLE
W6c: shipping-gate fixes — reap preview auto-spawn (ADR 0009) and worktree-remove-failure leak

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -114,7 +114,9 @@ than kept.
 observe it, per `docs/adr/0009-auto-spawn-never-on-observation.md`'s D5:
 `sgt doctor`, `sgt watch`, `sgt daemon stop` (ruled first for `watch` by
 `docs/gauntlet/contracts/WATCH.md`'s R-WATCH-3), and now also `status`,
-`work show`/`list`/`transcript`, `analytics`, and the TUI. Auto-spawn
-survives only on verbs that mutate durable state: `run`, `respond`,
-`retry`, `extend`, `cancel`. The principle behind the set, stated first in
+`work show`/`list`/`transcript`/`retained`, `work reap`'s unconfirmed
+preview (its `--yes` disposal path still mutates and stays outside this
+set), `analytics`, and the TUI. Auto-spawn survives only on verbs that
+mutate durable state: `run`, `respond`, `retry`, `extend`, `cancel`, and
+`work reap --yes`. The principle behind the set, stated first in
 R-WATCH-3: "observation must not materialize the thing observed."

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1503,8 +1503,10 @@ fn client_for(descriptor: &RuntimeDescriptor) -> Result<ApiClient, CliError> {
 /// command in this file deliberately does not: **never call
 /// [`spawn_daemon`]**. Observation must not materialize the thing observed —
 /// fail-closed at both ends of the daemon's life, matching R-WATCH-3's own
-/// framing. Used by `watch`, `status`, `work show`/`list`/`transcript`,
-/// `analytics`, and `tui` — every verb ADR 0009 moved into the no-spawn set.
+/// framing. Used by `watch`, `status`, `work show`/`list`/`transcript`/
+/// `retained`, `work reap`'s unconfirmed preview (its `--yes` disposal path
+/// still mutates and still goes through [`ensure_daemon`]), `analytics`,
+/// and `tui` — every verb ADR 0009 moved into the no-spawn set.
 ///
 /// 1. A healthy descriptor → attach, exactly like [`ensure_daemon`].
 /// 2. No descriptor, or a descriptor whose PID is dead → refuse, naming the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -706,9 +706,12 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // #109's dispose verb mutates durable state (it deletes retained
             // artifacts and journals the outcome), so it joins
             // `cancel`/`retry`/`extend`'s bucket rather than the read-only
-            // `work list`/`show`/`transcript`/`retained` one.
-            let client = ensure_daemon(&data_dir).await?;
+            // `work list`/`show`/`transcript`/`retained` one. The preview
+            // path below never mutates, though, so it connects like
+            // `retained` (ADR 0009: observation must not materialize the
+            // thing observed) rather than auto-spawning a daemon.
             if !yes {
+                let client = observe_connect(&data_dir).await?;
                 let retained = client.retained().await?;
                 let mine: Vec<&Value> = retained["retained"]
                     .as_array()
@@ -735,6 +738,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                 }
                 return Ok(());
             }
+            let client = ensure_daemon(&data_dir).await?;
             let result = client.reap(&id, true).await?;
             if sgt.json {
                 print_json(&result);

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -746,8 +746,9 @@ pub struct RetainedBinding {
     /// Repository name.
     pub repository: String,
     /// Where the retained content actually lives: the patch file when
-    /// [`retain_dirty`] captured one, otherwise the worktree directory
-    /// itself (the submodule/capture-failure fallback, or a
+    /// [`retain_dirty`] captured one *and* removed the worktree, otherwise
+    /// the worktree directory itself (the submodule/capture-failure
+    /// fallback, a captured patch whose worktree removal then failed, or a
     /// `RetainedError`).
     pub path: PathBuf,
     /// `retained_dirty` or `retained_error` — the same bare-tag spelling
@@ -877,7 +878,8 @@ pub struct ReapReport {
 
 /// #109's dispose verb: permanently discard whatever `RetainedDirty`
 /// bindings still hold for this Work — the captured patch, or, in the
-/// submodule/capture-failure fallback, the worktree directory itself.
+/// submodule/capture-failure fallback (or a captured patch whose worktree
+/// removal then failed), the worktree directory itself.
 ///
 /// A deliberate, explicit, human-invoked action, never run on its own:
 /// `AGENTS.md`'s guardrail puts preserved state (a retained branch, a
@@ -2397,6 +2399,74 @@ mod tests {
             patch.bytes,
             patch_text.len() as u64,
             "the recorded size must match what was actually written"
+        );
+    }
+
+    /// no-mistakes review fix: if `retain_dirty` captures the patch but the
+    /// `git worktree remove --force` that follows fails, the worktree
+    /// directory is still on disk — reporting `patch: Some` in that case (the
+    /// pre-fix behavior) would make the directory invisible to
+    /// [`retained_bindings`]/`reap_binding`, which only look for it when
+    /// `patch` is `None`, leaking it permanently. `git worktree lock` makes
+    /// the removal fail deterministically, without needing root or a
+    /// filesystem-specific immutable bit.
+    #[test]
+    fn a_dirty_worktree_whose_removal_fails_falls_back_to_the_directory_not_a_leaked_patch() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface =
+            materialize(data.path(), "01LOCKED", std::slice::from_ref(&spec)).expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        std::fs::write(worktree.join("half-done.rs"), "fn main() {}\n").expect("dirty");
+        // A single `--force` (what `retain_dirty` actually passes) refuses on
+        // a locked worktree — "use 'remove -f -f' to override" — so this
+        // reliably fails the removal after the patch capture already
+        // succeeded, without touching filesystem permissions.
+        git(
+            &spec.path,
+            &["worktree", "lock", &worktree.display().to_string()],
+        )
+        .expect("lock the worktree");
+
+        let report = teardown(&surface);
+        let BindingDisposition::RetainedDirty { patch, .. } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected RetainedDirty: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        assert!(
+            patch.is_none(),
+            "a failed removal must fall back to patch: None, not report a patch over a \
+             directory that never actually went away: {patch:?}"
+        );
+        assert!(
+            worktree.exists(),
+            "the directory git refused to remove must still be there"
+        );
+
+        // The fix's whole point: `retained_bindings` must still find it, via
+        // the directory rather than a patch file that (best-effort) no
+        // longer exists.
+        let retained = retained_bindings(&report);
+        let entry = retained
+            .iter()
+            .find(|r| r.repository == "solo")
+            .unwrap_or_else(|| {
+                panic!("the locked binding must still be discoverable: {retained:?}")
+            });
+        assert_eq!(
+            entry.path, worktree,
+            "must point at the surviving directory"
+        );
+
+        // Cleanup: unlock so the tempdir's own teardown can remove it.
+        let _ = git(
+            &spec.path,
+            &["worktree", "unlock", &worktree.display().to_string()],
         );
     }
 

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -1042,18 +1042,32 @@ fn retain_dirty(binding: &RepositoryBinding, changes: String) -> BindingDisposit
         };
     };
     let path = binding.worktree_path.display().to_string();
-    // Whether or not the removal below succeeds, the patch is already
-    // durable, so nothing captured can be lost. A removal failure just means
-    // the directory did not get reclaimed this round — the next teardown
-    // retry, or `sgt work reap`, tries again (idempotent, same as every
-    // other disposition here).
-    let _ = git(
+    // The patch is already durable regardless of what happens next, so
+    // nothing captured can be lost. But if the worktree removal below fails,
+    // the directory is still on disk — reporting `patch: Some` in that case
+    // would make it invisible to `retained_bindings`/`reap_binding`, which
+    // only look for the worktree directory when `patch` is `None`. Falling
+    // back to the same `patch: None` shape the submodule/capture-failure
+    // paths above already use keeps that directory discoverable and
+    // reclaimable (`reap_binding`'s `patch: None` arm retries the same `git
+    // worktree remove`); the now-redundant patch file (its content already
+    // sitting uncommitted in the still-present directory) is removed
+    // best-effort so it does not become its own untracked leak.
+    match git(
         &binding.source_path,
         &["worktree", "remove", "--force", &path],
-    );
-    BindingDisposition::RetainedDirty {
-        changes,
-        patch: Some(patch),
+    ) {
+        Ok(_) => BindingDisposition::RetainedDirty {
+            changes,
+            patch: Some(patch),
+        },
+        Err(_) => {
+            let _ = std::fs::remove_file(&patch.path);
+            BindingDisposition::RetainedDirty {
+                changes,
+                patch: None,
+            }
+        }
     }
 }
 

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -510,12 +510,17 @@ fn t1_sgt_tui_refuses_without_a_daemon_and_names_the_remedy() {
 }
 
 /// ADR 0009's no-spawn set, on the rest of it: `status`, `work list`,
-/// `work show`, `work transcript`, and `analytics` all refuse rather than
+/// `work show`, `work transcript`, `work retained`, `work reap` (its
+/// unconfirmed preview only — the `--yes` disposal path still mutates and
+/// still belongs to `ensure_daemon`), and `analytics` all refuse rather than
 /// auto-spawn with no daemon running, and each names `sgt doctor` as the
 /// remedy — the same shape `t1_sgt_tui_refuses_without_a_daemon_and_names_the_remedy`
 /// pins for the TUI. A build that still routed any one of these through
 /// `ensure_daemon` (the pre-ADR-0009 behavior every one of them used to
-/// share) would exit 0 here and leave a daemon behind instead.
+/// share) would exit 0 here and leave a daemon behind instead. `work reap`
+/// specifically pins the no-mistakes review fix that had its unconfirmed
+/// preview path calling `ensure_daemon` — auto-spawning a daemon just to
+/// preview a disposal nothing asked to happen yet.
 #[test]
 fn t1_observation_verbs_refuse_without_a_daemon_and_name_the_remedy() {
     let data = DataDir::new();
@@ -524,6 +529,8 @@ fn t1_observation_verbs_refuse_without_a_daemon_and_name_the_remedy() {
         vec!["work", "list"],
         vec!["work", "show", "01SOMENONEXISTENTWORKID000"],
         vec!["work", "transcript", "01SOMENONEXISTENTWORKID000"],
+        vec!["work", "retained"],
+        vec!["work", "reap", "01SOMENONEXISTENTWORKID000"],
         vec!["analytics"],
     ] {
         let output = Command::new(SGT)


### PR DESCRIPTION
Lane PR into `integration/path-to-mac-2026-08-15`. Custody of the fix commits produced by the **dispatched shipping gate** (Work `01M02VBSZ945TPHGDK6TJEHGPT`, `validate-and-ship`, 7/40 turns).

This is the first gate run in this repo's history to execute as a Work rather than Captain-serial — ADR 0005's ruling, finally running.

## Two real defects, both in W4's output, both past every prior review

W4 went through its own `30-review` stage, four green local gate runs (clippy + 657 tests), and a four-axis blind gauntlet on the plan behind it. These survived all of that.

**1. `sgt work reap <id>` auto-spawned a daemon on its preview path — ADR 0009 violation.**

W4 reasoned correctly that reap *mutates* durable state, so it joins `cancel`/`retry`/`extend`'s bucket and needs `ensure_daemon`. But the **preview** path (no `--yes`) never mutates — and it was auto-spawning anyway. ADR 0009 is explicit: *observation must not materialize the thing observed.* The fix connects via `observe_connect` for the preview and defers `ensure_daemon` to the mutating path.

Subtle precisely because the *verb* is correctly classified; only one branch of it isn't.

**2. `retain_dirty` mis-reported the retained path when worktree removal failed** — pointing an operator at the captured patch while the directory still existed.

Both carry regression tests, and the gate's test agent verified each **fails pre-fix and passes post-fix** rather than asserting it.

## Also in here

`no-mistakes(document)` updated stale doc comments and `docs/glossary.md` for the same area — including the glossary's "no-spawn set" definition, which the auto-spawn bug had quietly falsified.

## Why this took four attempts

The gate produced **four false `passed` verdicts** first — `outcome: passed` with `review`/`test`/`document`/`lint` all `skipped`. The Work refused to accept them every time, filed **#120**, and escalated `ask-user` five times across dispatches rather than report a green it hadn't earned. It also corrected the orchestrator's diagnosis *and* #120's own original framing.

Root cause: `no-mistakes` caches `default_branch` at registration and never re-derives it; this estate's Work-surface repo was registered mid-sprint while `origin` sat on the integration branch, so the gate's diff base **was the branch under review**. Empty diff → skip everything → pass. Fixed with `no-mistakes init`. **#120 stays open** — the defect is general to any estate whose `origin` is a local path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)