### PR TITLE
Bump toml_edit 0.22 → 0.25.13 (resumes the abandoned #174)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,17 +3247,11 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -3270,14 +3264,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3286,14 +3281,8 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3910,18 +3899,12 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "2.0.19"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-stream = "0.1"
 toml = "1.1.4"
-toml_edit = { version = "0.22", features = ["parse", "display"] }
+toml_edit = { version = "0.25", features = ["parse", "display"] }
 tracing = "0.1.44"
 tracing-subscriber = "0.3"
 ulid = "3.0.0"


### PR DESCRIPTION
Resumes #174, which Dependabot opened and then closed with *"no longer updatable"* after a rebase request — the grouped update couldn't resolve, and the bump needs a `Cargo.toml` constraint change rather than a lockfile-only update. `0.25.13` is current and real; `main` was still on `0.22.27`.

## Why this got a real review

`toml_edit` is what parses and edits `sergeant.toml`, and ADR 0008 makes that manifest authoritative over storage paths. Three minor versions on a `0.x` crate is semver-breaking by convention. The dangerous failure here isn't a compile error — it's a **silent** change in formatting preservation or in what counts as malformed, which would corrupt estate config instead of failing loudly.

## Breaking changes, walked against actual usage

| change | version | touches us? |
|---|---|---|
| deprecated APIs removed | 0.23.0 | no |
| `ArrayOfTables::remove` return type | 0.23.0 | call discards the value — inert |
| `Array::push/insert` decor deferred to render | 0.23.0 | no |
| `Table::position` type | 0.23.0 | unused |
| `InlineTable::preamble`, `Table::set_position` signature | 0.24.0 | unused |
| `Time::second/nanosecond` → `Option` | 0.25.0 | unused |
| **TOML 1.1 parse leniency** | 0.24.0 | **yes — the one live change** |

`manifest.rs` uses `DocumentMut`, `Table`, `Item`, `ArrayOfTables`, and `value()`. `cargo tree -i` confirms `toml_edit` is a direct, sole-owner dependency with no transitive users.

## The one live change, and why it's acceptable

TOML 1.1 leniency means trailing commas, multi-line inline tables, and more escapes now parse — so **some previously-rejected hand-edited manifests will now be accepted**.

That's additive, not silently-wrong: accepted TOML still *means* the same thing, and the validating round-trip through `Workspace::from_config_structural` is untouched. A widened accept set is tolerable; a changed interpretation would not have been.

## Verified

`fmt` · `clippy -D warnings` · full `cargo test` — all green, including `manifest.rs`'s format-preservation and malformed-input-refusal tests and `m8_estate_cli`'s real-CLI estate tests.

Manually, against a real git origin: `sgt init` + `sgt repo add`, **a hand-written comment survives at the end of the manifest**, and `sgt doctor` reports healthy on the result. Format preservation is the reason this crate is a dependency at all.

`cargo deny check bans licenses sources` passes on the new graph — the policy CI now enforces, which #174's original branch never ran.