### PR TITLE
tui: build Overlay::ConnectionDetail's render body and key binding (#154)

### DIFF
--- a/GAUNTLET.md
+++ b/GAUNTLET.md
@@ -102,6 +102,17 @@ never assigned to T2, T3, or T4 — `Overlay::SlashPalette::owner()` says so
 in the running code, and the proposal's own implementation-status note
 (added this entry) says so in prose. Tracked for a future round, not lost.
 
+**A third gap, found unnamed — now closed.** `Overlay::ConnectionDetail`
+(§7.4/§8.1) had no render body and, unlike every other overlay this entry
+lists, no key binding anywhere opened it — never named as deferred like
+the two gaps above, just silently absent (issue #154). Closed by a
+follow-up Work on `integration/t-series-followup-2026-08-16`: a dedicated
+`c` key (mouse capture stays disabled per §8.9, so no click target was
+possible) opens a read-only panel over the live/reconnecting/auth-failed
+state `src/tui/connection.rs` already tracked — no new state added.
+`Overlay::ConnectionDetail::owner()` now returns `None` alongside the
+rest of this entry's built overlays.
+
 **Evidence discipline, not narrated.** Every merge in this table was
 gated on an independent post-merge `cargo test` run by Captain (never the
 dispatched Work's own self-report) — two of the ten Works (T1b, and the

--- a/reference/proposal-tui-t-series.md
+++ b/reference/proposal-tui-t-series.md
@@ -60,7 +60,7 @@ relationship: >-
 
 Sections are numbered for contract citation. Every normative decision names its lowest viable Ponytail rung. The complete register is §22.
 
-**Implementation status (2026-08-16):** T0 through T4 are built, tested, and merged to `integration/t-series-2026-08-15` (head PR #131) — see `GAUNTLET.md`'s T-SERIES-BUILD entry for the full record. `status: proposed` above is left as-is rather than changed to `published`, since that branch has not merged to `main`; this is the owner's call, not this document's. Two named gaps are explicitly not built by this program: the slash palette (§15.3) and the Workflows-screen half of the `@` chooser (§15.4) — tracked, not silently dropped.
+**Implementation status (2026-08-16):** T0 through T4 are built, tested, and merged to `integration/t-series-2026-08-15` (head PR #131) — see `GAUNTLET.md`'s T-SERIES-BUILD entry for the full record. `status: proposed` above is left as-is rather than changed to `published`, since that branch has not merged to `main`; this is the owner's call, not this document's. Two named gaps are explicitly not built by this program: the slash palette (§15.3) and the Workflows-screen half of the `@` chooser (§15.4) — tracked, not silently dropped. A third gap went unnamed rather than tracked: `Overlay::ConnectionDetail` (§7.4/§8.1) had no render body and no key binding anywhere, closing issue #154. It is now closed by a follow-up Work on `integration/t-series-followup-2026-08-16` — see `GAUNTLET.md`'s T-SERIES-BUILD entry.
 
 ---
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -690,12 +690,13 @@ impl App {
                 }
                 Action::None
             }
-            // Every overlay still owned by a later Work (§7.4's note) plus
-            // Help (content-built at T1a, but generic close-only controls
-            // are all it ever needs): the mechanism this Work built at
-            // T1a — open, close, restore focus for free. RepoAddRemove,
-            // GroupEditRemove, and RetainedPreview have their own real arms
-            // above (T3); WorkflowChooser has its own real arm above (T2).
+            // SlashPalette is still owned by a later Work (§7.4's note);
+            // Help and ConnectionDetail have real content (T1a and issue
+            // #154 respectively) but need nothing beyond the generic
+            // close-only controls this Work built at T1a — open, close,
+            // restore focus for free. RepoAddRemove, GroupEditRemove, and
+            // RetainedPreview have their own real arms above (T3);
+            // WorkflowChooser has its own real arm above (T2).
             Overlay::Help | Overlay::SlashPalette | Overlay::ConnectionDetail => {
                 match key.code {
                     KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => self.overlay = None,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -444,6 +444,10 @@ impl App {
         match key {
             KeyCode::Char('~') => self.drawer_open = !self.drawer_open,
             KeyCode::Char('?') => self.overlay = Some(Overlay::Help),
+            // §7.4/§8.9: mouse capture stays disabled, so the connection
+            // detail overlay (issue #154) needs its own dedicated keyboard
+            // trigger rather than a click on the header's indicator.
+            KeyCode::Char('c') => self.overlay = Some(Overlay::ConnectionDetail),
             KeyCode::Char('1') => self.goto(Destination::Home),
             KeyCode::Char('2') => self.goto(Destination::Fleet),
             KeyCode::Char('3') => self.goto(Destination::Workflows),
@@ -1072,6 +1076,32 @@ mod tests {
         app.on_key(KeyCode::Char('?'));
         assert_eq!(app.overlay, Some(Overlay::Help));
         app.on_key(KeyCode::Esc);
+        assert!(app.overlay.is_none());
+    }
+
+    /// Issue #154: unlike every other overlay in §7.4's fixed set,
+    /// `Overlay::ConnectionDetail` had no key binding anywhere — `c` opens
+    /// it globally (mouse capture stays disabled, §8.9), and it closes the
+    /// same way `Help`/`SlashPalette` already do.
+    #[test]
+    fn connection_detail_opens_on_c_and_closes_on_esc_q_or_question_mark() {
+        let mut app = App::new();
+        app.on_key(KeyCode::Esc); // reach global focus from Home
+
+        assert!(app.overlay.is_none());
+        app.on_key(KeyCode::Char('c'));
+        assert_eq!(app.overlay, Some(Overlay::ConnectionDetail));
+        app.on_key(KeyCode::Esc);
+        assert!(app.overlay.is_none());
+
+        app.on_key(KeyCode::Char('c'));
+        assert_eq!(app.overlay, Some(Overlay::ConnectionDetail));
+        app.on_key(KeyCode::Char('q'));
+        assert!(app.overlay.is_none());
+
+        app.on_key(KeyCode::Char('c'));
+        assert_eq!(app.overlay, Some(Overlay::ConnectionDetail));
+        app.on_key(KeyCode::Char('?'));
         assert!(app.overlay.is_none());
     }
 

--- a/src/tui/geometry_matrix_tests.rs
+++ b/src/tui/geometry_matrix_tests.rs
@@ -577,6 +577,25 @@ fn geometry_palette_chooser_and_confirmations() {
         );
     }
 
+    // Issue #154: `Overlay::ConnectionDetail` had no render body and no key
+    // binding anywhere — this follow-up Work built both. Proven at every
+    // size, for every `Live` state, that the real body renders rather than
+    // the fixed "not built in this Work" placeholder every unbuilt overlay
+    // still falls back to (still proven above for the slash palette below).
+    for live in [Live::Attached, Live::Reconnecting, Live::AuthFailed] {
+        let mut detail = App::new();
+        detail.live = live;
+        detail.overlay = Some(Overlay::ConnectionDetail);
+        for (w, h) in SIZES {
+            let text = text_of(&draw_at(&detail, w, h));
+            assert!(
+                !text.contains("not built in this Work"),
+                "{live:?} connection detail at {w}x{h} must render its real body: {text}"
+            );
+            assert!(text.contains("Esc"), "{live:?} at {w}x{h}: {text}");
+        }
+    }
+
     // §15.3's slash palette: T1c deferred it and no later T-series Work
     // (T2, T3, this one) has claimed it — real gap, not silently dropped
     // (see this Work's commit message). Rendered here anyway so the fixed

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -296,7 +296,7 @@ fn footer_line(app: &App) -> Paragraph<'_> {
     } else if app.destination == Destination::Fleet && app.fleet.wants_text_focus() {
         "type to filter · Enter/Esc apply"
     } else {
-        "1-4 destinations · Tab cycle · ~ drawer · ? help · q quit"
+        "1-4 destinations · Tab cycle · ~ drawer · c connection · ? help · q quit"
     };
     Paragraph::new(Line::from(vec![
         Span::styled(keys, Style::default().fg(Token::Muted.rgb())),

--- a/src/tui/overlay.rs
+++ b/src/tui/overlay.rs
@@ -19,6 +19,7 @@ use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 use crate::api::field_text;
 
 use super::app::App;
+use super::connection::Live;
 use super::estate::{
     RepoOverlayMode, add_repo_body, group_form_body, remove_repo_body, retained_body,
 };
@@ -60,8 +61,11 @@ impl Overlay {
     /// The later Work that actually implements this overlay's content —
     /// `None` for the ones already built: [`Overlay::Help`] (T1a), T1c's
     /// four real confirmations (§13.10/§15.5), T2's live-catalog
-    /// [`Overlay::WorkflowChooser`] (§11.4, §15.4), and T3's three Estate
-    /// panels (§12.1/§12.2/§12.4).
+    /// [`Overlay::WorkflowChooser`] (§11.4, §15.4), T3's three Estate
+    /// panels (§12.1/§12.2/§12.4), and [`Overlay::ConnectionDetail`]
+    /// (§7.4/§8.1, issue #154 — a follow-up Work, since T1c's own scope note
+    /// only named the slash palette and the Workflows `@` chooser half as
+    /// deferred).
     fn owner(self) -> Option<&'static str> {
         match self {
             Overlay::Help
@@ -72,12 +76,12 @@ impl Overlay {
             | Overlay::WorkflowChooser
             | Overlay::RepoAddRemove
             | Overlay::GroupEditRemove
-            | Overlay::RetainedPreview => None,
+            | Overlay::RetainedPreview
+            | Overlay::ConnectionDetail => None,
             // §15.3 is explicitly out of T1c's scope (deferred alongside
             // §15.4's Workflows half and §15.6) — not this Work, and not yet
             // reassigned to a later one by name.
             Overlay::SlashPalette => Some("a later Work (§15.3)"),
-            Overlay::ConnectionDetail => Some("a later Work"),
         }
     }
 }
@@ -90,6 +94,7 @@ Navigation
   Tab / S-Tab cycle destinations
   ~           toggle the Attention drawer
   ?           this help
+  c           connection detail (live/reconnecting/auth failed)
   q / Esc     back, or quit from a top-level destination
 
 Fleet
@@ -147,6 +152,7 @@ pub fn render(frame: &mut Frame, area: Rect, overlay: Overlay, app: &App) {
         Overlay::GroupEditRemove => group_form_body(&app.estate.group_form),
         Overlay::RetainedPreview => retained_body(&app.estate),
         Overlay::WorkflowChooser => workflow_chooser_body(app),
+        Overlay::ConnectionDetail => connection_detail_body(app),
         _ => format!(
             "{} is not built in this Work.\n\n{} implements it.\n\nEsc closes this panel.",
             overlay.title(),
@@ -327,6 +333,43 @@ fn workflow_chooser_body(app: &App) -> String {
     lines.join("\n")
 }
 
+/// §7.4/§8.1, issue #154: a read-only view over the connection state
+/// already tracked in [`super::connection`] for the header's own indicator
+/// (`app.live`, [`Live::label`]) and the footer's own status line
+/// (`app.status`) — no new state, just both put in one place with the
+/// explanation the one-line header has no room for.
+fn connection_detail_body(app: &App) -> String {
+    let (state, detail) = match app.live {
+        Live::Attached => (
+            "live",
+            "The SSE tail is attached; events are applied as they arrive.",
+        ),
+        Live::Reconnecting => (
+            "reconnecting",
+            "The tail dropped and the loop is retrying on its own capped \
+             exponential backoff (issue #16) — recovery does not wait on a \
+             keystroke, but this screen does not claim to be live again \
+             until it actually is.",
+        ),
+        Live::AuthFailed => (
+            "auth failed",
+            "The daemon rejected this client's token. Automatic retries \
+             stopped: a rejected token will not start working just \
+             because this process asks again — restart sgt to pick up a \
+             fresh one.",
+        ),
+    };
+    let mut body = format!(
+        "state    {state}\nheader   {}\n\n{detail}",
+        app.live.label()
+    );
+    if !app.status.is_empty() {
+        body.push_str(&format!("\n\nlast status\n  {}", app.status));
+    }
+    body.push_str("\n\nEsc/q closes this panel.");
+    body
+}
+
 /// A `percent_x` × `percent_y` box, centered in `area`.
 fn centered(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
     let [area] = Layout::vertical([Constraint::Percentage(percent_y)])
@@ -344,7 +387,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn help_t1c_t2_and_t3_panels_are_built_here() {
+    fn help_t1c_t2_t3_and_connection_detail_panels_are_built_here() {
         for built in [
             Overlay::Help,
             Overlay::CancelConfirmation,
@@ -355,15 +398,15 @@ mod tests {
             Overlay::RepoAddRemove,
             Overlay::GroupEditRemove,
             Overlay::RetainedPreview,
+            Overlay::ConnectionDetail,
         ] {
             assert!(
                 built.owner().is_none(),
                 "{built:?} must be built in this Work"
             );
         }
-        for later in [Overlay::SlashPalette, Overlay::ConnectionDetail] {
-            assert!(later.owner().is_some(), "{later:?} must name who builds it");
-        }
+        let later = Overlay::SlashPalette;
+        assert!(later.owner().is_some(), "{later:?} must name who builds it");
     }
 
     /// §15.4/§11.4: the chooser lists the live catalog by name, with the
@@ -477,6 +520,56 @@ mod tests {
             body.contains(&u64::MAX.to_string()),
             "the sum must saturate at u64::MAX, not panic or wrap: {body}"
         );
+    }
+
+    #[test]
+    fn connection_detail_shows_live_when_attached() {
+        let app = App::new();
+        assert_eq!(app.live, Live::Attached, "a fresh app assumes the tail");
+        let body = connection_detail_body(&app);
+        assert!(body.contains("live"), "{body}");
+        assert!(!body.to_lowercase().contains("reconnecting"), "{body}");
+    }
+
+    #[test]
+    fn connection_detail_names_reconnecting_and_the_automatic_retry() {
+        let mut app = App::new();
+        app.live = Live::Reconnecting;
+        let body = connection_detail_body(&app);
+        assert!(body.contains("reconnecting"), "{body}");
+        assert!(
+            body.to_lowercase().contains("backoff"),
+            "the automatic-retry explanation must be present: {body}"
+        );
+    }
+
+    #[test]
+    fn connection_detail_names_auth_failure_and_that_retries_stopped() {
+        let mut app = App::new();
+        app.live = Live::AuthFailed;
+        let body = connection_detail_body(&app);
+        assert!(body.contains("auth failed"), "{body}");
+        assert!(
+            body.to_lowercase().contains("stopped"),
+            "the terminal-failure explanation must be present: {body}"
+        );
+    }
+
+    #[test]
+    fn connection_detail_includes_the_last_status_line_when_present() {
+        let mut app = App::new();
+        app.live = Live::Reconnecting;
+        app.status = "live tail closed — reconnecting…".to_string();
+        let body = connection_detail_body(&app);
+        assert!(body.contains("live tail closed — reconnecting…"), "{body}");
+    }
+
+    #[test]
+    fn connection_detail_omits_the_last_status_section_when_empty() {
+        let mut app = App::new();
+        app.status = String::new();
+        let body = connection_detail_body(&app);
+        assert!(!body.contains("last status"), "{body}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `Overlay::ConnectionDetail` (§7.4/§8.1) existed in `src/tui/overlay.rs` with a title but no render body, and unlike every other overlay had no key binding anywhere that opened it — a real gap the T-SERIES-BUILD program's own scope note never named (unlike the slash palette and the Workflows `@` chooser half, which were tracked as deferred).
- **Keyboard trigger choice (for review):** mouse capture stays disabled per §8.9, so a click on the header's connection indicator isn't possible. This PR binds a dedicated global `c` key (alongside `~` drawer, `?` help, `1`-`4` destinations) to open the overlay; `Esc`/`q`/`?` close it, matching every other overlay's convention. `c` was free — not bound anywhere else in the global handler — and is gated behind `!wants_text_focus()` like the other single-char globals, so it won't leak into Fleet's filter or Home's form.
- **Render body:** a read-only view sourced entirely from state `src/tui/connection.rs` already tracks — `app.live` (`Live::Attached`/`Reconnecting`/`AuthFailed`, including the header's own label) and `app.status` (the footer's last status line, folded in as "last status" when non-empty). No new state was added. Each state gets a short explanation: `Attached` says the tail is live, `Reconnecting` names the automatic capped-backoff retry (issue #16), `AuthFailed` explains why automatic retries stopped (a rejected token won't start working on its own).
- Added unit tests in `src/tui/overlay.rs` matching the existing overlay test style (per-state body assertions, the "owner" gap-tracking test moved `ConnectionDetail` from "later" to "built"), a key-binding test in `src/tui/app.rs` (open on `c`, close on `Esc`/`q`/`?`), and a geometry-matrix case in `src/tui/geometry_matrix_tests.rs` proving the real body renders (not the "not built in this Work" placeholder) across every size for `Attached`/`Reconnecting`/`AuthFailed`.
- Updated `GAUNTLET.md`'s T-SERIES-BUILD entry and `reference/proposal-tui-t-series.md`'s implementation-status note to name this as a third, previously-unnamed gap (distinct from the two already-tracked ones), now closed.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, 15 binaries, 0 failed)
- [x] Manually traced `on_key_global`'s text-focus guard to confirm `c` can't collide with Fleet/Home text entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)