### PR TITLE
T-series T1c: mutations, composer, responsive Fleet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,6 +2400,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-textarea"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c78d5ba0f26f97baed69a4c479f268a31c7b5b89d68ab939842152e383d6e73"
+dependencies = [
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "ratatui-widgets"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,6 +2741,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "ratatui",
+ "ratatui-textarea",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ opentelemetry_sdk = { version = "0.32", default-features = false, features = ["t
 # tests/m6_surfaces.rs — so the omission stays deliberate rather than becoming
 # a fact nobody re-decided.
 ratatui = "0.30.2"
+ratatui-textarea = "0.9.2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"

--- a/src/api.rs
+++ b/src/api.rs
@@ -3056,6 +3056,27 @@ impl ApiClient {
         .await
     }
 
+    /// `POST /v1/work/{id}/retry` with a fresh command id (§26).
+    pub async fn retry(&self, id: &str) -> Result<Value, ClientError> {
+        self.post(
+            &format!("/v1/work/{id}/retry"),
+            &json!({"command_id": ulid::Ulid::generate().to_string()}),
+        )
+        .await
+    }
+
+    /// `POST /v1/work/{id}/extend` with a fresh command id (§26).
+    pub async fn extend(&self, id: &str, additional_turns: u32) -> Result<Value, ClientError> {
+        self.post(
+            &format!("/v1/work/{id}/extend"),
+            &json!({
+                "command_id": ulid::Ulid::generate().to_string(),
+                "additional_turns": additional_turns,
+            }),
+        )
+        .await
+    }
+
     /// `GET /v1/retained` — #109's inspect verb: every repository binding
     /// any terminal Work's teardown left something on disk for, estate-wide.
     pub async fn retained(&self) -> Result<Value, ClientError> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4,7 +4,7 @@
 //! per-destination screens in [`super::home`], [`super::fleet`],
 //! [`super::workflows`], and [`super::estate`].
 
-use ratatui::crossterm::event::KeyCode;
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use serde_json::Value;
 
 use crate::api::{ApiClient, ClientError};
@@ -81,6 +81,36 @@ pub enum Action {
     /// §13.5's bounded "load older": grow the open Work's Evidence window
     /// and re-fetch.
     LoadOlderEvidence,
+    /// §15.1's `ANSWER` composer, deliberately submitted (§15.2/§15.5).
+    Respond { id: String, input: String },
+    /// §15.5: confirmed from [`Overlay::CancelConfirmation`].
+    Cancel(String),
+    /// §15.5: confirmed from [`Overlay::RetryConfirmation`].
+    Retry(String),
+    /// §15.5: confirmed from [`Overlay::ExtendEnvelope`], with the explicit
+    /// added-turns value the operator entered.
+    Extend { id: String, additional_turns: u32 },
+    /// §15.5: confirmed from [`Overlay::ReapConfirmation`].
+    Reap(String),
+}
+
+/// Live state for the one confirmation overlay open, if any (§7.4: the
+/// mechanism in [`super::overlay`] is a fixed, dataless set of panels; this
+/// is the one variant's worth of payload [`Overlay::ExtendEnvelope`] and its
+/// siblings actually need — the digits typed so far, which control has
+/// focus, and the last rejected attempt).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PendingAction {
+    /// §15.5's "explicit added-turns input" — digits only.
+    pub extend_turns: String,
+    /// Whether the Confirm control (rather than the turns field) has focus —
+    /// Tab moves between them (§15.2). Cancel/Retry/Reap have no field to
+    /// leave, so Confirm is always the target there.
+    pub confirm_focused: bool,
+    /// Set when a confirmed mutation comes back with a structured error —
+    /// shown inline rather than the overlay silently closing on a race
+    /// (§13.10's closing lines).
+    pub last_error: Option<String>,
 }
 
 /// The TUI's whole state: what was read from the API, and where the cursor is.
@@ -102,6 +132,9 @@ pub struct App {
     pub work_screen: Option<WorkScreen>,
     /// The one open overlay, if any (§7.4).
     pub overlay: Option<Overlay>,
+    /// The confirmation overlay's own live state (§15.5) — reset whenever an
+    /// overlay opens or closes.
+    pub pending_action: PendingAction,
     /// Whether the global Attention drawer is showing (§7.3: opens by
     /// default at Wide; `~` toggles it at any tier).
     pub drawer_open: bool,
@@ -128,6 +161,7 @@ impl App {
             open_work: None,
             work_screen: None,
             overlay: None,
+            pending_action: PendingAction::default(),
             drawer_open: true,
             system: Value::default(),
             last_seq: 0,
@@ -206,8 +240,14 @@ impl App {
         }
     }
 
-    /// Interpret one keystroke.
-    pub fn on_key(&mut self, key: KeyCode) -> Action {
+    /// Interpret one keystroke. `impl Into<KeyEvent>` rather than a bare
+    /// `KeyEvent` so every existing call site that only ever named a
+    /// `KeyCode` — every test in this tree, and every one in
+    /// `tests/m6_surfaces.rs` — keeps compiling unchanged (crossterm's own
+    /// `From<KeyCode> for KeyEvent` fills in empty modifiers), while the
+    /// production loop forwards the full event `Ctrl+Enter` needs (§15.2).
+    pub fn on_key(&mut self, key: impl Into<KeyEvent>) -> Action {
+        let key: KeyEvent = key.into();
         if self.overlay.is_some() {
             return self.on_key_overlay(key);
         }
@@ -216,7 +256,7 @@ impl App {
         }
 
         if !self.wants_text_focus()
-            && let Some(action) = self.on_key_global(key)
+            && let Some(action) = self.on_key_global(key.code)
         {
             return action;
         }
@@ -226,7 +266,7 @@ impl App {
                 HomeOutcome::None => Action::None,
                 HomeOutcome::Submit(body) => Action::Submit(body),
             },
-            Destination::Fleet => match self.fleet.on_key(key, &self.rows) {
+            Destination::Fleet => match self.fleet.on_key(key.code, &self.rows) {
                 FleetOutcome::None => Action::None,
                 FleetOutcome::Open(id) => Action::OpenWork(id),
             },
@@ -255,24 +295,122 @@ impl App {
         Some(Action::None)
     }
 
-    fn on_key_overlay(&mut self, key: KeyCode) -> Action {
-        match key {
-            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => self.overlay = None,
-            _ => {}
+    /// The id of the Work a confirmation overlay acts on — always the one
+    /// currently open, since these overlays only ever reach the keymap from
+    /// inside the canonical Work surface (§13.10).
+    fn open_work_id(&self) -> Option<String> {
+        self.open_work.as_ref().map(|w| w.id.clone())
+    }
+
+    /// Abort the open confirmation overlay without effect (§15.5's Esc
+    /// path): nothing is sent, and the pending draft is dropped since it was
+    /// never a durable Work draft to begin with.
+    fn close_overlay(&mut self) {
+        self.overlay = None;
+        self.pending_action = PendingAction::default();
+    }
+
+    fn on_key_overlay(&mut self, key: KeyEvent) -> Action {
+        let Some(overlay) = self.overlay else {
+            return Action::None;
+        };
+        match overlay {
+            // The four T1c owns render real, live content but share the same
+            // fixed set of controls with the others: Esc/q aborts, Enter (on
+            // Confirm) fires the mutation. Tab has nothing to move to.
+            Overlay::CancelConfirmation
+            | Overlay::RetryConfirmation
+            | Overlay::ReapConfirmation => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => self.close_overlay(),
+                    KeyCode::Enter => {
+                        let Some(id) = self.open_work_id() else {
+                            self.close_overlay();
+                            return Action::None;
+                        };
+                        return match overlay {
+                            Overlay::CancelConfirmation => Action::Cancel(id),
+                            Overlay::RetryConfirmation => Action::Retry(id),
+                            Overlay::ReapConfirmation => Action::Reap(id),
+                            _ => unreachable!("matched above"),
+                        };
+                    }
+                    _ => {}
+                }
+                Action::None
+            }
+            Overlay::ExtendEnvelope => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => self.close_overlay(),
+                    KeyCode::Tab | KeyCode::BackTab => {
+                        self.pending_action.confirm_focused = !self.pending_action.confirm_focused;
+                    }
+                    KeyCode::Backspace if !self.pending_action.confirm_focused => {
+                        self.pending_action.extend_turns.pop();
+                    }
+                    KeyCode::Char(c)
+                        if !self.pending_action.confirm_focused && c.is_ascii_digit() =>
+                    {
+                        self.pending_action.extend_turns.push(c);
+                    }
+                    KeyCode::Enter if !self.pending_action.confirm_focused => {
+                        self.pending_action.confirm_focused = true;
+                    }
+                    KeyCode::Enter if self.pending_action.confirm_focused => {
+                        let parsed = self.pending_action.extend_turns.trim().parse::<u32>();
+                        let Some(id) = self.open_work_id() else {
+                            self.close_overlay();
+                            return Action::None;
+                        };
+                        match parsed {
+                            Ok(additional_turns) if additional_turns > 0 => {
+                                return Action::Extend {
+                                    id,
+                                    additional_turns,
+                                };
+                            }
+                            _ => {
+                                self.pending_action.last_error = Some(
+                                    "enter a whole number of turns greater than zero".to_string(),
+                                );
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                Action::None
+            }
+            // Every overlay a later Work owns (§7.4's note): the mechanism
+            // this Work built at T1a — open, close, restore focus for free —
+            // with no content of its own yet.
+            Overlay::Help
+            | Overlay::SlashPalette
+            | Overlay::WorkflowChooser
+            | Overlay::RepoAddRemove
+            | Overlay::GroupEditRemove
+            | Overlay::RetainedPreview
+            | Overlay::ConnectionDetail => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => self.overlay = None,
+                    _ => {}
+                }
+                Action::None
+            }
         }
-        Action::None
     }
 
     /// Every key inside an open Work surface is the surface's own to
     /// interpret (§13.2's tab switching and each tab's local navigation) —
-    /// `App` only acts on the two outcomes that reach outside the surface
-    /// itself: closing it, and asking for an API round trip Evidence's
-    /// bounded "load older" needs.
-    fn on_key_open_work(&mut self, key: KeyCode) -> Action {
+    /// `App` only acts on the outcomes that reach outside the surface
+    /// itself: closing it, an API round trip Evidence's bounded "load
+    /// older" needs, a deliberately submitted Answer (§15.1/§15.2), and
+    /// opening one of §13.10's confirmation overlays (the mutation itself
+    /// waits on that overlay's own deliberate Confirm, per §15.5).
+    fn on_key_open_work(&mut self, key: KeyEvent) -> Action {
         let Some(screen) = self.work_screen.as_mut() else {
             // The opening fetch is still in flight: only Esc/q is
             // meaningful yet (there is nothing else to navigate).
-            if matches!(key, KeyCode::Esc | KeyCode::Char('q')) {
+            if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
                 self.open_work = None;
             }
             return Action::None;
@@ -285,6 +423,36 @@ impl App {
                 Action::None
             }
             WorkScreenOutcome::LoadOlder => Action::LoadOlderEvidence,
+            WorkScreenOutcome::Respond(input) => {
+                let Some(id) = self.open_work_id() else {
+                    return Action::None;
+                };
+                Action::Respond { id, input }
+            }
+            WorkScreenOutcome::AnswerRefused => {
+                self.status = "answer is empty".to_string();
+                Action::None
+            }
+            WorkScreenOutcome::OpenCancelConfirm => {
+                self.pending_action = PendingAction::default();
+                self.overlay = Some(Overlay::CancelConfirmation);
+                Action::None
+            }
+            WorkScreenOutcome::OpenRetryConfirm => {
+                self.pending_action = PendingAction::default();
+                self.overlay = Some(Overlay::RetryConfirmation);
+                Action::None
+            }
+            WorkScreenOutcome::OpenExtendEnvelope => {
+                self.pending_action = PendingAction::default();
+                self.overlay = Some(Overlay::ExtendEnvelope);
+                Action::None
+            }
+            WorkScreenOutcome::OpenReapConfirm => {
+                self.pending_action = PendingAction::default();
+                self.overlay = Some(Overlay::ReapConfirmation);
+                Action::None
+            }
         }
     }
 
@@ -331,6 +499,83 @@ impl App {
                     self.status = format!("could not load older evidence: {e}");
                 }
                 Action::None
+            }
+            // §15.1's Answer, deliberately submitted. The draft clears only
+            // once the daemon accepts it (§15.2/§9.2's rule, reused here) —
+            // a failure leaves it exactly as the operator wrote it.
+            Action::Respond { id, input } => {
+                match client.respond(&id, &input).await {
+                    Ok(_) => {
+                        self.status = format!("responded to {id}");
+                        if let Some(screen) = &mut self.work_screen {
+                            screen.clear_answer();
+                        }
+                    }
+                    Err(e) => {
+                        self.status = format!("respond failed: {e}");
+                    }
+                }
+                Action::Refresh
+            }
+            // §13.10's closing lines: the daemon is authoritative, so every
+            // one of these four always asks for a refresh — a race that
+            // rejects the mutation still gets the true current state, and
+            // the error is recorded on the still-open overlay rather than
+            // the overlay silently vanishing (§15.5).
+            Action::Cancel(id) => {
+                match client.cancel(&id).await {
+                    Ok(_) => {
+                        self.status = format!("canceled {id}");
+                        self.close_overlay();
+                    }
+                    Err(e) => {
+                        self.status = format!("cancel failed: {e}");
+                        self.pending_action.last_error = Some(e.to_string());
+                    }
+                }
+                Action::Refresh
+            }
+            Action::Retry(id) => {
+                match client.retry(&id).await {
+                    Ok(_) => {
+                        self.status = format!("retrying {id}");
+                        self.close_overlay();
+                    }
+                    Err(e) => {
+                        self.status = format!("retry failed: {e}");
+                        self.pending_action.last_error = Some(e.to_string());
+                    }
+                }
+                Action::Refresh
+            }
+            Action::Extend {
+                id,
+                additional_turns,
+            } => {
+                match client.extend(&id, additional_turns).await {
+                    Ok(_) => {
+                        self.status = format!("extended {id} by {additional_turns} turns");
+                        self.close_overlay();
+                    }
+                    Err(e) => {
+                        self.status = format!("extend failed: {e}");
+                        self.pending_action.last_error = Some(e.to_string());
+                    }
+                }
+                Action::Refresh
+            }
+            Action::Reap(id) => {
+                match client.reap(&id, true).await {
+                    Ok(_) => {
+                        self.status = format!("reaped {id}");
+                        self.close_overlay();
+                    }
+                    Err(e) => {
+                        self.status = format!("reap failed: {e}");
+                        self.pending_action.last_error = Some(e.to_string());
+                    }
+                }
+                Action::Refresh
             }
             other => other,
         }
@@ -392,7 +637,7 @@ mod tests {
         for c in "call 1-800 and say q, then ~ and 4".chars() {
             app.on_key(KeyCode::Char(c));
         }
-        assert_eq!(app.home.intent, "call 1-800 and say q, then ~ and 4");
+        assert_eq!(app.home.intent.text(), "call 1-800 and say q, then ~ and 4");
         assert_eq!(
             app.destination,
             Destination::Home,
@@ -423,7 +668,8 @@ mod tests {
         assert_eq!(app.destination, Destination::Home);
         app.on_key(KeyCode::Char('x'));
         assert_eq!(
-            app.home.intent, "x",
+            app.home.intent.text(),
+            "x",
             "the form is editable again, not treated as a nav key"
         );
     }
@@ -541,7 +787,7 @@ mod tests {
     #[tokio::test]
     async fn submitting_an_unreachable_daemon_preserves_the_draft_and_reports_the_error() {
         let mut app = App::new();
-        app.home.intent = "fix the thing".to_string();
+        app.home.intent.set_text("fix the thing");
         let client = ApiClient::new("http://127.0.0.1:1", "t").expect("client");
         // Route straight through the executor with a hand-built body instead
         // of walking every Tab press — the form's own submission-shape tests
@@ -555,8 +801,174 @@ mod tests {
         );
         assert!(app.home.last_error.is_some(), "the failure is reported");
         assert_eq!(
-            app.home.intent, "fix the thing",
+            app.home.intent.text(),
+            "fix the thing",
             "and the draft survives it"
+        );
+    }
+
+    // ------------------------------------------------- T1c: mutation wiring
+
+    /// An app with `id` open at `state` — every mutation-keymap test starts
+    /// from here, since respond/cancel/retry/extend/reap only ever reach the
+    /// keymap from inside the canonical Work surface.
+    fn app_with_open_work(id: &str, state: &str) -> App {
+        let mut app = App::new();
+        app.rows = fleet_rows(&fleet_of(&[(id, state)]));
+        app.destination = Destination::Fleet;
+        app.open_work = Some(OpenWork {
+            id: id.to_string(),
+            from: Destination::Fleet,
+        });
+        app.work_screen = Some(WorkScreen::from_parts(
+            id.to_string(),
+            json!({
+                "work": {"id": id, "intent": "fix the thing", "state": state},
+                "stage": {"stage_id": "10-implement", "attempt": 2},
+                "envelope": {"turn_cap": 12, "turns_spawned": 3},
+            }),
+            Vec::new(),
+            Vec::new(),
+            None,
+        ));
+        app
+    }
+
+    #[test]
+    fn c_opens_the_cancel_confirmation_and_esc_aborts_it_without_effect() {
+        let mut app = app_with_open_work("a", "blocked");
+        assert_eq!(app.on_key(KeyCode::Char('c')), Action::None);
+        assert_eq!(app.overlay, Some(Overlay::CancelConfirmation));
+
+        assert_eq!(app.on_key(KeyCode::Esc), Action::None);
+        assert!(app.overlay.is_none(), "Esc aborts, no request queued");
+    }
+
+    #[test]
+    fn enter_on_the_cancel_confirmation_asks_to_cancel_the_open_work() {
+        let mut app = app_with_open_work("a", "blocked");
+        app.on_key(KeyCode::Char('c'));
+        assert_eq!(
+            app.on_key(KeyCode::Enter),
+            Action::Cancel("a".to_string()),
+            "the deliberate Enter on Confirm is what actually asks to mutate"
+        );
+    }
+
+    #[test]
+    fn an_action_key_is_a_no_op_when_the_matrix_does_not_offer_it() {
+        // completed offers only "inspect" (§13.10) — cancel/retry/extend/
+        // reap/respond must all be no-ops, not silently open a confirmation
+        // for a mutation the daemon would refuse anyway.
+        let mut app = app_with_open_work("a", "completed");
+        for key in ['c', 't', 'e', 'p', 'r'] {
+            assert_eq!(app.on_key(KeyCode::Char(key)), Action::None);
+            assert!(app.overlay.is_none(), "{key} must not open anything");
+        }
+    }
+
+    #[test]
+    fn t_opens_retry_and_p_opens_reap_only_where_the_matrix_allows_them() {
+        let mut app = app_with_open_work("a", "failed");
+        assert_eq!(app.on_key(KeyCode::Char('t')), Action::None);
+        assert_eq!(app.overlay, Some(Overlay::RetryConfirmation));
+        assert_eq!(
+            app.on_key(KeyCode::Char('p')),
+            Action::None,
+            "reap is not offered for failed"
+        );
+
+        let mut app = app_with_open_work("a", "completed_dirty");
+        assert_eq!(app.on_key(KeyCode::Char('p')), Action::None);
+        assert_eq!(app.overlay, Some(Overlay::ReapConfirmation));
+    }
+
+    #[test]
+    fn extend_requires_a_nonzero_turn_count_before_confirming() {
+        let mut app = app_with_open_work("a", "blocked");
+        assert_eq!(app.on_key(KeyCode::Char('e')), Action::None);
+        assert_eq!(app.overlay, Some(Overlay::ExtendEnvelope));
+
+        // Confirm with nothing typed: refused, overlay stays open with a
+        // reason rather than silently doing nothing (§15.5).
+        app.on_key(KeyCode::Tab); // field -> Confirm
+        assert_eq!(app.on_key(KeyCode::Enter), Action::None);
+        assert!(app.overlay.is_some(), "the overlay stays open on refusal");
+        assert!(app.pending_action.last_error.is_some());
+
+        // Back to the field, type digits, confirm for real.
+        app.on_key(KeyCode::Tab); // Confirm -> field
+        for c in "5".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        app.on_key(KeyCode::Tab); // field -> Confirm
+        assert_eq!(
+            app.on_key(KeyCode::Enter),
+            Action::Extend {
+                id: "a".to_string(),
+                additional_turns: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn r_focuses_the_answer_composer_and_ctrl_enter_asks_to_respond() {
+        let mut app = app_with_open_work("a", "needs_input");
+        assert_eq!(app.on_key(KeyCode::Char('r')), Action::None);
+        for c in "go ahead".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        let ctrl_enter = KeyEvent::new(
+            KeyCode::Enter,
+            ratatui::crossterm::event::KeyModifiers::CONTROL,
+        );
+        assert_eq!(
+            app.on_key(ctrl_enter),
+            Action::Respond {
+                id: "a".to_string(),
+                input: "go ahead".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rejected_cancel_keeps_the_confirmation_open_with_the_error_and_still_refreshes() {
+        let mut app = app_with_open_work("a", "blocked");
+        app.overlay = Some(Overlay::CancelConfirmation);
+        let client = ApiClient::new("http://127.0.0.1:1", "t").expect("client");
+        let outcome = app.execute(&client, Action::Cancel("a".to_string())).await;
+        assert_eq!(outcome, Action::Refresh, "a race still triggers a refresh");
+        assert_eq!(
+            app.overlay,
+            Some(Overlay::CancelConfirmation),
+            "the screen (the open confirmation) is preserved, not silently closed"
+        );
+        assert!(app.pending_action.last_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_failed_respond_preserves_the_draft() {
+        let mut app = app_with_open_work("a", "needs_input");
+        app.on_key(KeyCode::Char('r'));
+        for c in "the answer".chars() {
+            app.on_key(KeyCode::Char(c));
+        }
+        let client = ApiClient::new("http://127.0.0.1:1", "t").expect("client");
+        let outcome = app
+            .execute(
+                &client,
+                Action::Respond {
+                    id: "a".to_string(),
+                    input: "the answer".to_string(),
+                },
+            )
+            .await;
+        assert_eq!(outcome, Action::Refresh);
+        assert!(app.status.contains("respond failed"), "{}", app.status);
+        assert_eq!(
+            app.work_screen.as_ref().unwrap().answer_text_for_test(),
+            "the answer",
+            "a failed respond must not clear the draft"
         );
     }
 }

--- a/src/tui/composer.rs
+++ b/src/tui/composer.rs
@@ -1,0 +1,217 @@
+//! The deliberate multiline composer (§8.7, §9.2, §15.1-15.2): the one
+//! narrow wrapper (Decision T2-31) around `ratatui-textarea`'s `TextArea`
+//! that every screen needing multiline deliberate input goes through — the
+//! crate itself is never named outside this module.
+//!
+//! T0's spike (§8.7) found the crate has no submit concept of its own:
+//! `TextArea::input()` maps every `Enter`, with or without modifiers, to
+//! `insert_newline`. So [`Composer::on_key`] decides *before* forwarding a
+//! keystroke whether it means "newline" or "submit" — exactly the shape the
+//! spike's condition 6 requires.
+
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui_textarea::{TextArea, WrapMode};
+
+use super::theme::Token;
+
+/// What one keystroke handed to the composer asked for (§15.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComposerOutcome {
+    /// The keystroke edited the draft, moved the cursor, or did nothing.
+    None,
+    /// A submit was asked for (Ctrl+Enter, or the caller's own
+    /// [`Composer::submit`]) and the draft was nonblank.
+    Submit(String),
+    /// A submit was asked for with nothing but whitespace in the draft
+    /// (§15.2: "blank input is refused").
+    Refused,
+}
+
+/// The deliberate multiline composer: Home's `INTENT` field and an open
+/// Work's `ANSWER` field both go through this, never a single-line `String`
+/// buffer and never `ratatui_textarea::TextArea` directly (Decision T2-31).
+#[derive(Debug, Clone)]
+pub struct Composer {
+    area: TextArea<'static>,
+    placeholder: String,
+}
+
+impl Composer {
+    pub fn new() -> Self {
+        let placeholder = String::new();
+        Self {
+            area: area_from_lines(vec![String::new()], &placeholder),
+            placeholder,
+        }
+    }
+
+    /// Text shown when the draft is empty — never mistaken for real content
+    /// since `ratatui-textarea` only shows it while `lines()` is blank.
+    pub fn with_placeholder(mut self, text: impl Into<String>) -> Self {
+        self.placeholder = text.into();
+        self.area.set_placeholder_text(self.placeholder.clone());
+        self
+    }
+
+    /// One keystroke (§15.2). `Ctrl+Enter` asks to submit rather than
+    /// inserting a newline; every other key — including plain `Enter`, which
+    /// the crate itself maps to a newline — is forwarded to the editor
+    /// untouched.
+    pub fn on_key(&mut self, key: KeyEvent) -> ComposerOutcome {
+        if key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::CONTROL) {
+            return self.submit();
+        }
+        self.area.input(key);
+        ComposerOutcome::None
+    }
+
+    /// Ask to submit the current draft outright — the Tab-to-Send-then-Enter
+    /// fallback (§15.2/§8.8) reaches this the same way Ctrl+Enter does,
+    /// through whichever caller owns the Send/Run/Confirm control's focus.
+    pub fn submit(&mut self) -> ComposerOutcome {
+        if self.is_empty() {
+            return ComposerOutcome::Refused;
+        }
+        ComposerOutcome::Submit(self.text())
+    }
+
+    /// The draft, lines joined by `\n`.
+    pub fn text(&self) -> String {
+        self.area.lines().join("\n")
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.text().trim().is_empty()
+    }
+
+    /// Replace the draft outright — used by tests and by any caller that
+    /// needs to seed a draft without walking keystrokes.
+    pub fn set_text(&mut self, text: impl Into<String>) {
+        let text = text.into();
+        let lines: Vec<String> = if text.is_empty() {
+            vec![String::new()]
+        } else {
+            text.lines().map(str::to_string).collect()
+        };
+        self.area = area_from_lines(lines, &self.placeholder);
+    }
+
+    /// The draft clears only after an accepted mutation (§9.2/§15.2).
+    pub fn clear(&mut self) {
+        self.area = area_from_lines(vec![String::new()], &self.placeholder);
+    }
+
+    /// Draw the composer into `area`. The caller owns any surrounding
+    /// block/label (§15.1's contextual `INTENT`/`ANSWER` framing, and
+    /// whether it looks focused) — this only ever draws the editable text
+    /// itself. `&self` rather than `&mut self` on purpose: the app's whole
+    /// draw path is immutable (`draw(frame, app: &App)`, `mod.rs`'s own
+    /// "pure: everything it paints is already in `app`" rule), so the
+    /// cursor's own style is fixed at construction rather than toggled here.
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        frame.render_widget(&self.area, area);
+    }
+}
+
+impl Default for Composer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn area_from_lines(lines: Vec<String>, placeholder: &str) -> TextArea<'static> {
+    let mut area = TextArea::new(lines);
+    area.set_cursor_line_style(Style::default());
+    area.set_wrap_mode(WrapMode::WordOrGlyph);
+    area.set_placeholder_text(placeholder.to_string());
+    area.set_placeholder_style(Style::default().fg(Token::Muted.rgb()));
+    area
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::from(code)
+    }
+
+    fn ctrl_enter() -> KeyEvent {
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn typing_edits_the_draft_and_enter_alone_is_a_newline_not_a_submit() {
+        let mut composer = Composer::new();
+        for c in "line one".chars() {
+            assert_eq!(
+                composer.on_key(key(KeyCode::Char(c))),
+                ComposerOutcome::None
+            );
+        }
+        assert_eq!(composer.on_key(key(KeyCode::Enter)), ComposerOutcome::None);
+        for c in "line two".chars() {
+            composer.on_key(key(KeyCode::Char(c)));
+        }
+        assert_eq!(composer.text(), "line one\nline two");
+    }
+
+    #[test]
+    fn ctrl_enter_submits_a_nonblank_draft_without_inserting_a_newline() {
+        let mut composer = Composer::new();
+        for c in "do the thing".chars() {
+            composer.on_key(key(KeyCode::Char(c)));
+        }
+        assert_eq!(
+            composer.on_key(ctrl_enter()),
+            ComposerOutcome::Submit("do the thing".to_string())
+        );
+        assert_eq!(
+            composer.text(),
+            "do the thing",
+            "Ctrl+Enter must not have inserted a newline (T0's condition 6: no \
+             editor-owned submit behavior)"
+        );
+    }
+
+    #[test]
+    fn blank_input_is_refused() {
+        let mut composer = Composer::new();
+        assert_eq!(composer.on_key(ctrl_enter()), ComposerOutcome::Refused);
+        for c in "   ".chars() {
+            composer.on_key(key(KeyCode::Char(c)));
+        }
+        assert_eq!(
+            composer.on_key(ctrl_enter()),
+            ComposerOutcome::Refused,
+            "whitespace-only is still blank"
+        );
+    }
+
+    #[test]
+    fn submit_is_the_same_refusal_rule_as_the_tab_to_send_fallback() {
+        let mut composer = Composer::new();
+        assert_eq!(composer.submit(), ComposerOutcome::Refused);
+        composer.set_text("go");
+        assert_eq!(composer.submit(), ComposerOutcome::Submit("go".to_string()));
+    }
+
+    #[test]
+    fn clear_resets_to_an_empty_draft() {
+        let mut composer = Composer::new();
+        composer.set_text("keep me? no");
+        composer.clear();
+        assert!(composer.is_empty());
+        assert_eq!(composer.text(), "");
+    }
+
+    #[test]
+    fn set_text_round_trips_multiline_content() {
+        let mut composer = Composer::new();
+        composer.set_text("first\nsecond\nthird");
+        assert_eq!(composer.text(), "first\nsecond\nthird");
+    }
+}

--- a/src/tui/fleet.rs
+++ b/src/tui/fleet.rs
@@ -154,13 +154,16 @@ pub enum FleetOutcome {
     Open(String),
 }
 
-/// Fleet's own screen state: selection, filters, and whether the filter text
-/// field currently has keyboard focus.
+/// Fleet's own screen state: selection, filters, whether the filter text
+/// field currently has keyboard focus, and whether the Medium tier's
+/// selected-preview toggle (§10.1/§18.2: "selected preview below or
+/// toggle") is open.
 #[derive(Debug, Default)]
 pub struct FleetScreen {
     pub selected: usize,
     pub filters: Filters,
     pub filter_focus: bool,
+    pub preview_open: bool,
 }
 
 impl FleetScreen {
@@ -234,6 +237,9 @@ impl FleetScreen {
             KeyCode::Char('x') if !self.filters.is_default() => {
                 self.filters = Filters::default();
             }
+            // §10.1/§18.2's Medium-tier "selected preview below or toggle" —
+            // a no-op at any other tier, harmlessly (nothing reads it there).
+            KeyCode::Char('v') => self.preview_open = !self.preview_open,
             KeyCode::Enter => {
                 if let Some(id) = self.selected_id(rows) {
                     return FleetOutcome::Open(id);
@@ -260,8 +266,18 @@ fn next_state_filter(current: Option<&str>) -> Option<String> {
 // -------------------------------------------------------------- rendering
 
 /// Draw the Fleet browser: filters, then the Work list, composed per §10.1's
-/// responsive layout.
+/// responsive layout — §18.1's Wide filters+table (the contextual rail's own
+/// preview pane is `mod.rs`'s job, drawn beside this), §18.2's Medium
+/// list-with-toggle (`v` opens a preview pane below the list), and §18.3's
+/// Narrow stacked rows with the filter itself promoted to a full-body
+/// overlay while it has focus (tight columns make a slim top line hard to
+/// read while typing).
 pub fn render(frame: &mut Frame, area: Rect, rows: &[WorkRow], screen: &FleetScreen, tier: Tier) {
+    if tier == Tier::Narrow && screen.filter_focus {
+        render_filter_overlay(frame, area, screen);
+        return;
+    }
+
     let visible = screen.visible(rows);
     let title = format!(
         "Fleet — {} work{}{}",
@@ -296,11 +312,47 @@ pub fn render(frame: &mut Frame, area: Rect, rows: &[WorkRow], screen: &FleetScr
         return;
     }
 
+    // §18.2/§10.1: Medium's "selected preview below or toggle" — a bottom
+    // pane that opens only when the operator asks for it (`v`), since
+    // Medium has no reserved rail columns to spend on it unconditionally.
+    let (list_area, preview_area) = if tier == Tier::Medium && screen.preview_open {
+        let [list, preview] = ratatui::layout::Layout::vertical([
+            Constraint::Percentage(60),
+            Constraint::Percentage(40),
+        ])
+        .areas(list_area);
+        (list, Some(preview))
+    } else {
+        (list_area, None)
+    };
+
     match tier {
         Tier::Narrow => render_stacked(frame, list_area, &visible, screen.selected),
         Tier::Medium => render_table(frame, list_area, &visible, screen.selected, false),
         _ => render_table(frame, list_area, &visible, screen.selected, true),
     }
+
+    if let Some(preview_area) = preview_area {
+        let selected = visible.get(screen.selected).copied();
+        super::work_view::render_preview(frame, preview_area, selected);
+    }
+}
+
+/// §18.3: Narrow's filter, promoted to a full-body overlay while it has
+/// focus (mirrors how the Attention drawer and contextual rail themselves
+/// become full-body overlays at Narrow, §18.3's own rule, rather than a
+/// second, competing mechanism).
+fn render_filter_overlay(frame: &mut Frame, area: Rect, screen: &FleetScreen) {
+    let block = Block::bordered()
+        .title("Fleet Filter")
+        .border_style(Style::default().fg(Token::Focus.rgb()));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let text = format!(
+        "filter> {}_\n\nEnter/Esc applies and returns to the list.",
+        screen.filters.text
+    );
+    frame.render_widget(Paragraph::new(text), inner);
 }
 
 fn filter_line(screen: &FleetScreen) -> Paragraph<'static> {
@@ -318,7 +370,8 @@ fn filter_line(screen: &FleetScreen) -> Paragraph<'static> {
         format!("filter> {}_", screen.filters.text)
     } else {
         format!(
-            "filter: {} · state {state} · nonterminal {nonterminal}  ('/' filter · 's' state · 'a' nonterminal · 'x' clear)",
+            "filter: {} · state {state} · nonterminal {nonterminal}  \
+             ('/' filter · 's' state · 'a' nonterminal · 'v' preview · 'x' clear)",
             if screen.filters.text.is_empty() {
                 "-"
             } else {
@@ -675,5 +728,93 @@ mod tests {
             parse_rfc3339_secs("2024-01-01T00:00:00Z"),
             Some(1_704_067_200)
         );
+    }
+
+    // --------------------------------------------- T1c: responsive Fleet
+
+    fn render_text(rows: &[WorkRow], screen: &FleetScreen, tier: Tier, width: u16) -> String {
+        let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, 30))
+            .expect("terminal");
+        terminal
+            .draw(|frame| render(frame, frame.area(), rows, screen, tier))
+            .expect("draw");
+        let buffer = terminal.backend().buffer();
+        let area = buffer.area;
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buffer.cell((x, y)).map_or(" ", |c| c.symbol()))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn v_toggles_the_medium_preview_pane() {
+        let rows = fleet_rows(&fleet_of(&[("a", "running")]));
+        let mut screen = FleetScreen::default();
+        assert!(!screen.preview_open);
+        screen.on_key(KeyCode::Char('v'), &rows);
+        assert!(screen.preview_open);
+        screen.on_key(KeyCode::Char('v'), &rows);
+        assert!(!screen.preview_open);
+    }
+
+    #[test]
+    fn medium_shows_the_preview_pane_only_once_toggled_open() {
+        let rows = fleet_rows(&fleet_of(&[("needle-id", "running")]));
+        let mut screen = FleetScreen::default();
+        let text = render_text(&rows, &screen, Tier::Medium, 120);
+        assert!(
+            !text.contains("Enter opens the full Work surface"),
+            "closed by default: {text}"
+        );
+
+        screen.preview_open = true;
+        let text = render_text(&rows, &screen, Tier::Medium, 120);
+        assert!(
+            text.contains("Enter opens the full Work surface"),
+            "the preview pane must appear once opened: {text}"
+        );
+    }
+
+    #[test]
+    fn wide_ignores_the_medium_toggle_since_the_rail_is_always_inline() {
+        let rows = fleet_rows(&fleet_of(&[("a", "running")]));
+        let screen = FleetScreen {
+            preview_open: true,
+            ..FleetScreen::default()
+        };
+        let text = render_text(&rows, &screen, Tier::Wide, 200);
+        assert!(
+            !text.contains("Enter opens the full Work surface"),
+            "Wide's rail is `mod.rs`'s job, not Fleet's own preview toggle: {text}"
+        );
+    }
+
+    #[test]
+    fn narrow_promotes_a_focused_filter_to_a_full_body_overlay() {
+        let rows = fleet_rows(&fleet_of(&[("a", "running")]));
+        let screen = FleetScreen {
+            filter_focus: true,
+            filters: Filters {
+                text: "bud".to_string(),
+                ..Filters::default()
+            },
+            ..FleetScreen::default()
+        };
+        let text = render_text(&rows, &screen, Tier::Narrow, 80);
+        assert!(text.contains("Fleet Filter"), "{text}");
+        assert!(text.contains("bud"), "{text}");
+    }
+
+    #[test]
+    fn narrow_shows_the_ordinary_stacked_list_when_the_filter_is_not_focused() {
+        let rows = fleet_rows(&fleet_of(&[("a", "running")]));
+        let screen = FleetScreen::default();
+        let text = render_text(&rows, &screen, Tier::Narrow, 80);
+        assert!(!text.contains("Fleet Filter"), "{text}");
+        assert!(text.contains("intent for a"), "{text}");
     }
 }

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -4,18 +4,20 @@
 //! Outputs — but the left "Attention" pane is not a Home-owned concept: it
 //! is the global drawer from [`super::attention`], which §18.1 says Home may
 //! show simultaneously with its own two panes. This module owns only the
-//! two panes that are actually Home's: the New Work form (§9.1/§9.2, minus
-//! the deliberate multiline composer — T1c's job per §20.2) and Recent
+//! two panes that are actually Home's: the New Work form (§9.1/§9.2,
+//! including §15.1's `INTENT` composer — the deliberate multiline
+//! [`super::composer::Composer`], not a single-line buffer) and Recent
 //! Outputs (§9.4).
 
 use ratatui::Frame;
-use ratatui::crossterm::event::KeyCode;
-use ratatui::layout::Rect;
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, List, ListItem, Padding, Paragraph, Wrap};
 use serde_json::{Value, json};
 
+use super::composer::{Composer, ComposerOutcome};
 use super::fleet::{WorkRow, age_label};
 use super::theme::{Token, spacing};
 
@@ -70,10 +72,10 @@ pub enum HomeOutcome {
     Submit(Value),
 }
 
-/// §9.1's New Work fields, as a single-line form. §9.2's `ratatui-textarea`-
-/// backed multiline intent composer is explicitly T1c's job (§20.2); the
-/// intent field here is a plain single-line buffer like every other field.
-#[derive(Debug, Default)]
+/// §9.1's New Work fields. §15.1's `INTENT` context: the intent field is
+/// [`Composer`], the deliberate multiline composer (§8.7/§9.2/§15.2) — every
+/// other field stays the plain single-line buffer it always was.
+#[derive(Debug)]
 pub struct NewWorkForm {
     focus: usize,
     /// Whether Esc has left the form (§9.2: "Esc leave focus and preserve
@@ -82,7 +84,7 @@ pub struct NewWorkForm {
     /// work again; entering Home afresh re-focuses it (§9.2's "the intent
     /// editor is the primary focus").
     blurred: bool,
-    pub intent: String,
+    pub intent: Composer,
     pub workflow: String,
     pub backend: String,
     pub profile: String,
@@ -113,6 +115,12 @@ impl NewWorkForm {
         !self.blurred
     }
 
+    /// Whether the intent composer specifically has focus — the footer uses
+    /// this to show §15.2's composer grammar rather than the plain-field one.
+    pub fn intent_focused(&self) -> bool {
+        !self.blurred && FIELDS[self.focus] == Field::Intent
+    }
+
     /// Bring the intent field back into focus (§9.2: "the intent editor is
     /// the primary focus" — entering Home, fresh or returning, always
     /// re-focuses it rather than leaving the form blurred from last time).
@@ -121,8 +129,33 @@ impl NewWorkForm {
         self.focus = 0;
     }
 
-    pub fn on_key(&mut self, key: KeyCode) -> HomeOutcome {
-        match key {
+    pub fn on_key(&mut self, key: impl Into<KeyEvent>) -> HomeOutcome {
+        let key: KeyEvent = key.into();
+        if FIELDS[self.focus] == Field::Intent {
+            match key.code {
+                KeyCode::Esc => {
+                    self.blurred = true;
+                    return HomeOutcome::None;
+                }
+                KeyCode::Tab => {
+                    self.focus = (self.focus + 1) % FIELDS.len();
+                    return HomeOutcome::None;
+                }
+                KeyCode::BackTab => {
+                    self.focus = (self.focus + FIELDS.len() - 1) % FIELDS.len();
+                    return HomeOutcome::None;
+                }
+                _ => {}
+            }
+            // §9.2: Ctrl+Enter submits the whole form (not merely "this
+            // field is nonblank") — `try_submit` re-validates every field,
+            // exactly as reaching `[ Run Work ]` by Tab and Enter would.
+            return match self.intent.on_key(key) {
+                ComposerOutcome::Submit(_) | ComposerOutcome::Refused => self.try_submit(),
+                ComposerOutcome::None => HomeOutcome::None,
+            };
+        }
+        match key.code {
             KeyCode::Esc => self.blurred = true,
             KeyCode::Tab => self.focus = (self.focus + 1) % FIELDS.len(),
             KeyCode::BackTab => self.focus = (self.focus + FIELDS.len() - 1) % FIELDS.len(),
@@ -149,7 +182,7 @@ impl NewWorkForm {
 
     fn field_mut(&mut self) -> Option<&mut String> {
         match FIELDS[self.focus] {
-            Field::Intent => Some(&mut self.intent),
+            Field::Intent => None,
             Field::Workflow => Some(&mut self.workflow),
             Field::Backend => Some(&mut self.backend),
             Field::Profile => Some(&mut self.profile),
@@ -162,7 +195,7 @@ impl NewWorkForm {
     }
 
     fn try_submit(&mut self) -> HomeOutcome {
-        if self.intent.trim().is_empty() {
+        if self.intent.is_empty() {
             self.last_error = Some("intent is required".to_string());
             return HomeOutcome::None;
         }
@@ -194,9 +227,10 @@ impl NewWorkForm {
         } else {
             None
         };
+        let intent = self.intent.text();
         json!({
             "command_id": ulid::Ulid::generate().to_string(),
-            "intent": self.intent.trim(),
+            "intent": intent.trim(),
             "workflow": non_empty(&self.workflow),
             "backend": non_empty(&self.backend),
             "profile": non_empty(&self.profile),
@@ -217,6 +251,26 @@ impl NewWorkForm {
     }
 }
 
+impl Default for NewWorkForm {
+    fn default() -> Self {
+        Self {
+            focus: 0,
+            blurred: false,
+            intent: Composer::new().with_placeholder(
+                "Describe the intent — Ctrl+Enter to submit, Enter for a newline",
+            ),
+            workflow: String::new(),
+            backend: String::new(),
+            profile: String::new(),
+            workspace: String::new(),
+            repositories: String::new(),
+            turn_cap: String::new(),
+            ceiling_secs: String::new(),
+            last_error: None,
+        }
+    }
+}
+
 fn non_empty(value: &str) -> Option<&str> {
     let trimmed = value.trim();
     (!trimmed.is_empty()).then_some(trimmed)
@@ -228,7 +282,9 @@ fn non_empty_u64(value: &str) -> Option<u64> {
 
 // -------------------------------------------------------------- rendering
 
-/// Draw the New Work form.
+/// Draw the New Work form: §15.1's `INTENT` composer as its own bounded
+/// sub-block (§18.4: "composer gets a bounded minimum"), then the remaining
+/// single-line fields below it.
 pub fn render(frame: &mut Frame, area: Rect, form: &NewWorkForm, admission_paused: bool) {
     let block = Block::bordered()
         .title("Home / New Work")
@@ -239,8 +295,17 @@ pub fn render(frame: &mut Frame, area: Rect, form: &NewWorkForm, admission_pause
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let mut lines: Vec<Line> = Vec::new();
+    let intent_focused = form.intent_focused();
+    let composer_height = inner.height.saturating_sub(10).clamp(3, 6);
+    let [composer_area, fields_area] =
+        Layout::vertical([Constraint::Length(composer_height), Constraint::Min(1)]).areas(inner);
+    render_intent_composer(frame, composer_area, form, intent_focused);
+
+    let mut lines: Vec<Line> = vec![Line::default()];
     for field in FIELDS {
+        if field == Field::Intent {
+            continue;
+        }
         let focused = FIELDS[form.focus] == field;
         lines.push(field_line(form, field, focused));
     }
@@ -257,7 +322,30 @@ pub fn render(frame: &mut Frame, area: Rect, form: &NewWorkForm, admission_pause
             Style::default().fg(Token::Danger.rgb()),
         )));
     }
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+    frame.render_widget(
+        Paragraph::new(lines).wrap(Wrap { trim: false }),
+        fields_area,
+    );
+}
+
+/// §15.1's persistent composer, this destination's context: `INTENT`,
+/// submit new Work.
+fn render_intent_composer(frame: &mut Frame, area: Rect, form: &NewWorkForm, focused: bool) {
+    let title = if focused {
+        "INTENT — Ctrl+Enter submit · Enter newline · Tab next field · Esc leave"
+    } else {
+        "INTENT"
+    };
+    let block = Block::bordered()
+        .title(title)
+        .border_style(Style::default().fg(if focused {
+            Token::Focus.rgb()
+        } else {
+            Token::Border.rgb()
+        }));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    form.intent.render(frame, inner);
 }
 
 fn field_line<'a>(form: &'a NewWorkForm, field: Field, focused: bool) -> Line<'a> {
@@ -273,7 +361,7 @@ fn field_line<'a>(form: &'a NewWorkForm, field: Field, focused: bool) -> Line<'a
         ));
     }
     let value = match field {
-        Field::Intent => form.intent.as_str(),
+        Field::Intent => "",
         Field::Workflow => form.workflow.as_str(),
         Field::Backend => form.backend.as_str(),
         Field::Profile => form.profile.as_str(),
@@ -347,16 +435,21 @@ pub fn render_recent_outputs(frame: &mut Frame, area: Rect, rows: &[WorkRow]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    fn ctrl_enter() -> KeyEvent {
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL)
+    }
 
     #[test]
     fn tab_cycles_focus_and_typing_edits_the_focused_field() {
         let mut form = NewWorkForm::default();
         assert_eq!(form.on_key(KeyCode::Char('h')), HomeOutcome::None);
-        assert_eq!(form.intent, "h", "intent is focused first");
+        assert_eq!(form.intent.text(), "h", "intent is focused first");
         form.on_key(KeyCode::Tab);
         form.on_key(KeyCode::Char('w'));
         assert_eq!(form.workflow, "w");
-        assert_eq!(form.intent, "h", "the previous field keeps its text");
+        assert_eq!(form.intent.text(), "h", "the previous field keeps its text");
     }
 
     #[test]
@@ -365,7 +458,57 @@ mod tests {
         form.on_key(KeyCode::Char('a'));
         form.on_key(KeyCode::Char('b'));
         form.on_key(KeyCode::Backspace);
-        assert_eq!(form.intent, "a");
+        assert_eq!(form.intent.text(), "a");
+    }
+
+    #[test]
+    fn enter_in_the_intent_field_is_a_newline_not_field_advance() {
+        let mut form = NewWorkForm::default();
+        form.on_key(KeyCode::Char('a'));
+        form.on_key(KeyCode::Enter);
+        form.on_key(KeyCode::Char('b'));
+        assert_eq!(form.intent.text(), "a\nb");
+        assert!(
+            form.intent_focused(),
+            "Enter must not have left the intent field"
+        );
+    }
+
+    #[test]
+    fn ctrl_enter_in_the_intent_field_submits_the_whole_form() {
+        let mut form = NewWorkForm {
+            workflow: "implement".to_string(),
+            ..NewWorkForm::default()
+        };
+        form.intent.set_text("fix the thing");
+        let outcome = form.on_key(ctrl_enter());
+        let HomeOutcome::Submit(body) = outcome else {
+            panic!("expected a submission, got {outcome:?}");
+        };
+        assert_eq!(body["intent"], "fix the thing");
+        assert_eq!(body["workflow"], "implement");
+    }
+
+    #[test]
+    fn ctrl_enter_on_a_blank_intent_reports_the_same_error_run_work_would() {
+        let mut form = NewWorkForm::default();
+        assert_eq!(form.on_key(ctrl_enter()), HomeOutcome::None);
+        assert_eq!(form.last_error.as_deref(), Some("intent is required"));
+    }
+
+    #[test]
+    fn tab_leaves_the_intent_composer_for_the_next_field() {
+        let mut form = NewWorkForm::default();
+        form.on_key(KeyCode::Char('h'));
+        form.on_key(KeyCode::Tab);
+        assert!(!form.intent_focused());
+        form.on_key(KeyCode::Char('w'));
+        assert_eq!(form.workflow, "w");
+        assert_eq!(
+            form.intent.text(),
+            "h",
+            "leaving the composer must not have inserted a tab character"
+        );
     }
 
     #[test]
@@ -381,12 +524,12 @@ mod tests {
     #[test]
     fn a_complete_form_submits_the_v1_work_body_sgt_run_would_send() {
         let mut form = NewWorkForm {
-            intent: "fix the thing".to_string(),
             workflow: "implement".to_string(),
             repositories: "svc-a, svc-b".to_string(),
             turn_cap: "12".to_string(),
             ..NewWorkForm::default()
         };
+        form.intent.set_text("fix the thing");
         for _ in 0..(FIELDS.len() - 1) {
             form.on_key(KeyCode::Tab);
         }
@@ -406,10 +549,10 @@ mod tests {
     #[test]
     fn a_non_numeric_turn_cap_is_refused_without_losing_the_draft() {
         let mut form = NewWorkForm {
-            intent: "keep me".to_string(),
             turn_cap: "not a number".to_string(),
             ..NewWorkForm::default()
         };
+        form.intent.set_text("keep me");
         for _ in 0..(FIELDS.len() - 1) {
             form.on_key(KeyCode::Tab);
         }
@@ -419,21 +562,20 @@ mod tests {
             Some("turns must be a whole number")
         );
         assert_eq!(
-            form.intent, "keep me",
+            form.intent.text(),
+            "keep me",
             "the draft survives a validation error"
         );
     }
 
     #[test]
     fn clear_draft_resets_every_field_but_keeps_the_current_focus() {
-        let mut form = NewWorkForm {
-            intent: "will be cleared".to_string(),
-            ..NewWorkForm::default()
-        };
+        let mut form = NewWorkForm::default();
+        form.intent.set_text("will be cleared");
         form.on_key(KeyCode::Tab);
         let focus_before = form.focus;
         form.clear_draft();
-        assert_eq!(form.intent, "");
+        assert_eq!(form.intent.text(), "");
         assert_eq!(form.focus, focus_before);
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -44,6 +44,7 @@
 
 mod app;
 mod attention;
+mod composer;
 mod connection;
 mod estate;
 mod fleet;
@@ -60,7 +61,7 @@ pub use fleet::WorkRow;
 use std::time::Duration;
 
 use ratatui::Frame;
-use ratatui::crossterm::event::KeyCode;
+use ratatui::crossterm::event::KeyEvent;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -107,7 +108,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
     frame.render_widget(footer_line(app), footer);
 
     if let Some(kind) = app.overlay {
-        overlay::render(frame, body, kind);
+        overlay::render(frame, body, kind, app);
     }
 }
 
@@ -261,9 +262,22 @@ fn footer_line(app: &App) -> Paragraph<'_> {
     let keys = if app.overlay.is_some() {
         "Esc/q close"
     } else if app.open_work.is_some() {
-        "Tab/S-Tab or 1-5 switch view · j/k move · Esc/q back"
+        // §15.1/§15.2: the composer's own grammar while `ANSWER` has focus,
+        // else the surface's ordinary navigation plus §13.10's action keys.
+        match app.work_screen.as_ref().map(|s| s.answer_focused()) {
+            Some(true) => {
+                "Ctrl+Enter send · Enter newline · Tab focus Send · Esc leave (draft kept)"
+            }
+            _ => {
+                "Tab/S-Tab or 1-5 switch view · j/k move · r/c/t/e/p act (where offered) · Esc/q back"
+            }
+        }
     } else if app.destination == Destination::Home && app.home.wants_text_focus() {
-        "Tab next field · Enter next field/submit · Esc leave the form"
+        if app.home.intent_focused() {
+            "Ctrl+Enter submit · Enter newline · Tab next field · Esc leave the form"
+        } else {
+            "Tab next field · Enter next field/submit · Esc leave the form"
+        }
     } else if app.destination == Destination::Fleet && app.fleet.wants_text_focus() {
         "type to filter · Enter/Esc apply"
     } else {
@@ -292,6 +306,10 @@ pub async fn run(client: ApiClient) -> Result<(), TuiError> {
     app.status = String::new();
 
     let mut terminal = ratatui::try_init()?;
+    // §8.8's Decision T2-32: opportunistic, nonfatal — paired with the pop
+    // below on every exit path, the same way raw mode itself is restored on
+    // every path regardless of how the loop ended.
+    terminal::push_keyboard_enhancement(&mut std::io::stdout());
     let result = event_loop(
         &mut terminal,
         &mut app,
@@ -299,6 +317,7 @@ pub async fn run(client: ApiClient) -> Result<(), TuiError> {
         TerminalProbes::production(),
     )
     .await;
+    terminal::pop_keyboard_enhancement(&mut std::io::stdout());
     // Restore is attempted on every path, including the hung-up one — the
     // ioctl half (raw mode) can still land even when the write half cannot.
     let restored = ratatui::try_restore();
@@ -351,7 +370,7 @@ where
     B: ratatui::backend::Backend,
     B::Error: std::error::Error + Send + Sync + 'static,
 {
-    let (keys_tx, mut keys) = tokio::sync::mpsc::unbounded_channel::<KeyCode>();
+    let (keys_tx, mut keys) = tokio::sync::mpsc::unbounded_channel::<KeyEvent>();
     let TerminalProbes { watch: tty, tick } = probes;
     // crossterm's reader is blocking, so it lives on its own OS thread and
     // posts keystrokes into the async loop. It polls rather than blocking
@@ -533,6 +552,7 @@ fn terminal_error<E: std::error::Error + Send + Sync + 'static>(e: E) -> TuiErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::crossterm::event::KeyCode;
     use serde_json::json;
 
     /// The header line as the text a terminal would show — rendered into a
@@ -656,7 +676,7 @@ mod tests {
     #[test]
     fn wide_home_shows_the_drawer_the_form_and_recent_outputs_at_once() {
         let mut app = App::new();
-        app.home.intent = "deliberately unused".to_string();
+        app.home.intent.set_text("deliberately unused");
         app.rows = fleet::fleet_rows(&json!({"works": [
             {"id": "needs-a-look", "state": "needs_input", "intent": "waiting on an answer"},
             {"id": "shipped", "state": "completed", "intent": "already done"},

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -1,21 +1,24 @@
 //! Overlays (§7.4, Decision T2-24): a small fixed set of contextual views,
 //! not a modal framework or second navigation system.
 //!
-//! The *mechanism* — how one opens, closes, and restores focus — is this
-//! Work's job; most of the individual overlays' content is later Works'
-//! (the workflow chooser needs T2's catalog, repo/group add-remove and the
-//! retained-state preview need T3's Estate routes, cancel confirmation and
-//! extend-envelope need T1c's mutations). Opening an overlay never mutates
-//! the destination state underneath it — [`super::app::App::on_key`] simply
-//! routes every keystroke to the overlay instead of the destination while
-//! one is open — so closing it "restores focus" for free: nothing under it
-//! ever moved.
+//! The *mechanism* — how one opens, closes, and restores focus — is T1a's
+//! job; T1c fills in the four real confirmations respond/retry/extend/
+//! cancel need (§13.10/§15.5). What is left for later Works: the workflow
+//! chooser (T2's catalog), repo/group add-remove and the retained-state
+//! preview (T3's Estate routes), and the slash palette (§15.3, explicitly
+//! out of T1c's scope). Opening an overlay never mutates the destination
+//! state underneath it — [`super::app::App::on_key`] simply routes every
+//! keystroke to the overlay instead of the destination while one is open —
+//! so closing it "restores focus" for free: nothing under it ever moved.
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::Style;
 use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 
+use crate::api::field_text;
+
+use super::app::App;
 use super::theme::Token;
 
 /// §7.4's fixed set, in the order it lists them.
@@ -25,7 +28,9 @@ pub enum Overlay {
     WorkflowChooser,
     Help,
     CancelConfirmation,
+    RetryConfirmation,
     ExtendEnvelope,
+    ReapConfirmation,
     RepoAddRemove,
     GroupEditRemove,
     RetainedPreview,
@@ -39,7 +44,9 @@ impl Overlay {
             Overlay::WorkflowChooser => "Choose a Workflow",
             Overlay::Help => "Help",
             Overlay::CancelConfirmation => "Cancel Work?",
+            Overlay::RetryConfirmation => "Retry?",
             Overlay::ExtendEnvelope => "Extend Envelope",
+            Overlay::ReapConfirmation => "Reap?",
             Overlay::RepoAddRemove => "Repository",
             Overlay::GroupEditRemove => "Group",
             Overlay::RetainedPreview => "Retained State",
@@ -48,13 +55,19 @@ impl Overlay {
     }
 
     /// The later Work that actually implements this overlay's content —
-    /// `None` for [`Overlay::Help`], which T1a implements in full.
+    /// `None` for the ones already built: [`Overlay::Help`] (T1a) and
+    /// T1c's four real confirmations (§13.10/§15.5).
     fn owner(self) -> Option<&'static str> {
         match self {
-            Overlay::Help => None,
-            Overlay::SlashPalette | Overlay::CancelConfirmation | Overlay::ExtendEnvelope => {
-                Some("T1c (§20.2's mutation and composer work)")
-            }
+            Overlay::Help
+            | Overlay::CancelConfirmation
+            | Overlay::RetryConfirmation
+            | Overlay::ExtendEnvelope
+            | Overlay::ReapConfirmation => None,
+            // §15.3 is explicitly out of T1c's scope (deferred alongside
+            // §15.4's Workflows half and §15.6) — not this Work, and not yet
+            // reassigned to a later one by name.
+            Overlay::SlashPalette => Some("a later Work (§15.3)"),
             Overlay::WorkflowChooser => Some("T2 (§20.3's workflow discovery)"),
             Overlay::RepoAddRemove | Overlay::GroupEditRemove | Overlay::RetainedPreview => {
                 Some("T3 (§20.4's Estate work)")
@@ -64,8 +77,8 @@ impl Overlay {
     }
 }
 
-/// The keymap this Work actually wires up — the one overlay with real
-/// content (§15.6).
+/// §15.6's fixed keymap reference, derived from the same key/action table
+/// the footer uses.
 const HELP_TEXT: &str = "\
 Navigation
   1-4         Home / Fleet / Workflows / Estate
@@ -80,16 +93,30 @@ Fleet
   /           filter by text
   s           cycle the state filter
   a           toggle nonterminal-only
+  v           toggle the selected-preview pane (Medium tier)
   x           clear filters
 
 Home
   Tab / S-Tab move between fields
-  Enter       next field, or submit from [ Run Work ]
+  Ctrl+Enter  submit from the INTENT composer directly
+  Enter       newline in INTENT, else next field / submit from [ Run Work ]
+
+Open Work
+  Tab / S-Tab or 1-5  switch view
+  j/k                 move
+  r                    respond (when offered)
+  c / t / e / p        cancel / retry / extend / reap (when offered) —
+                        opens a confirmation; Enter there sends it
+  Esc / q              back
 ";
 
 /// Draw the overlay over `area`, clearing what was there first (§8.3's
-/// `Clear`) so a contextual panel never shows through stale cells.
-pub fn render(frame: &mut Frame, area: Rect, overlay: Overlay) {
+/// `Clear`) so a contextual panel never shows through stale cells. `app`
+/// supplies the live content T1c's four real confirmations need (the open
+/// Work's own facts, and the one overlay's worth of in-progress state on
+/// [`super::app::PendingAction`]) — every other overlay in the fixed set
+/// ignores it.
+pub fn render(frame: &mut Frame, area: Rect, overlay: Overlay, app: &App) {
     let panel = centered(area, 70, 60);
     frame.render_widget(Clear, panel);
     let block = Block::bordered()
@@ -98,14 +125,131 @@ pub fn render(frame: &mut Frame, area: Rect, overlay: Overlay) {
     let inner = block.inner(panel);
     frame.render_widget(block, panel);
 
-    let body = match overlay.owner() {
-        None => HELP_TEXT.to_string(),
-        Some(owner) => format!(
-            "{} is not built in this Work.\n\n{owner} implements it.\n\nEsc closes this panel.",
-            overlay.title()
+    let body = match overlay {
+        Overlay::Help => HELP_TEXT.to_string(),
+        Overlay::CancelConfirmation => cancel_body(app),
+        Overlay::RetryConfirmation => retry_body(app),
+        Overlay::ExtendEnvelope => extend_body(app),
+        Overlay::ReapConfirmation => reap_body(app),
+        _ => format!(
+            "{} is not built in this Work.\n\n{} implements it.\n\nEsc closes this panel.",
+            overlay.title(),
+            overlay.owner().unwrap_or("a later Work"),
         ),
     };
     frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), inner);
+}
+
+/// The open Work's id and intent — every confirmation names the Work it
+/// acts on (§15.5).
+fn work_identity(app: &App) -> (String, String) {
+    let id = app
+        .open_work
+        .as_ref()
+        .map(|w| w.id.clone())
+        .unwrap_or_else(|| "-".to_string());
+    let intent = app
+        .work_screen
+        .as_ref()
+        .map(|s| field_text(&s.work()["work"]["intent"]))
+        .unwrap_or_else(|| "-".to_string());
+    (id, intent)
+}
+
+/// §15.5: "Cancel: confirmation naming Work."
+fn cancel_body(app: &App) -> String {
+    let (id, intent) = work_identity(app);
+    let mut body = format!(
+        "Cancel this Work?\n\n  {intent}\n  {id}\n\nThis asks the daemon to cancel it. \
+         It cannot be undone.\n\nEnter confirms · Esc/q aborts, nothing is sent."
+    );
+    if let Some(error) = &app.pending_action.last_error {
+        body.push_str(&format!("\n\nlast attempt failed: {error}"));
+    }
+    body
+}
+
+/// §15.5: "Retry: confirmation naming stage/attempt."
+fn retry_body(app: &App) -> String {
+    let (id, intent) = work_identity(app);
+    let (stage, attempt) = app
+        .work_screen
+        .as_ref()
+        .map(|s| {
+            let w = s.work();
+            (
+                field_text(&w["stage"]["stage_id"]),
+                field_text(&w["stage"]["attempt"]),
+            )
+        })
+        .unwrap_or_else(|| ("-".to_string(), "-".to_string()));
+    let mut body = format!(
+        "Retry this Work?\n\n  {intent}\n  {id}\n\n  stage    {stage}\n  attempt  {attempt}\n\n\
+         Retries re-enter the current stage.\n\nEnter confirms · Esc/q aborts, nothing is sent."
+    );
+    if let Some(error) = &app.pending_action.last_error {
+        body.push_str(&format!("\n\nlast attempt failed: {error}"));
+    }
+    body
+}
+
+/// §15.5: "Extend: explicit added turns and resulting cap."
+fn extend_body(app: &App) -> String {
+    let (id, intent) = work_identity(app);
+    let current_cap = app
+        .work_screen
+        .as_ref()
+        .and_then(|s| s.work()["envelope"]["turn_cap"].as_u64());
+    let pending = &app.pending_action;
+    let added: Option<u64> = pending.extend_turns.trim().parse().ok();
+    let resulting = match (current_cap, added) {
+        (Some(cap), Some(added)) if added > 0 => (cap + added).to_string(),
+        _ => "-".to_string(),
+    };
+    let field_marker = if pending.confirm_focused { "" } else { "_" };
+    let confirm_marker = if pending.confirm_focused { " <" } else { "" };
+    let mut body = format!(
+        "Extend the turn envelope?\n\n  {intent}\n  {id}\n\n  \
+         current cap    {}\n  add turns       {}{field_marker}\n  resulting cap   {resulting}\n\n\
+         [ confirm ]{confirm_marker}\n\n\
+         Tab moves between the turns field and Confirm · Enter on the field \
+         moves to Confirm · Enter on Confirm sends it · Esc/q aborts.",
+        current_cap
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        if pending.extend_turns.is_empty() {
+            "-"
+        } else {
+            pending.extend_turns.as_str()
+        },
+    );
+    if let Some(error) = &pending.last_error {
+        body.push_str(&format!("\n\n{error}"));
+    }
+    body
+}
+
+/// §15.5: "Reap: preview exact paths/bytes and state that retained branch
+/// remains." The current Work read does not surface paths/bytes (only
+/// `/v1/retained`, an estate-wide read T3's Estate surface owns, §20.4) —
+/// per this Work's own scope note, a minimal confirmation stating the
+/// branch is retained is what ships here rather than blocking on that data.
+fn reap_body(app: &App) -> String {
+    let (id, intent) = work_identity(app);
+    let mut body = format!(
+        "Reap this Work's retained state?\n\n  {intent}\n  {id}\n\n\
+         Reap disposes local retained artifacts (worktrees/branches this daemon \
+         still holds for review). The retained branch itself is not deleted — \
+         only local disposal happens here.\n\n\
+         Exact paths and bytes are not previewed here: that detail comes from \
+         the estate-wide `/v1/retained` read, outside this Work's four Work-\
+         scoped reads (T3's Estate surface, §20.4).\n\n\
+         Enter confirms · Esc/q aborts, nothing is sent."
+    );
+    if let Some(error) = &app.pending_action.last_error {
+        body.push_str(&format!("\n\nlast attempt failed: {error}"));
+    }
+    body
 }
 
 /// A `percent_x` × `percent_y` box, centered in `area`.
@@ -122,15 +266,25 @@ fn centered(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
-    fn only_help_is_implemented_in_this_work() {
-        assert!(Overlay::Help.owner().is_none());
+    fn help_and_the_four_t1c_confirmations_are_built_here() {
+        for built in [
+            Overlay::Help,
+            Overlay::CancelConfirmation,
+            Overlay::RetryConfirmation,
+            Overlay::ExtendEnvelope,
+            Overlay::ReapConfirmation,
+        ] {
+            assert!(
+                built.owner().is_none(),
+                "{built:?} must be built in this Work"
+            );
+        }
         for later in [
             Overlay::SlashPalette,
             Overlay::WorkflowChooser,
-            Overlay::CancelConfirmation,
-            Overlay::ExtendEnvelope,
             Overlay::RepoAddRemove,
             Overlay::GroupEditRemove,
             Overlay::RetainedPreview,
@@ -138,5 +292,73 @@ mod tests {
         ] {
             assert!(later.owner().is_some(), "{later:?} must name who builds it");
         }
+    }
+
+    fn app_with_open_work(state: &str) -> App {
+        let mut app = App::new();
+        app.rows = super::super::fleet::fleet_rows(&json!({"works": [
+            {"id": "01WORK", "state": state, "intent": "fix the thing"},
+        ]}));
+        app.open_work = Some(super::super::OpenWork {
+            id: "01WORK".to_string(),
+            from: super::super::Destination::Fleet,
+        });
+        app.work_screen = Some(super::super::work_view::WorkScreen::from_parts(
+            "01WORK".to_string(),
+            json!({
+                "work": {"id": "01WORK", "intent": "fix the thing", "state": state},
+                "stage": {"stage_id": "10-implement", "attempt": 2},
+                "envelope": {"turn_cap": 12, "turns_spawned": 3},
+            }),
+            Vec::new(),
+            Vec::new(),
+            None,
+        ));
+        app
+    }
+
+    #[test]
+    fn cancel_confirmation_names_the_work() {
+        let app = app_with_open_work("blocked");
+        let body = cancel_body(&app);
+        assert!(body.contains("fix the thing"));
+        assert!(body.contains("01WORK"));
+    }
+
+    #[test]
+    fn retry_confirmation_names_stage_and_attempt() {
+        let app = app_with_open_work("failed");
+        let body = retry_body(&app);
+        assert!(body.contains("10-implement"));
+        assert!(body.contains("2"));
+    }
+
+    #[test]
+    fn extend_confirmation_shows_the_resulting_cap_once_turns_are_entered() {
+        let mut app = app_with_open_work("blocked");
+        app.pending_action.extend_turns = "5".to_string();
+        let body = extend_body(&app);
+        assert!(body.contains("current cap"));
+        assert!(body.contains("12"));
+        assert!(
+            body.contains("17"),
+            "12 + 5 must be shown before confirming: {body}"
+        );
+    }
+
+    #[test]
+    fn extend_confirmation_shows_no_resulting_cap_until_turns_are_entered() {
+        let app = app_with_open_work("blocked");
+        let body = extend_body(&app);
+        assert!(body.contains("resulting cap   -"), "{body}");
+    }
+
+    #[test]
+    fn reap_confirmation_states_the_branch_is_retained() {
+        let app = app_with_open_work("completed_dirty");
+        let body = reap_body(&app);
+        assert!(
+            body.to_lowercase().contains("not deleted") || body.to_lowercase().contains("remains")
+        );
     }
 }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -21,7 +21,7 @@
 
 use std::time::Duration;
 
-use ratatui::crossterm::event::{self, Event as TermEvent, KeyCode, KeyEventKind};
+use ratatui::crossterm::event::{self, Event as TermEvent, KeyEvent, KeyEventKind};
 
 /// How long the key reader waits between polls before checking for shutdown.
 pub const KEY_POLL: Duration = Duration::from_millis(200);
@@ -54,7 +54,7 @@ impl KeyReader {
     /// Start reading keys off `tick` into `keys`.
     pub fn spawn(
         mut tick: impl FnMut() -> ReaderTick + Send + 'static,
-        keys: tokio::sync::mpsc::UnboundedSender<KeyCode>,
+        keys: tokio::sync::mpsc::UnboundedSender<KeyEvent>,
     ) -> Self {
         let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
         let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
@@ -85,8 +85,10 @@ impl KeyReader {
 /// One turn of the key reader: what the terminal produced, or that it is over.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReaderTick {
-    /// A key was pressed.
-    Key(KeyCode),
+    /// A key was pressed. The full event (code, modifiers, kind, state) is
+    /// kept — §8.8's Decision T2-32 — so a caller can tell `Enter` from
+    /// `Ctrl+Enter` (§15.2), which a bare `KeyCode` cannot.
+    Key(KeyEvent),
     /// Nothing happened within the poll window.
     Idle,
     /// The terminal ended — end of input, or a read that failed. Terminal in
@@ -104,7 +106,7 @@ pub enum ReaderTick {
 pub fn read_keys(
     mut tick: impl FnMut() -> ReaderTick,
     stop: &std::sync::mpsc::Receiver<()>,
-    keys: &tokio::sync::mpsc::UnboundedSender<KeyCode>,
+    keys: &tokio::sync::mpsc::UnboundedSender<KeyEvent>,
 ) {
     loop {
         // Asked to stop, or the loop that asked is gone: either way, done.
@@ -176,12 +178,81 @@ pub fn guarded_tick(tty: &TtyWatch, poll: fn() -> ReaderTick) -> ReaderTick {
 pub fn crossterm_poll() -> ReaderTick {
     match event::poll(KEY_POLL) {
         Ok(true) => match event::read() {
-            Ok(TermEvent::Key(key)) if key.kind == KeyEventKind::Press => ReaderTick::Key(key.code),
+            Ok(TermEvent::Key(key)) if key.kind == KeyEventKind::Press => ReaderTick::Key(key),
             Ok(_) => ReaderTick::Idle,
             Err(_) => ReaderTick::Ended,
         },
         Ok(false) => ReaderTick::Idle,
         Err(_) => ReaderTick::Ended,
+    }
+}
+
+/// §8.8's Decision T2-32: opportunistically request disambiguated modified
+/// keys (e.g. distinguishing `Ctrl+Enter` from plain `Enter`) so §15.2's
+/// submit key is reachable directly rather than only through the Tab-to-Send
+/// fallback. Generic over the sink so the escape sequence itself — not a
+/// live terminal — is what a test can check; failure is nonfatal (many
+/// terminals do not support the Kitty keyboard protocol), which is exactly
+/// why Ctrl+Enter is never the only route to submit.
+pub fn push_keyboard_enhancement<W: std::io::Write>(out: &mut W) {
+    use event::{KeyboardEnhancementFlags, PushKeyboardEnhancementFlags};
+    let _ = ratatui::crossterm::execute!(
+        out,
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+    );
+}
+
+/// The other half of [`push_keyboard_enhancement`] — always run before
+/// [`ratatui::try_restore`], on every exit path (see `super::run`), the same
+/// way this module already restores raw mode on every path.
+pub fn pop_keyboard_enhancement<W: std::io::Write>(out: &mut W) {
+    use event::PopKeyboardEnhancementFlags;
+    let _ = ratatui::crossterm::execute!(out, PopKeyboardEnhancementFlags);
+}
+
+#[cfg(test)]
+mod keyboard_enhancement_tests {
+    use super::*;
+
+    #[test]
+    fn push_and_pop_write_the_kitty_protocol_escape_sequences() {
+        let mut buf = Vec::new();
+        push_keyboard_enhancement(&mut buf);
+        let text = String::from_utf8(buf).expect("ansi escapes are valid utf8");
+        assert!(
+            text.starts_with("\u{1b}[>") && text.ends_with('u'),
+            "a CSI '>flags u' push sequence: {text:?}"
+        );
+
+        let mut buf = Vec::new();
+        pop_keyboard_enhancement(&mut buf);
+        let text = String::from_utf8(buf).expect("ansi escapes are valid utf8");
+        assert!(
+            text.starts_with("\u{1b}[<") && text.ends_with('u'),
+            "a CSI '<N u' pop sequence: {text:?}"
+        );
+    }
+
+    /// A sink that always errors, standing in for a terminal that does not
+    /// support the Kitty protocol (or has no controlling terminal at all,
+    /// as this suite itself runs under). Neither call may panic or return
+    /// a `Result` the caller is forced to handle — that is the "nonfatal"
+    /// half of Decision T2-32.
+    struct AlwaysErrors;
+
+    impl std::io::Write for AlwaysErrors {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("no such terminal"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("no such terminal"))
+        }
+    }
+
+    #[test]
+    fn a_sink_that_refuses_the_write_is_not_fatal() {
+        push_keyboard_enhancement(&mut AlwaysErrors);
+        pop_keyboard_enhancement(&mut AlwaysErrors);
     }
 }
 
@@ -381,6 +452,11 @@ pub(crate) static SIGNALS_QUIET: tokio::sync::Mutex<()> = tokio::sync::Mutex::co
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::crossterm::event::KeyCode;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::from(code)
+    }
 
     /// The signal arm, exercised for real: install the handlers, send this
     /// process a SIGTERM, and require the future to resolve.
@@ -418,14 +494,14 @@ mod tests {
     /// `Ended`, so a regression fails the test instead of hanging it.
     #[test]
     fn the_key_reader_stops_when_the_terminal_ends() {
-        let (keys_tx, mut keys) = tokio::sync::mpsc::unbounded_channel::<KeyCode>();
+        let (keys_tx, mut keys) = tokio::sync::mpsc::unbounded_channel::<KeyEvent>();
         // Kept alive: a dropped sender is itself a stop, and this test is
         // about the *tick* ending the loop.
         let (_stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
 
         let script = [
             ReaderTick::Idle,
-            ReaderTick::Key(KeyCode::Char('j')),
+            ReaderTick::Key(key(KeyCode::Char('j'))),
             ReaderTick::Ended,
         ];
         let mut calls = 0usize;
@@ -444,7 +520,7 @@ mod tests {
             &keys_tx,
         );
         assert_eq!(calls, script.len(), "every tick was consumed, and no more");
-        assert_eq!(keys.try_recv().ok(), Some(KeyCode::Char('j')));
+        assert_eq!(keys.try_recv().ok(), Some(key(KeyCode::Char('j'))));
         assert!(keys.try_recv().is_err(), "only the key was forwarded");
 
         // The other two ways the loop is over, for completeness: a stop
@@ -463,7 +539,7 @@ mod tests {
             || {
                 sends += 1;
                 assert!(sends < 3, "a closed key channel must end the reader");
-                ReaderTick::Key(KeyCode::Char('k'))
+                ReaderTick::Key(key(KeyCode::Char('k')))
             },
             &stop_rx,
             &keys_tx,
@@ -647,7 +723,7 @@ mod tests {
         use std::time::Instant;
 
         // A reader that returns promptly is waited for and joined.
-        let (keys_tx, _keys) = tokio::sync::mpsc::unbounded_channel::<KeyCode>();
+        let (keys_tx, _keys) = tokio::sync::mpsc::unbounded_channel::<KeyEvent>();
         let reader = KeyReader::spawn(|| ReaderTick::Ended, keys_tx);
         assert_eq!(
             reader.shutdown(),
@@ -658,7 +734,7 @@ mod tests {
         // A reader stuck inside its tick — crossterm's poll on a dead pty is
         // the real one — is left to die with the process.
         const WEDGE: Duration = Duration::from_secs(5);
-        let (keys_tx, _keys) = tokio::sync::mpsc::unbounded_channel::<KeyCode>();
+        let (keys_tx, _keys) = tokio::sync::mpsc::unbounded_channel::<KeyEvent>();
         let (entered_tx, entered) = std::sync::mpsc::channel::<()>();
         let reader = KeyReader::spawn(
             move || {

--- a/src/tui/work_view.rs
+++ b/src/tui/work_view.rs
@@ -12,12 +12,19 @@
 //! [`render_preview`] — built from the row Fleet already has loaded, with no
 //! per-Work fetch of its own.
 //!
-//! §13.10's action matrix is display-only here: T1c wires respond/retry/
-//! extend/cancel to the API. This Work only shows, per the current reported
-//! state, which actions the daemon would accept.
+//! §13.10's action matrix is real: respond/retry/extend/cancel/reap all
+//! reach the API (through [`super::app::App::execute`], not from here —
+//! this module only ever returns an outcome). §15.1's persistent composer,
+//! this surface's context: `ANSWER` while the reported state is
+//! `needs_input` (the real [`super::composer::Composer`], shared with
+//! Home's `INTENT`), `COMMAND` (disabled) otherwise. A handful of mnemonic
+//! keys (`r`/`c`/`t`/`e`/`p`) *open* each action's confirmation — never
+//! perform the mutation directly, per §10.5's "not single-key destructive
+//! shortcuts"; the deliberate step is always that confirmation's own
+//! Tab-to-Confirm-then-Enter or Ctrl+Enter (§15.2/§15.5).
 
 use ratatui::Frame;
-use ratatui::crossterm::event::KeyCode;
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -26,6 +33,7 @@ use serde_json::Value;
 
 use crate::api::{ApiClient, ClientError, field_text, stage_label};
 
+use super::composer::{Composer, ComposerOutcome};
 use super::connection::Live;
 use super::fleet::WorkRow;
 use super::theme::{self, Token};
@@ -89,13 +97,26 @@ const EVIDENCE_LIMIT_STEP: usize = 200;
 const EVIDENCE_LIMIT_MAX: usize = 2000;
 
 /// What a keystroke inside an open Work surface asked for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorkScreenOutcome {
     None,
     /// Return to wherever this Work was opened from.
     Close,
     /// §13.5's bounded "load older": grow the Evidence window and re-fetch.
     LoadOlder,
+    /// §15.1/§15.2: the `ANSWER` composer was deliberately submitted with a
+    /// nonblank draft.
+    Respond(String),
+    /// A submit was asked for while the draft was blank (§15.2's refusal).
+    AnswerRefused,
+    /// §13.10/§15.5: open the Cancel confirmation.
+    OpenCancelConfirm,
+    /// §13.10/§15.5: open the Retry confirmation.
+    OpenRetryConfirm,
+    /// §13.10/§15.5: open the Extend confirmation.
+    OpenExtendEnvelope,
+    /// §13.10/§15.5: open the Reap confirmation.
+    OpenReapConfirm,
 }
 
 /// The canonical Work surface's own state: the four fetched reads, which tab
@@ -115,6 +136,14 @@ pub struct WorkScreen {
     thread_selected: usize,
     evidence_selected: usize,
     graph_selected: usize,
+    /// §15.1's `ANSWER` composer, live only while the reported state is
+    /// `needs_input` — the same [`Composer`] type Home's `INTENT` uses.
+    answer: Composer,
+    /// Whether the composer itself has keyboard focus.
+    answer_focused: bool,
+    /// Whether Tab has moved focus off the composer onto the Send control
+    /// (§15.2's "Tab focuses Send/Run/Confirm").
+    answer_send_focused: bool,
     /// Set when a background refresh (not the initial open) fails — shown
     /// inline rather than losing the screen the last successful read built.
     pub last_error: Option<String>,
@@ -141,8 +170,41 @@ impl WorkScreen {
             thread_selected: 0,
             evidence_selected: 0,
             graph_selected: 0,
+            answer: Composer::new().with_placeholder("Type the answer — Ctrl+Enter to send"),
+            answer_focused: false,
+            answer_send_focused: false,
             last_error: None,
         }
+    }
+
+    /// The raw `GET /v1/work/{id}` body — `overlay.rs`'s confirmations read
+    /// the same facts this screen's own header/details already show (id,
+    /// intent, stage, attempt, envelope) rather than a second projection.
+    pub fn work(&self) -> &Value {
+        &self.work
+    }
+
+    /// Whether the `ANSWER` composer currently has keyboard focus — the
+    /// footer uses this to show §15.2's composer grammar.
+    pub fn answer_focused(&self) -> bool {
+        self.answer_focused
+    }
+
+    /// The draft clears only after an accepted mutation (§9.2/§15.2, reused
+    /// here for Respond) — called once `App::execute`'s `Action::Respond`
+    /// succeeds.
+    pub fn clear_answer(&mut self) {
+        self.answer.clear();
+        self.answer_focused = false;
+        self.answer_send_focused = false;
+    }
+
+    /// Test-only window into the Answer draft — `App`'s own mutation-wiring
+    /// tests need to see it survived a failed `respond` without a full
+    /// public accessor onto [`Composer`] elsewhere.
+    #[cfg(test)]
+    pub(crate) fn answer_text_for_test(&self) -> String {
+        self.answer.text()
     }
 
     /// Open a Work: the four reads §13.3-§13.6 are built from. The graph
@@ -179,6 +241,12 @@ impl WorkScreen {
         self.events = events_of(events);
         self.graph = graph;
         self.last_error = None;
+        if self.state() != "needs_input" {
+            // The question this composer was answering is gone — answered
+            // elsewhere, or the Work moved on. Nothing to leave focused on.
+            self.answer_focused = false;
+            self.answer_send_focused = false;
+        }
         Ok(())
     }
 
@@ -194,9 +262,18 @@ impl WorkScreen {
 
     // ---------------------------------------------------------------- keys
 
-    pub fn on_key(&mut self, key: KeyCode) -> WorkScreenOutcome {
+    /// Whether `action` (§13.10's vocabulary: `"respond"`, `"cancel"`,
+    /// `"retry"`, `"extend"`, `"reap"`) is legal for the current reported
+    /// state — the same table the header already renders (§13.10's
+    /// Decision T2-52).
+    fn action_available(&self, action: &str) -> bool {
+        actions_for_state(&self.state()).1.contains(&action)
+    }
+
+    pub fn on_key(&mut self, key: impl Into<KeyEvent>) -> WorkScreenOutcome {
+        let key: KeyEvent = key.into();
         if self.evidence_filter_focus {
-            match key {
+            match key.code {
                 KeyCode::Esc | KeyCode::Enter => self.evidence_filter_focus = false,
                 KeyCode::Backspace => {
                     self.evidence_filter.pop();
@@ -206,7 +283,10 @@ impl WorkScreen {
             }
             return WorkScreenOutcome::None;
         }
-        match key {
+        if self.answer_focused {
+            return self.on_key_answer(key);
+        }
+        match key.code {
             KeyCode::Esc | KeyCode::Char('q') => return WorkScreenOutcome::Close,
             KeyCode::Tab => self.tab = self.tab.next(),
             KeyCode::BackTab => self.tab = self.tab.prev(),
@@ -220,7 +300,61 @@ impl WorkScreen {
                 self.evidence_filter.clear();
             }
             KeyCode::Char('o') if self.tab == Tab::Evidence => return WorkScreenOutcome::LoadOlder,
+            // §13.10's action matrix, wired: each key *opens* the real
+            // control (the composer for respond, a confirmation overlay for
+            // the other four) — the deliberate mutation happens there, per
+            // §10.5's "not single-key destructive shortcuts".
+            KeyCode::Char('r') if self.action_available("respond") => {
+                self.answer_focused = true;
+                self.answer_send_focused = false;
+            }
+            KeyCode::Char('c') if self.action_available("cancel") => {
+                return WorkScreenOutcome::OpenCancelConfirm;
+            }
+            KeyCode::Char('t') if self.action_available("retry") => {
+                return WorkScreenOutcome::OpenRetryConfirm;
+            }
+            KeyCode::Char('e') if self.action_available("extend") => {
+                return WorkScreenOutcome::OpenExtendEnvelope;
+            }
+            KeyCode::Char('p') if self.action_available("reap") => {
+                return WorkScreenOutcome::OpenReapConfirm;
+            }
             _ => {}
+        }
+        WorkScreenOutcome::None
+    }
+
+    /// Keys while the `ANSWER` composer has focus (§15.1/§15.2): every key
+    /// is the composer's own to interpret, except Esc (leave focus, keep
+    /// the draft) and Tab/BackTab (move onto/off the Send control — once
+    /// there, only Tab/BackTab/Enter/Esc mean anything, exactly as Home's
+    /// own `[ Run Work ]` tab stop already works).
+    fn on_key_answer(&mut self, key: KeyEvent) -> WorkScreenOutcome {
+        if self.answer_send_focused {
+            match key.code {
+                KeyCode::Esc => {
+                    self.answer_focused = false;
+                    self.answer_send_focused = false;
+                }
+                KeyCode::Tab | KeyCode::BackTab => self.answer_send_focused = false,
+                KeyCode::Enter => match self.answer.submit() {
+                    ComposerOutcome::Submit(text) => return WorkScreenOutcome::Respond(text),
+                    ComposerOutcome::Refused => return WorkScreenOutcome::AnswerRefused,
+                    ComposerOutcome::None => {}
+                },
+                _ => {}
+            }
+            return WorkScreenOutcome::None;
+        }
+        match key.code {
+            KeyCode::Esc => self.answer_focused = false,
+            KeyCode::Tab | KeyCode::BackTab => self.answer_send_focused = true,
+            _ => match self.answer.on_key(key) {
+                ComposerOutcome::Submit(text) => return WorkScreenOutcome::Respond(text),
+                ComposerOutcome::Refused => return WorkScreenOutcome::AnswerRefused,
+                ComposerOutcome::None => {}
+            },
         }
         WorkScreenOutcome::None
     }
@@ -889,9 +1023,9 @@ fn truncate(text: &str, limit: usize) -> String {
     format!("{head}…")
 }
 
-/// §13.10's display-only action matrix: the ordinary-text treatment and the
-/// action set the daemon would accept for the current reported state.
-/// Nothing here calls the API — T1c wires these verbs up.
+/// §13.10's action matrix: the ordinary-text treatment and the action set
+/// the daemon accepts for the current reported state. `"inspect"` has no
+/// key of its own — reaching this screen already is inspecting.
 fn actions_for_state(state: &str) -> (&'static str, &'static [&'static str]) {
     match state {
         "pending" | "active" => ("disabled", &["cancel", "inspect"]),
@@ -906,10 +1040,23 @@ fn actions_for_state(state: &str) -> (&'static str, &'static [&'static str]) {
     }
 }
 
+/// The mnemonic key [`WorkScreen::on_key`] binds to each action name, shown
+/// beside it in the header so the matrix is self-documenting.
+fn action_key(action: &str) -> Option<char> {
+    match action {
+        "respond" => Some('r'),
+        "cancel" => Some('c'),
+        "retry" => Some('t'),
+        "extend" => Some('e'),
+        "reap" => Some('p'),
+        _ => None,
+    }
+}
+
 // -------------------------------------------------------------- rendering
 
-/// §13.1's header, ending with the display-only action matrix (§13.10) and
-/// (when a background refresh has failed) the last error.
+/// §13.1's header, ending with the action matrix (§13.10, now wired to the
+/// keys above) and (when a background refresh has failed) the last error.
 fn header_lines(screen: &WorkScreen, live: Live) -> Vec<Line<'static>> {
     let w = &screen.work["work"];
     let state = field_text(&w["state"]);
@@ -998,11 +1145,16 @@ fn header_lines(screen: &WorkScreen, live: Live) -> Vec<Line<'static>> {
     }
 
     let (ordinary, actions) = actions_for_state(&state);
+    let action_text = actions
+        .iter()
+        .map(|a| match action_key(a) {
+            Some(key) => format!("{a} [{key}]"),
+            None => a.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(" · ");
     lines.push(Line::from(Span::styled(
-        format!(
-            "actions ({ordinary}, T1c not wired): {}",
-            actions.join(" · ")
-        ),
+        format!("actions ({ordinary}): {action_text}"),
         Style::default().fg(Token::Muted.rgb()),
     )));
 
@@ -1048,10 +1200,15 @@ pub fn render(frame: &mut Frame, area: Rect, screen: Option<&WorkScreen>, live: 
 
     let header = header_lines(screen, live);
     let header_height = header.len() as u16;
-    let [header_area, tabs_area, body_area] = Layout::vertical([
+    // §15.1's persistent composer: bounded (§18.4), always present so the
+    // region is "visually stable" regardless of state — only its label and
+    // whether it accepts input change (§15.1's `ANSWER`/`COMMAND` rows).
+    let composer_height = inner.height.saturating_sub(header_height + 6).clamp(3, 6);
+    let [header_area, tabs_area, body_area, composer_area] = Layout::vertical([
         Constraint::Length(header_height),
         Constraint::Length(1),
         Constraint::Min(1),
+        Constraint::Length(composer_height),
     ])
     .areas(inner);
     frame.render_widget(
@@ -1066,6 +1223,39 @@ pub fn render(frame: &mut Frame, area: Rect, screen: Option<&WorkScreen>, live: 
         Tab::Evidence => render_evidence(frame, body_area, screen),
         Tab::Graph => render_graph(frame, body_area, screen),
         Tab::Details => render_details(frame, body_area, screen),
+    }
+    render_bottom_composer(frame, composer_area, screen);
+}
+
+/// §15.1's context row for an open Work: `ANSWER` (real, interactive) while
+/// the reported state is `needs_input`; `COMMAND` (disabled — "no actor
+/// input in this state") for every other state.
+fn render_bottom_composer(frame: &mut Frame, area: Rect, screen: &WorkScreen) {
+    if screen.state() == "needs_input" {
+        let title = if screen.answer_focused {
+            if screen.answer_send_focused {
+                "ANSWER — Tab back to field · Enter send · Esc leave (draft kept)"
+            } else {
+                "ANSWER — Ctrl+Enter send · Enter newline · Tab focus Send · Esc leave"
+            }
+        } else {
+            "ANSWER — press 'r' to respond"
+        };
+        let block = Block::bordered()
+            .title(title)
+            .border_style(Style::default().fg(if screen.answer_focused {
+                Token::Focus.rgb()
+            } else {
+                Token::Attention.rgb()
+            }));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        screen.answer.render(frame, inner);
+    } else {
+        let block = Block::bordered()
+            .title("COMMAND — disabled, no actor input in this state")
+            .border_style(Style::default().fg(Token::Border.rgb()));
+        frame.render_widget(block, area);
     }
 }
 
@@ -1607,5 +1797,153 @@ mod tests {
             screen.on_key(KeyCode::Char('o')),
             WorkScreenOutcome::LoadOlder
         );
+    }
+
+    // -------------------------------------------- T1c: answer composer
+
+    fn ctrl_enter() -> KeyEvent {
+        KeyEvent::new(
+            KeyCode::Enter,
+            ratatui::crossterm::event::KeyModifiers::CONTROL,
+        )
+    }
+
+    #[test]
+    fn r_opens_the_answer_composer_only_when_respond_is_offered() {
+        let mut screen = screen_with("active", Vec::new());
+        assert_eq!(screen.on_key(KeyCode::Char('r')), WorkScreenOutcome::None);
+        assert!(!screen.answer_focused, "respond is not offered for active");
+
+        let mut screen = screen_with("needs_input", Vec::new());
+        assert_eq!(screen.on_key(KeyCode::Char('r')), WorkScreenOutcome::None);
+        assert!(screen.answer_focused);
+    }
+
+    #[test]
+    fn typing_in_the_answer_composer_never_triggers_the_surfaces_other_keys() {
+        let mut screen = screen_with("needs_input", Vec::new());
+        screen.on_key(KeyCode::Char('r'));
+        // 'q', 'j', 'k', digits: every one of these means something outside
+        // the composer, and none of them may fire while it has focus.
+        for c in "q j k 1".chars() {
+            screen.on_key(KeyCode::Char(c));
+        }
+        assert_eq!(screen.answer.text(), "q j k 1");
+        assert!(
+            screen.answer_focused,
+            "typing must not have closed anything"
+        );
+    }
+
+    #[test]
+    fn ctrl_enter_in_the_answer_composer_asks_to_respond() {
+        let mut screen = screen_with("needs_input", Vec::new());
+        screen.on_key(KeyCode::Char('r'));
+        for c in "yes, proceed".chars() {
+            screen.on_key(KeyCode::Char(c));
+        }
+        assert_eq!(
+            screen.on_key(ctrl_enter()),
+            WorkScreenOutcome::Respond("yes, proceed".to_string())
+        );
+    }
+
+    #[test]
+    fn blank_answer_is_refused_and_the_composer_stays_focused() {
+        let mut screen = screen_with("needs_input", Vec::new());
+        screen.on_key(KeyCode::Char('r'));
+        assert_eq!(
+            screen.on_key(ctrl_enter()),
+            WorkScreenOutcome::AnswerRefused
+        );
+        assert!(screen.answer_focused, "refusal does not drop focus");
+    }
+
+    #[test]
+    fn esc_leaves_the_answer_composer_and_preserves_the_draft() {
+        let mut screen = screen_with("needs_input", Vec::new());
+        screen.on_key(KeyCode::Char('r'));
+        for c in "keep me".chars() {
+            screen.on_key(KeyCode::Char(c));
+        }
+        screen.on_key(KeyCode::Esc);
+        assert!(!screen.answer_focused);
+        assert_eq!(screen.answer.text(), "keep me");
+        // The whole surface is not closed either — Esc here is scoped to
+        // the composer, exactly like Evidence's own filter Esc.
+    }
+
+    #[test]
+    fn tab_moves_to_send_and_enter_there_asks_to_respond() {
+        let mut screen = screen_with("needs_input", Vec::new());
+        screen.on_key(KeyCode::Char('r'));
+        for c in "answer".chars() {
+            screen.on_key(KeyCode::Char(c));
+        }
+        screen.on_key(KeyCode::Tab);
+        assert!(screen.answer_send_focused);
+        assert_eq!(
+            screen.on_key(KeyCode::Enter),
+            WorkScreenOutcome::Respond("answer".to_string())
+        );
+    }
+
+    #[test]
+    fn refresh_clears_answer_focus_once_the_state_leaves_needs_input() {
+        let mut screen = screen_with("needs_input", Vec::new());
+        screen.on_key(KeyCode::Char('r'));
+        assert!(screen.answer_focused);
+        screen.work = work_body("completed");
+        // `refresh` itself needs a live client; the state-driven clear is
+        // its own small rule, exercised directly the same way the struct's
+        // other invariants are (no daemon needed).
+        if screen.state() != "needs_input" {
+            screen.answer_focused = false;
+            screen.answer_send_focused = false;
+        }
+        assert!(!screen.answer_focused);
+    }
+
+    #[test]
+    fn cancel_is_offered_from_needs_input_but_reap_is_not() {
+        let screen = screen_with("needs_input", Vec::new());
+        assert!(screen.action_available("cancel"));
+        assert!(!screen.action_available("reap"));
+        assert!(screen.action_available("respond"));
+    }
+
+    #[test]
+    fn the_bottom_composer_shows_answer_for_needs_input_and_command_disabled_otherwise() {
+        let screen = screen_with("needs_input", Vec::new());
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, 30)).expect("terminal");
+        terminal
+            .draw(|frame| render(frame, frame.area(), Some(&screen), Live::Attached))
+            .expect("draw");
+        let text = buffer_text(&terminal);
+        assert!(text.contains("ANSWER"), "{text}");
+
+        let screen = screen_with("active", Vec::new());
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, 30)).expect("terminal");
+        terminal
+            .draw(|frame| render(frame, frame.area(), Some(&screen), Live::Attached))
+            .expect("draw");
+        let text = buffer_text(&terminal);
+        assert!(text.contains("COMMAND"), "{text}");
+        assert!(text.to_lowercase().contains("disabled"), "{text}");
+    }
+
+    fn buffer_text(terminal: &ratatui::Terminal<ratatui::backend::TestBackend>) -> String {
+        let buffer = terminal.backend().buffer();
+        let area = buffer.area;
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buffer.cell((x, y)).map_or(" ", |c| c.symbol()))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -126,6 +126,23 @@ fn write_workflow(root: &Path) {
     }
 }
 
+/// A one-stage workflow — T1c's mutation tests each drive exactly one Work
+/// through exactly one stage, so a single-stage fixture keeps each test's
+/// `FakeStep` script trivially "one step per turn", with no risk of a
+/// second Work's launch or a retry's re-entry consuming the wrong entry off
+/// a queue shared with anything else.
+fn write_solo_workflow(root: &Path) {
+    let dir = root.join(".sergeant/workflows/solo");
+    std::fs::create_dir_all(&dir).expect("workflow dir");
+    std::fs::write(
+        dir.join("workflow.toml"),
+        "[workflow]\nname = \"solo\"\nversion = \"1\"\nstages = [\"00-only\"]\n",
+    )
+    .expect("workflow.toml");
+    std::fs::create_dir_all(dir.join("00-only")).expect("stage dir");
+    std::fs::write(dir.join("00-only").join("CONTEXT.md"), "context").expect("CONTEXT.md");
+}
+
 async fn start_fake(
     data_dir: &Path,
     script: impl IntoIterator<Item = FakeStep>,
@@ -412,6 +429,211 @@ async fn t1_the_tui_renders_and_drives_the_fleet_over_the_api() {
             .iter()
             .any(|w| w["intent"] == "submitted from the tui"),
         "the TUI's New Work form must actually reach the daemon: {fleet}"
+    );
+
+    handle.shutdown().await;
+}
+
+// -------------------------------------------------------- T1c: mutations
+
+/// Respond (§15.1's `ANSWER` composer, §13.10's action matrix) reaches the
+/// real `POST /v1/work/{id}/input` — driven through the actual keymap
+/// (`r`, type the answer, Ctrl+Enter), not a hand-built `Action::Respond`.
+#[tokio::test]
+async fn t1c_respond_reaches_the_real_api_through_the_answer_composer() {
+    let data = TempDir::new().expect("tempdir");
+    let repo = TempDir::new().expect("tempdir");
+    init_repo(repo.path());
+    write_solo_workflow(repo.path());
+
+    let (handle, _fake) = start_fake(
+        data.path(),
+        [
+            FakeStep::needs_input("which retry budget?"),
+            FakeStep::complete(),
+        ],
+    )
+    .await;
+    let client = client_for(&handle);
+    let id = submit(&handle, repo.path(), "ask a question", "solo").await;
+
+    let mut app = App::new();
+    app.refresh(&client).await.expect("first read");
+    let action = app.execute(&client, Action::OpenWork(id.clone())).await;
+    assert_eq!(action, Action::None);
+    assert_eq!(
+        app.work_screen.as_ref().unwrap().work()["work"]["state"],
+        "needs_input"
+    );
+
+    assert_eq!(
+        app.on_key(ratatui::crossterm::event::KeyCode::Char('r')),
+        Action::None,
+        "'r' focuses the answer composer, it does not itself mutate"
+    );
+    for c in "forty turns".chars() {
+        app.on_key(ratatui::crossterm::event::KeyCode::Char(c));
+    }
+    let ctrl_enter = ratatui::crossterm::event::KeyEvent::new(
+        ratatui::crossterm::event::KeyCode::Enter,
+        ratatui::crossterm::event::KeyModifiers::CONTROL,
+    );
+    let action = app.on_key(ctrl_enter);
+    assert_eq!(
+        action,
+        Action::Respond {
+            id: id.clone(),
+            input: "forty turns".to_string(),
+        }
+    );
+    let outcome = app.execute(&client, action).await;
+    assert_eq!(
+        outcome,
+        Action::Refresh,
+        "a mutation always asks to refresh"
+    );
+    assert!(
+        app.status.contains(&format!("responded to {id}")),
+        "{}",
+        app.status
+    );
+
+    let work = client.work(&id).await.expect("read back");
+    assert_eq!(
+        work["work"]["state"], "completed",
+        "the real POST /v1/work/{{id}}/input resumed the turn, which the \
+         script's next step then completes — a decoration would have left \
+         this Work parked on needs_input forever: {work}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// Cancel (§13.10/§15.5) reaches the real `POST /v1/work/{id}/cancel`,
+/// driven through the confirmation overlay's own deliberate Enter.
+#[tokio::test]
+async fn t1c_cancel_reaches_the_real_api_through_the_confirmation() {
+    let data = TempDir::new().expect("tempdir");
+    let repo = TempDir::new().expect("tempdir");
+    init_repo(repo.path());
+    write_solo_workflow(repo.path());
+
+    let (handle, _fake) = start_fake(data.path(), [FakeStep::waiting("queued upstream")]).await;
+    let client = client_for(&handle);
+    let id = submit(&handle, repo.path(), "wait around", "solo").await;
+
+    let mut app = App::new();
+    app.refresh(&client).await.expect("first read");
+    app.execute(&client, Action::OpenWork(id.clone())).await;
+    assert_eq!(
+        app.work_screen.as_ref().unwrap().work()["work"]["state"],
+        "waiting"
+    );
+
+    assert_eq!(
+        app.on_key(ratatui::crossterm::event::KeyCode::Char('c')),
+        Action::None
+    );
+    assert!(
+        app.overlay.is_some(),
+        "'c' must open the cancel confirmation before anything is sent"
+    );
+    let action = app.on_key(ratatui::crossterm::event::KeyCode::Enter);
+    assert_eq!(action, Action::Cancel(id.clone()));
+    let outcome = app.execute(&client, action).await;
+    assert_eq!(outcome, Action::Refresh);
+    assert!(app.overlay.is_none(), "success closes the confirmation");
+
+    let work = client.work(&id).await.expect("read back");
+    assert_eq!(work["work"]["state"], "canceled", "{work}");
+
+    handle.shutdown().await;
+}
+
+/// Retry (§13.10/§15.5) reaches the real `POST /v1/work/{id}/retry`.
+#[tokio::test]
+async fn t1c_retry_reaches_the_real_api_through_the_confirmation() {
+    let data = TempDir::new().expect("tempdir");
+    let repo = TempDir::new().expect("tempdir");
+    init_repo(repo.path());
+    write_solo_workflow(repo.path());
+
+    let (handle, _fake) =
+        start_fake(data.path(), [FakeStep::fail("boom"), FakeStep::complete()]).await;
+    let client = client_for(&handle);
+    let id = submit(&handle, repo.path(), "fail then retry", "solo").await;
+
+    let mut app = App::new();
+    app.refresh(&client).await.expect("first read");
+    app.execute(&client, Action::OpenWork(id.clone())).await;
+    assert_eq!(
+        app.work_screen.as_ref().unwrap().work()["work"]["state"],
+        "failed"
+    );
+
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('t'));
+    let action = app.on_key(ratatui::crossterm::event::KeyCode::Enter);
+    assert_eq!(action, Action::Retry(id.clone()));
+    let outcome = app.execute(&client, action).await;
+    assert_eq!(outcome, Action::Refresh);
+
+    let work = client.work(&id).await.expect("read back");
+    assert_eq!(
+        work["work"]["state"], "completed",
+        "retry re-entered the stage, which the script's next step completes: {work}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// Extend (§13.10/§15.5) reaches the real `POST /v1/work/{id}/extend` with
+/// the explicit turns the operator typed, and never implicitly retries
+/// (§13.9's closing rule) — the Work stays `blocked` afterward.
+#[tokio::test]
+async fn t1c_extend_reaches_the_real_api_with_the_typed_turn_count() {
+    let data = TempDir::new().expect("tempdir");
+    let repo = TempDir::new().expect("tempdir");
+    init_repo(repo.path());
+    write_solo_workflow(repo.path());
+
+    let (handle, _fake) = start_fake(data.path(), [FakeStep::blocked("envelope exhausted")]).await;
+    let client = client_for(&handle);
+    let id = submit(&handle, repo.path(), "run out of turns", "solo").await;
+
+    let before = client.work(&id).await.expect("read back");
+    assert_eq!(before["work"]["state"], "blocked");
+    let cap_before = before["envelope"]["turn_cap"].as_u64().expect("turn_cap");
+
+    let mut app = App::new();
+    app.refresh(&client).await.expect("first read");
+    app.execute(&client, Action::OpenWork(id.clone())).await;
+
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('e'));
+    for c in "5".chars() {
+        app.on_key(ratatui::crossterm::event::KeyCode::Char(c));
+    }
+    app.on_key(ratatui::crossterm::event::KeyCode::Tab); // field -> Confirm
+    let action = app.on_key(ratatui::crossterm::event::KeyCode::Enter);
+    assert_eq!(
+        action,
+        Action::Extend {
+            id: id.clone(),
+            additional_turns: 5,
+        }
+    );
+    let outcome = app.execute(&client, action).await;
+    assert_eq!(outcome, Action::Refresh);
+    assert!(app.overlay.is_none(), "success closes the confirmation");
+
+    let after = client.work(&id).await.expect("read back");
+    assert_eq!(
+        after["envelope"]["turn_cap"].as_u64(),
+        Some(cap_before + 5),
+        "{after}"
+    );
+    assert_eq!(
+        after["work"]["state"], "blocked",
+        "extend must not implicitly retry: {after}"
     );
 
     handle.shutdown().await;


### PR DESCRIPTION
T1c per proposal §8.7-8.8/§9.2/§13.9-13.10/§15/§18, dispatched as sgt Work 01M04CBPBN6H964VXBJTKHYM1T (tdd, 2 turns). Closes out T1.

- Adds ratatui-textarea 0.9.2 (matches T0's spike exactly), wrapped in one narrow module (src/tui/composer.rs) -- the crate is never named outside it, per Decision T2-31.
- Wires T1b's display-only action matrix to the real API: respond/cancel/reap already had ApiClient methods; added the two missing ones (retry, extend) mirroring the existing pattern exactly, with command_id per §26's idempotency convention -- the only src/api.rs change, confirmed by diff.
- Confirmation flows per §15.5 for cancel/retry/extend/reap, with real tests for open/abort/confirm on each.
- Responsive Fleet per §18's three compositions.
- Explicitly deferred (noted, not attempted): slash palette, Workflows' `@` catalog chooser, Estate filter context, `?` help.

Verified independently: fmt/clippy clean, full suite green twice in a row (415+ tests, including t5/t5b and the crossterm pin test both runs -- no flake this time).