### PR TITLE
T-series T3: Estate

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -21,7 +21,7 @@ use axum::http::{HeaderMap, Method, StatusCode, header};
 use axum::middleware::{self, Next};
 use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -29,6 +29,7 @@ use tokio::sync::{broadcast, mpsc, watch};
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::backend::Deferred;
+use crate::cli::doctor;
 use crate::daemon::{
     KIND_ADMISSION_PAUSED, KIND_ADMISSION_RESUMED, KIND_BACKEND_PROBED, KIND_DAEMON_STARTED,
     KIND_DAEMON_STOPPED,
@@ -38,6 +39,7 @@ use crate::domain::execution::{
     KIND_EXECUTION_ABANDONED, KIND_EXECUTION_RECONCILED, KIND_EXECUTION_RESERVED,
     KIND_EXECUTION_STARTED, KIND_EXECUTION_STOPPED,
 };
+use crate::domain::manifest::{self, ManifestError};
 use crate::domain::work::{
     EnvelopeRequest, IntentDetail, KIND_COMMAND_ACCEPTED, KIND_COMMAND_REJECTED, KIND_WORK_BLOCKED,
     KIND_WORK_CANCELED, KIND_WORK_COMPLETED, KIND_WORK_FAILED, KIND_WORK_NEEDS_INPUT,
@@ -48,6 +50,7 @@ use crate::domain::workflow::{
     KIND_STAGE_FAILED, KIND_STAGE_INPUT_RECEIVED, KIND_STAGE_NEEDS_INPUT, KIND_STAGE_RESUMED,
     KIND_STAGE_WAITING, KIND_WORKFLOW_BOUND,
 };
+use crate::domain::workspace::{InstructionPolicy, Workspace};
 use crate::runtime::analytics::{Analytics, AnalyticsError, CANNED_QUERIES};
 use crate::runtime::engine::{
     Engine, EngineError, KIND_TURN_CEILING_INTERRUPTED, KIND_TURN_ENVELOPE_EXTENDED,
@@ -396,6 +399,17 @@ pub fn router(state: ApiState) -> Router {
         .route("/work/{id}/extend", post(work_extend))
         .route("/work/{id}/reap", post(reap_work))
         .route("/retained", get(list_retained))
+        .route(
+            "/estate/repos",
+            get(estate_list_repos).post(estate_add_repo),
+        )
+        .route("/estate/repos/{name}", delete(estate_remove_repo))
+        .route(
+            "/estate/groups",
+            get(estate_list_groups).post(estate_add_group),
+        )
+        .route("/estate/groups/{name}", delete(estate_remove_group))
+        .route("/doctor", get(doctor_report))
         .route("/admission/pause", post(pause_admission))
         .route("/graph/work/{id}", get(work_graph))
         .route("/analytics", get(analytics_index))
@@ -2424,6 +2438,323 @@ async fn list_retained(State(state): State<ApiState>) -> Response {
     Json(json!({"retained": entries})).into_response()
 }
 
+// ------------------------------------------------------------------ estate
+//
+// §16.2/§16.3: thin daemon-side wrappers over `crate::domain::manifest`'s
+// existing add_repo/remove_repo/add_group/remove_group and
+// `crate::cli::doctor`'s existing Report — no logic is duplicated here, and
+// none of it touches the journal or `Core`: manifest edits are not engine
+// state (R-NS-4, `src/domain/manifest.rs`'s own module doc), so unlike every
+// other mutation in this file there is no `command_id`/replay pair.
+
+/// The estate root these routes edit: an upward walk from this daemon's own
+/// `data_dir`, unscoped — correct for the default `<estate_root>/.sergeant/
+/// data` layout `sgt init` always produces, deterministic, and dependent on
+/// nothing but the one fact [`ApiState`] already carries.
+///
+/// The process's own working directory is deliberately **not** consulted —
+/// a long-running daemon's cwd is not reliably the estate root in every real
+/// deployment, and unlike a walk that simply finds nothing, a cwd that
+/// happens to sit inside a *different* estate (an unrelated git checkout
+/// that is itself one, `sgt`'s own self-hosting shape among them) would
+/// silently resolve to the wrong manifest rather than failing closed — the
+/// one outcome R-NS-4's discipline exists to prevent.
+fn resolve_estate_root(data_dir: &std::path::Path) -> Result<PathBuf, Box<Response>> {
+    match Workspace::estate_root(data_dir, None) {
+        Ok(Some(root)) => Ok(root),
+        Ok(None) => Err(Box::new(error_response(
+            StatusCode::NOT_FOUND,
+            "no_estate",
+            "no estate found walking up from this daemon's data dir (bounded at $HOME) — run \
+             `sgt init` first, or start the daemon on a data dir under the estate root",
+        ))),
+        Err(e) => Err(Box::new(error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "estate_invalid",
+            e.to_string(),
+        ))),
+    }
+}
+
+/// Stable per-variant code for a [`ManifestError`], for the same
+/// `{"error": {"code", "message"}}` shape every other route answers with.
+fn manifest_error_code(e: &ManifestError) -> &'static str {
+    match e {
+        ManifestError::Io { .. } => "io",
+        ManifestError::Parse { .. } => "parse",
+        ManifestError::Locked { .. } => "locked",
+        ManifestError::Invalid { .. } => "invalid",
+        ManifestError::NoEstate { .. } => "no_estate",
+        ManifestError::InvalidName { .. } => "invalid_name",
+        ManifestError::RepoAlreadyDeclared { .. } => "repo_already_declared",
+        ManifestError::RepoNotDeclared { .. } => "repo_not_declared",
+        ManifestError::RepoInUseByGroups { .. } => "repo_in_use_by_groups",
+        ManifestError::GroupNotDeclared { .. } => "group_not_declared",
+        ManifestError::NotAGroupMember { .. } => "not_a_group_member",
+        ManifestError::ExistingPathNotAGitRepository { .. } => "existing_path_not_a_git_repository",
+        ManifestError::NoPathAndNoOrigin { .. } => "no_path_and_no_origin",
+        ManifestError::CloneFailed { .. } => "clone_failed",
+        ManifestError::MalformedSection { .. } => "malformed_section",
+    }
+}
+
+/// HTTP status for a [`ManifestError`]: 4xx where the caller can fix the
+/// request (a bad name, a dangling reference, a missing declaration), 502
+/// for a failed outbound clone, 409 for a concurrent-edit or already-exists
+/// conflict, 500 only where the local filesystem itself is unavailable.
+fn manifest_error_status(e: &ManifestError) -> StatusCode {
+    match e {
+        ManifestError::Io { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+        ManifestError::Parse { .. }
+        | ManifestError::Invalid { .. }
+        | ManifestError::ExistingPathNotAGitRepository { .. }
+        | ManifestError::MalformedSection { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+        ManifestError::Locked { .. } | ManifestError::RepoAlreadyDeclared { .. } => {
+            StatusCode::CONFLICT
+        }
+        ManifestError::NoEstate { .. }
+        | ManifestError::RepoNotDeclared { .. }
+        | ManifestError::GroupNotDeclared { .. }
+        | ManifestError::NotAGroupMember { .. } => StatusCode::NOT_FOUND,
+        ManifestError::InvalidName { .. } | ManifestError::NoPathAndNoOrigin { .. } => {
+            StatusCode::BAD_REQUEST
+        }
+        ManifestError::RepoInUseByGroups { .. } => StatusCode::CONFLICT,
+        ManifestError::CloneFailed { .. } => StatusCode::BAD_GATEWAY,
+    }
+}
+
+/// The error body a [`ManifestError`] answers with — the exact refusal text
+/// (remedy included, per its own `Display`) `sgt repo`/`sgt group` already
+/// print, never a second explanation of the same defect.
+fn manifest_error_response(e: &ManifestError) -> Response {
+    error_response(
+        manifest_error_status(e),
+        manifest_error_code(e),
+        e.to_string(),
+    )
+}
+
+/// The declared repositories, read the same way `sgt repo list --json` does.
+fn workspace_read(estate_root: &std::path::Path) -> Result<Workspace, Box<Response>> {
+    Workspace::from_config_allow_empty(&estate_root.join(crate::domain::workspace::WORKSPACE_FILE))
+        .map_err(|e| {
+            Box::new(error_response(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "estate_invalid",
+                e.to_string(),
+            ))
+        })
+}
+
+/// `GET /v1/estate/repos` (§16.2) — the same read `sgt repo list --json`
+/// already performs, over the daemon's own estate.
+async fn estate_list_repos(State(state): State<ApiState>) -> Response {
+    let estate_root = match resolve_estate_root(&state.data_dir) {
+        Ok(root) => root,
+        Err(resp) => return *resp,
+    };
+    let workspace = match workspace_read(&estate_root) {
+        Ok(w) => w,
+        Err(resp) => return *resp,
+    };
+    let repos: Vec<Value> = workspace
+        .repositories
+        .iter()
+        .map(|r| {
+            json!({
+                "name": r.name,
+                "path": r.path,
+                "origin": workspace.repository_origin(&r.name),
+                "instructions": workspace.instruction_policy(&r.name).as_str(),
+            })
+        })
+        .collect();
+    Json(json!({"repos": repos})).into_response()
+}
+
+#[derive(Debug, Deserialize)]
+struct AddRepoRequest {
+    name: String,
+    #[serde(default)]
+    origin: Option<String>,
+    #[serde(default)]
+    instructions: Option<String>,
+}
+
+/// `POST /v1/estate/repos` (§16.2) — `manifest::add_repo` exactly, including
+/// its populate-or-verify clone behavior, which is why this runs off the
+/// blocking pool rather than inline (§22.6's tradeoff, same shape as
+/// `reap_work`'s filesystem call): a real `git clone` can take real time,
+/// and nothing here holds the core guard while it runs — this route never
+/// touches `Core` at all.
+async fn estate_add_repo(
+    State(state): State<ApiState>,
+    body: Result<Json<AddRepoRequest>, JsonRejection>,
+) -> Response {
+    let req = match parse_body(body) {
+        Ok(r) => r,
+        Err(resp) => return *resp,
+    };
+    let instructions = match req.instructions.as_deref() {
+        None => None,
+        Some("local") => Some(InstructionPolicy::Local),
+        Some("suppress") => Some(InstructionPolicy::Suppress),
+        Some(other) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                format!("instructions {other:?} is not recognized (use \"local\" or \"suppress\")"),
+            );
+        }
+    };
+    let estate_root = match resolve_estate_root(&state.data_dir) {
+        Ok(root) => root,
+        Err(resp) => return *resp,
+    };
+    let name = req.name.clone();
+    let origin = req.origin.clone();
+    let result =
+        blocking_sync(|| manifest::add_repo(&estate_root, &name, origin.as_deref(), instructions));
+    match result {
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(json!({
+                "name": req.name,
+                "path": format!("repos/{}", req.name),
+                "origin": req.origin,
+                "instructions": req.instructions,
+            })),
+        )
+            .into_response(),
+        Err(e) => manifest_error_response(&e),
+    }
+}
+
+/// `DELETE /v1/estate/repos/{name}` (§16.2) — `manifest::remove_repo`
+/// exactly; the group-reference refusal it returns reaches the caller
+/// structured, not reworded.
+async fn estate_remove_repo(State(state): State<ApiState>, Path(name): Path<String>) -> Response {
+    let estate_root = match resolve_estate_root(&state.data_dir) {
+        Ok(root) => root,
+        Err(resp) => return *resp,
+    };
+    match blocking_sync(|| manifest::remove_repo(&estate_root, &name)) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => manifest_error_response(&e),
+    }
+}
+
+/// `GET /v1/estate/groups` (§16.2) — the same read `sgt group list --json`
+/// already performs.
+async fn estate_list_groups(State(state): State<ApiState>) -> Response {
+    let estate_root = match resolve_estate_root(&state.data_dir) {
+        Ok(root) => root,
+        Err(resp) => return *resp,
+    };
+    let workspace = match workspace_read(&estate_root) {
+        Ok(w) => w,
+        Err(resp) => return *resp,
+    };
+    let groups: Vec<Value> = workspace
+        .groups
+        .iter()
+        .map(|(name, g)| json!({"name": name, "repos": g.repos, "brief": g.brief}))
+        .collect();
+    Json(json!({"groups": groups})).into_response()
+}
+
+#[derive(Debug, Deserialize)]
+struct AddGroupRequest {
+    name: String,
+    #[serde(default)]
+    repos: Vec<String>,
+    #[serde(default)]
+    brief: Option<String>,
+}
+
+/// `POST /v1/estate/groups` (§16.2) — `manifest::add_group` exactly,
+/// including its mkdir-p create/extend semantics (creating an existing group
+/// unions in new members; re-adding a member already present is a no-op).
+async fn estate_add_group(
+    State(state): State<ApiState>,
+    body: Result<Json<AddGroupRequest>, JsonRejection>,
+) -> Response {
+    let req = match parse_body(body) {
+        Ok(r) => r,
+        Err(resp) => return *resp,
+    };
+    let estate_root = match resolve_estate_root(&state.data_dir) {
+        Ok(root) => root,
+        Err(resp) => return *resp,
+    };
+    let name = req.name.clone();
+    let repos = req.repos.clone();
+    let brief = req.brief.clone();
+    let result =
+        blocking_sync(|| manifest::add_group(&estate_root, &name, &repos, brief.as_deref()));
+    match result {
+        Ok(()) => {
+            let workspace = match workspace_read(&estate_root) {
+                Ok(w) => w,
+                Err(resp) => return *resp,
+            };
+            let members = workspace
+                .groups
+                .get(&req.name)
+                .map(|g| g.repos.clone())
+                .unwrap_or_default();
+            Json(json!({"name": req.name, "repos": members, "brief": req.brief})).into_response()
+        }
+        Err(e) => manifest_error_response(&e),
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RemoveGroupRequest {
+    #[serde(default)]
+    repos: Vec<String>,
+}
+
+/// `DELETE /v1/estate/groups/{name}` (§16.2) — `manifest::remove_group`
+/// exactly: an omitted or empty `repos` body removes the whole group,
+/// otherwise only the named members (each of which must already be one).
+async fn estate_remove_group(
+    State(state): State<ApiState>,
+    Path(name): Path<String>,
+    body: axum::body::Bytes,
+) -> Response {
+    let repos = if body.is_empty() {
+        Vec::new()
+    } else {
+        match serde_json::from_slice::<RemoveGroupRequest>(&body) {
+            Ok(r) => r.repos,
+            Err(e) => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request",
+                    format!("invalid JSON body: {e}"),
+                );
+            }
+        }
+    };
+    let estate_root = match resolve_estate_root(&state.data_dir) {
+        Ok(root) => root,
+        Err(resp) => return *resp,
+    };
+    match blocking_sync(|| manifest::remove_group(&estate_root, &name, &repos)) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => manifest_error_response(&e),
+    }
+}
+
+/// `GET /v1/doctor` (§16.3) — the same `doctor::Report::to_json()`
+/// `sgt doctor --json` already prints, computed exactly once here.
+async fn doctor_report(State(state): State<ApiState>) -> Response {
+    let report = doctor::run(&state.data_dir).await;
+    Json(report.to_json()).into_response()
+}
+
 /// Catch the analytical projection up to the journal, then hand it to `f`.
 ///
 /// The projection is folded lazily, at read time, rather than on every
@@ -3004,6 +3335,18 @@ impl ApiClient {
         Self::into_value(response).await
     }
 
+    /// Authenticated DELETE with a JSON body, returning the parsed body.
+    pub async fn delete(&self, path: &str, body: &Value) -> Result<Value, ClientError> {
+        let response = self
+            .http
+            .delete(format!("{}{path}", self.endpoint))
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await?;
+        Self::into_value(response).await
+    }
+
     /// `GET /v1/system`.
     pub async fn system(&self) -> Result<Value, ClientError> {
         self.get("/v1/system").await
@@ -3095,6 +3438,67 @@ impl ApiClient {
             }),
         )
         .await
+    }
+
+    /// `GET /v1/estate/repos` (§16.2/§20.4) — declared repositories.
+    pub async fn repos(&self) -> Result<Value, ClientError> {
+        self.get("/v1/estate/repos").await
+    }
+
+    /// `POST /v1/estate/repos` (§16.2/§20.4) — `manifest::add_repo`.
+    pub async fn add_repo(
+        &self,
+        name: &str,
+        origin: Option<&str>,
+        instructions: Option<&str>,
+    ) -> Result<Value, ClientError> {
+        self.post(
+            "/v1/estate/repos",
+            &json!({"name": name, "origin": origin, "instructions": instructions}),
+        )
+        .await
+    }
+
+    /// `DELETE /v1/estate/repos/{name}` (§16.2/§20.4) — `manifest::remove_repo`.
+    pub async fn remove_repo(&self, name: &str) -> Result<Value, ClientError> {
+        self.delete(&format!("/v1/estate/repos/{}", urlencode(name)), &json!({}))
+            .await
+    }
+
+    /// `GET /v1/estate/groups` (§16.2/§20.4) — declared groups.
+    pub async fn groups(&self) -> Result<Value, ClientError> {
+        self.get("/v1/estate/groups").await
+    }
+
+    /// `POST /v1/estate/groups` (§16.2/§20.4) — `manifest::add_group`'s
+    /// mkdir-p create/extend semantics.
+    pub async fn add_group(
+        &self,
+        name: &str,
+        repos: &[String],
+        brief: Option<&str>,
+    ) -> Result<Value, ClientError> {
+        self.post(
+            "/v1/estate/groups",
+            &json!({"name": name, "repos": repos, "brief": brief}),
+        )
+        .await
+    }
+
+    /// `DELETE /v1/estate/groups/{name}` (§16.2/§20.4) — `manifest::remove_group`;
+    /// empty `repos` removes the whole group, otherwise just those members.
+    pub async fn remove_group(&self, name: &str, repos: &[String]) -> Result<Value, ClientError> {
+        self.delete(
+            &format!("/v1/estate/groups/{}", urlencode(name)),
+            &json!({"repos": repos}),
+        )
+        .await
+    }
+
+    /// `GET /v1/doctor` (§16.3/§20.4) — the same `doctor::Report` `sgt doctor
+    /// --json` prints.
+    pub async fn doctor(&self) -> Result<Value, ClientError> {
+        self.get("/v1/doctor").await
     }
 
     /// Open the SSE live tail at `GET /v1/events/stream?from=N`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1754,7 +1754,7 @@ fn report_daemon_stop(json: bool, status: &str, message: &str) {
 /// `retry`, `extend`, `cancel`) start one on demand; this one is asking
 /// whether the installation is sound, and starting the thing under
 /// examination would answer a different question.
-mod doctor {
+pub(crate) mod doctor {
     use std::path::{Path, PathBuf};
     use std::process::Command;
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -10,6 +10,10 @@ use serde_json::Value;
 use crate::api::{ApiClient, ClientError};
 
 use super::connection::Live;
+use super::estate::{
+    EstateOutcome, EstateScreen, GroupFormOutcome, PendingRepoAdd, PendingRepoAddOutcome,
+    RepoFormOutcome,
+};
 use super::fleet::{FleetOutcome, FleetScreen, WorkRow, fleet_rows};
 use super::home::{HomeOutcome, NewWorkForm};
 use super::overlay::Overlay;
@@ -92,6 +96,31 @@ pub enum Action {
     Extend { id: String, additional_turns: u32 },
     /// §15.5: confirmed from [`Overlay::ReapConfirmation`].
     Reap(String),
+    /// §12.1/§16.2: `POST /v1/estate/repos`, confirmed from
+    /// [`Overlay::RepoAddRemove`]'s add mode. Runs off the render loop
+    /// (§12.1's spinner/elapsed rule) — see [`App::execute`].
+    AddRepo {
+        name: String,
+        origin: Option<String>,
+        instructions: Option<String>,
+    },
+    /// §12.1/§16.2: `DELETE /v1/estate/repos/{name}`, confirmed from
+    /// [`Overlay::RepoAddRemove`]'s remove mode.
+    RemoveRepo(String),
+    /// §12.2/§16.2: `POST /v1/estate/groups`, confirmed from
+    /// [`Overlay::GroupEditRemove`]'s edit mode.
+    AddGroup {
+        name: String,
+        repos: Vec<String>,
+        brief: Option<String>,
+    },
+    /// §12.2/§16.2: `DELETE /v1/estate/groups/{name}`, confirmed from
+    /// [`Overlay::GroupEditRemove`]'s remove mode.
+    RemoveGroup { name: String, repos: Vec<String> },
+    /// §12.3/§12.4: Health's disk-pressure detail asking to open
+    /// [`Overlay::RetainedPreview`] — `GET /v1/retained`, the same
+    /// estate-wide read [`Action::Reap`] already has a client method for.
+    LoadRetained,
 }
 
 /// Live state for the one confirmation overlay open, if any (§7.4: the
@@ -135,6 +164,15 @@ pub struct App {
     /// The confirmation overlay's own live state (§15.5) — reset whenever an
     /// overlay opens or closes.
     pub pending_action: PendingAction,
+    /// Estate's three sub-screens (§12) and their edit forms.
+    pub estate: EstateScreen,
+    /// The Work id [`Overlay::ReapConfirmation`] acts on when it was opened
+    /// from [`Overlay::RetainedPreview`] (§12.4) rather than from an open
+    /// Work surface — `None` the rest of the time. [`App::open_work_id`]
+    /// stays the source inside an open Work; this is Estate's own source,
+    /// so the same confirmation panel and [`Action::Reap`] serve both without
+    /// a second reap implementation.
+    pub retained_reap_id: Option<String>,
     /// Whether the global Attention drawer is showing (§7.3: opens by
     /// default at Wide; `~` toggles it at any tier).
     pub drawer_open: bool,
@@ -162,6 +200,8 @@ impl App {
             work_screen: None,
             overlay: None,
             pending_action: PendingAction::default(),
+            estate: EstateScreen::default(),
+            retained_reap_id: None,
             drawer_open: true,
             system: Value::default(),
             last_seq: 0,
@@ -201,7 +241,58 @@ impl App {
                 }
             }
         }
+        // §12: read only while Estate is in front — the same
+        // fetch-what-the-current-screen-shows discipline as `work_screen`
+        // above, so browsing Home or Fleet never costs an extra doctor run.
+        // Best-effort, same reasoning as `work_screen`'s: a failed estate
+        // read must not blank fleet/system data that loaded fine.
+        if self.destination == Destination::Estate {
+            match client.repos().await {
+                Ok(result) => {
+                    self.estate.repos = result["repos"].as_array().cloned().unwrap_or_default();
+                }
+                Err(e) => self.estate.last_error = Some(e.to_string()),
+            }
+            match client.groups().await {
+                Ok(result) => {
+                    self.estate.groups = result["groups"].as_array().cloned().unwrap_or_default();
+                }
+                Err(e) => self.estate.last_error = Some(e.to_string()),
+            }
+            match client.doctor().await {
+                Ok(result) => self.estate.doctor = result,
+                Err(e) => self.estate.last_error = Some(e.to_string()),
+            }
+            self.estate.clamp();
+        }
         Ok(())
+    }
+
+    /// Non-blocking poll of any Estate mutation kicked off the render loop
+    /// (§12.1) — called every loop tick, whether or not a key arrived, so a
+    /// slow `git clone` finishes on its own schedule instead of waiting for
+    /// the next keystroke. Returns whether the screen needs a re-read.
+    pub fn poll_background(&mut self) -> bool {
+        match self.estate.poll() {
+            Some(PendingRepoAddOutcome::InProgress) | None => false,
+            Some(PendingRepoAddOutcome::Done(result)) => {
+                self.estate.pending_repo_add = None;
+                match result {
+                    Ok(_) => {
+                        self.status = "repo added".to_string();
+                        if self.overlay == Some(Overlay::RepoAddRemove) {
+                            self.overlay = None;
+                        }
+                        true
+                    }
+                    Err(e) => {
+                        self.status = format!("add repo failed: {e}");
+                        self.estate.repo_form.last_error = Some(e.to_string());
+                        false
+                    }
+                }
+            }
+        }
     }
 
     /// Fold one live event into the app. Returns whether the screens need
@@ -270,7 +361,35 @@ impl App {
                 FleetOutcome::None => Action::None,
                 FleetOutcome::Open(id) => Action::OpenWork(id),
             },
-            Destination::Workflows | Destination::Estate => Action::None,
+            Destination::Workflows => Action::None,
+            // §12: Tab/BackTab are Estate's own (sub-tab switching, guarded
+            // out of `on_key_global` below) — everything else it does not
+            // recognize falls through to `EstateOutcome::None`.
+            Destination::Estate => match self.estate.on_key(key.code) {
+                EstateOutcome::None => Action::None,
+                EstateOutcome::OpenAddRepo => {
+                    self.estate.repo_form.reset_for_add();
+                    self.overlay = Some(Overlay::RepoAddRemove);
+                    Action::None
+                }
+                EstateOutcome::OpenRemoveRepo(name) => {
+                    self.estate.repo_form.reset_for_remove(name);
+                    self.overlay = Some(Overlay::RepoAddRemove);
+                    Action::None
+                }
+                EstateOutcome::OpenGroupEdit => {
+                    let existing = self.estate.selected_group().cloned();
+                    self.estate.group_form.reset_for_edit(existing.as_ref());
+                    self.overlay = Some(Overlay::GroupEditRemove);
+                    Action::None
+                }
+                EstateOutcome::OpenGroupRemove(name) => {
+                    self.estate.group_form.reset_for_remove(name);
+                    self.overlay = Some(Overlay::GroupEditRemove);
+                    Action::None
+                }
+                EstateOutcome::OpenRetained => Action::LoadRetained,
+            },
         }
     }
 
@@ -284,8 +403,15 @@ impl App {
             KeyCode::Char('2') => self.goto(Destination::Fleet),
             KeyCode::Char('3') => self.goto(Destination::Workflows),
             KeyCode::Char('4') => self.goto(Destination::Estate),
-            KeyCode::Tab => self.goto(self.destination.next()),
-            KeyCode::BackTab => self.goto(self.destination.prev()),
+            // §12: inside Estate, Tab/BackTab switch its own Repositories/
+            // Groups/Health sub-tabs instead — the guard leaves them
+            // unmatched here so they fall through to `EstateScreen::on_key`.
+            KeyCode::Tab if self.destination != Destination::Estate => {
+                self.goto(self.destination.next())
+            }
+            KeyCode::BackTab if self.destination != Destination::Estate => {
+                self.goto(self.destination.prev())
+            }
             KeyCode::Char('q') | KeyCode::Esc => {
                 self.quit = true;
                 return Some(Action::Quit);
@@ -308,6 +434,7 @@ impl App {
     fn close_overlay(&mut self) {
         self.overlay = None;
         self.pending_action = PendingAction::default();
+        self.retained_reap_id = None;
     }
 
     fn on_key_overlay(&mut self, key: KeyEvent) -> Action {
@@ -315,12 +442,10 @@ impl App {
             return Action::None;
         };
         match overlay {
-            // The four T1c owns render real, live content but share the same
-            // fixed set of controls with the others: Esc/q aborts, Enter (on
-            // Confirm) fires the mutation. Tab has nothing to move to.
-            Overlay::CancelConfirmation
-            | Overlay::RetryConfirmation
-            | Overlay::ReapConfirmation => {
+            // T1c owns render real, live content but share the same fixed
+            // set of controls: Esc/q aborts, Enter (on Confirm) fires the
+            // mutation. Tab has nothing to move to.
+            Overlay::CancelConfirmation | Overlay::RetryConfirmation => {
                 match key.code {
                     KeyCode::Esc | KeyCode::Char('q') => self.close_overlay(),
                     KeyCode::Enter => {
@@ -331,9 +456,101 @@ impl App {
                         return match overlay {
                             Overlay::CancelConfirmation => Action::Cancel(id),
                             Overlay::RetryConfirmation => Action::Retry(id),
-                            Overlay::ReapConfirmation => Action::Reap(id),
                             _ => unreachable!("matched above"),
                         };
+                    }
+                    _ => {}
+                }
+                Action::None
+            }
+            // Same fixed controls as above, but the Work id can come from
+            // either an open Work surface (§13.10) or §12.4's Retained
+            // preview — [`App::retained_reap_id`] is Estate's own source, so
+            // this stays the one Reap implementation either way.
+            Overlay::ReapConfirmation => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => self.close_overlay(),
+                    KeyCode::Enter => {
+                        let Some(id) = self
+                            .open_work_id()
+                            .or_else(|| self.retained_reap_id.clone())
+                        else {
+                            self.close_overlay();
+                            return Action::None;
+                        };
+                        return Action::Reap(id);
+                    }
+                    _ => {}
+                }
+                Action::None
+            }
+            // §12.1's Add/Remove Repository panel — form input reaches
+            // `RepoForm::on_key`, and the outcome either closes the overlay
+            // locally (an abort) or asks the loop to run the mutation.
+            Overlay::RepoAddRemove => {
+                match self.estate.repo_form.on_key(key) {
+                    RepoFormOutcome::None => {}
+                    RepoFormOutcome::Close => self.overlay = None,
+                    RepoFormOutcome::Submit {
+                        name,
+                        origin,
+                        instructions,
+                    } => {
+                        return Action::AddRepo {
+                            name,
+                            origin,
+                            instructions,
+                        };
+                    }
+                    RepoFormOutcome::ConfirmRemove(name) => return Action::RemoveRepo(name),
+                }
+                Action::None
+            }
+            // §12.2's create/extend/remove-members/remove-group panel, same
+            // shape as `RepoAddRemove` above.
+            Overlay::GroupEditRemove => {
+                match self.estate.group_form.on_key(key) {
+                    GroupFormOutcome::None => {}
+                    GroupFormOutcome::Close => self.overlay = None,
+                    GroupFormOutcome::Submit { name, repos, brief } => {
+                        return Action::AddGroup { name, repos, brief };
+                    }
+                    GroupFormOutcome::ConfirmRemove { name, repos } => {
+                        return Action::RemoveGroup { name, repos };
+                    }
+                }
+                Action::None
+            }
+            // §12.4's estate-wide retained-state list: browse with j/k,
+            // `p`/Enter opens the same [`Overlay::ReapConfirmation`] T1c
+            // already built rather than a second reap implementation.
+            Overlay::RetainedPreview => {
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        let len = self.estate.retained.len();
+                        if len > 0 {
+                            self.estate.retained_selected =
+                                (self.estate.retained_selected + 1) % len;
+                        }
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        let len = self.estate.retained.len();
+                        if len > 0 {
+                            self.estate.retained_selected =
+                                (self.estate.retained_selected + len - 1) % len;
+                        }
+                    }
+                    KeyCode::Char('p') | KeyCode::Enter => {
+                        if let Some(id) = self
+                            .estate
+                            .selected_retained()
+                            .and_then(|e| e["work_id"].as_str())
+                        {
+                            self.retained_reap_id = Some(id.to_string());
+                            self.pending_action = PendingAction::default();
+                            self.overlay = Some(Overlay::ReapConfirmation);
+                        }
                     }
                     _ => {}
                 }
@@ -380,15 +597,13 @@ impl App {
                 }
                 Action::None
             }
-            // Every overlay a later Work owns (§7.4's note): the mechanism
-            // this Work built at T1a — open, close, restore focus for free —
-            // with no content of its own yet.
+            // Every overlay still owned by a later Work (§7.4's note) plus
+            // Help (content-built at T1a, but generic close-only controls
+            // are all it ever needs): the mechanism this Work built at
+            // T1a — open, close, restore focus for free.
             Overlay::Help
             | Overlay::SlashPalette
             | Overlay::WorkflowChooser
-            | Overlay::RepoAddRemove
-            | Overlay::GroupEditRemove
-            | Overlay::RetainedPreview
             | Overlay::ConnectionDetail => {
                 match key.code {
                     KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => self.overlay = None,
@@ -576,6 +791,87 @@ impl App {
                     }
                 }
                 Action::Refresh
+            }
+            // §12.1: kicked off, not awaited — a real `git clone` can take
+            // real wall-clock time, and [`App::poll_background`] (called
+            // every loop tick, key or not) is what notices it finished. The
+            // overlay's own body shows the spinner and elapsed time while
+            // `estate.pending_repo_add` is `Some`.
+            Action::AddRepo {
+                name,
+                origin,
+                instructions,
+            } => {
+                let client = client.clone();
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                let (spawn_name, spawn_origin, spawn_instructions) =
+                    (name.clone(), origin.clone(), instructions.clone());
+                tokio::spawn(async move {
+                    let result = client
+                        .add_repo(
+                            &spawn_name,
+                            spawn_origin.as_deref(),
+                            spawn_instructions.as_deref(),
+                        )
+                        .await;
+                    let _ = tx.send(result);
+                });
+                self.estate.repo_form.last_error = None;
+                self.estate.pending_repo_add = Some(PendingRepoAdd::new(name, rx));
+                Action::None
+            }
+            Action::RemoveRepo(name) => {
+                match client.remove_repo(&name).await {
+                    Ok(_) => {
+                        self.status = format!("removed repo {name}");
+                        self.overlay = None;
+                    }
+                    Err(e) => {
+                        self.status = format!("remove repo failed: {e}");
+                        self.estate.repo_form.last_error = Some(e.to_string());
+                    }
+                }
+                Action::Refresh
+            }
+            Action::AddGroup { name, repos, brief } => {
+                match client.add_group(&name, &repos, brief.as_deref()).await {
+                    Ok(_) => {
+                        self.status = format!("group {name} updated");
+                        self.overlay = None;
+                    }
+                    Err(e) => {
+                        self.status = format!("group update failed: {e}");
+                        self.estate.group_form.last_error = Some(e.to_string());
+                    }
+                }
+                Action::Refresh
+            }
+            Action::RemoveGroup { name, repos } => {
+                match client.remove_group(&name, &repos).await {
+                    Ok(_) => {
+                        self.status = format!("group {name} updated");
+                        self.overlay = None;
+                    }
+                    Err(e) => {
+                        self.status = format!("group remove failed: {e}");
+                        self.estate.group_form.last_error = Some(e.to_string());
+                    }
+                }
+                Action::Refresh
+            }
+            Action::LoadRetained => {
+                match client.retained().await {
+                    Ok(result) => {
+                        self.estate.retained =
+                            result["retained"].as_array().cloned().unwrap_or_default();
+                        self.estate.retained_selected = 0;
+                        self.overlay = Some(Overlay::RetainedPreview);
+                    }
+                    Err(e) => {
+                        self.status = format!("could not load retained state: {e}");
+                    }
+                }
+                Action::None
             }
             other => other,
         }

--- a/src/tui/estate.rs
+++ b/src/tui/estate.rs
@@ -1,31 +1,1149 @@
-//! Estate (§12): stub destination for T1a.
+//! Estate (§12): Repositories, Groups, and Health, over the seven `/v1/
+//! estate/*` and `/v1/doctor` routes T3 adds to [`crate::api`] — thin
+//! wrappers over `crate::domain::manifest`/`crate::cli::doctor` that this
+//! module never reaches for directly (§30's rule: the TUI talks to the
+//! daemon and nothing else).
 //!
-//! T3 builds the `/v1/estate/repos`, `/v1/estate/groups`, and `/v1/doctor`
-//! API routes as thin wrappers over `crate::domain::manifest`/`mod doctor`,
-//! and the Repositories/Groups/Health screens consumed through `ApiClient`
-//! (§20.4). Nothing here reaches for that data early — there is no route to
-//! reach it through yet, and this Work does not touch `src/api.rs`.
+//! §12.5 names what this screen deliberately does not build: `sgt init`,
+//! daemon foreground/stop, harness passthrough, data-dir relocation, a raw
+//! manifest editor, CPU/memory/process monitoring.
+
+use std::time::Instant;
 
 use ratatui::Frame;
-use ratatui::layout::Rect;
-use ratatui::style::Style;
-use ratatui::widgets::{Block, Paragraph, Wrap};
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, List, ListItem, Padding, Paragraph, Wrap};
+use serde_json::Value;
+
+use crate::api::{ClientError, field_text};
 
 use super::theme::Token;
 
-pub fn render(frame: &mut Frame, area: Rect) {
-    let block = Block::bordered()
-        .title("Estate")
-        .border_style(Style::default().fg(Token::Border.rgb()));
+/// §12's three sub-screens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EstateTab {
+    Repositories,
+    Groups,
+    Health,
+}
+
+impl EstateTab {
+    const ALL: [EstateTab; 3] = [
+        EstateTab::Repositories,
+        EstateTab::Groups,
+        EstateTab::Health,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            EstateTab::Repositories => "Repositories",
+            EstateTab::Groups => "Groups",
+            EstateTab::Health => "Health",
+        }
+    }
+
+    fn next(self) -> EstateTab {
+        let i = Self::ALL.iter().position(|t| *t == self).unwrap_or(0);
+        Self::ALL[(i + 1) % Self::ALL.len()]
+    }
+
+    fn prev(self) -> EstateTab {
+        let i = Self::ALL.iter().position(|t| *t == self).unwrap_or(0);
+        Self::ALL[(i + Self::ALL.len() - 1) % Self::ALL.len()]
+    }
+}
+
+/// What a keystroke on the Estate screen itself (not one of its overlays)
+/// asked for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EstateOutcome {
+    None,
+    /// `a` on Repositories: open [`super::overlay::Overlay::RepoAddRemove`]
+    /// in add mode.
+    OpenAddRepo,
+    /// `x`/`d` on Repositories, with a repo selected: open the same overlay
+    /// in remove-confirmation mode (§12.1's exact confirmation text).
+    OpenRemoveRepo(String),
+    /// `a` on Groups: open [`super::overlay::Overlay::GroupEditRemove`] in
+    /// edit mode (create a new group, or extend the selected one).
+    OpenGroupEdit,
+    /// `x`/`d` on Groups, with a group selected: open the same overlay in
+    /// remove mode.
+    OpenGroupRemove(String),
+    /// `r` on Health, with the `disk_pressure` check selected: open
+    /// [`super::overlay::Overlay::RetainedPreview`] (§12.4).
+    OpenRetained,
+}
+
+/// A repo-add POST kicked off the render loop (§12.1: "the existing clone/
+/// register operation runs off the render loop"). Polled non-blockingly
+/// every tick from [`super::event_loop`] via [`EstateScreen::poll`] — never
+/// awaited inline, so a slow `git clone` never stalls a keystroke or a
+/// redraw.
+pub struct PendingRepoAdd {
+    pub name: String,
+    pub started: Instant,
+    rx: tokio::sync::oneshot::Receiver<Result<Value, ClientError>>,
+}
+
+impl PendingRepoAdd {
+    pub fn new(
+        name: String,
+        rx: tokio::sync::oneshot::Receiver<Result<Value, ClientError>>,
+    ) -> Self {
+        Self {
+            name,
+            started: Instant::now(),
+            rx,
+        }
+    }
+}
+
+/// One outcome of polling a [`PendingRepoAdd`].
+pub enum PendingRepoAddOutcome {
+    /// Still running — nothing to do but keep showing the spinner.
+    InProgress,
+    Done(Result<Value, ClientError>),
+}
+
+/// One field of the add-repo form, in tab order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RepoField {
+    Name,
+    Origin,
+    Instructions,
+    Confirm,
+}
+const REPO_FIELDS: [RepoField; 4] = [
+    RepoField::Name,
+    RepoField::Origin,
+    RepoField::Instructions,
+    RepoField::Confirm,
+];
+
+/// `Overlay::RepoAddRemove`'s own mode (§12.1's two flows share one panel).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepoOverlayMode {
+    Add,
+    ConfirmRemove { name: String },
+}
+
+/// §12.1's Add form: `name`, optional `origin`, `instructions: local|suppress`.
+#[derive(Debug)]
+pub struct RepoForm {
+    pub mode: RepoOverlayMode,
+    focus: usize,
+    pub name: String,
+    pub origin: String,
+    /// Cycled by Enter on the field: `None` (unset, the manifest default),
+    /// `Some("local")`, `Some("suppress")`.
+    pub instructions: Option<&'static str>,
+    pub last_error: Option<String>,
+}
+
+impl Default for RepoForm {
+    fn default() -> Self {
+        Self {
+            mode: RepoOverlayMode::Add,
+            focus: 0,
+            name: String::new(),
+            origin: String::new(),
+            instructions: None,
+            last_error: None,
+        }
+    }
+}
+
+/// What an [`RepoForm`]/[`GroupForm`] keystroke asked the overlay to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepoFormOutcome {
+    None,
+    Close,
+    /// Add mode's Confirm: the `POST /v1/estate/repos` body.
+    Submit {
+        name: String,
+        origin: Option<String>,
+        instructions: Option<String>,
+    },
+    /// Remove mode's Confirm: `DELETE /v1/estate/repos/{name}`.
+    ConfirmRemove(String),
+}
+
+impl RepoForm {
+    pub fn reset_for_add(&mut self) {
+        *self = RepoForm::default();
+    }
+
+    pub fn reset_for_remove(&mut self, name: String) {
+        *self = RepoForm {
+            mode: RepoOverlayMode::ConfirmRemove { name },
+            ..RepoForm::default()
+        };
+    }
+
+    pub fn on_key(&mut self, key: KeyEvent) -> RepoFormOutcome {
+        match &self.mode {
+            RepoOverlayMode::ConfirmRemove { name } => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => RepoFormOutcome::Close,
+                KeyCode::Enter => RepoFormOutcome::ConfirmRemove(name.clone()),
+                _ => RepoFormOutcome::None,
+            },
+            RepoOverlayMode::Add => {
+                match key.code {
+                    KeyCode::Esc => return RepoFormOutcome::Close,
+                    KeyCode::Tab => {
+                        self.focus = (self.focus + 1) % REPO_FIELDS.len();
+                        return RepoFormOutcome::None;
+                    }
+                    KeyCode::BackTab => {
+                        self.focus = (self.focus + REPO_FIELDS.len() - 1) % REPO_FIELDS.len();
+                        return RepoFormOutcome::None;
+                    }
+                    KeyCode::Enter => {
+                        return match REPO_FIELDS[self.focus] {
+                            RepoField::Instructions => {
+                                self.instructions = match self.instructions {
+                                    None => Some("local"),
+                                    Some("local") => Some("suppress"),
+                                    _ => None,
+                                };
+                                RepoFormOutcome::None
+                            }
+                            RepoField::Confirm => self.try_submit(),
+                            _ => {
+                                self.focus = (self.focus + 1) % REPO_FIELDS.len();
+                                RepoFormOutcome::None
+                            }
+                        };
+                    }
+                    KeyCode::Backspace => {
+                        if let Some(field) = self.field_mut() {
+                            field.pop();
+                        }
+                    }
+                    KeyCode::Char(c) => {
+                        if let Some(field) = self.field_mut() {
+                            field.push(c);
+                        }
+                    }
+                    _ => {}
+                }
+                RepoFormOutcome::None
+            }
+        }
+    }
+
+    fn field_mut(&mut self) -> Option<&mut String> {
+        match REPO_FIELDS[self.focus] {
+            RepoField::Name => Some(&mut self.name),
+            RepoField::Origin => Some(&mut self.origin),
+            RepoField::Instructions | RepoField::Confirm => None,
+        }
+    }
+
+    fn try_submit(&mut self) -> RepoFormOutcome {
+        let name = self.name.trim().to_string();
+        if name.is_empty() {
+            self.last_error = Some("name is required".to_string());
+            return RepoFormOutcome::None;
+        }
+        let origin = (!self.origin.trim().is_empty()).then(|| self.origin.trim().to_string());
+        RepoFormOutcome::Submit {
+            name,
+            origin,
+            instructions: self.instructions.map(str::to_string),
+        }
+    }
+}
+
+/// One field of the group edit form, in tab order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GroupField {
+    Name,
+    Repos,
+    Brief,
+    Confirm,
+}
+const GROUP_FIELDS: [GroupField; 4] = [
+    GroupField::Name,
+    GroupField::Repos,
+    GroupField::Brief,
+    GroupField::Confirm,
+];
+
+/// `Overlay::GroupEditRemove`'s own mode (§12.2's full lifecycle in one
+/// panel): create-or-extend, or remove (selected members, or the whole
+/// group when none are named).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroupOverlayMode {
+    Edit,
+    Remove { name: String },
+}
+
+/// §12.2's group form: create, extend membership, remove selected members,
+/// or remove the group — `manifest::add_group`'s mkdir-p union semantics and
+/// `manifest::remove_group`'s "empty repos removes the whole group" both
+/// reached exactly as they already behave, never reimplemented here.
+#[derive(Debug)]
+pub struct GroupForm {
+    pub mode: GroupOverlayMode,
+    focus: usize,
+    pub name: String,
+    /// Edit mode: repos to add (union in). Remove mode: repos to remove
+    /// (blank removes the whole group).
+    pub repos: String,
+    pub brief: String,
+    pub last_error: Option<String>,
+}
+
+impl Default for GroupForm {
+    fn default() -> Self {
+        Self {
+            mode: GroupOverlayMode::Edit,
+            focus: 0,
+            name: String::new(),
+            repos: String::new(),
+            brief: String::new(),
+            last_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroupFormOutcome {
+    None,
+    Close,
+    /// Edit mode's Confirm: the `POST /v1/estate/groups` body.
+    Submit {
+        name: String,
+        repos: Vec<String>,
+        brief: Option<String>,
+    },
+    /// Remove mode's Confirm: the `DELETE /v1/estate/groups/{name}` body —
+    /// empty `repos` removes the whole group.
+    ConfirmRemove {
+        name: String,
+        repos: Vec<String>,
+    },
+}
+
+impl GroupForm {
+    /// Edit mode, pre-filled from an existing group (extend) or blank
+    /// (create).
+    pub fn reset_for_edit(&mut self, existing: Option<&Value>) {
+        *self = GroupForm {
+            mode: GroupOverlayMode::Edit,
+            name: existing
+                .and_then(|g| g["name"].as_str())
+                .unwrap_or_default()
+                .to_string(),
+            ..GroupForm::default()
+        };
+    }
+
+    pub fn reset_for_remove(&mut self, name: String) {
+        *self = GroupForm {
+            mode: GroupOverlayMode::Remove { name },
+            ..GroupForm::default()
+        };
+    }
+
+    pub fn on_key(&mut self, key: KeyEvent) -> GroupFormOutcome {
+        match key.code {
+            KeyCode::Esc => return GroupFormOutcome::Close,
+            KeyCode::Tab => {
+                self.focus = (self.focus + 1) % GROUP_FIELDS.len();
+                return GroupFormOutcome::None;
+            }
+            KeyCode::BackTab => {
+                self.focus = (self.focus + GROUP_FIELDS.len() - 1) % GROUP_FIELDS.len();
+                return GroupFormOutcome::None;
+            }
+            KeyCode::Enter if GROUP_FIELDS[self.focus] == GroupField::Confirm => {
+                return self.try_submit();
+            }
+            KeyCode::Enter => {
+                self.focus = (self.focus + 1) % GROUP_FIELDS.len();
+            }
+            KeyCode::Backspace => {
+                if let Some(field) = self.field_mut() {
+                    field.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                if let Some(field) = self.field_mut() {
+                    field.push(c);
+                }
+            }
+            _ => {}
+        }
+        GroupFormOutcome::None
+    }
+
+    fn field_mut(&mut self) -> Option<&mut String> {
+        match GROUP_FIELDS[self.focus] {
+            GroupField::Name => match &self.mode {
+                GroupOverlayMode::Edit => Some(&mut self.name),
+                GroupOverlayMode::Remove { .. } => None,
+            },
+            GroupField::Repos => Some(&mut self.repos),
+            GroupField::Brief => match &self.mode {
+                GroupOverlayMode::Edit => Some(&mut self.brief),
+                GroupOverlayMode::Remove { .. } => None,
+            },
+            GroupField::Confirm => None,
+        }
+    }
+
+    fn split_repos(&self) -> Vec<String> {
+        self.repos
+            .split([',', ' '])
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn try_submit(&mut self) -> GroupFormOutcome {
+        match &self.mode {
+            GroupOverlayMode::Edit => {
+                let name = self.name.trim().to_string();
+                if name.is_empty() {
+                    self.last_error = Some("name is required".to_string());
+                    return GroupFormOutcome::None;
+                }
+                let brief = (!self.brief.trim().is_empty()).then(|| self.brief.trim().to_string());
+                GroupFormOutcome::Submit {
+                    name,
+                    repos: self.split_repos(),
+                    brief,
+                }
+            }
+            GroupOverlayMode::Remove { name } => GroupFormOutcome::ConfirmRemove {
+                name: name.clone(),
+                repos: self.split_repos(),
+            },
+        }
+    }
+}
+
+/// The Estate destination's whole state: three sub-screens' data and
+/// selection, plus the two edit forms and the retained-state preview
+/// [`super::overlay::Overlay::RepoAddRemove`]/[`super::overlay::Overlay::
+/// GroupEditRemove`]/[`super::overlay::Overlay::RetainedPreview`] need.
+pub struct EstateScreen {
+    pub tab: EstateTab,
+    /// `GET /v1/estate/repos`'s `repos` array.
+    pub repos: Vec<Value>,
+    /// `GET /v1/estate/groups`'s `groups` array.
+    pub groups: Vec<Value>,
+    /// `GET /v1/doctor`'s whole report body.
+    pub doctor: Value,
+    pub repo_selected: usize,
+    pub group_selected: usize,
+    pub check_selected: usize,
+    pub repo_form: RepoForm,
+    pub group_form: GroupForm,
+    pub pending_repo_add: Option<PendingRepoAdd>,
+    /// `GET /v1/retained`'s entries — populated when
+    /// [`super::overlay::Overlay::RetainedPreview`] opens (§12.4: reuses the
+    /// existing estate-wide read, not a new route).
+    pub retained: Vec<Value>,
+    pub retained_selected: usize,
+    /// Set on a failed mutation, so it stays visible next to the action that
+    /// caused it (§17.5) rather than only flashing on the status line.
+    pub last_error: Option<String>,
+}
+
+impl Default for EstateScreen {
+    fn default() -> Self {
+        Self {
+            tab: EstateTab::Repositories,
+            repos: Vec::new(),
+            groups: Vec::new(),
+            doctor: Value::Null,
+            repo_selected: 0,
+            group_selected: 0,
+            check_selected: 0,
+            repo_form: RepoForm::default(),
+            group_form: GroupForm::default(),
+            pending_repo_add: None,
+            retained: Vec::new(),
+            retained_selected: 0,
+            last_error: None,
+        }
+    }
+}
+
+impl EstateScreen {
+    /// Clamp every selection index to the data currently loaded, the same
+    /// discipline [`super::fleet::FleetScreen::clamp`] applies — a refresh
+    /// that shrinks a list must never leave a selection pointing past its end.
+    pub fn clamp(&mut self) {
+        self.repo_selected = clamp_index(self.repo_selected, self.repos.len());
+        self.group_selected = clamp_index(self.group_selected, self.groups.len());
+        let checks = self.doctor["checks"].as_array().map_or(0, Vec::len);
+        self.check_selected = clamp_index(self.check_selected, checks);
+        self.retained_selected = clamp_index(self.retained_selected, self.retained.len());
+    }
+
+    pub fn selected_repo(&self) -> Option<&Value> {
+        self.repos.get(self.repo_selected)
+    }
+
+    pub fn selected_group(&self) -> Option<&Value> {
+        self.groups.get(self.group_selected)
+    }
+
+    pub fn selected_check(&self) -> Option<&Value> {
+        self.doctor["checks"]
+            .as_array()
+            .and_then(|c| c.get(self.check_selected))
+    }
+
+    pub fn selected_retained(&self) -> Option<&Value> {
+        self.retained.get(self.retained_selected)
+    }
+
+    /// Non-blocking poll of an in-flight repo add (§12.1). Called every loop
+    /// tick from [`super::event_loop`] — `Ok(Empty)` means still running.
+    pub fn poll(&mut self) -> Option<PendingRepoAddOutcome> {
+        let pending = self.pending_repo_add.as_mut()?;
+        match pending.rx.try_recv() {
+            Ok(result) => Some(PendingRepoAddOutcome::Done(result)),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                Some(PendingRepoAddOutcome::InProgress)
+            }
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                Some(PendingRepoAddOutcome::Done(Err(ClientError::Transport(
+                    "the add-repo task ended without answering".to_string(),
+                ))))
+            }
+        }
+    }
+
+    /// Keys the Estate screen itself handles, outside any overlay — tab
+    /// switching and list navigation are captured here, ahead of the global
+    /// destination-nav keys, the same way [`super::work_view::WorkScreen`]
+    /// captures its own `Tab`.
+    pub fn on_key(&mut self, key: KeyCode) -> EstateOutcome {
+        match key {
+            KeyCode::Tab => self.tab = self.tab.next(),
+            KeyCode::BackTab => self.tab = self.tab.prev(),
+            KeyCode::Char('h') | KeyCode::Left => self.tab = self.tab.prev(),
+            KeyCode::Char('l') | KeyCode::Right => self.tab = self.tab.next(),
+            KeyCode::Down | KeyCode::Char('j') => self.move_selection(1),
+            KeyCode::Up | KeyCode::Char('k') => self.move_selection(-1),
+            KeyCode::Char('a') => {
+                return match self.tab {
+                    EstateTab::Repositories => EstateOutcome::OpenAddRepo,
+                    EstateTab::Groups => EstateOutcome::OpenGroupEdit,
+                    EstateTab::Health => EstateOutcome::None,
+                };
+            }
+            KeyCode::Char('x') | KeyCode::Char('d') => {
+                return match self.tab {
+                    EstateTab::Repositories => self
+                        .selected_repo()
+                        .and_then(|r| r["name"].as_str())
+                        .map(|n| EstateOutcome::OpenRemoveRepo(n.to_string()))
+                        .unwrap_or(EstateOutcome::None),
+                    EstateTab::Groups => self
+                        .selected_group()
+                        .and_then(|g| g["name"].as_str())
+                        .map(|n| EstateOutcome::OpenGroupRemove(n.to_string()))
+                        .unwrap_or(EstateOutcome::None),
+                    EstateTab::Health => EstateOutcome::None,
+                };
+            }
+            KeyCode::Char('r')
+                if self.tab == EstateTab::Health
+                    && self
+                        .selected_check()
+                        .and_then(|c| c["name"].as_str())
+                        .map(|n| n == "disk_pressure")
+                        .unwrap_or(false) =>
+            {
+                return EstateOutcome::OpenRetained;
+            }
+            _ => {}
+        }
+        EstateOutcome::None
+    }
+
+    fn move_selection(&mut self, delta: i64) {
+        let (selected, len) = match self.tab {
+            EstateTab::Repositories => (&mut self.repo_selected, self.repos.len()),
+            EstateTab::Groups => (&mut self.group_selected, self.groups.len()),
+            EstateTab::Health => (
+                &mut self.check_selected,
+                self.doctor["checks"].as_array().map_or(0, Vec::len),
+            ),
+        };
+        if len == 0 {
+            return;
+        }
+        *selected = ((*selected as i64 + delta).rem_euclid(len as i64)) as usize;
+    }
+}
+
+fn clamp_index(index: usize, len: usize) -> usize {
+    if len == 0 { 0 } else { index.min(len - 1) }
+}
+
+// -------------------------------------------------------------- rendering
+
+pub fn render(frame: &mut Frame, area: Rect, estate: &EstateScreen) {
+    let [tabs_area, body_area] =
+        Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(area);
+    render_tabs(frame, tabs_area, estate.tab);
+    match estate.tab {
+        EstateTab::Repositories => render_repos(frame, body_area, estate),
+        EstateTab::Groups => render_groups(frame, body_area, estate),
+        EstateTab::Health => render_health(frame, body_area, estate),
+    }
+}
+
+fn render_tabs(frame: &mut Frame, area: Rect, active: EstateTab) {
+    let mut spans = vec![Span::raw("Estate  ")];
+    for tab in EstateTab::ALL {
+        let style = if tab == active {
+            Style::default()
+                .fg(Token::Focus.rgb())
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Token::Muted.rgb())
+        };
+        spans.push(Span::styled(format!("{}  ", tab.label()), style));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn bordered(title: &str) -> Block<'_> {
+    Block::bordered()
+        .title(title)
+        .border_style(Style::default().fg(Token::Border.rgb()))
+        .padding(Padding::horizontal(1))
+}
+
+fn render_repos(frame: &mut Frame, area: Rect, estate: &EstateScreen) {
+    let block = bordered("Repositories — a add · x remove");
     let inner = block.inner(area);
     frame.render_widget(block, area);
+    if estate.repos.is_empty() {
+        frame.render_widget(
+            Paragraph::new("no repositories declared").wrap(Wrap { trim: false }),
+            inner,
+        );
+        return;
+    }
+    let groups_by_repo = |name: &str| -> String {
+        let members: Vec<&str> = estate
+            .groups
+            .iter()
+            .filter(|g| {
+                g["repos"]
+                    .as_array()
+                    .map(|repos| repos.iter().any(|r| r.as_str() == Some(name)))
+                    .unwrap_or(false)
+            })
+            .filter_map(|g| g["name"].as_str())
+            .collect();
+        if members.is_empty() {
+            "-".to_string()
+        } else {
+            members.join(", ")
+        }
+    };
+    let items: Vec<ListItem> = estate
+        .repos
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let name = field_text(&r["name"]);
+            let style = if i == estate.repo_selected {
+                Style::default().add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default()
+            };
+            let line = format!(
+                "{:<20} {:<40} origin={:<28} instructions={:<10} groups={}",
+                name,
+                field_text(&r["path"]),
+                field_text(&r["origin"]),
+                field_text(&r["instructions"]),
+                groups_by_repo(&name),
+            );
+            ListItem::new(line).style(style)
+        })
+        .collect();
+    frame.render_widget(List::new(items), inner);
+}
+
+fn render_groups(frame: &mut Frame, area: Rect, estate: &EstateScreen) {
+    let block = bordered("Groups — a create/extend · x remove");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if estate.groups.is_empty() {
+        frame.render_widget(
+            Paragraph::new("no groups declared").wrap(Wrap { trim: false }),
+            inner,
+        );
+        return;
+    }
+    let items: Vec<ListItem> = estate
+        .groups
+        .iter()
+        .enumerate()
+        .map(|(i, g)| {
+            let style = if i == estate.group_selected {
+                Style::default().add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default()
+            };
+            let repos: Vec<String> = g["repos"]
+                .as_array()
+                .map(|r| {
+                    r.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let line = format!(
+                "{:<20} [{}]{}",
+                field_text(&g["name"]),
+                repos.join(", "),
+                g["brief"]
+                    .as_str()
+                    .map(|b| format!("  {b}"))
+                    .unwrap_or_default(),
+            );
+            ListItem::new(line).style(style)
+        })
+        .collect();
+    frame.render_widget(List::new(items), inner);
+}
+
+fn render_health(frame: &mut Frame, area: Rect, estate: &EstateScreen) {
+    let [list_area, detail_area] =
+        Layout::vertical([Constraint::Percentage(60), Constraint::Min(3)]).areas(area);
+    let block = bordered("Health — GET /v1/doctor");
+    let inner = block.inner(list_area);
+    frame.render_widget(block, list_area);
+    let checks = estate.doctor["checks"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    if checks.is_empty() {
+        frame.render_widget(
+            Paragraph::new("no report yet").wrap(Wrap { trim: false }),
+            inner,
+        );
+    } else {
+        let items: Vec<ListItem> = checks
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                let status = field_text(&c["status"]);
+                let color = match status.as_str() {
+                    "ok" => Token::Success,
+                    "warn" => Token::Warning,
+                    "fail" => Token::Danger,
+                    _ => Token::Muted,
+                };
+                let style = if i == estate.check_selected {
+                    Style::default()
+                        .fg(color.rgb())
+                        .add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default().fg(color.rgb())
+                };
+                let line = format!(
+                    "[{:<4}] {:<20} {}",
+                    status,
+                    field_text(&c["name"]),
+                    field_text(&c["detail"]),
+                );
+                ListItem::new(line).style(style)
+            })
+            .collect();
+        frame.render_widget(List::new(items), inner);
+    }
+
+    let detail_block = bordered("Detail");
+    let detail_inner = detail_block.inner(detail_area);
+    frame.render_widget(detail_block, detail_area);
+    let detail = match estate.selected_check() {
+        Some(check) => {
+            let mut text = format!(
+                "{}  [{}]\n\n{}",
+                field_text(&check["name"]),
+                field_text(&check["status"]),
+                field_text(&check["detail"]),
+            );
+            if let Some(remedy) = check["remedy"].as_str() {
+                text.push_str(&format!("\n\nremedy: {remedy}"));
+            }
+            if check["name"].as_str() == Some("disk_pressure") {
+                text.push_str("\n\nr  view retained estate-wide state");
+            }
+            text
+        }
+        None => "healthy — no check to detail".to_string(),
+    };
     frame.render_widget(
-        Paragraph::new(
-            "Estate is not built yet.\n\n\
-             T3 adds the repo/group/doctor API routes and the Repositories, \
-             Groups, and Health screens here (§12, §20.4).",
-        )
-        .wrap(Wrap { trim: false }),
-        inner,
+        Paragraph::new(detail).wrap(Wrap { trim: false }),
+        detail_inner,
     );
+}
+
+/// §12.1's exact confirmation text — reused verbatim by
+/// [`super::overlay::render`].
+pub fn remove_repo_body(name: &str, last_error: Option<&str>) -> String {
+    let mut body = format!(
+        "Remove {name} from the estate?\n\n\
+         This removes the estate declaration.\n\
+         It does not delete repos/{name} from disk.\n\n\
+         Enter confirms · Esc/q aborts, nothing is sent."
+    );
+    if let Some(error) = last_error {
+        body.push_str(&format!("\n\nlast attempt failed: {error}"));
+    }
+    body
+}
+
+/// The add-repo form body, including the spinner/elapsed line while a clone
+/// or verify is in flight (§12.1: "no fabricated clone percentage").
+pub fn add_repo_body(form: &RepoForm, pending: Option<&PendingRepoAdd>) -> String {
+    if let Some(pending) = pending {
+        let mut body = format!(
+            "Adding {}…\n\n  * {}s elapsed\n\nThis runs off the render loop; the screen stays live.",
+            pending.name,
+            pending.started.elapsed().as_secs(),
+        );
+        if let Some(error) = &form.last_error {
+            body.push_str(&format!("\n\nlast attempt failed: {error}"));
+        }
+        return body;
+    }
+    let focus_marker = |focused: bool| if focused { " <" } else { "" };
+    let field_marker = |focused: bool| if focused { "" } else { "_" };
+    let name_focused = form_focused(form, RepoField::Name);
+    let origin_focused = form_focused(form, RepoField::Origin);
+    let instructions_focused = form_focused(form, RepoField::Instructions);
+    let confirm_focused = form_focused(form, RepoField::Confirm);
+    let mut body = format!(
+        "Add a repository\n\n  \
+         name          {}{}\n  \
+         origin        {}{}\n  \
+         instructions  {}{}\n\n  \
+         [ confirm ]{}\n\n\
+         Tab moves between fields · Enter cycles instructions/confirms · Esc/q aborts.",
+        form.name,
+        field_marker(name_focused),
+        form.origin,
+        field_marker(origin_focused),
+        form.instructions.unwrap_or("(default)"),
+        field_marker(instructions_focused),
+        focus_marker(confirm_focused),
+    );
+    if let Some(error) = &form.last_error {
+        body.push_str(&format!("\n\n{error}"));
+    }
+    body
+}
+
+fn form_focused(form: &RepoForm, field: RepoField) -> bool {
+    REPO_FIELDS[form.focus_index()] == field
+}
+
+impl RepoForm {
+    fn focus_index(&self) -> usize {
+        self.focus
+    }
+}
+
+/// The group edit/remove form body.
+pub fn group_form_body(form: &GroupForm) -> String {
+    match &form.mode {
+        GroupOverlayMode::Edit => {
+            let field_marker = |focused: bool| if focused { "" } else { "_" };
+            let focus_marker = |focused: bool| if focused { " <" } else { "" };
+            let name_focused = group_focused(form, GroupField::Name);
+            let repos_focused = group_focused(form, GroupField::Repos);
+            let brief_focused = group_focused(form, GroupField::Brief);
+            let confirm_focused = group_focused(form, GroupField::Confirm);
+            let mut body = format!(
+                "Create or extend a group\n\n  \
+                 name    {}{}\n  \
+                 repos   {}{}  (comma/space-separated; adds to existing membership)\n  \
+                 brief   {}{}\n\n  \
+                 [ confirm ]{}\n\n\
+                 Tab moves between fields · Enter on Confirm sends it · Esc/q aborts.",
+                form.name,
+                field_marker(name_focused),
+                form.repos,
+                field_marker(repos_focused),
+                form.brief,
+                field_marker(brief_focused),
+                focus_marker(confirm_focused),
+            );
+            if let Some(error) = &form.last_error {
+                body.push_str(&format!("\n\n{error}"));
+            }
+            body
+        }
+        GroupOverlayMode::Remove { name } => {
+            let field_marker = |focused: bool| if focused { "" } else { "_" };
+            let focus_marker = |focused: bool| if focused { " <" } else { "" };
+            let repos_focused = group_focused(form, GroupField::Repos);
+            let confirm_focused = group_focused(form, GroupField::Confirm);
+            let mut body = format!(
+                "Remove from group {name}?\n\n  \
+                 members to remove   {}{}  (blank removes the whole group)\n\n  \
+                 [ confirm ]{}\n\n\
+                 Tab moves between fields · Enter on Confirm sends it · Esc/q aborts.",
+                form.repos,
+                field_marker(repos_focused),
+                focus_marker(confirm_focused),
+            );
+            if let Some(error) = &form.last_error {
+                body.push_str(&format!("\n\n{error}"));
+            }
+            body
+        }
+    }
+}
+
+fn group_focused(form: &GroupForm, field: GroupField) -> bool {
+    GROUP_FIELDS[form.focus] == field
+}
+
+/// The retained-state preview body (§12.4): estate-wide, from the existing
+/// `GET /v1/retained` read — never a new route.
+pub fn retained_body(estate: &EstateScreen) -> String {
+    if estate.retained.is_empty() {
+        return "nothing retained across the estate.\n\nEsc/q closes this panel.".to_string();
+    }
+    let mut lines = vec!["Retained state (estate-wide)\n".to_string()];
+    for (i, entry) in estate.retained.iter().enumerate() {
+        let marker = if i == estate.retained_selected {
+            ">"
+        } else {
+            " "
+        };
+        lines.push(format!(
+            "{marker} {:<12} {:<20} {:<10} {}b  {}",
+            field_text(&entry["work_id"]),
+            field_text(&entry["repository"]),
+            field_text(&entry["disposition"]),
+            field_text(&entry["bytes"]),
+            field_text(&entry["path"]),
+        ));
+    }
+    lines.push(String::new());
+    lines.push("j/k move · p reap the selected Work's retained state · Esc/q closes".to_string());
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn repos_estate() -> EstateScreen {
+        EstateScreen {
+            repos: vec![
+                json!({"name": "svc-a", "path": "repos/svc-a", "origin": "git@x:svc-a", "instructions": "suppress"}),
+                json!({"name": "svc-b", "path": "repos/svc-b", "origin": null, "instructions": "local"}),
+            ],
+            groups: vec![json!({"name": "core", "repos": ["svc-a"], "brief": "core services"})],
+            ..EstateScreen::default()
+        }
+    }
+
+    #[test]
+    fn tab_key_cycles_repositories_groups_health() {
+        let mut estate = EstateScreen::default();
+        assert_eq!(estate.tab, EstateTab::Repositories);
+        estate.on_key(KeyCode::Tab);
+        assert_eq!(estate.tab, EstateTab::Groups);
+        estate.on_key(KeyCode::Tab);
+        assert_eq!(estate.tab, EstateTab::Health);
+        estate.on_key(KeyCode::BackTab);
+        assert_eq!(estate.tab, EstateTab::Groups);
+    }
+
+    #[test]
+    fn j_k_move_the_selection_on_the_active_tab() {
+        let mut estate = repos_estate();
+        assert_eq!(estate.repo_selected, 0);
+        estate.on_key(KeyCode::Char('j'));
+        assert_eq!(estate.repo_selected, 1);
+        estate.on_key(KeyCode::Char('k'));
+        assert_eq!(estate.repo_selected, 0);
+    }
+
+    #[test]
+    fn a_opens_add_repo_on_repositories_and_group_edit_on_groups() {
+        let mut estate = repos_estate();
+        assert_eq!(
+            estate.on_key(KeyCode::Char('a')),
+            EstateOutcome::OpenAddRepo
+        );
+        estate.tab = EstateTab::Groups;
+        assert_eq!(
+            estate.on_key(KeyCode::Char('a')),
+            EstateOutcome::OpenGroupEdit
+        );
+    }
+
+    #[test]
+    fn x_opens_remove_for_the_selected_repo_or_group() {
+        let mut estate = repos_estate();
+        assert_eq!(
+            estate.on_key(KeyCode::Char('x')),
+            EstateOutcome::OpenRemoveRepo("svc-a".to_string())
+        );
+        estate.tab = EstateTab::Groups;
+        assert_eq!(
+            estate.on_key(KeyCode::Char('x')),
+            EstateOutcome::OpenGroupRemove("core".to_string())
+        );
+    }
+
+    #[test]
+    fn r_opens_retained_only_for_the_disk_pressure_check() {
+        let mut estate = EstateScreen {
+            tab: EstateTab::Health,
+            doctor: json!({"checks": [
+                {"name": "git", "status": "ok", "detail": "found"},
+                {"name": "disk_pressure", "status": "warn", "detail": "82% full"},
+            ]}),
+            ..EstateScreen::default()
+        };
+        assert_eq!(estate.on_key(KeyCode::Char('r')), EstateOutcome::None);
+        estate.on_key(KeyCode::Char('j'));
+        assert_eq!(
+            estate.on_key(KeyCode::Char('r')),
+            EstateOutcome::OpenRetained
+        );
+    }
+
+    #[test]
+    fn clamp_pulls_a_selection_back_when_a_refresh_shrinks_the_list() {
+        let mut estate = repos_estate();
+        estate.repo_selected = 5;
+        estate.clamp();
+        assert_eq!(estate.repo_selected, 1);
+    }
+
+    #[test]
+    fn remove_repo_body_states_the_declaration_is_removed_not_the_disk_copy() {
+        let body = remove_repo_body("svc-a", None);
+        assert!(body.contains("This removes the estate declaration."));
+        assert!(body.contains("It does not delete repos/svc-a from disk."));
+    }
+
+    #[test]
+    fn add_repo_form_tab_cycles_through_fields_and_confirm_submits() {
+        let mut form = RepoForm::default();
+        form.on_key(KeyCode::Char('a').into());
+        form.on_key(KeyCode::Tab.into());
+        form.on_key(KeyCode::Char('b').into());
+        assert_eq!(form.name, "a");
+        assert_eq!(form.origin, "b");
+        form.on_key(KeyCode::Tab.into());
+        form.on_key(KeyCode::Enter.into()); // cycles instructions to "local"
+        assert_eq!(form.instructions, Some("local"));
+        form.on_key(KeyCode::Tab.into());
+        let outcome = form.on_key(KeyCode::Enter.into());
+        assert_eq!(
+            outcome,
+            RepoFormOutcome::Submit {
+                name: "a".to_string(),
+                origin: Some("b".to_string()),
+                instructions: Some("local".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn add_repo_form_refuses_an_empty_name() {
+        let mut form = RepoForm::default();
+        form.reset_for_add();
+        form.on_key(KeyCode::Tab.into());
+        form.on_key(KeyCode::Tab.into());
+        form.on_key(KeyCode::Tab.into());
+        let outcome = form.on_key(KeyCode::Enter.into());
+        assert_eq!(outcome, RepoFormOutcome::None);
+        assert!(form.last_error.is_some());
+    }
+
+    #[test]
+    fn remove_repo_form_confirms_with_the_prefilled_name() {
+        let mut form = RepoForm::default();
+        form.reset_for_remove("svc-a".to_string());
+        let outcome = form.on_key(KeyCode::Enter.into());
+        assert_eq!(outcome, RepoFormOutcome::ConfirmRemove("svc-a".to_string()));
+    }
+
+    #[test]
+    fn group_edit_form_submits_split_repos() {
+        let mut form = GroupForm::default();
+        form.reset_for_edit(None);
+        form.name = "core".to_string();
+        form.on_key(KeyCode::Tab.into());
+        form.on_key(KeyCode::Char('a').into());
+        form.on_key(KeyCode::Char(',').into());
+        form.on_key(KeyCode::Char('b').into());
+        form.on_key(KeyCode::Tab.into());
+        form.on_key(KeyCode::Tab.into());
+        let outcome = form.on_key(KeyCode::Enter.into());
+        assert_eq!(
+            outcome,
+            GroupFormOutcome::Submit {
+                name: "core".to_string(),
+                repos: vec!["a".to_string(), "b".to_string()],
+                brief: None,
+            }
+        );
+    }
+
+    #[test]
+    fn group_remove_form_defaults_to_whole_group_when_repos_left_blank() {
+        let mut form = GroupForm::default();
+        form.reset_for_remove("core".to_string());
+        // Name(0, disabled in Remove mode) -> Repos(1) -> Brief(2, also
+        // disabled) -> Confirm(3): three Tabs from the default focus reach
+        // Confirm without ever typing into the (blank) repos field.
+        form.on_key(KeyCode::Tab.into());
+        form.on_key(KeyCode::Tab.into());
+        form.on_key(KeyCode::Tab.into());
+        let outcome = form.on_key(KeyCode::Enter.into());
+        assert_eq!(
+            outcome,
+            GroupFormOutcome::ConfirmRemove {
+                name: "core".to_string(),
+                repos: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn retained_body_lists_estate_wide_entries_not_just_one_work() {
+        let estate = EstateScreen {
+            retained: vec![
+                json!({"work_id": "01A", "repository": "svc-a", "disposition": "retained_dirty", "bytes": 120, "path": "/data/a"}),
+                json!({"work_id": "01B", "repository": "svc-b", "disposition": "retained_dirty", "bytes": 40, "path": "/data/b"}),
+            ],
+            ..EstateScreen::default()
+        };
+        let body = retained_body(&estate);
+        assert!(body.contains("01A"));
+        assert!(body.contains("01B"));
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -147,8 +147,8 @@ fn draw_body(frame: &mut Frame, area: Rect, app: &App, tier: Tier) {
 
 /// §18.1: drawer | primary body | contextual rail, all inline. The rail's
 /// content is destination-specific and only defined for Home (Recent
-/// Outputs, §9.4) and Fleet (selected Work preview, §10.1) — Workflows and
-/// Estate are stubs with nothing yet to preview there.
+/// Outputs, §9.4) and Fleet (selected Work preview, §10.1) — §12 names no
+/// rail content for Estate, so it (like Workflows) has none.
 fn draw_wide(frame: &mut Frame, area: Rect, app: &App) {
     let has_rail = matches!(app.destination, Destination::Home | Destination::Fleet);
     // §8.10's spacing scale: `region` (3 cells) is the outer margin between
@@ -190,7 +190,7 @@ fn draw_primary(frame: &mut Frame, area: Rect, app: &App, tier: Tier) {
         Destination::Home => home::render(frame, area, &app.home, admission_paused),
         Destination::Fleet => fleet::render(frame, area, &app.rows, &app.fleet, tier),
         Destination::Workflows => workflows::render(frame, area),
-        Destination::Estate => estate::render(frame, area),
+        Destination::Estate => estate::render(frame, area, &app.estate),
     }
 }
 
@@ -516,6 +516,12 @@ where
                         break 'session;
                     }
                 }
+            }
+            // §12.1: a repo add kicked off the render loop is polled every
+            // tick, key or not — a slow `git clone` must finish on its own
+            // schedule, not wait for the next keystroke.
+            if app.poll_background() {
+                needs_refresh = true;
             }
             if needs_refresh && let Err(e) = app.refresh(client).await {
                 app.status = format!("refresh failed: {e}");

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -19,6 +19,9 @@ use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 use crate::api::field_text;
 
 use super::app::App;
+use super::estate::{
+    RepoOverlayMode, add_repo_body, group_form_body, remove_repo_body, retained_body,
+};
 use super::theme::Token;
 
 /// §7.4's fixed set, in the order it lists them.
@@ -55,23 +58,24 @@ impl Overlay {
     }
 
     /// The later Work that actually implements this overlay's content —
-    /// `None` for the ones already built: [`Overlay::Help`] (T1a) and
-    /// T1c's four real confirmations (§13.10/§15.5).
+    /// `None` for the ones already built: [`Overlay::Help`] (T1a), T1c's
+    /// four real confirmations (§13.10/§15.5), and T3's three Estate panels
+    /// (§12.1/§12.2/§12.4).
     fn owner(self) -> Option<&'static str> {
         match self {
             Overlay::Help
             | Overlay::CancelConfirmation
             | Overlay::RetryConfirmation
             | Overlay::ExtendEnvelope
-            | Overlay::ReapConfirmation => None,
+            | Overlay::ReapConfirmation
+            | Overlay::RepoAddRemove
+            | Overlay::GroupEditRemove
+            | Overlay::RetainedPreview => None,
             // §15.3 is explicitly out of T1c's scope (deferred alongside
             // §15.4's Workflows half and §15.6) — not this Work, and not yet
             // reassigned to a later one by name.
             Overlay::SlashPalette => Some("a later Work (§15.3)"),
             Overlay::WorkflowChooser => Some("T2 (§20.3's workflow discovery)"),
-            Overlay::RepoAddRemove | Overlay::GroupEditRemove | Overlay::RetainedPreview => {
-                Some("T3 (§20.4's Estate work)")
-            }
             Overlay::ConnectionDetail => Some("a later Work"),
         }
     }
@@ -131,6 +135,16 @@ pub fn render(frame: &mut Frame, area: Rect, overlay: Overlay, app: &App) {
         Overlay::RetryConfirmation => retry_body(app),
         Overlay::ExtendEnvelope => extend_body(app),
         Overlay::ReapConfirmation => reap_body(app),
+        Overlay::RepoAddRemove => match &app.estate.repo_form.mode {
+            RepoOverlayMode::Add => {
+                add_repo_body(&app.estate.repo_form, app.estate.pending_repo_add.as_ref())
+            }
+            RepoOverlayMode::ConfirmRemove { name } => {
+                remove_repo_body(name, app.estate.repo_form.last_error.as_deref())
+            }
+        },
+        Overlay::GroupEditRemove => group_form_body(&app.estate.group_form),
+        Overlay::RetainedPreview => retained_body(&app.estate),
         _ => format!(
             "{} is not built in this Work.\n\n{} implements it.\n\nEsc closes this panel.",
             overlay.title(),
@@ -269,13 +283,16 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn help_and_the_four_t1c_confirmations_are_built_here() {
+    fn help_t1c_and_t3_panels_are_built_here() {
         for built in [
             Overlay::Help,
             Overlay::CancelConfirmation,
             Overlay::RetryConfirmation,
             Overlay::ExtendEnvelope,
             Overlay::ReapConfirmation,
+            Overlay::RepoAddRemove,
+            Overlay::GroupEditRemove,
+            Overlay::RetainedPreview,
         ] {
             assert!(
                 built.owner().is_none(),
@@ -285,9 +302,6 @@ mod tests {
         for later in [
             Overlay::SlashPalette,
             Overlay::WorkflowChooser,
-            Overlay::RepoAddRemove,
-            Overlay::GroupEditRemove,
-            Overlay::RetainedPreview,
             Overlay::ConnectionDetail,
         ] {
             assert!(later.owner().is_some(), "{later:?} must name who builds it");

--- a/tests/estate_routes.rs
+++ b/tests/estate_routes.rs
@@ -1,0 +1,430 @@
+//! T-series T3 acceptance: the seven `/v1/estate/*`/`/v1/doctor` routes
+//! (`reference/proposal-tui-t-series.md` §16.2/§16.3) as thin daemon-side
+//! wrappers over `crate::domain::manifest`/`crate::cli::doctor` — never a
+//! second implementation of repo/group/doctor semantics.
+//!
+//! Same in-process daemon rig as `tests/m2_daemon_api.rs`/`tests/
+//! m6_surfaces.rs` (`daemon::start_with` + a real HTTP client over its
+//! loopback endpoint), plus a real git fixture the same way `tests/
+//! m8_estate_cli.rs` builds one for `sgt repo add`'s populate-or-verify.
+//!
+//! Every estate here uses the default `<estate_root>/.sergeant/data` layout
+//! — `src/api.rs`'s `resolve_estate_root` finds it by walking up from
+//! `data_dir` alone, with no dependency on the test process's own working
+//! directory (deliberately: `current_dir` is global process state, and nothing
+//! here needs to touch it).
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use sergeant_rs::api::ApiClient;
+use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "sergeant tests")
+        .env("GIT_AUTHOR_EMAIL", "tests@example.invalid")
+        .env("GIT_COMMITTER_NAME", "sergeant tests")
+        .env("GIT_COMMITTER_EMAIL", "tests@example.invalid")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn init_repo(path: &Path) {
+    std::fs::create_dir_all(path).expect("repo dir");
+    git(path, &["init", "-b", "main"]);
+    std::fs::write(path.join("README.md"), "# fixture\n").expect("write file");
+    git(path, &["add", "."]);
+    git(path, &["commit", "-m", "initial"]);
+}
+
+/// A bare `[estate]` manifest with no `[[repo]]` entries yet (the state a
+/// fresh `sgt init` leaves), with `data_dir` at the default nested path this
+/// daemon-rig can start straight off, and returns `(estate_root, data_dir)`.
+fn estate() -> (TempDir, std::path::PathBuf) {
+    let root = TempDir::new().expect("estate tempdir");
+    std::fs::write(
+        root.path().join("sergeant.toml"),
+        "[estate]\nname = \"t3-estate\"\n",
+    )
+    .expect("write sergeant.toml");
+    let data_dir = root.path().join(".sergeant/data");
+    std::fs::create_dir_all(&data_dir).expect("data dir");
+    (root, data_dir)
+}
+
+async fn start(data_dir: &Path) -> DaemonHandle {
+    daemon::start_with(data_dir, DaemonConfig::default())
+        .await
+        .expect("daemon start")
+}
+
+fn client_for(handle: &DaemonHandle) -> ApiClient {
+    ApiClient::new(&handle.endpoint, &handle.token).expect("client")
+}
+
+// -------------------------------------------------------------- repos
+
+#[tokio::test]
+async fn get_estate_repos_reflects_the_manifest_empty_then_populated() {
+    let (root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let empty = client.repos().await.expect("get repos");
+    assert_eq!(empty["repos"].as_array().expect("array").len(), 0);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    client
+        .add_repo("svc-a", Some(origin), None)
+        .await
+        .expect("add repo");
+
+    let repos = client.repos().await.expect("get repos again");
+    let list = repos["repos"].as_array().expect("array");
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["name"], "svc-a");
+    assert_eq!(list[0]["origin"], origin);
+    assert!(
+        root.path().join("repos/svc-a/.git").exists(),
+        "the real populate-or-verify clone must have actually run"
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn post_estate_repos_honors_the_instructions_choice() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    let result = client
+        .add_repo("svc-b", Some(origin), Some("local"))
+        .await
+        .expect("add repo");
+    assert_eq!(result["instructions"], "local");
+
+    let repos = client.repos().await.expect("get repos");
+    let list = repos["repos"].as_array().expect("array");
+    assert_eq!(list[0]["instructions"], "local");
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn post_estate_repos_refuses_a_duplicate_name_with_the_manifest_refusal() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    client
+        .add_repo("svc-a", Some(origin), None)
+        .await
+        .expect("first add");
+
+    let err = client
+        .add_repo("svc-a", Some(origin), None)
+        .await
+        .expect_err("a second add of the same name must be refused");
+    let text = err.to_string();
+    assert!(
+        text.contains("already declared"),
+        "the daemon's refusal must carry `manifest::add_repo`'s own wording, not a reworded \
+         one: {text}"
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn delete_estate_repos_removes_the_declaration_but_not_the_clone() {
+    let (root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    client
+        .add_repo("svc-a", Some(origin), None)
+        .await
+        .expect("add repo");
+
+    client.remove_repo("svc-a").await.expect("remove repo");
+
+    let repos = client.repos().await.expect("get repos");
+    assert_eq!(repos["repos"].as_array().expect("array").len(), 0);
+    assert!(
+        root.path().join("repos/svc-a/.git").exists(),
+        "§12.1: removing the estate declaration must never delete repos/<name> from disk"
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn delete_estate_repos_refuses_while_a_group_still_references_it() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    client
+        .add_repo("svc-a", Some(origin), None)
+        .await
+        .expect("add repo");
+    client
+        .add_group("core", &["svc-a".to_string()], None)
+        .await
+        .expect("add group");
+
+    let err = client
+        .remove_repo("svc-a")
+        .await
+        .expect_err("still referenced by a group");
+    let text = err.to_string();
+    assert!(
+        text.contains("core") && text.contains("still a member"),
+        "the group-reference refusal must name the referencing group and stay structured: \
+         {text}"
+    );
+
+    handle.shutdown().await;
+}
+
+// -------------------------------------------------------------- groups
+
+#[tokio::test]
+async fn post_estate_groups_creates_then_extends_by_union() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    for name in ["svc-a", "svc-b"] {
+        client
+            .add_repo(name, Some(origin), None)
+            .await
+            .expect("add repo");
+    }
+
+    let created = client
+        .add_group("core", &["svc-a".to_string()], Some("core services"))
+        .await
+        .expect("create group");
+    assert_eq!(created["repos"], serde_json::json!(["svc-a"]));
+
+    // mkdir-p semantics: a second `add_group` on the same name unions in the
+    // new member and leaves the existing one untouched, rather than erroring
+    // or replacing the membership outright.
+    let extended = client
+        .add_group("core", &["svc-b".to_string()], None)
+        .await
+        .expect("extend group");
+    let members: Vec<&str> = extended["repos"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|v| v.as_str().expect("str"))
+        .collect();
+    assert_eq!(members, vec!["svc-a", "svc-b"]);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn post_estate_groups_refuses_an_undeclared_member() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let err = client
+        .add_group("core", &["ghost".to_string()], None)
+        .await
+        .expect_err("ghost was never declared as a repository");
+    assert!(
+        err.to_string().contains("not a declared repository"),
+        "{err}"
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn get_estate_groups_reflects_the_manifest() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    client
+        .add_repo("svc-a", Some(origin), None)
+        .await
+        .expect("add repo");
+    client
+        .add_group("core", &["svc-a".to_string()], Some("core services"))
+        .await
+        .expect("add group");
+
+    let groups = client.groups().await.expect("get groups");
+    let list = groups["groups"].as_array().expect("array");
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["name"], "core");
+    assert_eq!(list[0]["brief"], "core services");
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn delete_estate_groups_with_named_repos_removes_only_those_members() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    for name in ["svc-a", "svc-b"] {
+        client
+            .add_repo(name, Some(origin), None)
+            .await
+            .expect("add repo");
+    }
+    client
+        .add_group("core", &["svc-a".to_string(), "svc-b".to_string()], None)
+        .await
+        .expect("add group");
+
+    client
+        .remove_group("core", &["svc-a".to_string()])
+        .await
+        .expect("remove one member");
+
+    let groups = client.groups().await.expect("get groups");
+    let list = groups["groups"].as_array().expect("array");
+    assert_eq!(
+        list.len(),
+        1,
+        "the group itself must survive a partial removal"
+    );
+    assert_eq!(list[0]["repos"], serde_json::json!(["svc-b"]));
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn delete_estate_groups_with_no_repos_removes_the_whole_group() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    client
+        .add_repo("svc-a", Some(origin), None)
+        .await
+        .expect("add repo");
+    client
+        .add_group("core", &["svc-a".to_string()], None)
+        .await
+        .expect("add group");
+
+    client
+        .remove_group("core", &[])
+        .await
+        .expect("remove the whole group");
+
+    let groups = client.groups().await.expect("get groups");
+    assert_eq!(groups["groups"].as_array().expect("array").len(), 0);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn delete_estate_groups_refuses_a_nonmember() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let source = TempDir::new().expect("source repo tempdir");
+    init_repo(source.path());
+    let origin = source.path().to_str().expect("utf8 path");
+    for name in ["svc-a", "svc-b"] {
+        client
+            .add_repo(name, Some(origin), None)
+            .await
+            .expect("add repo");
+    }
+    client
+        .add_group("core", &["svc-a".to_string()], None)
+        .await
+        .expect("add group");
+
+    let err = client
+        .remove_group("core", &["svc-b".to_string()])
+        .await
+        .expect_err("svc-b was never a member of core");
+    assert!(err.to_string().contains("not a member"), "{err}");
+
+    handle.shutdown().await;
+}
+
+// -------------------------------------------------------------- doctor
+
+#[tokio::test]
+async fn get_doctor_matches_the_shape_sgt_doctor_json_already_prints() {
+    let (_root, data_dir) = estate();
+    let handle = start(&data_dir).await;
+    let client = client_for(&handle);
+
+    let report = client.doctor().await.expect("get doctor report");
+    assert!(report["healthy"].is_boolean());
+    assert_eq!(
+        report["data_dir"],
+        Value::String(data_dir.display().to_string())
+    );
+    let checks = report["checks"].as_array().expect("checks array");
+    assert!(!checks.is_empty(), "a real report names at least one check");
+    for check in checks {
+        assert!(check["name"].is_string());
+        assert!(matches!(
+            check["status"].as_str(),
+            Some("ok" | "warn" | "fail")
+        ));
+        assert!(check["detail"].is_string());
+    }
+    let names: Vec<&str> = checks.iter().filter_map(|c| c["name"].as_str()).collect();
+    assert!(names.contains(&"estate"), "{names:?}");
+    assert!(names.contains(&"disk_pressure"), "{names:?}");
+
+    handle.shutdown().await;
+}

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -639,6 +639,133 @@ async fn t1c_extend_reaches_the_real_api_with_the_typed_turn_count() {
     handle.shutdown().await;
 }
 
+/// §12.1 end to end: the Add-repo form's real `POST /v1/estate/repos` —
+/// kicked off the render loop rather than awaited inline (the spinner/
+/// elapsed rule), per T3's own routes over `crate::domain::manifest::
+/// add_repo`. `App::poll_background` (called every loop tick in production,
+/// polled directly here) is what notices the clone finished and closes the
+/// overlay.
+#[tokio::test]
+async fn t3_estate_add_repo_reaches_the_real_api_off_the_render_loop() {
+    // The default `<estate_root>/.sergeant/data` layout — `src/api.rs`'s
+    // `resolve_estate_root` walks up from the daemon's own data dir to find
+    // it, so the daemon must actually be started on a data dir nested under
+    // a real `sergeant.toml`, not a bare tempdir.
+    let estate_root = TempDir::new().expect("tempdir");
+    std::fs::write(
+        estate_root.path().join("sergeant.toml"),
+        "[estate]\nname = \"t3-tui-estate\"\n",
+    )
+    .expect("write sergeant.toml");
+    let data_dir = estate_root.path().join(".sergeant/data");
+    std::fs::create_dir_all(&data_dir).expect("data dir");
+    let source = TempDir::new().expect("tempdir");
+    init_repo(source.path());
+
+    let (handle, _fake) = start_fake(&data_dir, []).await;
+    let client = client_for(&handle);
+
+    let mut app = App::new();
+    app.refresh(&client).await.expect("first read");
+
+    app.on_key(ratatui::crossterm::event::KeyCode::Esc); // leave Home's form focus first
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('4'));
+    assert_eq!(app.destination, Destination::Estate);
+    let opened = app.on_key(ratatui::crossterm::event::KeyCode::Char('a'));
+    assert_eq!(
+        opened,
+        Action::None,
+        "opening the form is local, not a mutation"
+    );
+
+    for c in "svc-a".chars() {
+        app.on_key(ratatui::crossterm::event::KeyCode::Char(c));
+    }
+    app.on_key(ratatui::crossterm::event::KeyCode::Tab); // -> origin
+    for c in source.path().to_str().expect("utf8 path").chars() {
+        app.on_key(ratatui::crossterm::event::KeyCode::Char(c));
+    }
+    app.on_key(ratatui::crossterm::event::KeyCode::Tab); // -> instructions
+    app.on_key(ratatui::crossterm::event::KeyCode::Tab); // -> confirm
+    let action = app.on_key(ratatui::crossterm::event::KeyCode::Enter);
+    assert_eq!(
+        action,
+        Action::AddRepo {
+            name: "svc-a".to_string(),
+            origin: Some(source.path().to_str().expect("utf8 path").to_string()),
+            instructions: None,
+        }
+    );
+
+    let outcome = app.execute(&client, action).await;
+    assert_eq!(
+        outcome,
+        Action::None,
+        "the clone runs off the render loop — execute must return immediately, not await it"
+    );
+    assert!(
+        app.overlay.is_some(),
+        "the overlay stays open showing the spinner until the background add finishes"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let needs_refresh = loop {
+        let needs_refresh = app.poll_background();
+        if app.estate.pending_repo_add.is_none() {
+            break needs_refresh;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the background add-repo task must finish and be noticed"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    };
+    assert!(
+        needs_refresh,
+        "a successful add must ask for a refresh: {}",
+        app.status
+    );
+    assert!(app.overlay.is_none(), "success closes the add-repo overlay");
+    assert!(app.status.contains("repo added"), "{}", app.status);
+
+    app.refresh(&client).await.expect("re-read after the add");
+    assert!(
+        app.estate.repos.iter().any(|r| r["name"] == "svc-a"),
+        "the real POST must have declared the repo, not just returned success: {:?}",
+        app.estate.repos
+    );
+
+    handle.shutdown().await;
+}
+
+/// §12.3: Health renders the real `GET /v1/doctor` report — status, check
+/// name, and detail per check, reached by navigating there through the
+/// keymap (Estate's own Tab cycles Repositories → Groups → Health) rather
+/// than poking internal state the TUI itself cannot reach any other way.
+#[tokio::test]
+async fn t3_estate_health_renders_the_real_doctor_report() {
+    let data = TempDir::new().expect("tempdir");
+    let (handle, _fake) = start_fake(data.path(), []).await;
+    let client = client_for(&handle);
+
+    let mut app = App::new();
+    app.on_key(ratatui::crossterm::event::KeyCode::Esc); // leave Home's form focus first
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('4'));
+    app.on_key(ratatui::crossterm::event::KeyCode::Tab); // Repositories -> Groups
+    app.on_key(ratatui::crossterm::event::KeyCode::Tab); // Groups -> Health
+    app.refresh(&client).await.expect("first read");
+
+    let terminal = render(&app);
+    assert_shows(&terminal, "git", "the doctor report's git check");
+    assert_shows(
+        &terminal,
+        "disk_pressure",
+        "the doctor report's disk_pressure check",
+    );
+
+    handle.shutdown().await;
+}
+
 /// Acceptance 1's structural half, stated for the TUI alone: the terminal UI
 /// reaches state through the API client and nothing else. (Acceptance 5
 /// applies the same rule to both clients at once; this is the §30 sentence


### PR DESCRIPTION
T3 per proposal §12/§16.2-16.3, dispatched as sgt Work 01M04FJTPM5XX3JDVJMHE4KE3Z (tdd, 2 turns), running in parallel with T2 against the same base.

Adds the 7 estate/doctor routes from the T2-14 ruling as thin wrappers over crate::domain::manifest and mod doctor (confirmed by reading estate_add_repo/estate_remove_repo/doctor_report directly -- they call the real functions, not reimplementations). Builds Repositories, Groups, and Health screens replacing T1a's Estate stub, with full lifecycle parity (not read-only) and reuse of existing refusal/remedy text. src/cli.rs's one-line change (mod doctor -> pub(crate) mod doctor) is the minimal necessary visibility fix so the new API handler can call it -- no logic change.

Verified independently: fmt/clippy clean, full suite green (428+ unit tests, 12 new dedicated route tests, 44 m6_surfaces tests including everything T1a/T1b/T1c pinned).