### PR TITLE
tui: wire the Workflows-screen half of the @ chooser (§15.4, closes #153)

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -406,6 +406,16 @@ impl App {
                     self.goto(Destination::Home);
                     Action::None
                 }
+                // §15.4's Workflows half (issue #153): `@` on the Workflows
+                // screen opens the same live-catalog chooser Home's
+                // workflow field opens — the overlay is `App`-level state,
+                // so `Workflows` only asks for it, exactly as `Home` does
+                // above.
+                WorkflowsOutcome::OpenWorkflowChooser => {
+                    self.workflow_chooser_index = 0;
+                    self.overlay = Some(Overlay::WorkflowChooser);
+                    Action::None
+                }
             },
             // §12: Tab/BackTab are Estate's own (sub-tab switching, guarded
             // out of `on_key_global` below) — everything else it does not
@@ -656,9 +666,14 @@ impl App {
                 }
                 Action::None
             }
-            // §15.4/§11.4's live-catalog chooser: j/k move the highlighted
-            // entry, Enter selects it onto Home's workflow field and closes,
-            // Esc/q aborts with the field untouched.
+            // §15.4/§11.4's live-catalog chooser, opened either from Home's
+            // workflow field or from the Workflows screen itself (issue
+            // #153): j/k move the highlighted entry, Esc/q aborts with
+            // nothing touched. Enter's destination depends on which screen
+            // asked for it — `self.destination` still names that screen,
+            // since opening the overlay never changes it: Home gets the
+            // pick onto its workflow field, Workflows moves its own
+            // selection onto the picked entry instead.
             Overlay::WorkflowChooser => {
                 let entries = self.workflows.entries.len();
                 match key.code {
@@ -672,13 +687,17 @@ impl App {
                         self.workflow_chooser_index = self.workflow_chooser_index.saturating_sub(1);
                     }
                     KeyCode::Enter => {
-                        if let Some(name) = self
+                        let picked = self
                             .workflows
                             .entries
                             .get(self.workflow_chooser_index)
                             .and_then(|e| e["name"].as_str())
-                        {
-                            self.home.workflow = name.to_string();
+                            .map(str::to_string);
+                        if let Some(name) = picked {
+                            match self.destination {
+                                Destination::Workflows => self.workflows.select_by_name(&name),
+                                _ => self.home.workflow = name,
+                            }
                         }
                         self.close_overlay();
                     }
@@ -1464,13 +1483,13 @@ mod tests {
         assert_eq!(app.home.workflow, "implement", "the field is untouched");
     }
 
-    /// The `@` filter field on the Workflows destination owns the keyboard
+    /// The `/` filter field on the Workflows destination owns the keyboard
     /// exactly like Home's and Fleet's own text fields — `2`/`4` etc. must
     /// not be hijacked as destination-nav while typing a filter.
     #[test]
-    fn workflows_at_sign_filter_owns_the_keyboard_like_any_other_text_field() {
+    fn workflows_slash_filter_owns_the_keyboard_like_any_other_text_field() {
         let mut app = app_with_workflows(&["implement", "diagnose-bug"]);
-        app.on_key(KeyCode::Char('@'));
+        app.on_key(KeyCode::Char('/'));
         app.on_key(KeyCode::Char('4')); // would otherwise jump to Estate
         assert_eq!(app.destination, Destination::Workflows);
         app.on_key(KeyCode::Esc);
@@ -1479,6 +1498,51 @@ mod tests {
             app.destination,
             Destination::Estate,
             "global nav works again once the filter is left"
+        );
+    }
+
+    /// §15.4's Workflows half (issue #153): `@` while focused on the
+    /// Workflows screen itself opens the same live-catalog chooser Home's
+    /// workflow field opens; Enter here moves this screen's own selection
+    /// onto the picked entry instead of touching Home's field (`Overlay::
+    /// WorkflowChooser`'s Enter arm tells the two contexts apart by
+    /// `self.destination`, which opening the overlay never changes).
+    #[test]
+    fn at_sign_on_workflows_opens_the_chooser_and_enter_selects_it() {
+        let mut app = app_with_workflows(&["implement", "diagnose-bug"]);
+        assert_eq!(app.on_key(KeyCode::Char('@')), Action::None);
+        assert_eq!(app.overlay, Some(Overlay::WorkflowChooser));
+
+        app.on_key(KeyCode::Char('j'));
+        assert_eq!(app.on_key(KeyCode::Enter), Action::None);
+        assert!(app.overlay.is_none(), "selecting closes the chooser");
+        assert_eq!(
+            app.destination,
+            Destination::Workflows,
+            "picking from Workflows stays on Workflows, unlike Home's field pick"
+        );
+        assert_eq!(
+            app.workflows.selected_entry().unwrap()["name"],
+            "diagnose-bug"
+        );
+        assert_eq!(
+            app.home.workflow, "",
+            "Home's own field is untouched by a pick made from Workflows"
+        );
+    }
+
+    /// Esc/q aborts the chooser without changing Workflows' own selection.
+    #[test]
+    fn esc_aborts_the_workflow_chooser_opened_from_workflows_without_changing_selection() {
+        let mut app = app_with_workflows(&["implement", "diagnose-bug"]);
+        app.on_key(KeyCode::Char('@'));
+        app.on_key(KeyCode::Char('j')); // highlight diagnose-bug in the chooser
+        assert_eq!(app.on_key(KeyCode::Esc), Action::None);
+        assert!(app.overlay.is_none());
+        assert_eq!(
+            app.workflows.selected_entry().unwrap()["name"],
+            "implement",
+            "the underlying selection is untouched"
         );
     }
 

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -74,8 +74,9 @@ impl Overlay {
             | Overlay::GroupEditRemove
             | Overlay::RetainedPreview => None,
             // §15.3 is explicitly out of T1c's scope (deferred alongside
-            // §15.4's Workflows half and §15.6) — not this Work, and not yet
-            // reassigned to a later one by name.
+            // §15.4's Workflows half, since closed by issue #153, and
+            // §15.6) — not this Work, and not yet reassigned to a later one
+            // by name.
             Overlay::SlashPalette => Some("a later Work (§15.3)"),
             Overlay::ConnectionDetail => Some("a later Work"),
         }
@@ -305,9 +306,11 @@ fn reap_body(app: &App) -> String {
     body
 }
 
-/// §15.4/§11.4: Home's `@` chooser over the live catalog `App::refresh`
-/// already loaded — no second query, just the same `app.workflows.entries`
-/// the Workflows destination itself reads.
+/// §15.4/§11.4: the `@` chooser, opened from either Home's workflow field
+/// or the Workflows screen itself (issue #153), over the live catalog
+/// `App::refresh` already loaded — no second query, just the same
+/// `app.workflows.entries` the Workflows destination itself reads, and one
+/// piece of content shared by both trigger contexts.
 fn workflow_chooser_body(app: &App) -> String {
     if app.workflows.entries.is_empty() {
         return "No workflows available (the catalog has not loaded, or is empty).\n\n\

--- a/src/tui/workflows.rs
+++ b/src/tui/workflows.rs
@@ -33,11 +33,18 @@ pub enum WorkflowsOutcome {
     /// field and switching destinations) — this screen only names the
     /// workflow.
     UseInNewWork(String),
+    /// §15.4/T2-56's Workflows half (issue #153): open the same live-catalog
+    /// chooser Home's workflow field already opens (`Overlay::
+    /// WorkflowChooser`, `App`-level state) — this screen only asks for it,
+    /// the same way `HomeOutcome::OpenWorkflowChooser` does.
+    OpenWorkflowChooser,
 }
 
 /// Workflows' own screen state: the catalog `App::refresh` last read, local
-/// selection, and the `@` filter (§15.4: "In Workflows, `@` focuses catalog
-/// selection").
+/// selection, and the `/` filter (mirrors Fleet's own local filter, §10.3).
+/// `@` is reserved for §15.4's live-catalog chooser
+/// (`WorkflowsOutcome::OpenWorkflowChooser`) rather than this local filter,
+/// matching Home's own `@` binding on its workflow field.
 #[derive(Debug, Default)]
 pub struct WorkflowsScreen {
     /// `GET /v1/workflows`'s `workflows[]`, verbatim (§11.2's CatalogEntry
@@ -53,7 +60,7 @@ pub struct WorkflowsScreen {
 }
 
 impl WorkflowsScreen {
-    /// Entries the current `@` filter admits: a case-insensitive substring
+    /// Entries the current `/` filter admits: a case-insensitive substring
     /// match on name, description, or any tag (mirrors Fleet's own local
     /// filter, §10.3).
     pub fn visible(&self) -> Vec<&Value> {
@@ -71,7 +78,22 @@ impl WorkflowsScreen {
         self.visible().into_iter().nth(self.selected)
     }
 
-    /// Whether the `@` filter field currently owns the keyboard — `App`
+    /// Move the local selection onto the catalog entry named `name`, if it
+    /// is currently visible — how `Overlay::WorkflowChooser`'s Enter (opened
+    /// via `WorkflowsOutcome::OpenWorkflowChooser`) hands its pick back to
+    /// this screen, mirroring how the same overlay hands its pick to Home's
+    /// workflow field.
+    pub fn select_by_name(&mut self, name: &str) {
+        if let Some(index) = self
+            .visible()
+            .iter()
+            .position(|e| e["name"].as_str() == Some(name))
+        {
+            self.selected = index;
+        }
+    }
+
+    /// Whether the `/` filter field currently owns the keyboard — `App`
     /// consults this before routing a keystroke to a global destination-nav
     /// key, exactly as Home and Fleet's own text fields already do.
     pub fn wants_text_focus(&self) -> bool {
@@ -130,7 +152,8 @@ impl WorkflowsScreen {
                 }
             }
             KeyCode::Up | KeyCode::Char('k') => self.selected = self.selected.saturating_sub(1),
-            KeyCode::Char('@') => self.filter_focus = true,
+            KeyCode::Char('/') => self.filter_focus = true,
+            KeyCode::Char('@') => return WorkflowsOutcome::OpenWorkflowChooser,
             KeyCode::Char('x') if !self.filter.is_empty() => {
                 self.filter.clear();
                 self.clamp();
@@ -195,10 +218,10 @@ fn render_list(frame: &mut Frame, area: Rect, screen: &WorkflowsScreen) {
     let [filter_area, list_area] =
         Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(inner);
     let filter_text = if screen.filter_focus {
-        format!("@{}_", screen.filter)
+        format!("/{}_", screen.filter)
     } else {
         format!(
-            "filter: {}  ('@' filter · 'u' use in new work)",
+            "filter: {}  ('/' filter · '@' chooser · 'u' use in new work)",
             if screen.filter.is_empty() {
                 "-"
             } else {
@@ -459,11 +482,11 @@ mod tests {
     }
 
     #[test]
-    fn at_sign_focuses_the_filter_and_typing_narrows_the_visible_list() {
+    fn slash_focuses_the_filter_and_typing_narrows_the_visible_list() {
         let mut screen = WorkflowsScreen::default();
         screen.set_entries(vec![entry("implement"), entry("diagnose-bug")]);
         assert!(!screen.wants_text_focus());
-        screen.on_key(KeyCode::Char('@'));
+        screen.on_key(KeyCode::Char('/'));
         assert!(screen.wants_text_focus());
         for c in "diag".chars() {
             screen.on_key(KeyCode::Char(c));
@@ -485,11 +508,45 @@ mod tests {
     fn a_filter_matching_nothing_leaves_no_selection() {
         let mut screen = WorkflowsScreen::default();
         screen.set_entries(vec![entry("implement")]);
-        screen.on_key(KeyCode::Char('@'));
+        screen.on_key(KeyCode::Char('/'));
         for c in "nope".chars() {
             screen.on_key(KeyCode::Char(c));
         }
         assert!(screen.selected_entry().is_none());
+    }
+
+    /// §15.4/T2-56's Workflows half (issue #153): `@` asks `App` to open the
+    /// live-catalog chooser rather than doing anything locally — it does not
+    /// touch the `/` filter or the current selection.
+    #[test]
+    fn at_sign_asks_to_open_the_workflow_chooser() {
+        let mut screen = WorkflowsScreen::default();
+        screen.set_entries(vec![entry("implement"), entry("diagnose-bug")]);
+        assert_eq!(
+            screen.on_key(KeyCode::Char('@')),
+            WorkflowsOutcome::OpenWorkflowChooser
+        );
+        assert!(
+            !screen.wants_text_focus(),
+            "no literal '@' opened the filter"
+        );
+        assert_eq!(screen.selected_entry().unwrap()["name"], "implement");
+    }
+
+    #[test]
+    fn select_by_name_moves_the_selection_to_the_named_entry() {
+        let mut screen = WorkflowsScreen::default();
+        screen.set_entries(vec![entry("implement"), entry("diagnose-bug")]);
+        screen.select_by_name("diagnose-bug");
+        assert_eq!(screen.selected_entry().unwrap()["name"], "diagnose-bug");
+    }
+
+    #[test]
+    fn select_by_name_with_an_unknown_name_leaves_the_selection_unchanged() {
+        let mut screen = WorkflowsScreen::default();
+        screen.set_entries(vec![entry("implement"), entry("diagnose-bug")]);
+        screen.select_by_name("does-not-exist");
+        assert_eq!(screen.selected_entry().unwrap()["name"], "implement");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `@` on the Workflows screen (`src/tui/workflows.rs`) now opens the same `Overlay::WorkflowChooser` overlay Home's workflow field already opens (`src/tui/app.rs`, `src/tui/overlay.rs`'s `workflow_chooser_body`) — no duplicated overlay content, just a second trigger context, per the issue's scope.
- Enter in the chooser now branches on `self.destination`: from Home it sets `home.workflow` (unchanged); from Workflows it moves the screen's own selection onto the picked entry via a new `WorkflowsScreen::select_by_name`.
- Workflows' pre-existing local substring filter (which was also bound to `@`, conflicting with the above) moves to `/`, matching the filter-key convention Fleet and the Evidence tab already use.

Closes #153 (§15.4 / Decision T2-56's Workflows half).

## Test plan
- [x] `cargo test --lib` (479 passed)
- [x] `cargo test --test m6_surfaces` (45 passed)
- [x] `cargo clippy --lib --all-targets` (clean)
- [x] `cargo fmt --check` (clean)
- [x] New unit tests mirroring `at_sign_on_homes_workflow_field_opens_the_chooser_and_enter_selects_it`: `at_sign_on_workflows_opens_the_chooser_and_enter_selects_it`, `esc_aborts_the_workflow_chooser_opened_from_workflows_without_changing_selection`, plus screen-level `at_sign_asks_to_open_the_workflow_chooser` and `select_by_name_*` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)