### PR TITLE
Retrospective correction: the archive branches were a leak, not a save

### DIFF
--- a/docs/gauntlet/runs/path-to-mac-2026-08-15/retrospective.md
+++ b/docs/gauntlet/runs/path-to-mac-2026-08-15/retrospective.md
@@ -59,10 +59,32 @@ ledger commits against a stale base. But it sits in the pipeline's state as
 an open run, and nothing in sergeant knows it exists.
 
 This is **L22's shape one layer out**: a Work's own teardown is clean and
-journaled, while the *external tool* it drove keeps state that outlives it,
-with no verb on either side to reap it. Sergeant's disk-footprint contract
-(#109's larger item) covers what a Work writes to disk; it says nothing
-about state a Work creates in a third-party daemon.
+journaled, while the *external tool* it drove keeps state that outlives it.
+Sergeant's disk-footprint contract (#109's larger item) covers what a Work
+writes to disk; it says nothing about state a Work creates in a third-party
+daemon.
+
+**Corrected after filing (#124's own comment thread).** This section
+originally claimed no verb existed on either side to reap it. False:
+`no-mistakes axi abort --run <id>` exists precisely for this, and its help
+text names the worktree-teardown case — *"so an orphaned CI monitor (e.g.
+after a worktree was torn down) can be reaped deterministically."* The
+earlier attempt failed only because bare `axi abort` is branch-scoped and
+was run from another branch; the verb was reached for without reading its
+help, which is **L12** for the second time this session.
+
+The real gap is narrower and still worth fixing: **the mechanism exists and
+nothing calls it.** `validate-and-ship`'s `60-close-out` is the natural home
+— a gate Work that ends while its run is parked (five times this sprint,
+each correctly) leaves that run open by construction.
+
+**Disposing of it surfaced a second defect.** The parked run was *masking*
+the real one: `axi status` reports the most recent run without regard to
+whether it belongs to the current branch. With the stale run cancelled,
+status reports run `01M02VDEQ2F1HQJYXJGJQR4YT1` — **`outcome: passed`**, all
+nine steps, `review`/`test`/`document`/`lint` all `completed` with real
+durations. Anyone checking gate state between those two events would have
+read "parked, awaiting approval" for a sprint that had already passed.
 
 ### 1.3 Branch residue is three classes, and the merge check earned its keep
 

--- a/docs/gauntlet/runs/path-to-mac-2026-08-15/retrospective.md
+++ b/docs/gauntlet/runs/path-to-mac-2026-08-15/retrospective.md
@@ -80,19 +80,39 @@ into custody locally and **never landed on the integration branch**, so it
 existed on exactly one machine. A `-D` in the same sweep as the other ten
 would have destroyed it silently.
 
-Pushed to `archive/w6-gate-escalation` and `archive/w6b-gate-escalation`
-rather than merged: five near-duplicate ledger entries documenting one
-saga would bury the ledger, but the evidence has to survive somewhere
-durable.
+They were first pushed to `archive/w6-gate-escalation` and
+`archive/w6b-gate-escalation` rather than merged, on the reasoning that five
+near-duplicate ledger entries would bury the ledger but the evidence had to
+survive somewhere durable.
 
-The general lesson is about the **sweep**, not the branches: a cleanup that
-treats a session's artifacts as one homogeneous class will eventually delete
-the one that mattered. Here git's own merge check was the only thing
-distinguishing them, and it worked because the deletion used `-d` rather
-than `-D`. The previous retrospective recorded a session bundling four
+**That was wrong, and the owner caught it within the hour.** Checked
+properly, both branches contain **only `GAUNTLET.md` prose** — 166 and 155
+insertions, nothing else — and that prose is the Work's own account of a
+saga already recorded in three more discoverable places: **five first-person
+comments from the same Work on #120**, this retrospective's §1.2 and §3.1,
+and PR #122's body. The Works themselves remain journaled and their full
+intents retrievable. The branches preserved nothing unique, in the least
+findable location available. Both deleted.
+
+**This is L22 in miniature, committed roughly twenty minutes after writing
+§1.2 about it.** *"Correct retention is indistinguishable on disk from a
+leak"* — two permanent refs were created because deleting felt risky,
+without first asking whether the thing being preserved was actually the
+artifact. It was #120 all along.
+
+What *was* right: `git branch -d`'s merge check correctly flagged that those
+commits were not on the integration branch, and that was real signal. The
+error was inferring **"unmerged ⇒ must preserve"** instead of **"unmerged ⇒
+check whether it matters."** A safe default tells you to stop and look; it
+does not tell you what you are looking at.
+
+The general lesson is still about the **sweep**: a cleanup that treats a
+session's artifacts as one homogeneous class will eventually delete the one
+that mattered, and using `-d` rather than `-D` is what created the moment to
+check. The previous retrospective recorded a session bundling four
 destructive operations into one un-reviewable command; this is the same
-hazard at a smaller scale, caught by a safer default rather than by
-judgment.
+hazard at smaller scale, caught by a safer default — and then nearly
+converted into a leak by over-correcting.
 
 ---
 


### PR DESCRIPTION
One commit, docs only. It missed #111 by minutes — the correction was made after you merged.

## Why this matters rather than being a tidy-up

`main`'s copy of `retrospective.md` §1.3 currently says two `archive/*` branches were created to preserve the gate Work's diagnostic record, and presents that as the right call. **Both statements are now false:**

- The branches were checked properly afterwards and contain **only `GAUNTLET.md` prose** — 166 and 155 insertions, nothing else — whose substance already lives in three more discoverable places: **five first-person comments from the same Work on #120**, the retrospective's own §1.2/§3.1, and PR #122's body. The Works remain journaled with full intents retrievable.
- **Both branches have been deleted.** `main` therefore references two refs that do not exist.

So `main` documents a conclusion that was disproved and points at nothing. Left alone it becomes exactly the artifact this sprint spent the night correcting — a document that was true when written and quietly stopped being so.

## The finding it replaces it with

**L22 in miniature, committed about twenty minutes after writing the section describing L22.** Two permanent refs were created because deleting felt risky, without first asking whether the thing preserved was the artifact. It was #120 all along. *"Correct retention is indistinguishable on disk from a leak."*

The correction keeps what was genuinely right separate from what was wrong: `git branch -d` **correctly refused** to delete unmerged commits, and that was real signal. The error was inferring *"unmerged ⇒ must preserve"* rather than *"unmerged ⇒ check whether it matters."* A safe default creates the moment to look; it does not tell you what you are looking at.

## Three more tool-call instances, from the investigation itself

All L23's shape, and all in commands written to investigate a finding about exactly this:

- A ranged `git diff` against a remote-tracking ref that did not exist returned **empty** — readable as "nothing unique here," which would have justified keeping the branches.
- The same command's exit status was consumed by a trailing `tail`, reporting `rc=0` for a failed `git`.
- Both were only caught by re-running against **explicit SHAs with no pipe**.

Third and fourth instances this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)