### PR TITLE
Document release-artifact verification; correct installer-verifies claim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,26 @@ jobs:
   # this is packaging mechanics only, per the top-of-file note on dist's
   # topology — it does not create or depend on the release tag existing in
   # the repository, only on being told what tag string to embed.
+  #
+  # This job produces the installer script and, separately, the per-archive
+  # `.sha256` files (via `dist build --artifacts=local` in `package`,
+  # above). Nothing wires the two together: the generated
+  # `sergeant-rs-installer.sh` declares the local variables it would use to
+  # verify a downloaded archive's checksum but never assigns them, so its
+  # verification branch is unreachable and every install via this script
+  # prints "no checksums to verify" and installs unverified — confirmed by
+  # running the installer against a published release
+  # (`docs/measure-dist-conditions-2026-08-18.md`'s own "no checksums to
+  # verify" observation, condition 3, generalizes past the ad hoc local-server
+  # setup that first surfaced it — see that file's 2026-08-19 amendment).
+  # The documented, deliberate verification path is manual: README.md's
+  # "Installing a released binary instead of building from source" section
+  # walks `sha256sum -c` against the `.sha256` this job's sibling produces,
+  # plus `gh attestation verify` against the build-provenance attestation
+  # `draft-release` (below) creates. This job does not attempt to fix that
+  # gap — patching or post-processing `dist`'s generated installer to wire
+  # in checksum verification is a larger change with its own supply-chain
+  # risk surface, and is the owner's call, not a packaging-job comment's.
   package-installer:
     needs:
       - gate-b-ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ released before a release can proceed.
 
 ## [Unreleased]
 
+### Documentation
+
+- **Corrected: the shell installer does not verify downloads.** `dist`'s
+  generated `sergeant-rs-installer.sh` (published from v0.1.0 onward)
+  declares the local variables it would use to check a downloaded
+  archive's checksum but never assigns them anywhere in the script, so its
+  verification branch is structurally unreachable — every install via the
+  `curl | sh` convenience one-liner prints "no checksums to verify" and
+  installs unverified, confirmed by running the published v0.1.0 installer.
+  This was previously undocumented; README.md's "Installing a released
+  binary instead of building from source" section now states this plainly
+  and gives a manual, deliberate verification path instead: download the
+  archive and its `.sha256`, `sha256sum -c` it, then `gh attestation
+  verify` it against this repo's build-provenance attestation, then
+  extract and install by hand. `.github/workflows/release.yml`'s
+  `package-installer` job comment is corrected to match — it previously
+  read as though the shipped installer consumed the checksums `dist` also
+  generates; it does not.
+
 ## [0.1.0] - 2026-08-19
 
 First release. `sgt` is an AgentOS distro: instructions, skills, and

--- a/README.md
+++ b/README.md
@@ -52,6 +52,55 @@ intent, and drives `sgt run` on your behalf — see [`AGENTS.md`](AGENTS.md)
 for exactly how it routes and the loop it follows, and the [workflow
 catalog](#workflows) below for what a workflow actually is.
 
+### Installing a released binary instead of building from source
+
+`dist` (cargo-dist) publishes a prebuilt `sgt` for each [release](https://github.com/miztertea/sergeant-rs/releases), plus a `curl | sh` convenience installer:
+
+```sh
+curl -fsSL https://github.com/miztertea/sergeant-rs/releases/download/v0.1.0/sergeant-rs-installer.sh | sh
+```
+
+**This one-liner does not verify anything.** It downloads the archive for
+your platform and installs it — it does not check a checksum, a signature,
+or an attestation. If you watch its output you'll see it say so plainly:
+`no checksums to verify`. That line isn't a warning about a missing file;
+`dist`'s generated installer declares the local variables it would use to
+verify a checksum but nothing in the script ever assigns them, so the
+verification branch is structurally unreachable — the installer always
+takes the "nothing to verify" path, for every release. Convenient, but it
+gives you no evidence the artifact you're running is the one this project
+published.
+
+If you want that evidence, verify by hand — it's a few extra commands, run
+once per release:
+
+```sh
+# 1. Download the archive for your platform, its checksum file, and the installer.
+mkdir -p /tmp/sgt-install && cd /tmp/sgt-install
+gh release download v0.1.0 --repo miztertea/sergeant-rs \
+  -p 'sergeant-rs-x86_64-unknown-linux-gnu.tar.xz' \
+  -p 'sergeant-rs-x86_64-unknown-linux-gnu.tar.xz.sha256'
+
+# 2. Check the archive's contents match what was published.
+sha256sum -c sergeant-rs-x86_64-unknown-linux-gnu.tar.xz.sha256
+
+# 3. Check the archive was actually built by this repo's release workflow,
+#    not just that some file with a matching hash was uploaded somewhere.
+gh attestation verify sergeant-rs-x86_64-unknown-linux-gnu.tar.xz --owner miztertea
+
+# 4. Only after both checks pass, extract and install by hand.
+tar xf sergeant-rs-x86_64-unknown-linux-gnu.tar.xz
+install -m 755 sergeant-rs-x86_64-unknown-linux-gnu/sgt ~/.local/bin/sgt
+sgt --version
+```
+
+Step 2 confirms the bytes weren't corrupted or swapped in transit; step 3
+confirms they came from a GitHub Actions run of *this* repository's
+`release.yml`, via Sigstore/GitHub's build-provenance attestation — the
+thing the convenience one-liner skips entirely. Swap the target triple
+(`aarch64-apple-darwin`) and `~/.local/bin` for your platform and preferred
+install location as needed.
+
 Want to see the whole loop first, with no tokens spent and no estate to
 set up? `scripts/demo.sh` builds the debug binary itself and drives it end
 to end in a throwaway repo — submit → worktree → stage runs and *stops to

--- a/docs/measure-dist-conditions-2026-08-18.md
+++ b/docs/measure-dist-conditions-2026-08-18.md
@@ -237,3 +237,32 @@ installer checksum verification, and a real `publish: true` dry run of
 `release.yml` itself — none of which is a condition-5 veto candidate, all
 of which are narrower follow-up measurements rather than reasons to
 reconsider the tool choice.
+
+## Amendment, 2026-08-19
+
+Condition 3's verdict above ("pass, with a precise caveat") measured that
+the generated installer's *mechanics* — download, unpack, install, PATH
+wiring — work and produce a runnable binary. It did not measure whether
+those mechanics *verify* what they install, and the verdict text does not
+claim that they do. This amendment narrows the record because the
+distinction was since found to matter in practice: v0.1.0 published a real
+release with real `.sha256` files, the "no checksums to verify" line this
+measurement's "What this does NOT show" section already flagged as
+unexercised reproduced exactly as installed from that release, and
+inspection of the installer script (`sergeant-rs-installer.sh`, the same
+artifact this measurement generated) shows why — `_checksum_style` and
+`_checksum_value` are declared as locals and tested (`if [ -n
+"${_checksum_style:-}" ]`) but never assigned anywhere in the script
+outside `verify_checksum()`'s own parameter binding, so the verification
+branch this measurement's local-server run happened not to exercise is not
+merely unexercised — it is unreachable, for every install, on every
+platform, not a config gap specific to that ad hoc test setup.
+
+Nothing above is rewritten: mechanics-correct and verification-absent are
+both true, and this measurement only ever established the first. The
+second was never measured here, and this amendment is the record of that
+narrowing, not a correction of a wrong conclusion. The documented,
+deliberate verification path (`sha256sum -c` plus `gh attestation verify`)
+is now in README.md; `.github/workflows/release.yml`'s `package-installer`
+job comment is corrected to match. See CHANGELOG.md's `[Unreleased]`
+entry.


### PR DESCRIPTION
## Summary

Documentation-only, correcting an unwired guarantee: the published v0.1.0 shell installer does not verify what it downloads, and nothing in this repo previously said so — README.md silently implied it did by never saying otherwise, and release.yml's `package-installer` comment described the installer alongside the checksums `dist` generates without noting the two are never connected.

- **README.md**: new "Installing a released binary instead of building from source" section. States the `curl | sh` one-liner plainly as unverified, and gives a verified path a user can actually run: download the archive + `.sha256`, `sha256sum -c` it, `gh attestation verify` it against this repo's build-provenance attestation, then extract and install by hand.
- **.github/workflows/release.yml**: corrected the `package-installer` job comment to state what's true — dist generates the installer and the per-archive checksum files, the installer never consumes them, and the documented verification path is the manual one in README.
- **docs/measure-dist-conditions-2026-08-18.md**: appended a dated (2026-08-19) amendment narrowing condition 3's "pass, with a precise caveat" verdict — its measurement showed the installer's *mechanics* work, not that they *verify*. Not rewritten, per this repo's supersession/amendment convention (docs/adr/README.md; shape borrowed from ADR 0014's own in-file amendment block).
- **CHANGELOG.md**: `[Unreleased]` entry recording both facts so they carry into the next release notes.

## Root cause (confirmed by reading the shipped script, not inferred)

`sergeant-rs-installer.sh` (dist-generated) declares `_checksum_style`/`_checksum_value` as locals (lines 220-221) and tests them at line 286 (`if [ -n "${_checksum_style:-}" ]; then ... else say "no checksums to verify"`). Neither variable is ever assigned anywhere in the script outside `verify_checksum()`'s own parameter binding (`local _checksum_style="$2"` inside the function itself, line 1404) — so the `if` branch is structurally unreachable and every install takes the "nothing to verify" path. This is upstream (`dist`) generated-code behavior, not a Sergeant misconfiguration: `Cargo.toml`'s `[workspace.metadata.dist]` has no `checksum` key, and adding one would only pick the hash algorithm dist's own `.sha256` file uses — it does not wire anything into the installer.

## Verification commands actually run (against the published v0.1.0 release)

All run in `/var/tmp/sgt-verify-2026-08-19` (cleaned up after), never `/tmp`:

```
$ gh release download v0.1.0 --repo miztertea/sergeant-rs \
    -p 'sergeant-rs-x86_64-unknown-linux-gnu.tar.xz' \
    -p 'sergeant-rs-x86_64-unknown-linux-gnu.tar.xz.sha256' \
    -p 'sergeant-rs-installer.sh'
# succeeded, 3 files downloaded

$ sha256sum -c sergeant-rs-x86_64-unknown-linux-gnu.tar.xz.sha256
sergeant-rs-x86_64-unknown-linux-gnu.tar.xz: OK

$ gh attestation verify sergeant-rs-x86_64-unknown-linux-gnu.tar.xz --owner miztertea
# exit 0; --format json confirms a SLSA provenance v1 attestation signed via
# GitHub OIDC from .github/workflows/release.yml on refs/heads/main

$ tar xf sergeant-rs-x86_64-unknown-linux-gnu.tar.xz
$ install -m 755 sergeant-rs-x86_64-unknown-linux-gnu/sgt scratch-bin/sgt
$ scratch-bin/sgt --version
sgt 0.1.0

$ SERGEANT_RS_INSTALL_DIR=/var/tmp/sgt-verify-2026-08-19/scratch-install \
    bash -c "$(curl -fsSL https://github.com/miztertea/sergeant-rs/releases/download/v0.1.0/sergeant-rs-installer.sh)"
downloading sergeant-rs 0.1.0 x86_64-unknown-linux-gnu
no checksums to verify
installing to /var/tmp/sgt-verify-2026-08-19/scratch-install/bin
  sgt
everything's installed!
# exit 0 — the convenience one-liner reproducing the "no checksums to
# verify" line exactly, as documented, without touching the real install
```

Every command in README.md's new section was run standalone against v0.1.0 and succeeded before being committed (the `~/.local/bin` install target in the README uses the real home dir; the verification run above used `SERGEANT_RS_INSTALL_DIR`/a scratch `install -m 755` target instead, to avoid mutating this host's actual install while still exercising identical code paths).

## Doctrine citations

- **R2** (Ponytail — already in this codebase): the verification path reuses `dist`'s own `.sha256` output and GitHub's existing `attest-build-provenance` step in `release.yml`; nothing new was built.
- **J1** (local, reversible, non-contractual choice) for the wording/placement of the README section and the ADR-style amendment shape — doesn't change scope, security posture, or any contract.
- **J0** for the dist-installer fix itself (see below) — explicitly out of scope per the task; recorded as an open question rather than acted on.

## Explicitly not done (per scope)

- Did not patch/post-process dist's generated installer to add checksum verification.
- Did not add a `checksum` key to `Cargo.toml` (confirmed it wouldn't fix this).
- No `src/`/`tests/` changes — this is documentation-only, matching CLAUDE.md's "Code is code" (R-S0-12) boundary; if a code fix had seemed necessary I'd have stopped and flagged it instead of making one.

## Open question for the owner

The generated installer's checksum-verification gap is structural to `dist` 0.32.0, not a one-off. Two real fixes exist and both are bigger than this PR: (a) patch/post-process the generated `sergeant-rs-installer.sh` in `release.yml` to wire `_checksum_style`/`_checksum_value` before upload — smallest footprint, but hand-patching a third-party generated script is its own supply-chain risk surface and needs re-verifying on every `dist` version bump; (b) file upstream against cargo-dist, since this looks like a real dist defect (an installer that declares a checksum-verification code path with no way to reach it) rather than a Sergeant-specific gap. Recommend (b) first, with (a) as a stopgap only if upstream is slow — but this is the owner's call, not mine to make here.