### PR TITLE
Fix the coverage convention: it invoked 7 of 12 test suites

### DIFF
--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# C2 — the four integration suites that spawn no daemon of their own.
+# C2 — the integration suites that spawn no daemon of their own.
 #
 #   scripts/coverage/c2-suites.sh
 #
@@ -32,3 +32,32 @@ cov_stage_end 1 "the m3 test binary must write its own profile"
 cov_stage_begin c2-m5_projections
 cov_run cargo llvm-cov --no-report --test m5_projections || cov_fail "m5_projections failed under instrumentation"
 cov_stage_end 1 "the m5 test binary must write its own profile"
+
+# Added 2026-08-19. These four suites existed in tests/ but were invoked by no
+# stage script, so their profiles never reached the report: the convention was
+# measuring 87.97% where a plain `cargo llvm-cov` (which runs every suite)
+# measured 91.09% on identical code. The gap was not missing tests — it was
+# missing accounting, concentrated on exactly the files these suites cover
+# (the estate CLI verbs, watch.rs, the harness passthrough, the T2/T3 routes).
+# m8 and m9 spawn a daemon in a minority of their cases and m10 execs rather
+# than spawning, so all four sit here rather than in C3, whose floor rule is
+# written for suites dominated by real `sgt` subprocesses.
+cov_stage_begin c2-m8_estate_cli
+cov_run cargo llvm-cov --no-report --test m8_estate_cli || cov_fail "m8_estate_cli failed under instrumentation"
+cov_stage_end 1 "the m8 test binary must write its own profile"
+
+cov_stage_begin c2-m9_watch
+cov_run cargo llvm-cov --no-report --test m9_watch || cov_fail "m9_watch failed under instrumentation"
+cov_stage_end 1 "the m9 test binary must write its own profile"
+
+cov_stage_begin c2-m10_harness
+cov_run cargo llvm-cov --no-report --test m10_harness || cov_fail "m10_harness failed under instrumentation"
+cov_stage_end 1 "the m10 test binary must write its own profile"
+
+cov_stage_begin c2-estate_routes
+cov_run cargo llvm-cov --no-report --test estate_routes || cov_fail "estate_routes failed under instrumentation"
+cov_stage_end 1 "the estate_routes test binary must write its own profile"
+
+cov_stage_begin c2-t2_workflow_catalog
+cov_run cargo llvm-cov --no-report --test t2_workflow_catalog || cov_fail "t2_workflow_catalog failed under instrumentation"
+cov_stage_end 1 "the t2_workflow_catalog test binary must write its own profile"

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -30,3 +30,19 @@ cov_stage_begin c3-m6_surfaces
 cov_run cargo llvm-cov --no-report --test m6_surfaces || cov_fail "m6_surfaces failed under instrumentation"
 cov_stage_end 2 "m6 spawns daemons (TUI, doctor) and runs scripts/demo.sh; more than the test \
 binary's own profile must arrive, or no subprocess flushed"
+
+# Added 2026-08-19 alongside C2's five, closing the same accounting gap: this
+# suite existed but no stage script invoked it, so backend/docker.rs's real
+# coverage never reached the report.
+#
+# Floor is 1, not 2, and deliberately so. m7 drives a real Docker Engine and
+# self-skips with SKIPPED-ENV where Docker is unreachable (docs/DEVELOPMENT.md's
+# two-environments rule). On such a host the suite legitimately spawns no
+# container and flushes only its own test-binary profile — a floor of 2 would
+# read that correct, documented skip as a broken instrument and fail the stage.
+# The trade is stated rather than hidden: on a Docker-capable host this stage
+# will not catch a subprocess that silently failed to flush.
+cov_stage_begin c3-m7_docker_executor
+cov_run cargo llvm-cov --no-report --test m7_docker_executor || cov_fail "m7_docker_executor failed under instrumentation"
+cov_stage_end 1 "the m7 test binary must write its own profile; container subprocesses are not \
+required because the suite self-skips where Docker is unreachable"


### PR DESCRIPTION
Gate D failed the first release dry run at **87.97%** against a 90 floor. The code was never undertested — **the convention was not counting six suites** that exist in `tests/` and were invoked by no stage script.

```
m8_estate_cli   m9_watch   m10_harness
estate_routes   t2_workflow_catalog   m7_docker_executor
```

They map exactly onto the files that looked worst. `cli.rs` read 67% while `m8_estate_cli.rs` tests it thoroughly; `watch.rs` read 76.96% while `m9_watch` covers it.

## Result

| | lines | gate |
|---|---|---|
| before — 7 suites | 87.97% | **FAILS** |
| after — 12 suites | **91.09%** | **PASSES** |
| plain `cargo llvm-cov` | 91.09% | — |

The convention now agrees with a plain run **to the digit**, which is the proof the accounting gap is closed rather than papered over. `watch.rs` alone moved 76.96% → 98.34%.

**No tests were added. None were needed.**

## Why this nearly went the other way

The obvious response to a failing coverage gate is to write tests. That would have duplicated existing tests to satisfy a miscount, moved the honest number not at all, and left the gate still wrong — with the added cost of a second set of tests to maintain.

What caught it was noticing that a plain `cargo llvm-cov` **passed** at 91.09% while the convention **failed** at 87.97% on identical code. Two measurement paths disagreeing by 3 points on the same tree is a fact about the instrument, not the code, and no set of tests can exist in one path and not the other.

## Two placement judgments, stated in the scripts

- **The five non-Docker suites went to C2, not C3.** C3's floor demands ≥2 profraws because its suites are dominated by real `sgt` subprocesses. `m8`/`m9` spawn a daemon only in a minority of cases and `m10` execs rather than spawning, so C3's rule would misfire on them.
- **`m7_docker_executor` got a floor of 1, not 2.** It self-skips with `SKIPPED-ENV` where Docker is unreachable, so on such a host it legitimately flushes only its own profile — a floor of 2 would read a correct, documented skip as a broken instrument. The trade is in the comment: on a Docker-capable host this stage won't catch a subprocess that silently failed to flush.

## Baseline note

The 94.63% S-series baseline predates these suites entirely, so it was never the right comparison for the current tree. 91.09% is the first honest total for a fully-wired convention.

Companion analysis (unmerged, `analysis/coverage-regression`): `docs/coverage/regression-analysis-2026-08-19.md`.