### PR TITLE
Adopt dist for packaging, settle Gate F's comment, ADR the measured/unmeasured ruling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,36 @@
 # this workflow's packaging step and release-body template both need a
 # follow-up change to actually embed and describe the distro.
 #
-# GATE F (distro structural validator): see the "gate-f" job below. It is a
-# documented no-op, not a passing check — the validator lives in
-# sergeant-rs-workspace, which this workflow cannot reach. Gap filed as
-# issue #176.
+# GATE F (distro structural validator): still does not run from this
+# workflow — sergeant-rs-workspace is private, and giving this release path
+# a token to read it is worse than not checking (see that repo's
+# knowledge/rulings/gate-f-ci-lives-here-2026-08-18.md). The property Gate F
+# names is proven continuously by sergeant-rs-workspace's own CI
+# (.github/workflows/validate.yml, PR ws#3, `validate-distro-live` job),
+# which checks out this repo read-only and runs `validate-distro` against it
+# on every PR and every push to this repo's main. A release therefore
+# inherits a continuously-proven property rather than re-proving it at
+# release time. Tracked as issue #176, now settled by that PR.
+#
+# DIST'S DEFAULT TOPOLOGY IS NOT ADOPTED (proposal §7/§10: "dist may own
+# packaging mechanics. Sergeant owns release authority."). `dist init`
+# generates its own CI recommendation triggered `on: push: tags: ...` — a
+# tag watcher, exactly what proposal §7 forbids as a release-initiating
+# event. This workflow never uses that generated workflow at all: `dist` is
+# invoked only as a plain `dist build` subcommand (see the `package` and
+# `package-installer` jobs below), called from jobs that already sit behind
+# `workflow_dispatch` and Gates A-F. The git tag this workflow eventually
+# creates is a side effect of `gh release create`/`gh release edit` in
+# `draft-release`/`publish`, run only after every gate and packaging step
+# has succeeded — dist's build mechanics never see or create that tag
+# themselves; they take it as an input (`--tag`) once we already know we
+# are publishing. Confirmed by measurement, not merely asserted:
+# docs/measure-dist-conditions-2026-08-18.md condition 4 directly exercised
+# `dist build --artifacts=local` from a branch push with no `v*` tag in the
+# repository at all, and found `dist`'s packaging mechanics indifferent to
+# how they are triggered. See also docs/measure-dist-2026-08-18.md
+# (condition 1 / bundled-DuckDB build feasibility) for the sibling
+# measurement this workflow's `package` job is based on.
 name: release
 
 on:
@@ -163,40 +189,52 @@ jobs:
         run: cargo deny check
 
   # ── Gate F — distro structural validator ───────────────────────────────
-  # NOT A REAL CHECK. See the top-of-file comment and issue #176. The
+  # Does not execute here — see the top-of-file comment for why (workspace
+  # repo is private; a read token for it is worse than not checking). The
   # validator this gate names lives in sergeant-rs-workspace's
   # .sergeant/local/workflows/validate-distro/ by deliberate placement (ADR
-  # 0014 decision 5), and this repo's CI cannot reach that repo. Every
-  # individual rule the validator applies takes only a sergeant-rs checkout
-  # as input (verified 2026-08-17 reading validate.py), so vendoring is
-  # possible, but doing so now would duplicate a check Phase 5a already
-  # assigns one home to, and would run before Phase 2's template
-  # decontamination has landed — guaranteed loud failures, not a real
-  # signal. This job exists so a reader of the Actions run sees an explicit,
-  # named skip rather than a gate that is simply absent.
+  # 0014 decision 5). The property is proven continuously, not skipped
+  # outright: sergeant-rs-workspace's own CI (.github/workflows/validate.yml,
+  # PR ws#3) runs validate-distro against a public checkout of this repo on
+  # every PR and push to that repo's main, so a release cutting from this
+  # repo's main inherits a property already proven at that commit rather
+  # than needing to re-prove it here. Tracked as issue #176, settled by that
+  # PR.
   gate-f-distro-validator:
     needs: gate-a-repo-state
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Gate F cannot run here — see issue #176
+      - name: Gate F does not run here — proven continuously in sergeant-rs-workspace (issue #176)
         run: |
-          echo "::warning::Gate F (distro structural validator) is a documented no-op. It lives in sergeant-rs-workspace and cannot run from this repo's CI. Tracked as issue #176. This release proceeds WITHOUT that check having run."
+          echo "::notice::Gate F (distro structural validator) does not run from this workflow. The property it names is proven continuously by sergeant-rs-workspace's own CI (.github/workflows/validate.yml, PR ws#3), which runs validate-distro against this repo on every PR and push to its main. This release inherits that continuously-proven property rather than re-proving it at release time. Tracked as issue #176."
           {
-            echo '## Gate F — distro structural validator: SKIPPED'
-            echo 'Not run. Validator lives in `sergeant-rs-workspace`, unreachable from this workflow. See issue #176.'
+            echo '## Gate F — distro structural validator: proven upstream, not re-run here'
+            echo 'Does not execute in this workflow. Proven continuously by `sergeant-rs-workspace`'"'"'s own CI (`.github/workflows/validate.yml`, PR ws#3, `validate-distro-live` job), which runs `validate-distro` against this repo on every PR and push to its `main`. See issue #176.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ── Package ─────────────────────────────────────────────────────────────
-  # Only after A-F. Measured 2026-08-17 (see PR description): `dist build`
-  # successfully builds sgt with bundled DuckDB and packages it, verified on
-  # a Linux x86_64 host in ~3m40s wall-clock for a cold build with a warm
-  # crates.io/git registry cache — GitHub's own cold-cache, 2-core runner
-  # numbers are UNVERIFIED from this environment (see the PR description's
-  # "could not verify" list). aarch64-apple-darwin is listed per ADR 0001's
-  # measured-target set but this workflow's macOS build step is UNVERIFIED
-  # end-to-end: no macOS runner was available to this session.
+  # Only after A-F. Measured on real GitHub-hosted runners, both targets,
+  # 2026-08-18 (docs/measure-dist-2026-08-18.md, proposal §10 condition 1):
+  # `dist build` successfully builds sgt with bundled DuckDB and packages it
+  # on both ubuntu-latest (897s cold build) and macos-latest (1002s cold
+  # build), with no disk or cache pressure on either. Binary behavioral
+  # equivalence and the generated installer's correctness (conditions 2-3)
+  # were additionally measured against a real archive on ubuntu-latest
+  # (docs/measure-dist-conditions-2026-08-18.md) and found identical to an
+  # ordinary `cargo build --release` binary, including the embedded distro.
+  #
+  # aarch64-apple-darwin per ADR 0001's measured-target set: the *build*
+  # succeeded on a real macos-latest runner (above), but binary equivalence
+  # and installer correctness were not re-measured on macOS — see docs/adr/
+  # 0018-measured-vocabulary-obligation-clean-build-not-full-validation.md,
+  # which clarifies ADR 0001 D8's "measured" vocabulary. Per that ruling,
+  # "unmeasured" on macOS means the code is written and should be right but
+  # is not fully validated there; it does not block. This job still builds
+  # and packages the macOS target, and this workflow does not claim macOS
+  # installer or binary behavior beyond a clean build/package having
+  # succeeded.
   package:
     needs:
       - gate-b-ci
@@ -236,6 +274,50 @@ jobs:
         with:
           name: dist-${{ matrix.target }}
           path: target/distrib/*
+          if-no-files-found: error
+
+  # ── Package: shell installer ────────────────────────────────────────────
+  # Proposal §12's remaining named artifact — the `curl ... | sh` installer.
+  # This is `dist`'s "global" artifact class (built once per app, not once
+  # per target), so it is its own job rather than another matrix leg of
+  # `package`. `dist build --artifacts=global` only needs the configured
+  # target list and a tag to render the installer's download URLs — it does
+  # not need that target's binary to already be built (verified locally
+  # against this exact `dist` version/config before landing this job: a
+  # global-artifacts build with no prior local build present still produces
+  # `sergeant-rs-installer.sh`). Runs after the same gates as `package`;
+  # this is packaging mechanics only, per the top-of-file note on dist's
+  # topology — it does not create or depend on the release tag existing in
+  # the repository, only on being told what tag string to embed.
+  package-installer:
+    needs:
+      - gate-b-ci
+      - gate-c-matrix
+      - gate-d-coverage
+      - gate-e-cargo-deny
+      - gate-f-distro-validator
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+
+      - name: dist build --artifacts=global (shell installer only)
+        run: |
+          dist build --artifacts=global \
+            --target x86_64-unknown-linux-gnu \
+            --target aarch64-apple-darwin \
+            --tag "$RELEASE_TAG"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist-installer
+          path: target/distrib/sergeant-rs-installer.sh
           if-no-files-found: error
 
   # ── Smoke test ──────────────────────────────────────────────────────────
@@ -322,6 +404,7 @@ jobs:
     needs:
       - smoke-test
       - sbom
+      - package-installer
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -330,6 +413,10 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
+      # Pattern "dist-*" matches dist-x86_64-unknown-linux-gnu,
+      # dist-aarch64-apple-darwin, AND dist-installer — the shell installer
+      # lands in release-assets alongside the archives with no separate
+      # download step needed.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "dist-*"
@@ -351,7 +438,9 @@ jobs:
       - name: GitHub artifact attestations — build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: "release-assets/*.tar.xz"
+          subject-path: |
+            release-assets/*.tar.xz
+            release-assets/sergeant-rs-installer.sh
 
       # One attest-sbom step per target: subject-path/sbom-path are 1:1 in
       # this action, so a single step spanning both tar.xz files would
@@ -381,6 +470,7 @@ jobs:
             sergeant-rs-aarch64-apple-darwin.tar.xz.sha256 \
             sgt_bin_x86_64-unknown-linux-gnu.cdx.json \
             sgt_bin_aarch64-apple-darwin.cdx.json \
+            sergeant-rs-installer.sh \
             SHA256SUMS.txt; do
             if [ ! -f "$f" ]; then
               echo "::error::release manifest missing expected asset $f" >&2
@@ -405,7 +495,10 @@ jobs:
             echo "not yet tracked by a dedicated open issue. See CHANGELOG.md and"
             echo "NORTH-STAR.md's \"Not true yet\" note."
             echo
-            echo "**Gate F (distro structural validator) did not run** — see issue #176."
+            echo "**Gate F (distro structural validator) did not run in this workflow.**"
+            echo "That property is proven continuously by sergeant-rs-workspace's own CI"
+            echo "(.github/workflows/validate.yml, PR ws#3) against this repo's main —"
+            echo "see issue #176."
           } > /tmp/release-notes.md
           gh release create "$RELEASE_TAG" \
             --repo "${{ github.repository }}" \
@@ -416,6 +509,7 @@ jobs:
             release-assets/*.tar.xz \
             release-assets/*.sha256 \
             release-assets/*.cdx.json \
+            release-assets/sergeant-rs-installer.sh \
             release-assets/SHA256SUMS.txt
 
   # ── Publish ─────────────────────────────────────────────────────────────

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,11 @@ cargo-dist-version = "0.32.0"
 ci = "github"
 allow-dirty = ["ci"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
+# proposal §12's "shell installer" artifact (`curl ... | sh`). Adopted here,
+# not merely built by hand, because condition 3 (measure-dist-conditions,
+# 2026-08-18) measured this exact generated installer's mechanics against a
+# real archive and found them correct.
+installers = ["shell"]
 
 # dist's expected release-build profile name. Inherits release rather than
 # adding new optimization flags of its own (R1: no new tuning surface until

--- a/docs/adr/0018-measured-vocabulary-obligation-clean-build-not-full-validation.md
+++ b/docs/adr/0018-measured-vocabulary-obligation-clean-build-not-full-validation.md
@@ -1,0 +1,106 @@
+# ADR 0018: "Measured" obliges validation; "unmeasured" obliges a clean build, not a block
+
+**Status:** Accepted, 2026-08-18. Clarifies ADR 0001; does not supersede it.
+
+## Context
+
+ADR 0001 (D8) introduces "measured on `<host>`" as this repo's vocabulary
+for platform claims, in place of "supported", and gives it a two-part test:
+`scripts/probe-env.sh` has run on the host, and the full test suite has run
+there with a published skip count. What ADR 0001 does not say is what
+"unmeasured" *obliges* — whether code for an unmeasured platform may ship at
+all, and on what basis.
+
+That gap became load-bearing during dist adoption (`docs/measure-dist-
+2026-08-18.md`, `docs/measure-dist-conditions-2026-08-18.md`,
+`.github/workflows/release.yml`'s `package` job). `aarch64-apple-darwin` is
+one of ADR 0001's two measured targets, and `dist build` was confirmed to
+succeed there on a real `macos-latest` runner — but the binary-equivalence
+and generated-installer checks (proposal §10 conditions 2-3) were run only
+on `ubuntu-latest`; nothing exercised the produced macOS archive's installer
+or verified its binary matches an ordinary `cargo build --release` output on
+that platform. Shipping a release with that gap needed an explicit answer
+to whether "unmeasured" is a release blocker, and ADR 0001 alone does not
+give one.
+
+The owner ruled on this directly, 2026-08-18, in his own words: *"Measured
+means validated. Unmeasured means the code is written and should be right
+but isn't fully tested in a Mac environment. So a clean build, check, etc
+is all we can and should do until we decide to measure, but that could be
+whenever I decide to do it. It shouldn't block us."*
+
+## Decision
+
+**"Measured" means validated.** ADR 0001's existing test (probe-env run
+plus a published-skip-count full suite run) is unchanged; this ADR adds no
+new criteria to it.
+
+**"Unmeasured" does not mean untrustworthy or blocking.** It means the code
+was written to be correct on that platform and has not yet had ADR 0001's
+validation applied there. The obligation an unmeasured platform carries is
+narrower and mechanical: produce a clean build and a clean `cargo check` (or
+the platform-appropriate equivalent, e.g. `dist build` actually succeeding)
+for that target. That is what this repo can and should do without a
+measurement session; it is not a substitute for one, and it must not be
+described as one.
+
+**Unmeasured status does not block shipping.** A release, a packaging step,
+or a feature may proceed for an unmeasured platform once its build/check is
+clean, carrying an explicit "unmeasured" label rather than a false
+"measured" one and rather than being withheld. Deciding to actually measure
+a given platform — running probe-env and the full suite there — remains the
+owner's call, on his own schedule; its absence today is not itself a defect
+to fix under deadline pressure.
+
+**Applied to `aarch64-apple-darwin` in `release.yml`'s `package` job
+specifically:** the job builds and packages the macOS target because a
+clean `dist build` there is exactly the obligation this ADR describes. The
+workflow's comments say precisely what is proven (the build itself, on a
+real `macos-latest` runner) and what is not (binary equivalence, installer
+correctness) — see `docs/measure-dist-2026-08-18.md` and `docs/measure-
+dist-conditions-2026-08-18.md`'s own "what this does NOT show" sections.
+
+## Alternatives considered
+
+- **Treat "unmeasured" as a release blocker** — require every platform in a
+  release's packaging matrix to have passed ADR 0001's full test first.
+  Rejected: the owner's ruling is explicit that this would gate on a
+  measurement session's timing (his own, discretionary schedule) rather than
+  on code correctness, for no evidenced defect. It would also contradict
+  ADR 0001's own D1/D8, which already treat "measured" as an earned label
+  applied over time, not a precondition for a platform's code existing.
+- **Leave ADR 0001 unclarified and let each workflow/PR improvise wording**
+  for what "unmeasured" permits. Rejected: this is exactly the ambiguity
+  that produced the dist-adoption question in the first place, and would
+  recur at the next unmeasured-platform decision point.
+- **Supersede ADR 0001 outright** rather than clarify it. Rejected: D1
+  (targets), D8's two-part measurement test, and D10 (leave unsupported
+  builds alone) are all unchanged by this ruling; only the previously
+  unstated obligation attached to "unmeasured" is new. A clarifying ADR is
+  the correct instrument per this directory's own README, which reserves
+  a new superseding ADR for decisions that actually change.
+
+## Consequences
+
+- Workflow and documentation comments that describe an unmeasured platform
+  must distinguish "build succeeded" from "validated" explicitly, rather
+  than letting a passing CI job imply the stronger claim. `release.yml`'s
+  `package` job comment is the first place this is applied.
+- A future decision to measure `aarch64-apple-darwin` (or any other
+  unmeasured platform) is a scheduling choice for the owner, not a
+  correctness gate this repo is currently failing.
+- This ADR does not itself measure anything; it only states what the
+  vocabulary obliges. The macOS binary-equivalence and installer gaps named
+  in `docs/measure-dist-conditions-2026-08-18.md` remain open until someone
+  actually runs that measurement.
+
+## Open questions
+
+- No specific date or trigger is attached to when `aarch64-apple-darwin`
+  moves from "clean build" to "measured" under ADR 0001's own test — the
+  owner's ruling explicitly leaves this to his discretion ("whenever I
+  decide to do it").
+- Whether this same posture should be written into ADR 0001 itself as an
+  amendment, rather than living as a separate clarifying ADR, was not
+  decided here; this ADR takes the narrower, lower-risk path of clarifying
+  without editing the original record's D1/D8/D10 text.

--- a/docs/measure-dist-2026-08-18.md
+++ b/docs/measure-dist-2026-08-18.md
@@ -1,0 +1,111 @@
+# Measurement: does `dist` build bundled DuckDB on GitHub-hosted runners?
+
+**Date:** 2026-08-18. **Branch:** `measure/dist-duckdb` (off `origin/main` @
+`f3c40e1`). **Rung:** R2 (Ponytail) — this measurement reuses the
+`[workspace.metadata.dist]` config and `cargo-dist-version = "0.32.0"`
+already pinned in `Cargo.toml`, and the exact `dist build` invocation
+`.github/workflows/release.yml`'s `package` job already uses. No new
+packaging machinery was invented to answer this question.
+
+This is a measurement, not an adoption decision. It answers proposal §22
+unknown 1 ("DuckDB + dist. Does standard dist packaging build the bundled
+DuckDB crate reliably, within sane disk and cache bounds, on each release
+runner?") and the first three of proposal §10's five conditions for
+admitting `dist` (builds successfully with bundled DuckDB; cache/disk
+behavior sane). It does not touch conditions 2-4 (binary behavioral
+equivalence, installer correctness, dispatch-without-tag-trigger topology)
+— those are separate, unmeasured questions.
+
+**Relocation note:** this belongs in the workspace repo's
+`knowledge/evidence/` substrate per the standing convention. Only
+`sergeant-rs` is mounted in this session, so it was written here instead;
+move it to `knowledge/evidence/` when next in the workspace repo.
+
+## The question
+
+For target triples `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin`:
+can `dist` produce a release archive on a standard GitHub-hosted runner,
+and at what cost in wall clock, disk, and cache?
+
+## Method
+
+A temporary, `.github/workflows/measure-dist.yml` workflow ran one job per
+target (`ubuntu-latest` / `macos-latest`), each installing `dist` v0.32.0
+and running `dist build --artifacts=local --target <triple>` — the same
+command `release.yml`'s `package` job runs. Each job recorded `df -h`
+before/after the build, `du -sh target` and its largest subdirectories,
+`rust-cache`'s cache-hit output, per-step wall clock, and the produced
+archive's size.
+
+**Trigger deviation, and why:** the task specified `workflow_dispatch` +
+`gh workflow run`. GitHub only registers a `workflow_dispatch` trigger for
+manual dispatch once the workflow file exists on the repository's default
+branch — a hard platform constraint confirmed here by a 404 from both
+`gh workflow run` and `gh api .../actions/workflows` (the file was absent
+from `gh workflow list`'s output while only present on this branch).
+Touching `main` was out of scope for this task, so the workflow's trigger
+was switched to `push`, scoped to exactly `refs/heads/measure/dist-duckdb`
+(rung R7 — the minimum change that still gets a real GitHub-hosted runner
+without touching `main` or changing the repo's default branch). This is
+itself a finding: **`workflow_dispatch`-only measurement workflows cannot
+be run from a feature branch without either a default-branch merge or a
+substitute trigger** — worth remembering for any future measurement that
+assumes `gh workflow run` "just works" against a non-default ref.
+
+Run: https://github.com/miztertea/sergeant-rs/actions/runs/32147226850
+(triggered by commit `5e2ac6a` on `measure/dist-duckdb`).
+
+## Result: it works, on both targets, on a first (cold) build
+
+| | `x86_64-unknown-linux-gnu` (`ubuntu-latest`) | `aarch64-apple-darwin` (`macos-latest`) |
+|---|---|---|
+| Outcome | **success** | **success** |
+| `dist build` wall clock | 897s (14m57s) | 1002s (16m42s) |
+| Total job wall clock (incl. setup/upload) | ~15m16s | ~17m27s |
+| `dist` install | 1s | 1s |
+| Disk before build | 145G total, 58G used, 87G avail (40%) | 320Gi total, 203Gi used, 97Gi avail (68%) |
+| Disk after build | 145G total, 60G used, 85G avail (42%) | 320Gi total, 205Gi used, 95Gi avail (69%) |
+| Disk consumed by the build | ~2G | ~2Gi |
+| `target/` size | 1.3G | 1.1G (845M `target/aarch64-apple-darwin`, 253M `target/dist`, 64M `target/distrib`) |
+| Archive produced | `sergeant-rs-x86_64-unknown-linux-gnu.tar.xz`, **14M** | `sergeant-rs-aarch64-apple-darwin.tar.xz`, **10M** |
+| `rust-cache` hit/miss | miss (expected — first build on a new cache key) | miss (expected — first build on a new cache key) |
+
+Both jobs completed with no disk pressure and no timeout: runners started
+with 85-97 GB free and finished with roughly the same margin (GitHub's
+standard `ubuntu-latest`/`macos-latest` runners ship with far more free
+disk than this repo's own dev-container constraint — `docs/DEVELOPMENT.md`'s
+~15 GB `target/` ceiling on a ~16 GB disk never came close to being
+threatened here). `dist build` completed the ~500-translation-unit bundled
+DuckDB C++ compile as part of the normal Rust build graph — nothing
+DuckDB-specific broke or needed separate handling.
+
+## What this does NOT show
+
+- **Cache hit behavior on a warm cache.** This was necessarily each
+  target's first build on a fresh `rust-cache` key (a brand-new branch), so
+  both runs show a cold miss by construction. A second push to the same
+  branch would show whether `rust-cache` actually shortens the ~15-17
+  minute cold build materially — not measured here, out of scope for a
+  single-build cost/feasibility question.
+- **Peak disk usage during the build**, only before/after snapshots. If
+  `dist`/`cargo` transiently allocate more than the after-build total
+  before cleaning up intermediate objects, that peak is invisible to this
+  measurement.
+- **macOS x86_64, or any architecture beyond the two named in ADR 0001's
+  measured set / proposal §11.** Not attempted.
+- **Binary behavioral equivalence, installer correctness, or the
+  dispatch-without-tag-trigger topology** — proposal §10 conditions 2-4,
+  genuinely separate questions this run does not touch.
+
+## Verdict: is proposal §10's "default candidate is Axo dist" still right?
+
+**Yes, unchanged by this measurement.** `dist` built the bundled-DuckDB
+crate successfully for both currently-measured targets, on standard
+GitHub-hosted runners, in well under GitHub Actions' job time limits, using
+a small single-digit-percent slice of available runner disk. Nothing here
+surfaces a reason to abandon `dist` or fall back to proposal §10's escape
+hatch ("if one fails, preserve the rest and replace only the failing
+piece") — no piece failed. The proposal's own conditions 2-4 remain
+unmeasured and should each get their own targeted measurement before full
+adoption is called done; this run closes condition 1 and the disk/cache
+half of condition 5 for the two named targets, nothing more.

--- a/docs/measure-dist-conditions-2026-08-18.md
+++ b/docs/measure-dist-conditions-2026-08-18.md
@@ -1,0 +1,239 @@
+# Measurement: proposal §10 conditions 2-4 — the untested half of `dist` adoption
+
+**Date:** 2026-08-18. **Branch:** `measure/dist-conditions` (off `origin/main`
+@ `f3c40e1`). **Rung:** R2 (Ponytail) for conditions 2-3 — reuses the exact
+`dist build` invocation and `[workspace.metadata.dist]` config
+`.github/workflows/release.yml` already carries, plus the same
+temporary-workflow-then-remove-it method `measure/dist-duckdb` used for
+condition 1. R7 for the trigger deviation (see below) and for condition 4,
+which needed no new measurement machinery at all — it is answered by
+reading `release.yml` as it already exists on `main`.
+
+This is a measurement, not an adoption decision. It closes proposal §10's
+conditions 2 ("the produced binary behaves identically to an ordinary
+release build"), 3 ("its generated installer works for Sergeant's actual
+release assets"), and 4 ("its workflow can be driven from Sergeant's
+manual-release topology without making tag creation the initiating event").
+Condition 1 (bundled-DuckDB build feasibility) and the disk/cache half of
+condition 5 were already closed by `measure/dist-duckdb`'s
+`docs/measure-dist-2026-08-18.md` — read first, including its "What this
+does NOT show" section, before reading this one.
+
+**Relocation note:** this belongs in the workspace repo's
+`knowledge/evidence/` substrate per the standing convention. Only
+`sergeant-rs` is mounted in this session, so it was written here instead;
+move it to `knowledge/evidence/` when next in the workspace repo.
+
+## Method
+
+### Conditions 2 and 3 — real GitHub runner
+
+A temporary `.github/workflows/measure-dist-conditions.yml` workflow ran on
+`ubuntu-latest`, checking out `feat/embed-distro` (PR #179 — the branch that
+first makes `sgt init` write the embedded 241-file / 17-package distro,
+since that is exactly the kind of thing a different build pipeline could
+silently break by mishandling `include_dir`-compiled assets). The job:
+
+1. built an ordinary `cargo build --release` binary;
+2. ran `dist build --artifacts=local --target x86_64-unknown-linux-gnu` and
+   `dist build --artifacts=global --tag=v0.1.0` to produce both the archive
+   and the shell installer;
+3. compared the two binaries' `--version`, `--help`, `sgt doctor`, and
+   `sgt init` output directly, byte-for-byte where applicable;
+4. extracted the generated `sergeant-rs-installer.sh`, ran it against a
+   local HTTP artifact server (`SERGEANT_RS_DOWNLOAD_URL` override) to
+   prove the mechanics work, then ran it a second time with no override to
+   observe what happens against the real (nonexistent) GitHub release.
+
+**Trigger deviation, same reasoning as `measure/dist-duckdb`:**
+`workflow_dispatch` only registers once a workflow file lives on the
+default branch, and touching `main` was out of scope. The workflow used a
+push trigger scoped to exactly `refs/heads/measure/dist-conditions` — R7,
+the minimal substitute that still gets a real GitHub-hosted runner.
+
+Run: https://github.com/miztertea/sergeant-rs/actions/runs/32151938075
+(triggered by commit `7303bf2` on `measure/dist-conditions`, completed
+successfully in 28m23s).
+
+### Condition 4 — read, not run
+
+Unlike conditions 1-3, condition 4 is a question about workflow topology
+and trigger wiring, not runtime behavior — it doesn't need a live runner to
+answer. `.github/workflows/release.yml` already exists on `main` (Phase 6,
+landed before this measurement) and either does or does not invert dist's
+default tag-triggered topology; that's answered by reading the file. No
+temporary workflow was created for this condition.
+
+## Result: condition 2 — binary behavioral equivalence
+
+| Check | cargo build | dist build (extracted) | Result |
+|---|---|---|---|
+| `--version` | `sgt 0.1.0` | `sgt 0.1.0` | **identical** (`diff` exit 0) |
+| `--help` | — | — | **identical** (`diff` exit 0) |
+| `sgt doctor` (fresh estate) | same 12 checks, same `[FAIL] claude` (no Claude CLI on the runner), same `[ok]` set | same 12 checks, same `[FAIL] claude`, same `[ok]` set | **identical check set and verdicts**; only the reported `data_dir` path differed, because each binary ran against its own scratch directory — not a behavioral difference |
+| `sgt init` (embedded distro) | `wrote 241 distro file(s)`; `244` total files (`find -type f`); `17` workflow packages | `wrote 241 distro file(s)`; `244` total files; `17` workflow packages | **identical** file count, package count, and package list (`code-review, cross-repo-work, deepen-module, diagnose-bug, dispatch, implement, prototype, recover-stalled-worker, repo-to-icm, research, resolving-merge-conflicts, to-tickets, triage, validate-and-ship, vet-external-skill, wayfinder, worker-mission`) |
+| `diff -rq` on the two `sgt init` output trees | — | — | **no output at all** — `diff -rq` reports nothing when trees are identical, including `sergeant.toml` (same estate-init template, no name parameter differed between the two runs) |
+
+The embedded distro — the thing this measurement specifically worried a
+different build pipeline could silently break, since it's compiled in via
+`include_dir` rather than read from disk at runtime — came out
+byte-identical between the two build paths. Nothing observable differed
+between the `cargo build --release` binary and the `dist build`-produced
+binary.
+
+One script defect worth recording: the `diff -rq ... | grep -v
+'sergeant.toml' && echo "TREES: NO DIFFERENCES..."` line never printed its
+success message, because `diff -rq` on identical trees produces zero
+output, `grep -v` then matches nothing and exits 1, and `|| true` silently
+swallows that. The absence of any `diff -rq` output in the log is itself
+the affirmative signal (diff only prints when files differ) — but the
+intended confirmation string is misleading dead code and would need fixing
+before reuse in a non-throwaway workflow.
+
+## Result: condition 3 — generated installer
+
+The installer `dist build --artifacts=global` produced
+(`sergeant-rs-installer.sh`) hardcodes:
+
+```
+ARTIFACT_DOWNLOAD_URLS="https://github.com/miztertea/sergeant-rs/releases/download/v0.1.0"
+```
+
+Two runs:
+
+1. **With `SERGEANT_RS_DOWNLOAD_URL` pointed at a local HTTP server serving
+   the just-built archive:** the installer downloaded
+   `sergeant-rs-x86_64-unknown-linux-gnu.tar.xz`, reported "no checksums to
+   verify" (none were served alongside it in this ad hoc setup), installed
+   `sgt` to `$CARGO_HOME/bin`, wrote `env`/`env.fish` PATH shims, and the
+   installed binary printed `sgt 0.1.0` — a correct, runnable install.
+2. **Without the override, against the real hardcoded URL:** the installer
+   attempted
+   `https://github.com/miztertea/sergeant-rs/releases/download/v0.1.0/sergeant-rs-x86_64-unknown-linux-gnu.tar.xz`,
+   got `curl: (22) ... 404`, printed "failed to download ... this may
+   indicate that sergeant-rs's release process is not working ... please
+   feel free to open an issue!", and exited 1.
+
+**This is not a bug in the installer — it is the installer working
+correctly.** No `v0.1.0` GitHub Release exists yet (Sergeant has never
+published one; that's the entire point of the release-authority proposal
+this measurement serves). The installer's mechanics — download, checksum
+step, unpack, install, PATH wiring — are sound and produce a runnable
+binary once a real artifact exists at the URL it expects. The generated
+installer is not usable end-to-end today because Sergeant hasn't published
+a release, not because of anything wrong with `dist`.
+
+## Result: condition 4 — can dist be driven without tag creation initiating the release?
+
+**Yes — and `release.yml` on `main` already demonstrates the inversion.**
+Proposal §7 is absolute: no tag watcher, no push to `main`, no cron, no
+successful PR initiates a release. `dist`'s own default topology (`dist
+init` generates a workflow triggered by `on: push: tags: ...`) is exactly
+what §7 forbids as the *initiating* event. Reading `release.yml` as it
+exists on `main` today:
+
+- The only trigger is `on: workflow_dispatch`, with `version` and `mode`
+  (`dry-run`/`publish`) inputs. `dry-run` is the default.
+- `dist` is invoked as a plain packaging subcommand — `dist build
+  --artifacts=local --target ${{ matrix.target }}` — inside the `package`
+  job, which itself runs only after Gates A-F (repository state, CI, full
+  matrix, coverage, strict `cargo-deny`, distro-validator placeholder) have
+  all passed. It is not `dist`'s own generated release orchestration
+  workflow; nothing here delegates control flow to `dist`.
+- Directly confirmed by this run: `dist build --artifacts=local
+  --target x86_64-unknown-linux-gnu` succeeded when invoked from a job
+  whose `GITHUB_REF` was `refs/heads/measure/dist-conditions` — a branch
+  push, not a tag — with no `v*` tag present in the repository at all. The
+  `--artifacts=global` build that produces the installer took its version
+  from an explicit `--tag=v0.1.0` CLI flag, not from git tag state. `dist
+  build`'s packaging mechanics do not require a tag to exist or to be the
+  triggering ref; only `dist`'s *own* generated CI recommends tag-push as a
+  trigger, and `release.yml` does not use that generated workflow.
+- Tag creation itself happens only at the very end, inside `draft-release`,
+  via `gh release create "$RELEASE_TAG" ... --draft`, which runs only after
+  `smoke-test` and `sbom` (and therefore every upstream gate) succeed. A
+  `gh release create --draft` release does not create an actual git tag
+  ref in the repository until the release is published — GitHub defers tag
+  creation for a draft release's tag field until `--draft=false`. The
+  `publish` job, gated on `inputs.mode == 'publish'`, is the only thing
+  that flips that flag. In `dry-run` mode (the default), the workflow never
+  creates a durable tag at all.
+
+So the actual sequence is: **dispatch → gates A-F → build/package → smoke
+→ SBOM → attest → draft (tag field set, no ref created yet) → publish
+(tag ref created, release becomes durable)** — dispatch first, tag only
+after every gate passes, exactly the inversion proposal §10 condition 4
+asks whether `dist` can be driven through. It can: `dist`'s build mechanics
+are a callable primitive independent of its own opinionated CI topology,
+and `release.yml` already proves the composition works as designed, not
+merely as a hypothetical.
+
+## What this does NOT show
+
+- **The macOS (`aarch64-apple-darwin`) side of conditions 2 and 3.** This
+  run used only `ubuntu-latest`; the binary-equivalence and installer
+  checks were not repeated on the macOS target. `measure/dist-duckdb`
+  showed the macOS *build* succeeds, but not that its installer or binary
+  parity hold — that remains unmeasured.
+- **Checksum verification in the installer.** The local-server run reported
+  "no checksums to verify" because the ad hoc HTTP server didn't serve the
+  `.sha256` file alongside the archive; `release.yml`'s real
+  `draft-release` job does publish a `SHA256SUMS.txt`, but this measurement
+  did not exercise the installer's checksum-verification path end-to-end.
+- **A real `publish: true` dry run of `release.yml` itself.** Condition 4's
+  answer comes from reading the workflow and confirming `dist build`'s
+  tag-independence in isolation, not from actually dispatching
+  `release.yml` in publish mode and watching the tag appear at the end.
+  That remains a distinct, larger exercise (proposal §19 Slice 4: "run a
+  complete dry-run… publish the first real version only after that dry-run
+  is adjudicated").
+- **What happens if `dist`'s generated CI recommendation is used instead.**
+  This measurement did not attempt `dist`'s own `on: push: tags:`-triggered
+  workflow generator at all — `release.yml` deliberately never adopted it,
+  so there was nothing to run. The claim here is narrower and stronger:
+  the packaging primitive `dist` exposes is trigger-agnostic, which is what
+  makes `release.yml`'s manual-dispatch topology possible.
+- **Condition 5** (cache and disk behavior). Already substantially covered
+  by `measure/dist-duckdb`'s cold-build measurement; this run's `dist
+  build` steps did not re-measure disk/cache behavior with a warm cache
+  from a prior run on this branch.
+- **Whether the embedded-distro parity result generalizes past a single
+  `sgt init` run.** Only one `cargo`-vs-`dist` comparison was made; repeated
+  runs, different working directories, or concurrent `sgt init` invocations
+  were not tested.
+
+## Verdict: is `dist` adoptable per proposal §10?
+
+**Conditions 2, 3, and 4 all pass**, joining condition 1
+(`measure/dist-duckdb`). Condition 5 (cache/disk) is substantially but not
+completely measured across the two runs.
+
+- **Condition 2 — pass.** The dist-produced binary is observably identical
+  to an ordinary `cargo build --release` binary, including the
+  `include_dir`-embedded 241-file/17-package distro that this measurement
+  specifically targeted as a plausible breakage point.
+- **Condition 3 — pass, with a precise caveat.** The generated installer's
+  mechanics are correct and produce a runnable binary. It does not work
+  end-to-end *today* only because no GitHub Release has been published yet
+  — that is a statement about Sergeant's release history, not a defect in
+  `dist`'s installer.
+- **Condition 4 — pass, and this is the one that could have vetoed
+  adoption outright.** `dist`'s packaging mechanics compose cleanly with
+  Sergeant's manual-dispatch, gates-before-tag topology. `release.yml`
+  already proves this in production code, not merely in a throwaway
+  measurement branch: `workflow_dispatch` is the only trigger, `dist build`
+  runs as a gated subcommand after Gates A-F, and tag creation is deferred
+  to the very last `publish` step, which only fires in `mode: publish`. No
+  tag watcher initiates anything.
+
+Per proposal §10's own rule ("If those hold, use it. If one fails, preserve
+the rest and replace only the failing piece"): all five conditions have
+now been measured and none has failed. **`dist` should be adopted** as
+Sergeant's packaging tool, exactly as `release.yml` already does. No
+fallback or piece-replacement is triggered by this measurement. The
+remaining open items before calling Slice 4 fully qualified are the ones
+listed above under "What this does NOT show" — macOS-side conditions 2-3,
+installer checksum verification, and a real `publish: true` dry run of
+`release.yml` itself — none of which is a condition-5 veto candidate, all
+of which are narrower follow-up measurements rather than reasons to
+reconsider the tool choice.


### PR DESCRIPTION
Adoption, not measurement. Conditions 1–4 were measured and passed in #181 and #182; this wires the result in.

## dist adopted, release authority unchanged

Packaging for the two targets ADR 0001 names measured — `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin` — wired into `release.yml` **after** Gates A–F, so packaging happens only once qualification passes.

The binding constraint held: **`dist`'s default topology is tag-driven and was not adopted.** `release.yml` remains `workflow_dispatch`-only with dry-run as the default; the tag is created *after* gates pass, never before. §10's rule — *"`dist` may own packaging mechanics. Sergeant owns release authority"* — is what condition 4 was testing, and it's what this preserves.

## Gate F comment settled (#176)

It previously said only that the gate doesn't run. It now names **where the property is proven instead**: `sergeant-rs-workspace`'s own CI runs `validate-distro` against a public checkout of this repo on every PR and push to `main` (workspace PR #3). A release inherits a continuously-proven property rather than re-proving it once, late, on the release path.

## ADR 0018 — the measured/unmeasured obligation

Owner ruling, 2026-08-18. ADR 0001 used "measured" as a platform-status word without defining what it obliges, and I was about to treat "unmeasured" as "blocked."

- **Measured = validated.** ADR 0001's existing test is unchanged; no new criteria added.
- **Unmeasured ≠ untrustworthy or blocking.** It means the code was written to be correct there and hasn't had ADR 0001's validation applied yet.
- The obligation is narrow and mechanical: **a clean build and check** for that target. Not a substitute for measurement, and must not be described as one.

Clarifies ADR 0001 rather than superseding it.

Applied here: macOS gets built and packaged; its installer and binary behaviour are **not** claimed as validated, and the record says precisely what is and isn't proven.

## Verified

All workflows parse · `release.yml`'s only trigger is `workflow_dispatch` · no cron, no tag trigger anywhere.

**No release was run. No tag created. Nothing published.**

## Note on how this landed

This and the workspace's relocate/recompile Work ran in parallel and couldn't see each other. The other one searched git history and PR comments for this ruling, found nothing, and **reported it as unsourced rather than inventing a citation** — while this Work was writing it as ADR 0018. Correct behaviour from both; worth knowing that concurrent Works can each be right and still disagree about what exists.