### PR TITLE
Fix release.yml startup_failure: Gate B must grant ci.yml's pull-requests: read

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,17 @@ jobs:
   gate-b-ci:
     needs: gate-a-repo-state
     uses: ./.github/workflows/ci.yml
+    # ci.yml's dependency-review job declares `pull-requests: read`. A called
+    # workflow's GITHUB_TOKEN permissions can only stay the same or become
+    # MORE restrictive — a callee that tries to elevate past its caller is
+    # rejected at startup, before any job exists. Granting only
+    # `contents: read` here made the entire release run fail with
+    # `startup_failure` and zero jobs. A caller must grant the UNION of what
+    # every job in the called workflow declares, not what the gate itself
+    # appears to need.
     permissions:
       contents: read
+      pull-requests: read
 
   # ── Gate C — full measured-platform matrix ─────────────────────────────
   # Proposal §9.3. matrix.yml already exposes workflow_call (Slice 3).


### PR DESCRIPTION
The first release dry run failed with `startup_failure` and **zero jobs** — GitHub rejected the workflow before running anything.

## Cause

`ci.yml`'s `dependency-review` job declares `pull-requests: read`. `release.yml`'s `gate-b-ci` granted only `contents: read`.

Per GitHub's reusable-workflow rules, a called workflow's `GITHUB_TOKEN` permissions **can only stay the same or become more restrictive**. A callee that tries to elevate past its caller is rejected at startup — not at runtime, and with no job to attribute the failure to.

## How it was found

Bisected on a throwaway probe branch: a bare `uses: ./.github/workflows/ci.yml` reproduced the failure, while a minimal self-contained callee succeeded — isolating it to `ci.yml` rather than to local reusable calls generally. Then confirmed against GitHub's documentation, and verified by a probe granting `pull-requests: read`, which started normally.

Probe branch deleted.

## Scope

Only Gate B. `matrix.yml` and `coverage.yml` declare no job permission beyond `contents: read`.

## The coupling worth knowing about

**A caller must grant the union of what every job in the called workflow declares** — not what the gate itself appears to need. That rule is now a comment in the workflow.

It's a real and non-obvious cost of least-privilege-per-job (proposal §6.2): adding a permission to *any* job in `ci.yml` can break the release path, and the failure surfaces as a job-less `startup_failure` rather than anything pointing at the cause.