### PR TITLE
Embed the distro in sgt and have sgt init write it (closes #165)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2756,7 @@ dependencies = [
  "blake3",
  "clap",
  "duckdb",
+ "include_dir",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ axum = "0.8"
 blake3 = "1.8.6"
 clap = { version = "4.6.6", features = ["derive"] }
 duckdb = { version = "1", features = ["bundled"] }
+include_dir = { version = "0.7.4", default-features = false }
 opentelemetry = { version = "0.32", default-features = false, features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-blocking-client", "trace", "metrics"] }
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace", "metrics"] }

--- a/NORTH-STAR.md
+++ b/NORTH-STAR.md
@@ -24,7 +24,14 @@ that turns a general-purpose coding harness into an operator of your
 estate, carried by a durable intent-execution engine that runs those
 intents to completion in isolated worktrees.*
 
-**Not true yet, and marked as such (2026-08-17).** The embedding clause
+**Now true (2026-08-18), closing the note below.** `sgt init` embeds and
+writes the distro — `AGENTS.md`, `skills/`, `.sergeant/common/contexts/`,
+and `.sergeant/workflows/` (241 files, measured) — into a fresh estate,
+per-file idempotent so re-running `sgt init` stays a no-op (issue #165).
+The historical note this replaces is kept legible rather than deleted, per
+this document's own rule:
+
+*Not true yet, and marked as such (2026-08-17). The embedding clause
 above is the destination, not the current behavior: `sgt init` today
 writes `sergeant.toml`, `repos/`, and a `.gitignore`, and no workflow
 templates at all (issue #165; measured in
@@ -34,7 +41,12 @@ was written — as a present-tense assertion of behavior the binary does not
 have, which is exactly the instruction-fiction class this document's own
 amendments were correcting. A destination document is entitled to describe
 where it is going; it is not entitled to describe that as already working.
-This note stands until `sgt init` actually writes the distro.
+This note stands until `sgt init` actually writes the distro.*
+
+What is still not true: the `curl … | sh` installer step named in the
+finished-loop paragraph below is a separate, pre-existing release-pipeline
+concern (`release.yml`, Phase 6) this change does not touch or claim to
+close — only the embedding clause above is what this note is about.
 
 The finished loop: `curl … | sh` → `sgt init` → `sgt claude` → say *"let's
 work on the payment api"*, *"why is the ingress controller erroring?"*,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -959,6 +959,13 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
         Command::Init { name } => {
             let cwd = std::env::current_dir()?;
             let outcome = crate::domain::manifest::init_estate(&cwd, name.as_deref())?;
+            // ADR 0014 decision 1: the distro (AGENTS.md, skills/,
+            // .sergeant/common/contexts/, .sergeant/workflows/) is embedded
+            // in the binary and written here, not cloned. Per-file
+            // idempotent (`domain::distro::write_distro`), so this never
+            // turns a second `sgt init` on an already-initialized estate
+            // into anything but a no-op, and it writes only within `cwd`.
+            let distro_outcome = crate::domain::distro::write_distro(&cwd)?;
             // Re-resolve now that `sergeant.toml` exists: the `data_dir`
             // computed above ran before `init_estate` created it, so on a
             // fresh estate estate discovery had nothing to find yet and
@@ -973,12 +980,14 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                         "estate_section_added": outcome.estate_section_added,
                         "repos_dir_created": outcome.repos_dir_created,
                         "gitignore_updated": outcome.gitignore_updated,
-                        "changed": outcome.changed(),
+                        "distro_files_written": distro_outcome.written.len(),
+                        "distro_files_already_present": distro_outcome.skipped.len(),
+                        "changed": outcome.changed() || distro_outcome.changed(),
                     },
                     "doctor": report.to_json(),
                 }));
             } else {
-                if outcome.changed() {
+                if outcome.changed() || distro_outcome.changed() {
                     println!("initialized estate at {}", cwd.display());
                     if outcome.manifest_created {
                         println!("  created sergeant.toml");
@@ -991,6 +1000,13 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                     }
                     if outcome.gitignore_updated {
                         println!("  updated .gitignore");
+                    }
+                    if distro_outcome.changed() {
+                        println!(
+                            "  wrote {} distro file(s) (AGENTS.md, skills/, \
+                             .sergeant/common/contexts/, .sergeant/workflows/)",
+                            distro_outcome.written.len()
+                        );
                     }
                 } else {
                     println!(
@@ -2338,7 +2354,9 @@ pub(crate) mod doctor {
                 ),
                 format!(
                     "write a package to {}/<name>/workflow.toml before dispatching `--workflow \
-                     <name>` (#165 — sgt init does not scaffold any yet)",
+                     <name>`, or re-run `sgt init` — it writes the embedded distro's stock \
+                     packages for any that are missing (#165), without touching one already \
+                     present",
                     workflows_dir.display()
                 ),
             )

--- a/src/domain/distro.rs
+++ b/src/domain/distro.rs
@@ -1,0 +1,282 @@
+//! The distro — `AGENTS.md`, `skills/`, `.sergeant/common/contexts/`, and
+//! `.sergeant/workflows/` — embedded in the `sgt` binary at compile time and
+//! written into a fresh estate by `sgt init` (issue #165, ADR 0014 decision
+//! 1: "ships embedded in the `sgt` binary and is written to disk by `sgt
+//! init`. It is not a cloned directory.").
+//!
+//! Ponytail R5: no dependency already in `Cargo.lock` does whole-directory
+//! compile-time embedding — `include_str!` (stdlib, R3) is already used for
+//! the built-in `software-change` workflow
+//! (`domain::workflow::EMBEDDED_WORKFLOW_TOML`/`EMBEDDED_CONTEXTS`), but that
+//! precedent hand-lists five known literal paths; it does not generalize to
+//! 200+ files across an arbitrarily nested tree without either hand-listing
+//! every path (silently stale the moment a file is added and the list
+//! isn't) or a directory-walking build script (more code than the dependency
+//! it would replace, and re-solves a problem `include_dir` already solves
+//! narrowly). `include_dir` was chosen over `rust-embed`: `rust-embed`
+//! re-reads files from disk at runtime in debug builds (a `Cow`-based API
+//! and a `cfg`-branched code path this use case has no reason to carry —
+//! the estate the binary writes into is never the same tree the binary was
+//! built from), where `include_dir` gives exactly the shape needed —
+//! a `Dir<'static>` tree of `&'static [u8]` file contents, nothing else —
+//! for a two-crate addition (`include_dir` + its proc-macro half
+//! `include_dir_macros`, confirmed via `cargo add --dry-run` and `cargo
+//! fetch`; no transitive crates beyond those two). Measured cost of this
+//! addition, recorded in the commit message: release binary size delta and
+//! `cargo build --release` wall time, before vs. after.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use include_dir::{Dir, include_dir};
+
+use crate::runtime::fsutil::{create_dir_all_durable, write_atomic};
+
+static AGENTS_MD: &str = include_str!("../../AGENTS.md");
+static SKILLS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/skills");
+static CONTEXTS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/.sergeant/common/contexts");
+static WORKFLOWS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/.sergeant/workflows");
+
+/// Which paths this call actually wrote vs. left untouched because they
+/// already existed. `written.is_empty()` on a second `sgt init` is the
+/// no-op signal the AGENTS.md guardrail requires ("re-running `sgt init` on
+/// an already-initialized estate is a no-op, not a reset").
+#[derive(Debug, Default, Clone)]
+pub struct DistroWriteOutcome {
+    /// Paths created by this call, relative to the estate root.
+    pub written: Vec<PathBuf>,
+    /// Paths that already existed and were left alone, relative to the
+    /// estate root.
+    pub skipped: Vec<PathBuf>,
+}
+
+impl DistroWriteOutcome {
+    /// Whether this call wrote anything at all.
+    pub fn changed(&self) -> bool {
+        !self.written.is_empty()
+    }
+}
+
+/// Write the embedded distro into `estate_root`.
+///
+/// Per-file idempotent: a file that already exists at its target path is
+/// never overwritten, so a second `sgt init` on an already-initialized
+/// estate writes nothing (hard constraint: re-running init is a no-op, not
+/// a reset). Writes only under `estate_root` — `AGENTS.md`, `skills/`,
+/// `.sergeant/common/contexts/`, `.sergeant/workflows/` — and never touches
+/// `.sergeant/local/`, which is the user's own and which Phase 3's
+/// local-shadows-stock resolution (`domain::workflow::WorkflowDefinition::
+/// resolve`) depends on staying separate from stock.
+///
+/// `index.md` and `SKILL.md` front matter's `edition` field is rewritten to
+/// this binary's own version (`env!("CARGO_PKG_VERSION")`) as each file is
+/// written, rather than trusted verbatim from the embedded content — the
+/// mechanism ADR 0016 requires ("`sgt init`/update sets `edition` to the
+/// current distro version whenever it writes a stock copy") without relying
+/// on every future release remembering to hand-bump the checked-in
+/// front matter to match `Cargo.toml` before cutting the release.
+pub fn write_distro(estate_root: &Path) -> io::Result<DistroWriteOutcome> {
+    let mut outcome = DistroWriteOutcome::default();
+
+    write_file(
+        estate_root,
+        Path::new("AGENTS.md"),
+        AGENTS_MD.as_bytes(),
+        &mut outcome,
+    )?;
+    write_dir(estate_root, Path::new("skills"), &SKILLS, &mut outcome)?;
+    write_dir(
+        estate_root,
+        Path::new(".sergeant/common/contexts"),
+        &CONTEXTS,
+        &mut outcome,
+    )?;
+    write_dir(
+        estate_root,
+        Path::new(".sergeant/workflows"),
+        &WORKFLOWS,
+        &mut outcome,
+    )?;
+
+    Ok(outcome)
+}
+
+/// Recurse `dir` (an `include_dir!` tree), writing every file it contains
+/// under `estate_root/prefix/<file's own path within dir>` — `File::path()`
+/// already carries the full path relative to the tree's own root, so no
+/// manual path accumulation is needed as this recurses into subdirectories.
+fn write_dir(
+    estate_root: &Path,
+    prefix: &Path,
+    dir: &Dir<'static>,
+    outcome: &mut DistroWriteOutcome,
+) -> io::Result<()> {
+    for file in dir.files() {
+        write_file(
+            estate_root,
+            &prefix.join(file.path()),
+            file.contents(),
+            outcome,
+        )?;
+    }
+    for sub in dir.dirs() {
+        write_dir(estate_root, prefix, sub, outcome)?;
+    }
+    Ok(())
+}
+
+/// Write one file at `estate_root/rel_path` if and only if nothing is there
+/// yet. `rel_path`'s leaf name decides whether `edition` front matter gets
+/// rewritten to this binary's version before the bytes hit disk.
+fn write_file(
+    estate_root: &Path,
+    rel_path: &Path,
+    contents: &[u8],
+    outcome: &mut DistroWriteOutcome,
+) -> io::Result<()> {
+    let full_path = estate_root.join(rel_path);
+    if full_path.exists() {
+        outcome.skipped.push(rel_path.to_path_buf());
+        return Ok(());
+    }
+    if let Some(parent) = full_path.parent() {
+        create_dir_all_durable(parent)?;
+    }
+    let carries_edition = matches!(
+        rel_path.file_name().and_then(|n| n.to_str()),
+        Some("index.md") | Some("SKILL.md")
+    );
+    if carries_edition && let Ok(text) = std::str::from_utf8(contents) {
+        write_atomic(&full_path, rewrite_edition(text).as_bytes())?;
+        outcome.written.push(rel_path.to_path_buf());
+        return Ok(());
+    }
+    write_atomic(&full_path, contents)?;
+    outcome.written.push(rel_path.to_path_buf());
+    Ok(())
+}
+
+/// Replace the value of an `edition:` line inside the leading `---`
+/// front-matter block with this binary's own version. A file with no such
+/// line, or no front-matter block at all, is returned unchanged — this is
+/// deliberately narrower than a YAML parser (matching
+/// `domain::workflow::parse_index_front_matter`'s own "tiny local
+/// composition" rather than a general parser, Ponytail R6), scoped to
+/// exactly the shape `docs/icm/record-shapes.md` §1 fixes.
+fn rewrite_edition(text: &str) -> String {
+    let mut lines = text.lines();
+    let Some(first) = lines.next() else {
+        return text.to_string();
+    };
+    if first.trim() != "---" {
+        return text.to_string();
+    }
+
+    let mut out = String::with_capacity(text.len() + 8);
+    out.push_str(first);
+    out.push('\n');
+    let mut in_front_matter = true;
+    for line in lines {
+        if in_front_matter && line.trim() == "---" {
+            in_front_matter = false;
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+        if in_front_matter && line.trim_start().starts_with("edition:") {
+            out.push_str("edition: ");
+            out.push_str(env!("CARGO_PKG_VERSION"));
+            out.push('\n');
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrite_edition_replaces_the_value_inside_front_matter_only() {
+        let text = "---\nkind: workflow\nedition: 0.0.1\nname: x\n---\n\nedition: 0.0.1 in the body must survive\n";
+        let rewritten = rewrite_edition(text);
+        assert!(rewritten.contains(&format!("edition: {}", env!("CARGO_PKG_VERSION"))));
+        assert!(rewritten.contains("edition: 0.0.1 in the body must survive"));
+    }
+
+    #[test]
+    fn rewrite_edition_is_a_no_op_without_front_matter() {
+        let text = "no front matter here\nedition: 0.0.1\n";
+        assert_eq!(rewrite_edition(text), text);
+    }
+
+    #[test]
+    fn write_distro_is_per_file_idempotent() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let first = write_distro(tmp.path()).expect("first write");
+        assert!(first.changed());
+        assert!(tmp.path().join("AGENTS.md").is_file());
+        assert!(tmp.path().join(".sergeant/workflows").is_dir());
+
+        let sentinel = tmp.path().join("AGENTS.md");
+        let edited = "user-edited content, must survive a second call\n";
+        std::fs::write(&sentinel, edited).expect("simulate a user edit");
+
+        let second = write_distro(tmp.path()).expect("second write");
+        assert!(
+            !second.changed(),
+            "a second call must write nothing, got {:?}",
+            second.written
+        );
+        assert_eq!(
+            std::fs::read_to_string(&sentinel).expect("read AGENTS.md"),
+            edited,
+            "a second call must never clobber an existing file"
+        );
+    }
+
+    #[test]
+    fn write_distro_never_touches_local() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        write_distro(tmp.path()).expect("write");
+        assert!(!tmp.path().join(".sergeant/local").exists());
+    }
+
+    #[test]
+    fn write_distro_stamps_the_binary_edition() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        write_distro(tmp.path()).expect("write");
+
+        let mut checked_a_workflow = false;
+        for entry in std::fs::read_dir(tmp.path().join(".sergeant/workflows")).expect("read_dir") {
+            let entry = entry.expect("entry");
+            let index = entry.path().join("index.md");
+            if index.is_file() {
+                let text = std::fs::read_to_string(&index).expect("read index.md");
+                assert!(
+                    text.contains(&format!("edition: {}", env!("CARGO_PKG_VERSION"))),
+                    "{} must carry the binary's edition, got:\n{text}",
+                    index.display()
+                );
+                checked_a_workflow = true;
+            }
+        }
+        assert!(checked_a_workflow, "expected at least one stock index.md");
+
+        for entry in std::fs::read_dir(tmp.path().join("skills")).expect("read_dir") {
+            let entry = entry.expect("entry");
+            let skill_md = entry.path().join("SKILL.md");
+            if skill_md.is_file() {
+                let text = std::fs::read_to_string(&skill_md).expect("read SKILL.md");
+                assert!(
+                    text.contains(&format!("edition: {}", env!("CARGO_PKG_VERSION"))),
+                    "{} must carry the binary's edition, got:\n{text}",
+                    skill_md.display()
+                );
+            }
+        }
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,5 +1,6 @@
 //! Domain model: the core types describing work, execution, and workflow.
 
+pub mod distro;
 pub mod event;
 pub mod execution;
 pub mod manifest;

--- a/tests/m8_estate_cli.rs
+++ b/tests/m8_estate_cli.rs
@@ -178,6 +178,205 @@ fn init_scaffolds_and_is_idempotent() {
     );
 }
 
+// --------------------------------------------------------------- distro
+
+/// guard-map (#165): a fresh estate has the embedded distro on disk after
+/// `sgt init` — `AGENTS.md`, at least one `skills/*/SKILL.md`, at least one
+/// `.sergeant/common/contexts/*.md`, and more than zero stock workflow
+/// packages under `.sergeant/workflows/`. Mutation this kills: `sgt init`
+/// going back to scaffolding only `sergeant.toml`/`repos/`/`.gitignore`
+/// (issue #165's original defect) would fail every assertion here.
+#[test]
+fn init_writes_the_embedded_distro() {
+    let estate = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = estate.path().join("data-dir");
+    run(estate.path(), Some(&data_dir), &[], &["init"]).assert_ok("init");
+
+    assert!(estate.path().join("AGENTS.md").is_file());
+
+    let skills: Vec<_> = std::fs::read_dir(estate.path().join("skills"))
+        .expect("skills dir")
+        .flatten()
+        .filter(|e| e.path().join("SKILL.md").is_file())
+        .collect();
+    assert!(!skills.is_empty(), "expected at least one skill package");
+
+    let contexts: Vec<_> = std::fs::read_dir(estate.path().join(".sergeant/common/contexts"))
+        .expect("contexts dir")
+        .flatten()
+        .collect();
+    assert!(!contexts.is_empty(), "expected at least one context file");
+
+    let workflows: Vec<_> = std::fs::read_dir(estate.path().join(".sergeant/workflows"))
+        .expect("workflows dir")
+        .flatten()
+        .filter(|e| e.path().join("workflow.toml").is_file())
+        .collect();
+    assert!(
+        !workflows.is_empty(),
+        "expected at least one stock workflow package"
+    );
+}
+
+/// guard-map (hard constraint 1): a second `sgt init` on an
+/// already-initialized estate is a true no-op for the distro too — it does
+/// not overwrite a file a user has since edited, and it never creates
+/// `.sergeant/local/` (that directory is the user's own; stock never writes
+/// there — hard constraint 3, Phase 3's local-shadows-stock resolution
+/// depends on the separation). Mutation this kills: `write_distro` losing
+/// its per-file existence check (a second init would then clobber the
+/// user's edit back to stock content) or accidentally writing under
+/// `.sergeant/local/` instead of `.sergeant/workflows/`.
+#[test]
+fn init_writing_the_distro_is_idempotent_and_never_touches_local() {
+    let estate = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = estate.path().join("data-dir");
+    run(estate.path(), Some(&data_dir), &[], &["init"]).assert_ok("init");
+    assert!(!estate.path().join(".sergeant/local").exists());
+
+    let sentinel = "the user edited this doctrine file\n";
+    std::fs::write(estate.path().join("AGENTS.md"), sentinel).expect("simulate a user edit");
+
+    let second = run(estate.path(), Some(&data_dir), &[], &["--json", "init"]);
+    second.assert_ok("second init");
+    assert!(
+        !second.json()["outcome"]["changed"].as_bool().unwrap(),
+        "a second init must change nothing, got {}",
+        second.stdout
+    );
+    assert_eq!(
+        std::fs::read_to_string(estate.path().join("AGENTS.md")).expect("AGENTS.md"),
+        sentinel,
+        "a second init must never clobber a user's edited AGENTS.md"
+    );
+    assert!(
+        !estate.path().join(".sergeant/local").exists(),
+        "sgt init must never create .sergeant/local/ — that tree is the user's own"
+    );
+}
+
+/// guard-map (ADR 0016 / hard constraint 4): every stock template `sgt
+/// init` writes carries `edition: <this binary's Cargo.toml version>` in
+/// its front matter — the co-versioning mechanism (ADR 0014 decision 2):
+/// the value is stamped by `sgt init` itself
+/// (`domain::distro::rewrite_edition`, keyed off `env!("CARGO_PKG_VERSION")`)
+/// rather than trusted verbatim from whatever was checked into the embedded
+/// content. Mutation this kills: reverting `write_file` to write embedded
+/// bytes unmodified would still pass today (checked-in `edition: 0.1.0`
+/// happens to match `Cargo.toml`'s current `0.1.0`) but silently drifts the
+/// moment either one changes without the other being re-synced by hand —
+/// this test pins the binary version as the source of truth, not the
+/// checked-in string.
+#[test]
+fn init_written_templates_carry_the_binary_edition() {
+    let estate = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = estate.path().join("data-dir");
+    run(estate.path(), Some(&data_dir), &[], &["init"]).assert_ok("init");
+
+    let edition_line = format!("edition: {}", env!("CARGO_PKG_VERSION"));
+
+    let mut checked = 0;
+    for entry in std::fs::read_dir(estate.path().join(".sergeant/workflows"))
+        .expect("workflows dir")
+        .flatten()
+    {
+        let index = entry.path().join("index.md");
+        if index.is_file() {
+            let text = std::fs::read_to_string(&index).expect("index.md");
+            assert!(
+                text.contains(&edition_line),
+                "{} must carry {edition_line:?}, got:\n{text}",
+                index.display()
+            );
+            checked += 1;
+        }
+    }
+    assert!(checked > 0, "expected at least one stock index.md");
+
+    for entry in std::fs::read_dir(estate.path().join("skills"))
+        .expect("skills dir")
+        .flatten()
+    {
+        let skill_md = entry.path().join("SKILL.md");
+        if skill_md.is_file() {
+            let text = std::fs::read_to_string(&skill_md).expect("SKILL.md");
+            assert!(
+                text.contains(&edition_line),
+                "{} must carry {edition_line:?}, got:\n{text}",
+                skill_md.display()
+            );
+        }
+    }
+}
+
+/// guard-map (#165's own acceptance criterion): `sgt run --workflow <name>`
+/// resolves a stock package on a *freshly initialized* estate instead of
+/// 422ing — the exact failure issue #165 describes ("workflow \"research\"
+/// not found (looked in ...)"). This submits against `prototype`, a real
+/// shipped package, through the actual daemon (`support::DataDir`, a real
+/// spawn) rather than a hand-written fixture workflow, so the assertion is
+/// that resolution — not necessarily full execution — succeeds: any failure
+/// downstream of resolution (capability mismatch, etc.) is a different,
+/// acceptable outcome; a `workflow_error` naming "not found" is not.
+/// Mutation this kills: `sgt init` regressing back to writing no workflow
+/// packages (#165's original defect) would turn this submission's error
+/// code back into `workflow_error` with a "not found (looked in" message.
+#[test]
+fn run_workflow_resolves_against_a_freshly_initialized_estate() {
+    let data_dir = DataDir::new();
+    let estate = tempfile::TempDir::new().expect("tempdir");
+    run(estate.path(), Some(data_dir.path()), &[], &["init"]).assert_ok("init");
+
+    init_repo(&estate.path().join("repos").join("target"));
+    run(
+        estate.path(),
+        Some(data_dir.path()),
+        &[],
+        &["repo", "add", "target"],
+    )
+    .assert_ok("repo add");
+
+    let submitted = run(
+        estate.path(),
+        Some(data_dir.path()),
+        &[],
+        &[
+            "--json",
+            "run",
+            "--workflow",
+            "prototype",
+            "--backend",
+            "fake",
+            "--repo",
+            "target",
+            "try the embedded distro",
+        ],
+    );
+
+    // A submit-time API error prints as `sgt: {status}: {message}` on
+    // stderr (`ClientError::Api`'s `Display`, `src/api.rs`), not JSON on
+    // stdout — so on failure the fingerprint of issue #165's 422
+    // (`WorkflowError::NotFound`'s message, `src/domain/workflow.rs`) is
+    // checked there. Any failure *without* that fingerprint is a different,
+    // unrelated outcome (e.g. a capability mismatch) and is not what this
+    // test is pinning.
+    assert!(
+        !submitted.stderr.contains("not found (looked in"),
+        "must not hit the #165 422, got stdout: {}\nstderr: {}",
+        submitted.stdout,
+        submitted.stderr
+    );
+    if submitted.code == Some(0) {
+        assert!(
+            submitted.json()["work"]["id"].is_string(),
+            "a successful submit must carry a work id, got: {}",
+            submitted.stdout
+        );
+    }
+
+    data_dir.reap();
+}
+
 /// guard-map: on a host with no `claude` CLI reachable, `sgt init` still
 /// exits 0 and still scaffolds the estate — the bug this pins (GH runner CI,
 /// all `m8_estate_cli` tests, run 31659419098): doctor's `claude` row FAILs


### PR DESCRIPTION
Closes #165. This is the gap between what the repository builds and what `NORTH-STAR.md` promises.

## Before / after, on a genuinely fresh estate

```
$ mkdir /tmp/e && cd /tmp/e && git init && sgt init
```

| | before | after |
|---|---|---|
| distro files written | 0 | **241** |
| `sgt doctor` workflows | `[warn] 0 packages … any --workflow will 422` | `[ok] 17 workflow package(s) declared` |
| `sgt run --workflow triage` | `422 workflow not found` | resolves |
| `sgt workflow fork triage` | `no stock package … nothing to fork` | `forked workflow triage to …/.sergeant/local/workflows/triage` |

`sgt workflow fork` is the telling one. It shipped in Phase 3 and has been correctly refusing ever since, because there was never any stock to fork. It works now for the first time.

## Co-versioning is mechanical, not asserted

```
$ grep '^edition:' .sergeant/workflows/triage/index.md   →  edition: 0.1.0
$ sgt --version                                          →  sgt 0.1.0
```

ADR 0014 decision 2 says `v0.x.y` names one artifact identity — binary *and* the distro it writes. A fresh estate's stock is now identifiable as descending from this build, so a template and the binary that wrote it cannot silently diverge.

## Guardrails held

- **Re-init is a no-op.** `estate at /tmp/e is already initialized — nothing to do`. Nothing a user edited is overwritten. This was the constraint most worth failing the feature over.
- **Stock never touches `.sergeant/local/`.** Phase 3's local-shadows-stock resolution depends on that separation.
- Writes stay inside the estate being scaffolded.
- No diff verb added — ADR 0014 decision 4 is binding.

## Approach

`include_dir` at R5 (an installed-dependency rung, not a new mechanism). The commit records the R7 alternatives rejected — build-script writes, download-at-init, vendored tarball.

## NORTH-STAR

The dated "Not true yet" note is **superseded, not deleted** — kept legible per the document's own rule, and it does not overclaim: it now names what is *still* untrue, the `curl … | sh` installer step.

## Gates

`fmt` clean · `clippy -D warnings` clean · 15/15 suites `ok` · no leaked daemons.

Tests in `tests/m8_estate_cli.rs` cover: package count after init, `--workflow` resolution on a fresh estate, re-init changing nothing, init not writing into `.sergeant/local/`, and edition matching the binary version. Each revert-verified.

## What is still not done

- **`curl … | sh`** — no installer, no published release. `release.yml` exists but `dist`/DuckDB on hosted runners is unmeasured (proposal §22), so no release should be attempted yet.
- **#176** — Gate F cannot run in CI; the validator lives in the workspace repo.

So the loop is real from `sgt init` onward. The step before it isn't.