### PR TITLE
tui: wire the slash command palette (§15.3, closes #152)

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -16,8 +16,8 @@ use super::estate::{
 };
 use super::fleet::{FleetOutcome, FleetScreen, WorkRow, fleet_rows};
 use super::home::{HomeOutcome, NewWorkForm};
-use super::overlay::Overlay;
-use super::work_view::{WorkScreen, WorkScreenOutcome};
+use super::overlay::{Overlay, SlashCommand};
+use super::work_view::{Tab, WorkScreen, WorkScreenOutcome};
 use super::workflows::{WorkflowsOutcome, WorkflowsScreen};
 
 /// §7.1's top-level destinations, in their displayed order.
@@ -181,6 +181,10 @@ pub struct App {
     /// request field"). Reset whenever the overlay opens or closes, the same
     /// as `pending_action` above.
     pub workflow_chooser_index: usize,
+    /// [`Overlay::SlashPalette`]'s own live state: which [`SlashCommand`] is
+    /// highlighted (§15.3) — reset to `0` every time the palette opens, the
+    /// same as `workflow_chooser_index` above.
+    pub slash_palette_index: usize,
     /// Whether the global Attention drawer is showing (§7.3: opens by
     /// default at Wide; `~` toggles it at any tier).
     pub drawer_open: bool,
@@ -212,6 +216,7 @@ impl App {
             estate: EstateScreen::default(),
             retained_reap_id: None,
             workflow_chooser_index: 0,
+            slash_palette_index: 0,
             drawer_open: true,
             system: Value::default(),
             last_seq: 0,
@@ -390,6 +395,13 @@ impl App {
                     self.overlay = Some(Overlay::WorkflowChooser);
                     Action::None
                 }
+                // §15.3: `/` at the first non-whitespace position of the
+                // INTENT composer, same wiring shape as `@`'s chooser above.
+                HomeOutcome::OpenSlashPalette => {
+                    self.slash_palette_index = 0;
+                    self.overlay = Some(Overlay::SlashPalette);
+                    Action::None
+                }
             },
             Destination::Fleet => match self.fleet.on_key(key.code, &self.rows) {
                 FleetOutcome::None => Action::None,
@@ -480,6 +492,100 @@ impl App {
         self.overlay = None;
         self.pending_action = PendingAction::default();
         self.retained_reap_id = None;
+    }
+
+    /// §15.3's fixed vocabulary, run: the palette closes unconditionally —
+    /// Enter is the deliberate choice — and each command either changes
+    /// state directly or opens the exact overlay/composer its keyboard
+    /// mnemonic already does (§13.10's `r`/`c`/`t`/`e`/`p`, `?`, `q`), so
+    /// durable/destructive actions still land on their own confirmation
+    /// rather than skipping it (§15.5).
+    fn run_slash_command(&mut self, command: SlashCommand) -> Action {
+        self.overlay = None;
+        match command {
+            SlashCommand::Home => self.leave_open_work_and_goto(Destination::Home),
+            SlashCommand::Fleet => self.leave_open_work_and_goto(Destination::Fleet),
+            SlashCommand::Workflows => self.leave_open_work_and_goto(Destination::Workflows),
+            SlashCommand::Estate => self.leave_open_work_and_goto(Destination::Estate),
+            // §15.6's "q / Esc: back": leaves the open Work, same as Esc
+            // there — with none open there is nowhere to go back to.
+            SlashCommand::Back => {
+                if self.open_work.is_some() {
+                    self.open_work = None;
+                    self.work_screen = None;
+                }
+            }
+            SlashCommand::Refresh => return Action::Refresh,
+            SlashCommand::Retained => return Action::LoadRetained,
+            SlashCommand::Help => self.overlay = Some(Overlay::Help),
+            SlashCommand::Quit => {
+                self.quit = true;
+                return Action::Quit;
+            }
+            // §13.10's respond mnemonic (`r`), gated the same way: the
+            // composer only gains focus where the action matrix offers it.
+            SlashCommand::Answer => {
+                if self.work_action_available("respond")
+                    && let Some(screen) = self.work_screen.as_mut()
+                {
+                    screen.focus_answer();
+                }
+            }
+            // Durable/destructive per §15.5: this only ever opens the same
+            // confirmation the mnemonic key does — the mutation itself
+            // still waits on that overlay's own deliberate Confirm.
+            SlashCommand::Cancel => self.open_action_confirmation("cancel", Overlay::CancelConfirmation),
+            SlashCommand::Retry => self.open_action_confirmation("retry", Overlay::RetryConfirmation),
+            SlashCommand::Extend => self.open_action_confirmation("extend", Overlay::ExtendEnvelope),
+            SlashCommand::Reap => self.open_action_confirmation("reap", Overlay::ReapConfirmation),
+            SlashCommand::Evidence => self.show_work_tab(Tab::Evidence),
+            SlashCommand::Graph => self.show_work_tab(Tab::Graph),
+            SlashCommand::Details => self.show_work_tab(Tab::Details),
+            // No TUI destination reads the daemon's `/v1/analytics` routes
+            // yet (§16.1 lists the client method as a later addition) — said
+            // plainly rather than pretending a screen exists.
+            SlashCommand::Analytics => {
+                self.status = "/analytics is not built in this Work yet".to_string();
+            }
+        }
+        Action::None
+    }
+
+    /// §15.3's Home/Fleet/Workflows/Estate commands: an open Work has no
+    /// meaning once the destination underneath it changes, so it closes
+    /// first — the same effect `/back` has on its own.
+    fn leave_open_work_and_goto(&mut self, destination: Destination) {
+        self.open_work = None;
+        self.work_screen = None;
+        self.goto(destination);
+    }
+
+    /// Whether `action` is legal for the currently open Work's reported
+    /// state (§13.10) — `false` with no Work open, so every gated slash
+    /// command is a quiet no-op outside a canonical Work surface.
+    fn work_action_available(&self, action: &str) -> bool {
+        self.work_screen
+            .as_ref()
+            .is_some_and(|screen| screen.action_available(action))
+    }
+
+    /// §15.3's cancel/retry/extend/reap commands: open the same confirmation
+    /// overlay the mnemonic key does, only where the action matrix offers
+    /// it — otherwise a no-op, exactly like the mnemonic key itself.
+    fn open_action_confirmation(&mut self, action: &str, overlay: Overlay) {
+        if self.work_action_available(action) {
+            self.pending_action = PendingAction::default();
+            self.overlay = Some(overlay);
+        }
+    }
+
+    /// §15.3's evidence/graph/details commands: switch the open Work's tab,
+    /// the same effect the `3`/`4`/`5` digit keys have — a no-op with no
+    /// Work open.
+    fn show_work_tab(&mut self, tab: Tab) {
+        if let Some(screen) = self.work_screen.as_mut() {
+            screen.show_tab(tab);
+        }
     }
 
     fn on_key_overlay(&mut self, key: KeyEvent) -> Action {
@@ -686,13 +792,36 @@ impl App {
                 }
                 Action::None
             }
+            // §15.3's fixed vocabulary picker: j/k move the highlighted
+            // command, Enter runs it (`run_slash_command`, which closes the
+            // palette itself), Esc/q aborts with nothing run — the same
+            // shape as `Overlay::WorkflowChooser` above.
+            Overlay::SlashPalette => {
+                let len = SlashCommand::ALL.len();
+                match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => self.close_overlay(),
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if self.slash_palette_index + 1 < len {
+                            self.slash_palette_index += 1;
+                        }
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        self.slash_palette_index = self.slash_palette_index.saturating_sub(1);
+                    }
+                    KeyCode::Enter => {
+                        return self.run_slash_command(SlashCommand::ALL[self.slash_palette_index]);
+                    }
+                    _ => {}
+                }
+                Action::None
+            }
             // Every overlay still owned by a later Work (§7.4's note) plus
             // Help (content-built at T1a, but generic close-only controls
             // are all it ever needs): the mechanism this Work built at
             // T1a — open, close, restore focus for free. RepoAddRemove,
             // GroupEditRemove, and RetainedPreview have their own real arms
             // above (T3); WorkflowChooser has its own real arm above (T2).
-            Overlay::Help | Overlay::SlashPalette | Overlay::ConnectionDetail => {
+            Overlay::Help | Overlay::ConnectionDetail => {
                 match key.code {
                     KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => self.overlay = None,
                     _ => {}
@@ -754,6 +883,14 @@ impl App {
             WorkScreenOutcome::OpenReapConfirm => {
                 self.pending_action = PendingAction::default();
                 self.overlay = Some(Overlay::ReapConfirmation);
+                Action::None
+            }
+            // §15.3: `/` at the first non-whitespace position of the
+            // ANSWER composer, same wiring shape as the four confirmations
+            // above.
+            WorkScreenOutcome::OpenSlashPalette => {
+                self.slash_palette_index = 0;
+                self.overlay = Some(Overlay::SlashPalette);
                 Action::None
             }
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -507,8 +507,11 @@ impl App {
             SlashCommand::Fleet => self.leave_open_work_and_goto(Destination::Fleet),
             SlashCommand::Workflows => self.leave_open_work_and_goto(Destination::Workflows),
             SlashCommand::Estate => self.leave_open_work_and_goto(Destination::Estate),
-            // §15.6's "q / Esc: back": leaves the open Work, same as Esc
-            // there — with none open there is nowhere to go back to.
+            // §15.6's "q / Esc: back": leaves the open Work, the same
+            // effect Esc has there. Unlike Esc/q, this does not also quit
+            // from a top-level destination — `/quit` already names that
+            // outright, so with no Work open this is a deliberate no-op
+            // rather than an exit hidden behind a menu pick.
             SlashCommand::Back => {
                 if self.open_work.is_some() {
                     self.open_work = None;
@@ -516,6 +519,12 @@ impl App {
                 }
             }
             SlashCommand::Refresh => return Action::Refresh,
+            // §12.4's Retained preview: the `r` mnemonic only surfaces this
+            // from Estate/Health with the `disk_pressure` check selected,
+            // but the read itself (`GET /v1/retained`) is estate-wide, so
+            // the palette reaches it from anywhere, same as /evidence,
+            // /graph, and /details reach their tabs outside the mnemonic's
+            // own digit-key context.
             SlashCommand::Retained => return Action::LoadRetained,
             SlashCommand::Help => self.overlay = Some(Overlay::Help),
             SlashCommand::Quit => {
@@ -534,9 +543,15 @@ impl App {
             // Durable/destructive per §15.5: this only ever opens the same
             // confirmation the mnemonic key does — the mutation itself
             // still waits on that overlay's own deliberate Confirm.
-            SlashCommand::Cancel => self.open_action_confirmation("cancel", Overlay::CancelConfirmation),
-            SlashCommand::Retry => self.open_action_confirmation("retry", Overlay::RetryConfirmation),
-            SlashCommand::Extend => self.open_action_confirmation("extend", Overlay::ExtendEnvelope),
+            SlashCommand::Cancel => {
+                self.open_action_confirmation("cancel", Overlay::CancelConfirmation)
+            }
+            SlashCommand::Retry => {
+                self.open_action_confirmation("retry", Overlay::RetryConfirmation)
+            }
+            SlashCommand::Extend => {
+                self.open_action_confirmation("extend", Overlay::ExtendEnvelope)
+            }
             SlashCommand::Reap => self.open_action_confirmation("reap", Overlay::ReapConfirmation),
             SlashCommand::Evidence => self.show_work_tab(Tab::Evidence),
             SlashCommand::Graph => self.show_work_tab(Tab::Graph),
@@ -616,12 +631,13 @@ impl App {
             }
             // Same fixed controls as above, but the Work id can come from
             // either an open Work surface (§13.10) or §12.4's Retained
-            // preview — [`App::retained_reap_id`] is Estate's own source, so
-            // this stays the one Reap implementation either way.
+            // preview — [`App::retained_reap_id`] is Estate's own source,
+            // and takes precedence over an open Work when both are present,
+            // so this stays the one Reap implementation either way.
             Overlay::ReapConfirmation => {
                 match key.code {
                     KeyCode::Esc | KeyCode::Char('q') => {
-                        if self.open_work_id().is_none() && self.retained_reap_id.is_some() {
+                        if self.retained_reap_id.is_some() {
                             self.overlay = Some(Overlay::RetainedPreview);
                             self.pending_action = PendingAction::default();
                             self.retained_reap_id = None;
@@ -630,9 +646,17 @@ impl App {
                         }
                     }
                     KeyCode::Enter => {
+                        // `retained_reap_id` is the explicit selection made
+                        // inside §12.4's Retained preview, so it takes
+                        // precedence over an open Work — `/retained`
+                        // (§15.3) can now reach this preview with a Work
+                        // open, and reaping must target what the user
+                        // actually picked there, not whatever Work happens
+                        // to be open underneath.
                         let Some(id) = self
-                            .open_work_id()
-                            .or_else(|| self.retained_reap_id.clone())
+                            .retained_reap_id
+                            .clone()
+                            .or_else(|| self.open_work_id())
                         else {
                             self.close_overlay();
                             return Action::None;
@@ -799,7 +823,7 @@ impl App {
             Overlay::SlashPalette => {
                 let len = SlashCommand::ALL.len();
                 match key.code {
-                    KeyCode::Esc | KeyCode::Char('q') => self.close_overlay(),
+                    KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => self.close_overlay(),
                     KeyCode::Down | KeyCode::Char('j') => {
                         if self.slash_palette_index + 1 < len {
                             self.slash_palette_index += 1;

--- a/src/tui/composer.rs
+++ b/src/tui/composer.rs
@@ -76,18 +76,14 @@ impl Composer {
         ComposerOutcome::None
     }
 
-    /// §15.3's trigger condition (Decision T2-55): every line above the
-    /// cursor, and every character on the cursor's own line up to the
-    /// cursor, is blank — so a `/` typed here can only be the start of a
-    /// command, never a character inside typed text.
+    /// §15.3's trigger condition (Decision T2-55): the whole draft is
+    /// blank — every line, not just the ones up to the cursor — so a `/`
+    /// typed here can only become the draft's first non-whitespace
+    /// character, never a character inserted ahead of text that's already
+    /// there (e.g. after moving the cursor back to column 0 on a
+    /// non-blank line).
     fn at_first_nonwhitespace(&self) -> bool {
-        let cursor = self.area.cursor();
-        let lines = self.area.lines();
-        lines[..cursor.0].iter().all(|line| line.trim().is_empty())
-            && lines[cursor.0]
-                .chars()
-                .take(cursor.1)
-                .all(char::is_whitespace)
+        self.area.lines().iter().all(|line| line.trim().is_empty())
     }
 
     /// Ask to submit the current draft outright — the Tab-to-Send-then-Enter
@@ -240,7 +236,10 @@ mod tests {
     fn slash_elsewhere_in_the_draft_stays_literal_text() {
         let mut composer = Composer::new();
         for c in "fix the /path".chars() {
-            assert_eq!(composer.on_key(key(KeyCode::Char(c))), ComposerOutcome::None);
+            assert_eq!(
+                composer.on_key(key(KeyCode::Char(c))),
+                ComposerOutcome::None
+            );
         }
         assert_eq!(composer.text(), "fix the /path");
     }

--- a/src/tui/composer.rs
+++ b/src/tui/composer.rs
@@ -28,6 +28,10 @@ pub enum ComposerOutcome {
     /// A submit was asked for with nothing but whitespace in the draft
     /// (§15.2: "blank input is refused").
     Refused,
+    /// §15.3's Decision T2-55: `/` was typed at the first non-whitespace
+    /// position of the draft — the caller opens `Overlay::SlashPalette`
+    /// instead of this composer taking the character as text.
+    OpenSlashPalette,
 }
 
 /// The deliberate multiline composer: Home's `INTENT` field and an open
@@ -57,15 +61,33 @@ impl Composer {
     }
 
     /// One keystroke (§15.2). `Ctrl+Enter` asks to submit rather than
-    /// inserting a newline; every other key — including plain `Enter`, which
-    /// the crate itself maps to a newline — is forwarded to the editor
-    /// untouched.
+    /// inserting a newline; `/` at the first non-whitespace position asks to
+    /// open the slash palette rather than being inserted (§15.3); every
+    /// other key — including plain `Enter`, which the crate itself maps to a
+    /// newline — is forwarded to the editor untouched.
     pub fn on_key(&mut self, key: KeyEvent) -> ComposerOutcome {
         if key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::CONTROL) {
             return self.submit();
         }
+        if key.code == KeyCode::Char('/') && self.at_first_nonwhitespace() {
+            return ComposerOutcome::OpenSlashPalette;
+        }
         self.area.input(key);
         ComposerOutcome::None
+    }
+
+    /// §15.3's trigger condition (Decision T2-55): every line above the
+    /// cursor, and every character on the cursor's own line up to the
+    /// cursor, is blank — so a `/` typed here can only be the start of a
+    /// command, never a character inside typed text.
+    fn at_first_nonwhitespace(&self) -> bool {
+        let cursor = self.area.cursor();
+        let lines = self.area.lines();
+        lines[..cursor.0].iter().all(|line| line.trim().is_empty())
+            && lines[cursor.0]
+                .chars()
+                .take(cursor.1)
+                .all(char::is_whitespace)
     }
 
     /// Ask to submit the current draft outright — the Tab-to-Send-then-Enter
@@ -188,6 +210,66 @@ mod tests {
             composer.on_key(ctrl_enter()),
             ComposerOutcome::Refused,
             "whitespace-only is still blank"
+        );
+    }
+
+    #[test]
+    fn slash_on_an_empty_draft_opens_the_palette_instead_of_being_typed() {
+        let mut composer = Composer::new();
+        assert_eq!(
+            composer.on_key(key(KeyCode::Char('/'))),
+            ComposerOutcome::OpenSlashPalette
+        );
+        assert_eq!(composer.text(), "", "the '/' must not have been inserted");
+    }
+
+    #[test]
+    fn slash_after_leading_whitespace_still_opens_the_palette() {
+        let mut composer = Composer::new();
+        for c in "   ".chars() {
+            composer.on_key(key(KeyCode::Char(c)));
+        }
+        assert_eq!(
+            composer.on_key(key(KeyCode::Char('/'))),
+            ComposerOutcome::OpenSlashPalette
+        );
+        assert_eq!(composer.text(), "   ", "leading whitespace is untouched");
+    }
+
+    #[test]
+    fn slash_elsewhere_in_the_draft_stays_literal_text() {
+        let mut composer = Composer::new();
+        for c in "fix the /path".chars() {
+            assert_eq!(composer.on_key(key(KeyCode::Char(c))), ComposerOutcome::None);
+        }
+        assert_eq!(composer.text(), "fix the /path");
+    }
+
+    #[test]
+    fn slash_on_a_later_line_is_literal_when_the_first_line_has_content() {
+        let mut composer = Composer::new();
+        for c in "first".chars() {
+            composer.on_key(key(KeyCode::Char(c)));
+        }
+        composer.on_key(key(KeyCode::Enter));
+        assert_eq!(
+            composer.on_key(key(KeyCode::Char('/'))),
+            ComposerOutcome::None,
+            "an earlier nonblank line means this is not the first non-whitespace \
+             position of the draft"
+        );
+        assert_eq!(composer.text(), "first\n/");
+    }
+
+    #[test]
+    fn slash_at_the_start_of_a_blank_second_line_still_opens_the_palette() {
+        let mut composer = Composer::new();
+        composer.on_key(key(KeyCode::Enter));
+        assert_eq!(
+            composer.on_key(key(KeyCode::Char('/'))),
+            ComposerOutcome::OpenSlashPalette,
+            "every line above the cursor is blank, so this is still the draft's \
+             first non-whitespace position"
         );
     }
 

--- a/src/tui/geometry_matrix_tests.rs
+++ b/src/tui/geometry_matrix_tests.rs
@@ -577,19 +577,13 @@ fn geometry_palette_chooser_and_confirmations() {
         );
     }
 
-    // §15.3's slash palette: T1c deferred it and no later T-series Work
-    // (T2, T3, this one) has claimed it — real gap, not silently dropped
-    // (see this Work's commit message). Rendered here anyway so the fixed
-    // placeholder every unbuilt overlay falls back to is still proven at
-    // every size, rather than skipped because the feature is missing.
+    // §15.3's slash palette (Decision T2-55): the fixed vocabulary renders
+    // for real, the same shape as the chooser/repo/group panels above.
     let mut palette = App::new();
     palette.overlay = Some(Overlay::SlashPalette);
     for (w, h) in SIZES {
         let text = text_of(&draw_at(&palette, w, h));
-        assert!(
-            text.contains("not built in this Work"),
-            "slash palette placeholder at {w}x{h}: {text}"
-        );
+        assert!(text.contains("/home"), "palette at {w}x{h}: {text}");
     }
 }
 

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -75,6 +75,10 @@ pub enum HomeOutcome {
     /// field, this opens the live-catalog chooser (`Overlay::WorkflowChooser`,
     /// App-level state) instead of typing a literal `@`.
     OpenWorkflowChooser,
+    /// §15.3: `/` at the first non-whitespace position of the `INTENT`
+    /// composer opens `Overlay::SlashPalette` (App-level state) instead of
+    /// being typed literally.
+    OpenSlashPalette,
 }
 
 /// §9.1's New Work fields. §15.1's `INTENT` context: the intent field is
@@ -157,6 +161,7 @@ impl NewWorkForm {
             // exactly as reaching `[ Run Work ]` by Tab and Enter would.
             return match self.intent.on_key(key) {
                 ComposerOutcome::Submit(_) | ComposerOutcome::Refused => self.try_submit(),
+                ComposerOutcome::OpenSlashPalette => HomeOutcome::OpenSlashPalette,
                 ComposerOutcome::None => HomeOutcome::None,
             };
         }
@@ -606,6 +611,29 @@ mod tests {
             HomeOutcome::OpenWorkflowChooser
         );
         assert_eq!(form.workflow, "", "no literal '@' was typed into the field");
+    }
+
+    /// §15.3: `/` at the start of the still-empty `INTENT` composer asks
+    /// `App` to open the slash palette rather than being typed literally.
+    #[test]
+    fn slash_on_the_intent_field_asks_to_open_the_slash_palette() {
+        let mut form = NewWorkForm::default();
+        assert_eq!(
+            form.on_key(KeyCode::Char('/')),
+            HomeOutcome::OpenSlashPalette
+        );
+        assert_eq!(form.intent.text(), "", "no literal '/' was typed");
+    }
+
+    /// `/` typed into the intent field after other content is still
+    /// ordinary text — only the first non-whitespace position triggers it.
+    #[test]
+    fn slash_after_other_intent_text_is_ordinary_text() {
+        let mut form = NewWorkForm::default();
+        for c in "fix /path".chars() {
+            form.on_key(KeyCode::Char(c));
+        }
+        assert_eq!(form.intent.text(), "fix /path");
     }
 
     /// `@` typed into any other field is still ordinary text — only the

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -3,13 +3,15 @@
 //!
 //! The *mechanism* — how one opens, closes, and restores focus — is T1a's
 //! job; T1c fills in the four real confirmations respond/retry/extend/
-//! cancel need (§13.10/§15.5). What is left for later Works: the workflow
-//! chooser (T2's catalog), repo/group add-remove and the retained-state
-//! preview (T3's Estate routes), and the slash palette (§15.3, explicitly
-//! out of T1c's scope). Opening an overlay never mutates the destination
-//! state underneath it — [`super::app::App::on_key`] simply routes every
-//! keystroke to the overlay instead of the destination while one is open —
-//! so closing it "restores focus" for free: nothing under it ever moved.
+//! cancel need (§13.10/§15.5). T2 and T3 fill in the workflow chooser and
+//! the repo/group/retained-state panels respectively. The T-series follow-up
+//! fills in the last named gap, the slash palette (§15.3's Decision T2-55,
+//! `Overlay::SlashPalette`) — [`SlashCommand`]'s fixed vocabulary as a Rust
+//! enum and match, not a shell or plugin language. Opening an overlay never
+//! mutates the destination state underneath it — [`super::app::App::on_key`]
+//! simply routes every keystroke to the overlay instead of the destination
+//! while one is open — so closing it "restores focus" for free: nothing
+//! under it ever moved.
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
@@ -60,8 +62,9 @@ impl Overlay {
     /// The later Work that actually implements this overlay's content —
     /// `None` for the ones already built: [`Overlay::Help`] (T1a), T1c's
     /// four real confirmations (§13.10/§15.5), T2's live-catalog
-    /// [`Overlay::WorkflowChooser`] (§11.4, §15.4), and T3's three Estate
-    /// panels (§12.1/§12.2/§12.4).
+    /// [`Overlay::WorkflowChooser`] (§11.4, §15.4), T3's three Estate panels
+    /// (§12.1/§12.2/§12.4), and the T-series follow-up's
+    /// [`Overlay::SlashPalette`] (§15.3).
     fn owner(self) -> Option<&'static str> {
         match self {
             Overlay::Help
@@ -72,12 +75,108 @@ impl Overlay {
             | Overlay::WorkflowChooser
             | Overlay::RepoAddRemove
             | Overlay::GroupEditRemove
-            | Overlay::RetainedPreview => None,
-            // §15.3 is explicitly out of T1c's scope (deferred alongside
-            // §15.4's Workflows half and §15.6) — not this Work, and not yet
-            // reassigned to a later one by name.
-            Overlay::SlashPalette => Some("a later Work (§15.3)"),
+            | Overlay::RetainedPreview
+            | Overlay::SlashPalette => None,
             Overlay::ConnectionDetail => Some("a later Work"),
+        }
+    }
+}
+
+/// §15.3's fixed vocabulary (Decision T2-55): a Rust enum and match, not a
+/// shell or plugin language. [`SlashCommand::ALL`] is the palette's whole
+/// content, in the order the proposal lists it — explicitly *not*
+/// `/interrupt`, `/files`, `/web`, `/watch`, `/daemon`, `/init`, `/claude`,
+/// `/codex`, `/opencode`, or `/goose`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashCommand {
+    Home,
+    Fleet,
+    Workflows,
+    Estate,
+    Back,
+    Refresh,
+    Answer,
+    Retry,
+    Extend,
+    Cancel,
+    Evidence,
+    Graph,
+    Details,
+    Analytics,
+    Retained,
+    Reap,
+    Help,
+    Quit,
+}
+
+impl SlashCommand {
+    pub const ALL: [SlashCommand; 18] = [
+        SlashCommand::Home,
+        SlashCommand::Fleet,
+        SlashCommand::Workflows,
+        SlashCommand::Estate,
+        SlashCommand::Back,
+        SlashCommand::Refresh,
+        SlashCommand::Answer,
+        SlashCommand::Retry,
+        SlashCommand::Extend,
+        SlashCommand::Cancel,
+        SlashCommand::Evidence,
+        SlashCommand::Graph,
+        SlashCommand::Details,
+        SlashCommand::Analytics,
+        SlashCommand::Retained,
+        SlashCommand::Reap,
+        SlashCommand::Help,
+        SlashCommand::Quit,
+    ];
+
+    /// The literal `/word` §15.3 lists for this command.
+    pub fn word(self) -> &'static str {
+        match self {
+            SlashCommand::Home => "/home",
+            SlashCommand::Fleet => "/fleet",
+            SlashCommand::Workflows => "/workflows",
+            SlashCommand::Estate => "/estate",
+            SlashCommand::Back => "/back",
+            SlashCommand::Refresh => "/refresh",
+            SlashCommand::Answer => "/answer",
+            SlashCommand::Retry => "/retry",
+            SlashCommand::Extend => "/extend",
+            SlashCommand::Cancel => "/cancel",
+            SlashCommand::Evidence => "/evidence",
+            SlashCommand::Graph => "/graph",
+            SlashCommand::Details => "/details",
+            SlashCommand::Analytics => "/analytics",
+            SlashCommand::Retained => "/retained",
+            SlashCommand::Reap => "/reap",
+            SlashCommand::Help => "/help",
+            SlashCommand::Quit => "/quit",
+        }
+    }
+
+    /// One line of what selecting this command does — the palette is
+    /// self-documenting rather than requiring a second lookup in `?` help.
+    fn description(self) -> &'static str {
+        match self {
+            SlashCommand::Home => "go to Home",
+            SlashCommand::Fleet => "go to Fleet",
+            SlashCommand::Workflows => "go to Workflows",
+            SlashCommand::Estate => "go to Estate",
+            SlashCommand::Back => "leave the open Work",
+            SlashCommand::Refresh => "re-read the API now",
+            SlashCommand::Answer => "focus ANSWER (where respond is offered)",
+            SlashCommand::Retry => "open the retry confirmation (where offered)",
+            SlashCommand::Extend => "open the extend confirmation (where offered)",
+            SlashCommand::Cancel => "open the cancel confirmation (where offered)",
+            SlashCommand::Evidence => "open Work: Evidence tab",
+            SlashCommand::Graph => "open Work: Graph tab",
+            SlashCommand::Details => "open Work: Details tab",
+            SlashCommand::Analytics => "not built in this Work yet",
+            SlashCommand::Retained => "estate-wide retained-state preview",
+            SlashCommand::Reap => "open the reap confirmation (where offered)",
+            SlashCommand::Help => "this help",
+            SlashCommand::Quit => "leave the TUI",
         }
     }
 }
@@ -89,6 +188,7 @@ Navigation
   1-4         Home / Fleet / Workflows / Estate
   Tab / S-Tab cycle destinations
   ~           toggle the Attention drawer
+  /           slash command palette (INTENT/ANSWER, first non-whitespace)
   ?           this help
   q / Esc     back, or quit from a top-level destination
 
@@ -147,6 +247,7 @@ pub fn render(frame: &mut Frame, area: Rect, overlay: Overlay, app: &App) {
         Overlay::GroupEditRemove => group_form_body(&app.estate.group_form),
         Overlay::RetainedPreview => retained_body(&app.estate),
         Overlay::WorkflowChooser => workflow_chooser_body(app),
+        Overlay::SlashPalette => slash_palette_body(app),
         _ => format!(
             "{} is not built in this Work.\n\n{} implements it.\n\nEsc closes this panel.",
             overlay.title(),
@@ -327,6 +428,26 @@ fn workflow_chooser_body(app: &App) -> String {
     lines.join("\n")
 }
 
+/// §15.3's fixed vocabulary, one line per [`SlashCommand`] in
+/// [`SlashCommand::ALL`]'s order, with the highlighted entry marked exactly
+/// like [`workflow_chooser_body`] above.
+fn slash_palette_body(app: &App) -> String {
+    let mut lines = vec!["j/k move · Enter selects · Esc/q aborts\n".to_string()];
+    for (i, command) in SlashCommand::ALL.into_iter().enumerate() {
+        let marker = if i == app.slash_palette_index {
+            "▶ "
+        } else {
+            "  "
+        };
+        lines.push(format!(
+            "{marker}{:<12}{}",
+            command.word(),
+            command.description()
+        ));
+    }
+    lines.join("\n")
+}
+
 /// A `percent_x` × `percent_y` box, centered in `area`.
 fn centered(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
     let [area] = Layout::vertical([Constraint::Percentage(percent_y)])
@@ -344,7 +465,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn help_t1c_t2_and_t3_panels_are_built_here() {
+    fn help_t1c_t2_t3_and_the_slash_palette_are_built_here() {
         for built in [
             Overlay::Help,
             Overlay::CancelConfirmation,
@@ -355,15 +476,75 @@ mod tests {
             Overlay::RepoAddRemove,
             Overlay::GroupEditRemove,
             Overlay::RetainedPreview,
+            Overlay::SlashPalette,
         ] {
             assert!(
                 built.owner().is_none(),
                 "{built:?} must be built in this Work"
             );
         }
-        for later in [Overlay::SlashPalette, Overlay::ConnectionDetail] {
-            assert!(later.owner().is_some(), "{later:?} must name who builds it");
+        let later = Overlay::ConnectionDetail;
+        assert!(later.owner().is_some(), "{later:?} must name who builds it");
+    }
+
+    /// §15.3's exact vocabulary (Decision T2-55) — no more, no fewer, and
+    /// never one of the names §15.3 explicitly excludes.
+    #[test]
+    fn the_slash_vocabulary_is_exactly_15_3s_fixed_list() {
+        let words: Vec<&str> = SlashCommand::ALL.iter().map(|c| c.word()).collect();
+        assert_eq!(
+            words,
+            vec![
+                "/home",
+                "/fleet",
+                "/workflows",
+                "/estate",
+                "/back",
+                "/refresh",
+                "/answer",
+                "/retry",
+                "/extend",
+                "/cancel",
+                "/evidence",
+                "/graph",
+                "/details",
+                "/analytics",
+                "/retained",
+                "/reap",
+                "/help",
+                "/quit",
+            ]
+        );
+        for excluded in [
+            "/interrupt",
+            "/files",
+            "/web",
+            "/watch",
+            "/daemon",
+            "/init",
+            "/claude",
+            "/codex",
+            "/opencode",
+            "/goose",
+        ] {
+            assert!(
+                !words.contains(&excluded),
+                "{excluded} is explicitly excluded by §15.3"
+            );
         }
+    }
+
+    /// The palette lists every command with the highlighted entry marked,
+    /// same shape as [`workflow_chooser_lists_the_live_catalog_with_the_highlighted_entry_marked`].
+    #[test]
+    fn slash_palette_lists_every_command_with_the_highlighted_entry_marked() {
+        let mut app = App::new();
+        app.slash_palette_index = 3;
+        let body = slash_palette_body(&app);
+        for command in SlashCommand::ALL {
+            assert!(body.contains(command.word()), "{body}");
+        }
+        assert!(body.contains("▶ /estate"), "{body}");
     }
 
     /// §15.4/§11.4: the chooser lists the live catalog by name, with the

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -359,7 +359,12 @@ fn extend_body(app: &App) -> String {
 /// reaped, even though [`super::app::App::execute`]'s own `Action::Reap`
 /// correctly acts on `retained_reap_id` either way.
 fn reap_identity(app: &App) -> (String, String) {
-    if app.open_work.is_some() {
+    // `retained_reap_id` is the explicit selection made inside §12.4's
+    // Retained preview, so it takes precedence over an open Work — the
+    // two can now both be set at once since §15.3's `/retained` reaches
+    // that preview without first leaving an open Work (see the matching
+    // precedence in `App::on_key_overlay`'s `ReapConfirmation` arm).
+    if app.retained_reap_id.is_none() && app.open_work.is_some() {
         return work_identity(app);
     }
     let id = app

--- a/src/tui/work_view.rs
+++ b/src/tui/work_view.rs
@@ -117,6 +117,10 @@ pub enum WorkScreenOutcome {
     OpenExtendEnvelope,
     /// §13.10/§15.5: open the Reap confirmation.
     OpenReapConfirm,
+    /// §15.3: `/` at the first non-whitespace position of the `ANSWER`
+    /// composer opens `Overlay::SlashPalette` (App-level state) instead of
+    /// being typed literally.
+    OpenSlashPalette,
 }
 
 /// The canonical Work surface's own state: the four fetched reads, which tab
@@ -265,9 +269,23 @@ impl WorkScreen {
     /// Whether `action` (§13.10's vocabulary: `"respond"`, `"cancel"`,
     /// `"retry"`, `"extend"`, `"reap"`) is legal for the current reported
     /// state — the same table the header already renders (§13.10's
-    /// Decision T2-52).
-    fn action_available(&self, action: &str) -> bool {
+    /// Decision T2-52). `pub` so [`super::app::App`]'s §15.3 slash commands
+    /// gate on exactly this matrix rather than a second copy of it.
+    pub fn action_available(&self, action: &str) -> bool {
         actions_for_state(&self.state()).1.contains(&action)
+    }
+
+    /// §15.3's `/answer` command: the same effect as the mnemonic `r` key
+    /// (§13.10) — the caller has already checked [`WorkScreen::action_available`].
+    pub fn focus_answer(&mut self) {
+        self.answer_focused = true;
+        self.answer_send_focused = false;
+    }
+
+    /// §15.3's `/evidence`, `/graph`, `/details` commands: the same tab
+    /// switch the `1`-`5` digit keys already perform.
+    pub fn show_tab(&mut self, tab: Tab) {
+        self.tab = tab;
     }
 
     pub fn on_key(&mut self, key: impl Into<KeyEvent>) -> WorkScreenOutcome {
@@ -341,7 +359,10 @@ impl WorkScreen {
                 KeyCode::Enter => match self.answer.submit() {
                     ComposerOutcome::Submit(text) => return WorkScreenOutcome::Respond(text),
                     ComposerOutcome::Refused => return WorkScreenOutcome::AnswerRefused,
-                    ComposerOutcome::None => {}
+                    // `Composer::submit` never returns this — only
+                    // `Composer::on_key` interprets a typed `/` — but the
+                    // match must still be exhaustive.
+                    ComposerOutcome::None | ComposerOutcome::OpenSlashPalette => {}
                 },
                 _ => {}
             }
@@ -353,6 +374,7 @@ impl WorkScreen {
             _ => match self.answer.on_key(key) {
                 ComposerOutcome::Submit(text) => return WorkScreenOutcome::Respond(text),
                 ComposerOutcome::Refused => return WorkScreenOutcome::AnswerRefused,
+                ComposerOutcome::OpenSlashPalette => return WorkScreenOutcome::OpenSlashPalette,
                 ComposerOutcome::None => {}
             },
         }
@@ -1860,6 +1882,20 @@ mod tests {
             screen.on_key(ctrl_enter()),
             WorkScreenOutcome::Respond("yes, proceed".to_string())
         );
+    }
+
+    /// §15.3: `/` at the first non-whitespace position of the still-empty
+    /// `ANSWER` composer asks to open the slash palette rather than being
+    /// typed literally.
+    #[test]
+    fn slash_on_the_answer_composer_asks_to_open_the_slash_palette() {
+        let mut screen = screen_with("needs_input", Vec::new());
+        screen.on_key(KeyCode::Char('r'));
+        assert_eq!(
+            screen.on_key(KeyCode::Char('/')),
+            WorkScreenOutcome::OpenSlashPalette
+        );
+        assert_eq!(screen.answer.text(), "", "no literal '/' was typed");
     }
 
     #[test]

--- a/src/tui/work_view.rs
+++ b/src/tui/work_view.rs
@@ -283,9 +283,16 @@ impl WorkScreen {
     }
 
     /// §15.3's `/evidence`, `/graph`, `/details` commands: the same tab
-    /// switch the `1`-`5` digit keys already perform.
+    /// switch the `1`-`5` digit keys already perform. Those digit keys are
+    /// only reachable with the `ANSWER` composer unfocused (`on_key`
+    /// routes to `on_key_answer` first when it's focused) — the palette
+    /// has no such precondition, so this must drop focus itself or a
+    /// palette pick made mid-answer would switch the visible tab while
+    /// keys kept routing into the hidden draft.
     pub fn show_tab(&mut self, tab: Tab) {
         self.tab = tab;
+        self.answer_focused = false;
+        self.answer_send_focused = false;
     }
 
     pub fn on_key(&mut self, key: impl Into<KeyEvent>) -> WorkScreenOutcome {
@@ -1952,6 +1959,28 @@ mod tests {
             screen.answer_send_focused = false;
         }
         assert!(!screen.answer_focused);
+    }
+
+    /// §15.3: `/evidence`, `/graph`, `/details` reach `show_tab` while the
+    /// `ANSWER` composer may still be focused (the palette opens from
+    /// there via `/`). `on_key` routes to `on_key_answer` first whenever
+    /// `answer_focused` is set, so without this the visible tab would
+    /// change while keys kept landing in the hidden draft.
+    #[test]
+    fn show_tab_drops_answer_focus_so_the_new_tab_receives_keys() {
+        let mut screen = screen_with("needs_input", Vec::new());
+        screen.on_key(KeyCode::Char('r'));
+        assert!(screen.answer_focused);
+        screen.show_tab(Tab::Evidence);
+        assert!(!screen.answer_focused);
+        assert!(!screen.answer_send_focused);
+        assert_eq!(screen.tab, Tab::Evidence);
+        screen.on_key(KeyCode::Char('j'));
+        assert_eq!(
+            screen.answer.text(),
+            "",
+            "'j' navigated the tab, not the hidden draft"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wires `/` at the first non-whitespace position of the Home `INTENT` composer and the Work `ANSWER` composer to open `Overlay::SlashPalette` instead of typing the character literally — elsewhere in a draft, `/` stays ordinary text.
- Implements §15.3's fixed vocabulary (Decision T2-55) as a `SlashCommand` enum + match in `src/tui/overlay.rs` — no shell or plugin language — with exactly the listed 18 commands (`/home /fleet /workflows /estate /back /refresh /answer /retry /extend /cancel /evidence /graph /details /analytics /retained /reap /help /quit`) and none of the explicitly excluded ones (`/interrupt /files /web /watch /daemon /init /claude /codex /opencode /goose`).
- `j`/`k` moves the highlighted command, `Enter` runs it and closes the palette, `Esc`/`q` aborts with nothing run. Each command either changes state directly or opens the same overlay/composer its existing mnemonic key already does, so durable/destructive actions (cancel/retry/extend/reap) still land on their own confirmation (§15.5) rather than skipping it.
- Updates the stale `geometry_palette_chooser_and_confirmations` placeholder assertion (it expected the now-obsolete "not built in this Work" fallback) to check real palette content instead.

Closes #152.

## Test plan

- [x] `cargo build --lib`
- [x] `cargo test --lib` (484 passed)
- [x] `cargo clippy --lib --all-targets` (clean)
- [x] New unit tests in `src/tui/overlay.rs`, `src/tui/composer.rs`, `src/tui/home.rs`, `src/tui/work_view.rs` covering: exact vocabulary match against §15.3's list, exclusion of the named-excluded commands, `/` at first-nonwhitespace vs. mid-draft vs. after an earlier nonblank line, and palette rendering with the highlighted entry marked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)