### PR TITLE
Phase A: integrity reconciliation and retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ released before a release can proceed.
 
 ## [Unreleased]
 
+### Added
+
+- **Terminal Works now report an integrity disposition (#173).** At
+  retirement, teardown reconciles what a Work's worktree *actually* held
+  against what its binding claimed: the branch HEAD ended on and its tip,
+  whether HEAD was detached, and whether the worktree and its source
+  checkout still agree on one Git common directory. Divergences are
+  recorded as a closed vocabulary of findings
+  (`assigned_worktree_uncommitted`, `assigned_worktree_missing`,
+  `assigned_branch_mismatch`, `assigned_head_detached_or_unreferenced`,
+  `assigned_common_dir_mismatch`), and a terminal Work carries a
+  `clean`/`dirty` integrity disposition beside — never inside — its state.
+  A dirty completion reports as `completed_dirty`; `failed` and `canceled`
+  keep their own state strings and carry the axis in the new `integrity`
+  key, which `sgt work list`, `sgt work show`, and the TUI's work detail
+  all render. Work state, the state machine, and the transition table are
+  unchanged.
+
+  Before this, a worktree that checked out a different branch and committed
+  there was reported as a clean removal at the untouched base SHA —
+  indistinguishable from a surface nothing ever touched — while removing
+  the worktree destroyed the only record of where the output had gone.
+
+- **Teardown no longer removes a worktree holding unreferenced commits.** A
+  worktree whose HEAD is detached at a commit no named ref is proven to
+  reach is retained (`retained_unreferenced`) rather than removed, and `sgt
+  work reap` declines it with the remedy named. A removed worktree's HEAD
+  stops being a garbage-collection root; retaining it is how commits
+  nothing else points at survive.
+
+- **Estate drift is observed at retirement.** One `git rev-parse HEAD` per
+  bound repository mount, compared against the commit the Work was cut
+  from. Reported with `attribution: unknown` and never used to make a Work
+  dirty: a mount moving during the Work window is not evidence the Work
+  moved it.
+
+  Journal changes are additive. A `surface.torn_down` recorded before this
+  release replays unchanged and reads as *not assessed* — never as clean.
+
 ### Documentation
 
 - **Corrected: the shell installer does not verify downloads.** `dist`'s

--- a/src/api.rs
+++ b/src/api.rs
@@ -1473,6 +1473,7 @@ fn disposition_tag(disposition: &BindingDisposition) -> &'static str {
         BindingDisposition::RetainedDirty { .. } => "retained_dirty",
         BindingDisposition::Missing => "missing",
         BindingDisposition::RetainedError { .. } => "retained_error",
+        BindingDisposition::RetainedUnreferenced { .. } => "retained_unreferenced",
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -60,6 +60,7 @@ use crate::runtime::graph::{
     KIND_CONVERSATION_ASK, KIND_CONVERSATION_ASSISTANT_COMPLETED, KIND_CONVERSATION_TURN_ENDED,
     KIND_CONVERSATION_USER, KIND_TOOL_COMPLETED, KIND_TOOL_REQUESTED, KIND_USAGE_UPDATED,
 };
+use crate::runtime::integrity::IntegrityDisposition;
 use crate::runtime::journal::{Journal, JournalError};
 use crate::runtime::projection::{
     Projection, ProjectionError, WorkRegistry, WorkRun, is_absorbing, rederive_run,
@@ -1477,6 +1478,32 @@ fn disposition_tag(disposition: &BindingDisposition) -> &'static str {
     }
 }
 
+/// §11's integrity axis as a sibling key of `work`, for the two views C5
+/// makes mandatory (`sgt work list`, `sgt work show`).
+///
+/// `None` — the key renders as `null` — is **not assessed**: a Work whose
+/// surface never tore down, and a `surface.torn_down` journaled before Phase
+/// A. It never means clean, which is why this reads `run.integrity` (recorded
+/// by the retirement that assessed it) rather than deriving a verdict here
+/// from a teardown report that may predate the assessment entirely.
+///
+/// The findings and drift travel with the disposition rather than in a third
+/// key: a Work is dirty *because of* something, and a client that has to
+/// join two keys to say why will not.
+fn integrity_view(run: &WorkRun) -> Option<Value> {
+    let disposition = run.integrity?;
+    let teardown = run.teardown.as_ref();
+    Some(json!({
+        "disposition": disposition,
+        "findings": teardown
+            .map(|t| t.findings().cloned().collect::<Vec<_>>())
+            .unwrap_or_default(),
+        // §11.4: reported beside the findings, never among them, and never
+        // part of the disposition.
+        "drift": teardown.map(|t| t.drift.clone()).unwrap_or_default(),
+    }))
+}
+
 /// ADR 0007(b): a closing stage that declares a commit as its durable
 /// outcome must not be reported as plain `completed` when the branch never
 /// advanced and the worktree was left dirty — the safety net for when an
@@ -1518,7 +1545,24 @@ fn stranded_completion(work: &Work, run: &WorkRun) -> bool {
 /// every other state-machine consumer still see `Completed`; only the
 /// string an operator reads first changes.
 fn reported_state(work: &Work, run: Option<&WorkRun>) -> &'static str {
-    if run.is_some_and(|r| stranded_completion(work, r)) {
+    // §11.5: `completed_dirty` is the compact label for completed + dirty,
+    // and it is now reached two ways that union rather than compete. ADR
+    // 0007(b)'s `stranded_completion` infers dirtiness from the output
+    // pointer alone, which is all a pre-Phase-A journal can offer; §11's
+    // integrity disposition is the assessment retirement actually recorded.
+    // Either one is enough.
+    //
+    // `failed` and `canceled` keep their true state strings even when dirty
+    // (§11.5 adds no `failed_dirty` label and no transition target); the
+    // `integrity` sibling key carries that axis, and `sgt work list` renders
+    // it beside the state so C5's "distinguishable in default output" holds
+    // for all three terminal states.
+    let dirty_completion = run.is_some_and(|r| {
+        stranded_completion(work, r)
+            || (work.state == WorkState::Completed
+                && r.integrity == Some(IntegrityDisposition::Dirty))
+    });
+    if dirty_completion {
         "completed_dirty"
     } else {
         work.state.as_str()
@@ -1564,6 +1608,10 @@ fn work_view(core: &Core, engine: &Engine, work_id: &str) -> Value {
         "backend": run.as_ref().and_then(|r| r.backend.clone()),
         "route_source": run.as_ref().and_then(|r| r.route_source.clone()),
         "teardown": run.as_ref().and_then(|r| r.teardown.clone()),
+        // §11.5's orthogonal axis (C5, mandatory): the disposition retirement
+        // recorded, the §11.3 findings behind it, and §11.4's unattributed
+        // estate drift. `null` until a retirement assessed it.
+        "integrity": run.as_ref().and_then(integrity_view),
         // R-MVP1-2's sibling: named per repository once there is something to
         // point at.
         "output": work.and_then(|w| run.as_ref().and_then(|r| output_pointer(w, r))),
@@ -1651,6 +1699,15 @@ fn fleet_body(core: &Core, engine: &Engine) -> Value {
                     run.as_ref()
                         .and_then(|r| r.backend.clone())
                         .map_or(Value::Null, Value::String),
+                );
+                // C5: `sgt work list` is the default output a terminal-dirty
+                // Work must be distinguishable in. `state` above already
+                // carries it for a dirty *completion* (`completed_dirty`);
+                // this is what carries it for a dirty `failed`/`canceled`,
+                // whose state strings §11.5 leaves alone.
+                object.insert(
+                    "integrity".to_string(),
+                    run.as_ref().and_then(integrity_view).unwrap_or(Value::Null),
                 );
                 // MVP-3's envelope-visibility item, folded onto the fleet
                 // view exactly the way `work_view` folds it onto a single
@@ -5065,6 +5122,179 @@ mod tests {
             "an evicted stranded completion must not silently revert to plain \
              completed in `sgt work list` just because its run cache entry \
              aged out: {row}"
+        );
+    }
+
+    /// Amendment C3, the whole of it: a `surface.torn_down` journaled before
+    /// Phase A existed replays unchanged, and its integrity reads as **not
+    /// assessed** — never defaulted to clean.
+    ///
+    /// The distinction is the entire point of the amendment. An absent
+    /// assessment defaulted to `clean` would be core inventing a fact about
+    /// a retirement that predates the machinery that could have established
+    /// it — the exact silent-clean-report failure §17 says must become
+    /// impossible. So the payload here is hand-built rather than serialized
+    /// from today's types (the same technique
+    /// `a_stranded_completion_survives_terminal_run_cache_eviction` above
+    /// uses): a struct that gains a field cannot prove anything about an
+    /// event that never had it, only a literal old-shape payload can.
+    ///
+    /// Three things are checked past the disposition itself: the report
+    /// still deserializes into a `TeardownReport` (so `run.teardown` is
+    /// `Some`, and `runtime::recovery`'s completion-tail sweep — keyed on
+    /// `teardown.is_none()` — does not suddenly consider this work stranded);
+    /// ADR 0007(b)'s `completed_dirty` still fires from the output pointer
+    /// alone, which is all a pre-Phase-A journal can offer; and a new-shape
+    /// payload beside it does report its assessment.
+    #[test]
+    fn an_old_shape_torn_down_payload_replays_as_integrity_not_assessed() {
+        use crate::runtime::testing;
+
+        fn surface(work_id: &str) -> Value {
+            json!({"surface": {
+                "work_id": work_id,
+                "root": "/data/surfaces/x",
+                "bindings": [{
+                    "repository": "solo",
+                    "source_path": "/repos/solo",
+                    "base_branch": "main",
+                    "base_sha": "0".repeat(40),
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "head_sha": "0".repeat(40),
+                }],
+            }})
+        }
+
+        // Exactly the shape `surface.torn_down` had before this phase: no
+        // `integrity` sibling key, no `findings`, no `observed_head`, no
+        // `drift`.
+        fn old_shape_teardown(work_id: &str, clean: bool, disposition: Value) -> Value {
+            let mut binding = json!({
+                "repository": "solo",
+                "worktree_path": "/data/surfaces/x/solo",
+                "work_branch": format!("sergeant/{work_id}"),
+                "final_sha": "0".repeat(40),
+            });
+            let object = binding.as_object_mut().expect("binding object");
+            for (key, value) in disposition.as_object().expect("disposition object") {
+                object.insert(key.clone(), value.clone());
+            }
+            json!({"report": {"work_id": work_id, "clean": clean, "bindings": [binding]}})
+        }
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+
+        // An ordinary old completion: clean removal, nothing to report.
+        let ordinary = "01OLDSHAPE0000000001";
+        testing::submit(&mut core, ordinary, "torn down before Phase A");
+        testing::commit(
+            &mut core,
+            ordinary,
+            KIND_SURFACE_MATERIALIZED,
+            surface(ordinary),
+        );
+        testing::commit(&mut core, ordinary, KIND_WORK_COMPLETED, json!({}));
+        testing::commit(
+            &mut core,
+            ordinary,
+            KIND_SURFACE_TORN_DOWN,
+            old_shape_teardown(ordinary, true, json!({"disposition": "removed"})),
+        );
+
+        // An old stranded completion: ADR 0007(b)'s inference is all the
+        // journal can offer, and it must keep working untouched.
+        let stranded = "01OLDSHAPE0000000002";
+        testing::submit(&mut core, stranded, "declares a commit, never makes one");
+        testing::commit(
+            &mut core,
+            stranded,
+            KIND_SURFACE_MATERIALIZED,
+            surface(stranded),
+        );
+        testing::commit(&mut core, stranded, KIND_WORK_COMPLETED, json!({}));
+        testing::commit(
+            &mut core,
+            stranded,
+            KIND_SURFACE_TORN_DOWN,
+            old_shape_teardown(
+                stranded,
+                false,
+                json!({"disposition": "retained_dirty", "changes": " M half-done.rs"}),
+            ),
+        );
+
+        for work_id in [ordinary, stranded] {
+            let registry = core.registry.state();
+            let run = registry.run_view(work_id).expect("run");
+            assert!(
+                run.teardown.is_some(),
+                "{work_id}: the old-shape report must still deserialize, or \
+                 recovery's completion-tail sweep would treat this work as \
+                 stranded on every restart"
+            );
+            assert_eq!(
+                run.integrity, None,
+                "{work_id}: an absent assessment is 'not assessed', never clean"
+            );
+        }
+
+        let backends = BackendRegistry::new().with(Arc::new(
+            crate::backend::fake::FakeBackend::new(crate::backend::fake::FAKE_BACKEND_NAME),
+        ));
+        let engine = Engine::new(
+            Arc::new(backends),
+            Some(crate::backend::fake::FAKE_BACKEND_NAME.to_string()),
+            dir.path(),
+        );
+
+        let ordinary_view = work_view(&core, &engine, ordinary);
+        assert!(
+            ordinary_view["integrity"].is_null(),
+            "not assessed renders as null, not as a clean disposition: {ordinary_view}"
+        );
+        assert_eq!(ordinary_view["work"]["state"], "completed");
+        assert_eq!(
+            work_view(&core, &engine, stranded)["work"]["state"],
+            "completed_dirty",
+            "ADR 0007(b)'s output-pointer inference is unchanged by §11"
+        );
+
+        // And the new shape does carry its assessment through the same fold.
+        let assessed = "01NEWSHAPE0000000001";
+        testing::submit(&mut core, assessed, "assessed at retirement");
+        testing::commit(
+            &mut core,
+            assessed,
+            KIND_SURFACE_MATERIALIZED,
+            surface(assessed),
+        );
+        testing::commit(&mut core, assessed, KIND_WORK_COMPLETED, json!({}));
+        let mut payload = old_shape_teardown(assessed, true, json!({"disposition": "removed"}));
+        payload["report"]["bindings"][0]["findings"] = json!([{
+            "finding": "assigned_branch_mismatch",
+            "repository": "solo",
+            "worktree_path": "/data/surfaces/x/solo",
+            "expected_branch": format!("sergeant/{assessed}"),
+            "expected_sha": "0".repeat(40),
+            "observed_branch": "renegade",
+            "observed_sha": "1".repeat(40),
+            "evidence": "ended on renegade",
+        }]);
+        payload["integrity"] = json!("dirty");
+        testing::commit(&mut core, assessed, KIND_SURFACE_TORN_DOWN, payload);
+
+        let view = work_view(&core, &engine, assessed);
+        assert_eq!(view["integrity"]["disposition"], "dirty");
+        assert_eq!(
+            view["integrity"]["findings"][0]["finding"],
+            "assigned_branch_mismatch"
+        );
+        assert_eq!(
+            view["work"]["state"], "completed_dirty",
+            "a dirty completion reports the §11.5 compact label even without \
+             ADR 0007(b)'s stranded inference"
         );
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3147,4 +3147,52 @@ mod tests {
         let rendered = render_transcript(&json!({"turns": []}));
         assert_eq!(rendered, "no conversation recorded for this work\n");
     }
+
+    fn listed_work(state: &str, disposition: Option<&str>) -> Value {
+        let mut work = json!({"id": "w-1", "state": state, "intent": "do the thing"});
+        if let Some(disposition) = disposition {
+            work["integrity"] = json!({"disposition": disposition});
+        }
+        work
+    }
+
+    /// C5's acceptance criterion for the two terminal states §11.5 mints no
+    /// compact label for: a dirty `failed` or `canceled` Work has to be
+    /// distinguishable in `sgt work list`'s *default* output, not only under
+    /// `--json`. Garbling or inverting the suffix branch in
+    /// `list_state_label` fails here and nowhere else — every other
+    /// dirty-work assertion in the suite reads the `/v1/work` JSON body.
+    #[test]
+    fn list_state_label_appends_the_integrity_axis_to_failed_and_canceled() {
+        assert_eq!(
+            list_state_label(&listed_work("failed", Some("dirty"))),
+            "failed/dirty"
+        );
+        assert_eq!(
+            list_state_label(&listed_work("canceled", Some("dirty"))),
+            "canceled/dirty"
+        );
+    }
+
+    /// The other half of the branch: `completed_dirty` is minted by the API's
+    /// own `reported_state`, so the column must not say it twice.
+    #[test]
+    fn list_state_label_does_not_re_suffix_a_state_already_carrying_the_axis() {
+        assert_eq!(
+            list_state_label(&listed_work("completed_dirty", Some("dirty"))),
+            "completed_dirty"
+        );
+    }
+
+    /// A clean or not-assessed Work keeps its true state string — absent
+    /// integrity is "not assessed" (C3), never a dirty rendering.
+    #[test]
+    fn list_state_label_leaves_clean_and_unassessed_states_alone() {
+        assert_eq!(
+            list_state_label(&listed_work("completed", Some("clean"))),
+            "completed"
+        );
+        assert_eq!(list_state_label(&listed_work("failed", None)), "failed");
+        assert_eq!(list_state_label(&listed_work("running", None)), "running");
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -790,7 +790,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                                     println!(
                                         "{}  {}  {}",
                                         work["id"].as_str().unwrap_or("?"),
-                                        work["state"].as_str().unwrap_or("?"),
+                                        list_state_label(work),
                                         work["intent"].as_str().unwrap_or("?"),
                                     );
                                 }
@@ -828,6 +828,12 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                                 "backend",
                                 "output",
                                 "teardown",
+                                // §11 / C5: the integrity disposition and
+                                // the §11.3 findings behind it, folded the
+                                // same way `teardown` and `output` are —
+                                // "was my output where it should be" is
+                                // answerable from this one command.
+                                "integrity",
                                 // MVP-3's envelope-visibility item: turns
                                 // spent/capped and the effective ceiling,
                                 // folded in the same way every other key
@@ -1291,6 +1297,26 @@ fn render_transcript(result: &Value) -> String {
         out.push_str("\n\n");
     }
     out
+}
+
+/// The `state` column of `sgt work list`, with §11.5's integrity axis folded
+/// in — amendment C5's acceptance criterion, that a terminal-dirty Work is
+/// distinguishable in *default* output and not only in `--json`.
+///
+/// A dirty completion already reads `completed_dirty`: the API's own
+/// `reported_state` is where that compact label is minted, and re-appending
+/// anything to it here would say the same thing twice. `failed` and
+/// `canceled` keep their true state strings (§11.5 adds no label for them and
+/// no transition target), so the axis is appended to the column instead —
+/// `failed/dirty` — which is exactly how §11.5 writes the orthogonal pair.
+fn list_state_label(work: &Value) -> String {
+    let state = work["state"].as_str().unwrap_or("?");
+    let dirty = work["integrity"]["disposition"].as_str() == Some("dirty");
+    if dirty && !state.ends_with("_dirty") {
+        format!("{state}/dirty")
+    } else {
+        state.to_string()
+    }
 }
 
 /// #109's inspect verb (`GET /v1/retained`, `sgt work retained`): every

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -1555,7 +1555,24 @@ impl Engine {
                 SurfaceOutcome::Rematerialized(result),
             ) => self.settle_rematerialize(core, &work_id, &surface, index, attempt, result),
             (SurfaceEffect::Teardown { recovered, .. }, SurfaceOutcome::TornDown(report)) => {
-                let mut payload = json!({"report": report});
+                // §11.5's orthogonal axis, computed at the one point every
+                // terminal path converges on: cancel (`begin_retire_run`),
+                // failure and completion (`settle_stage`'s signal arms), and
+                // the crash-recovery re-run (`reconcile_terminal_surface`,
+                // which reaches here through this same arm and therefore
+                // records the same assessment, marked `recovered`).
+                //
+                // Deliberately *not* computed inside `teardown()`: the same
+                // function also runs as `materialize`'s partial-failure
+                // rollback, which is not a retirement and journals its report
+                // with no `integrity` key at all (see `settle_materialize`).
+                // An absent key means not assessed — never clean (C3).
+                //
+                // A sibling key rather than a field inside `report`: additive
+                // to the payload, so an old `surface.torn_down` deserializes
+                // into the same `TeardownReport` it always did.
+                let integrity = report.integrity();
+                let mut payload = json!({"report": report, "integrity": integrity});
                 if recovered {
                     payload["recovered"] = Value::Bool(true);
                 }

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -4997,9 +4997,12 @@ mod tests {
                     worktree_path: PathBuf::from(format!("/data/surfaces/{work_id}/solo")),
                     work_branch: format!("sergeant/{work_id}"),
                     final_sha: Some("1".repeat(40)),
+                    observed_head: None,
+                    findings: Vec::new(),
                     disposition,
                 }],
                 clean,
+                drift: Vec::new(),
             }
         }
 

--- a/src/runtime/integrity.rs
+++ b/src/runtime/integrity.rs
@@ -1,0 +1,297 @@
+//! Integrity observation and terminal dirtiness (proposal §11).
+//!
+//! §11 asks core to answer one question honestly at retirement: *was the
+//! surface this Work was assigned left in a state core can account for?* The
+//! answer is **orthogonal** to Work state. A Work that completed, failed, or
+//! was canceled stays exactly that; nothing here is a transition target, no
+//! [`WorkState`](crate::domain::work::WorkState) variant is added, and the
+//! transition table is untouched. This is the same shape ADR 0007(b) already
+//! uses for `reported_state`: the journal and the views carry the extra axis,
+//! the state machine never learns about it.
+//!
+//! Three vocabularies live here:
+//!
+//! - [`IntegrityFinding`] — §11.3's **closed** list of directly attributable
+//!   dirty findings. Closed means closed: an observation core cannot spell as
+//!   one of these variants is not reported as a finding at all.
+//! - [`EstateDriftObservation`] — §11.4's separate, *non*-attributable
+//!   observation. A mount moving during the Work window is not evidence the
+//!   Work moved it, so drift never makes a Work dirty and its attribution is
+//!   structurally [`DriftAttribution::Unknown`].
+//! - [`IntegrityDisposition`] — the two-valued axis §11.5 puts beside the
+//!   terminal state.
+//!
+//! Nothing in this module performs I/O. `runtime::surface` observes; this
+//! module is the vocabulary those observations are recorded in.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// §11.5's orthogonal axis: whether a terminal Work's assigned surface was
+/// left in a state core can account for.
+///
+/// `dirty` is never a state transition and never blocks one. `sgt work list`
+/// still reports the true terminal state; this rides beside it (and, for a
+/// dirty *completion*, is what makes `reported_state` say `completed_dirty` —
+/// §11.5's compact label, which the domain model still does not own).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IntegrityDisposition {
+    /// Every binding was retired with nothing left unaccounted for.
+    Clean,
+    /// At least one finding, or at least one binding core could not retire
+    /// cleanly. See [`crate::runtime::surface::TeardownReport::integrity`]
+    /// for exactly what earns this.
+    Dirty,
+}
+
+impl IntegrityDisposition {
+    /// The serialized spelling, for renderers that hold a value rather than
+    /// its JSON.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Clean => "clean",
+            Self::Dirty => "dirty",
+        }
+    }
+}
+
+/// What a binding's worktree HEAD **actually** pointed at when teardown
+/// looked — as opposed to the `work_branch` the binding claims.
+///
+/// §2.6's defect in one type: teardown used to read the branch it expected
+/// and never the worktree it had, so a worktree that ended up somewhere else
+/// was reported as though it had not. Recorded on every binding teardown can
+/// still inspect; `None` on a [`BindingTeardown`](crate::runtime::surface::BindingTeardown)
+/// means *not assessed* — a vanished worktree, a git that could not answer,
+/// or an event journaled before this field existed — never "it was where it
+/// should have been".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "head", rename_all = "snake_case")]
+pub enum ObservedHead {
+    /// HEAD was attached to a named local branch.
+    Branch {
+        /// The branch HEAD pointed at, short form.
+        branch: String,
+        /// That branch's tip, `None` only if it could not be resolved (an
+        /// unborn branch), which is recorded rather than guessed.
+        sha: Option<String>,
+    },
+    /// HEAD was detached at a commit. Always carries the commit: a HEAD whose
+    /// commit cannot be resolved at all is not classified as a detachment
+    /// here, it is left to teardown's own fail-closed status check.
+    Detached {
+        /// The commit HEAD was detached at.
+        sha: String,
+    },
+}
+
+/// §11.3's closed serialized vocabulary of directly attributable dirty
+/// findings: things that happened *in the Work's assigned surface* or were
+/// reported by its own execution, so attributing them to the Work is not a
+/// guess.
+///
+/// Every variant carries the expected value, the observed value, and an
+/// evidence string — §11.3's "expected and observed paths/refs/SHAs plus
+/// evidence" — because a finding an operator cannot act on is a warning, not
+/// a report.
+///
+/// The vocabulary is closed on purpose. An observation core cannot spell as
+/// one of these is not promoted into a free-form finding; it is either an
+/// [`EstateDriftObservation`] (unattributable) or it is not reported as a
+/// finding at all.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "finding", rename_all = "snake_case")]
+pub enum IntegrityFinding {
+    /// The assigned worktree had uncommitted or untracked changes at
+    /// teardown. Rides *alongside* the existing `retained_dirty` disposition
+    /// and #109's patch capture rather than replacing them: the disposition
+    /// says what was done with the content, this says what it means for the
+    /// Work.
+    AssignedWorktreeUncommitted {
+        /// Repository the binding names.
+        repository: String,
+        /// The assigned worktree.
+        worktree_path: PathBuf,
+        /// `git status --porcelain` output.
+        evidence: String,
+    },
+    /// The assigned worktree path was gone before teardown reached it.
+    AssignedWorktreeMissing {
+        /// Repository the binding names.
+        repository: String,
+        /// The worktree path that should have been there.
+        worktree_path: PathBuf,
+        /// What was looked for.
+        evidence: String,
+    },
+    /// §2.6 / #173: the worktree's HEAD was attached to a *different* named
+    /// branch than the one this binding was assigned. The observed branch and
+    /// its tip are recorded here because removing the worktree destroys the
+    /// only other record of them — and both branches stay durable (§11.7,
+    /// §12.1: teardown deletes neither the expected branch nor the one that
+    /// was actually used).
+    AssignedBranchMismatch {
+        /// Repository the binding names.
+        repository: String,
+        /// The assigned worktree.
+        worktree_path: PathBuf,
+        /// The branch this binding was assigned: `sergeant/<work-id>`.
+        expected_branch: String,
+        /// That branch's tip at teardown, if it resolved.
+        expected_sha: Option<String>,
+        /// The branch HEAD was actually on.
+        observed_branch: String,
+        /// That branch's tip at teardown, if it resolved.
+        observed_sha: Option<String>,
+        /// A one-line statement of the divergence.
+        evidence: String,
+    },
+    /// The worktree's HEAD was detached. `reachable` distinguishes the two
+    /// cases §11.7 treats very differently: a detached HEAD some named ref
+    /// still reaches is a finding and nothing more, while one no named ref is
+    /// *proven* to reach also retains the worktree
+    /// ([`RetainedUnreferenced`](crate::runtime::surface::BindingDisposition::RetainedUnreferenced))
+    /// rather than risk the commits.
+    AssignedHeadDetachedOrUnreferenced {
+        /// Repository the binding names.
+        repository: String,
+        /// The assigned worktree.
+        worktree_path: PathBuf,
+        /// The branch this binding was assigned.
+        expected_branch: String,
+        /// The commit HEAD was detached at.
+        observed_sha: String,
+        /// Whether a named ref in the source repository was proven to reach
+        /// that commit.
+        reachable: bool,
+        /// What was checked to decide `reachable`.
+        evidence: String,
+    },
+    /// The worktree and its source checkout did not agree on their canonical
+    /// Git common directory — the identity §2.7/§9.4 lock on. A worktree
+    /// answering with a different common dir than the repository it is
+    /// journaled against is not the worktree this binding thinks it is.
+    AssignedCommonDirMismatch {
+        /// Repository the binding names.
+        repository: String,
+        /// `git rev-parse --path-format=absolute --git-common-dir` run in
+        /// the binding's source checkout.
+        expected_common_dir: PathBuf,
+        /// The same question asked inside the assigned worktree.
+        observed_common_dir: PathBuf,
+        /// A one-line statement of the divergence.
+        evidence: String,
+    },
+    /// **Defined, not emitted (amendment C2).** An adapter observed the
+    /// execution running a Git command against something outside its assigned
+    /// surface.
+    ///
+    /// Emission is gated on *structured* adapter evidence that does not exist
+    /// today: the claude adapter fixes a session cwd and forwards raw `input`
+    /// blobs, so the only way to fire this now would be heuristic shell
+    /// parsing, which the gauntlet's C2 disposition explicitly refuses. The
+    /// variant lives here so the serialized vocabulary is the closed §11.3
+    /// list rather than a subset that would have to widen later — an adapter
+    /// that cannot prove this simply runs, and core reports only what it can
+    /// prove (§18). The emitter arrives with the evidence, not before it.
+    AdapterObservedOutsideSurfaceGitCommand {
+        /// Repository the binding names.
+        repository: String,
+        /// The assigned worktree the command should have been confined to.
+        worktree_path: PathBuf,
+        /// Where the adapter observed the command running, when it can say.
+        observed_path: Option<PathBuf>,
+        /// The adapter's own structured evidence, verbatim.
+        evidence: String,
+    },
+    /// **Defined, not emitted (amendment C2).** A backend reported writing
+    /// outside the Work's assigned surface. Gated on the same missing
+    /// structured evidence as
+    /// [`AdapterObservedOutsideSurfaceGitCommand`](Self::AdapterObservedOutsideSurfaceGitCommand);
+    /// see that variant for the full reasoning.
+    BackendReportedOutsideSurfaceWrite {
+        /// Repository the binding names.
+        repository: String,
+        /// The assigned worktree the write should have been confined to.
+        worktree_path: PathBuf,
+        /// Where the backend reported writing, when it can say.
+        observed_path: Option<PathBuf>,
+        /// The backend's own structured evidence, verbatim.
+        evidence: String,
+    },
+}
+
+impl IntegrityFinding {
+    /// The serialized kind, exactly as §11.3 spells it — for renderers that
+    /// hold the value rather than its JSON.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::AssignedWorktreeUncommitted { .. } => "assigned_worktree_uncommitted",
+            Self::AssignedWorktreeMissing { .. } => "assigned_worktree_missing",
+            Self::AssignedBranchMismatch { .. } => "assigned_branch_mismatch",
+            Self::AssignedHeadDetachedOrUnreferenced { .. } => {
+                "assigned_head_detached_or_unreferenced"
+            }
+            Self::AssignedCommonDirMismatch { .. } => "assigned_common_dir_mismatch",
+            Self::AdapterObservedOutsideSurfaceGitCommand { .. } => {
+                "adapter_observed_outside_surface_git_command"
+            }
+            Self::BackendReportedOutsideSurfaceWrite { .. } => {
+                "backend_reported_outside_surface_write"
+            }
+        }
+    }
+
+    /// The repository this finding is about.
+    pub fn repository(&self) -> &str {
+        match self {
+            Self::AssignedWorktreeUncommitted { repository, .. }
+            | Self::AssignedWorktreeMissing { repository, .. }
+            | Self::AssignedBranchMismatch { repository, .. }
+            | Self::AssignedHeadDetachedOrUnreferenced { repository, .. }
+            | Self::AssignedCommonDirMismatch { repository, .. }
+            | Self::AdapterObservedOutsideSurfaceGitCommand { repository, .. }
+            | Self::BackendReportedOutsideSurfaceWrite { repository, .. } => repository,
+        }
+    }
+}
+
+/// §11.4: who moved a mount. Core cannot tell, so this has exactly one value.
+///
+/// A one-variant enum rather than a string field is the point: nothing in
+/// this phase can record drift as attributed, because nothing in this phase
+/// can prove it. Captain, an editor, another Work, or an unrelated process
+/// may have done it. Direct adapter tool evidence would promote the same
+/// observation into an [`IntegrityFinding`] instead — a different type, not a
+/// different attribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DriftAttribution {
+    /// Core observed the difference and can prove nothing about its cause.
+    Unknown,
+}
+
+/// §11.4: a declared repository mount whose committed HEAD moved between the
+/// Work's admission base and its retirement.
+///
+/// **Never makes a Work dirty.** It is reported beside the findings, not
+/// among them.
+///
+/// **Bounded exactly as amendment C6 requires**, and no further: one
+/// `git rev-parse HEAD` per *bound* repository at retirement. No worktree
+/// walking, no `git status` on a mount, no unselected-repository calls, no
+/// polling. Observing drift in repositories this Work never selected needs
+/// the estate-bound daemon and is Phase D's work, not a widening of this.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EstateDriftObservation {
+    /// Repository name within the estate.
+    pub repository: String,
+    /// The commit this Work's binding was cut from.
+    pub before: String,
+    /// The mount's committed HEAD at retirement.
+    pub observed: String,
+    /// Always [`DriftAttribution::Unknown`] — see the type.
+    pub attribution: DriftAttribution,
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,5 @@
-//! Runtime: journal, projections, git, surfaces, routing, engine, recovery.
+//! Runtime: journal, projections, git, surfaces, integrity, routing, engine,
+//! recovery.
 
 pub mod analytics;
 pub mod blob;
@@ -6,6 +7,7 @@ pub mod engine;
 pub(crate) mod fsutil;
 pub mod git;
 pub mod graph;
+pub mod integrity;
 pub mod journal;
 pub mod projection;
 pub mod recovery;

--- a/src/runtime/projection.rs
+++ b/src/runtime/projection.rs
@@ -30,6 +30,7 @@ use crate::domain::workflow::{
 };
 use crate::domain::workspace::InstructionIdentity;
 use crate::runtime::fsutil::{create_dir_all_durable, write_atomic};
+use crate::runtime::integrity::IntegrityDisposition;
 use crate::runtime::journal::{Journal, JournalError};
 use crate::runtime::surface::{
     KIND_SURFACE_MATERIALIZED, KIND_SURFACE_MATERIALIZING, KIND_SURFACE_TORN_DOWN, SurfacePlan,
@@ -377,6 +378,17 @@ pub struct WorkRun {
     /// Teardown report, once the surface has been torn down.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub teardown: Option<TeardownReport>,
+    /// §11.5's integrity axis, as the retirement that recorded the teardown
+    /// assessed it. Orthogonal to [`Work::state`](crate::domain::work::Work),
+    /// which this never touches (ADR 0007(b)'s pattern: journal and view
+    /// metadata, not a state-machine value).
+    ///
+    /// `None` is **not assessed**, never clean: a `surface.torn_down`
+    /// journaled before this phase carries no assessment, and neither does
+    /// the rollback teardown `materialize` runs on a partial failure. Both
+    /// replay to `None` and every view says so (C3).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<IntegrityDisposition>,
     /// Every stage attempt, in the order they were entered.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub stages: Vec<StageRecord>,
@@ -710,6 +722,10 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
                 let run = state.runs.entry(work_id.clone()).or_default();
                 run.surface = Some(surface);
                 run.teardown = None;
+                // A rematerialized surface has not been assessed again yet;
+                // carrying the previous retirement's verdict forward would
+                // report a fact about a teardown this run has replaced.
+                run.integrity = None;
             }
         }
         KIND_SURFACE_TORN_DOWN => {
@@ -717,7 +733,14 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
                 event.work_id.as_ref(),
                 serde_json::from_value::<TeardownReport>(event.payload["report"].clone()),
             ) {
-                state.runs.entry(work_id.clone()).or_default().teardown = Some(report);
+                let run = state.runs.entry(work_id.clone()).or_default();
+                run.teardown = Some(report);
+                // Additive (§20.5 / C3): a `surface.torn_down` from before
+                // this phase — and the rollback teardown `materialize`
+                // journals on a partial failure — carry no `integrity` key,
+                // and `from_value(Null)` is an error, so both read back as
+                // "not assessed" rather than being defaulted to clean.
+                run.integrity = serde_json::from_value(event.payload["integrity"].clone()).ok();
             }
         }
         KIND_STAGE_ENTERED => {

--- a/src/runtime/recovery.rs
+++ b/src/runtime/recovery.rs
@@ -529,6 +529,121 @@ mod tests {
         );
     }
 
+    /// A temp git repository with one commit, run with a fixture identity so
+    /// nothing depends on the machine's own git config.
+    fn repo(path: &std::path::Path) -> crate::domain::workspace::RepositorySpec {
+        std::fs::create_dir_all(path).expect("repo dir");
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["commit", "--allow-empty", "-m", "initial"],
+        ] {
+            let output = std::process::Command::new("git")
+                .args(&args)
+                .current_dir(path)
+                .env("GIT_AUTHOR_NAME", "t")
+                .env("GIT_AUTHOR_EMAIL", "t@example.invalid")
+                .env("GIT_COMMITTER_NAME", "t")
+                .env("GIT_COMMITTER_EMAIL", "t@example.invalid")
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .output()
+                .expect("git");
+            assert!(output.status.success(), "git {args:?}: {output:?}");
+        }
+        crate::domain::workspace::RepositorySpec {
+            name: "solo".to_string(),
+            path: path.to_path_buf(),
+        }
+    }
+
+    /// §11 through the completion tail's crash window (issue #9): a teardown
+    /// a crash swallowed is re-run at startup and produces the *same*
+    /// integrity assessment it would have produced at retirement, marked
+    /// `recovered`.
+    ///
+    /// This is the property that makes the assessment trustworthy at all.
+    /// `reconcile_terminal_surface` reaches the identical `settle_surface`
+    /// arm every live terminal path does, so there is one computation point
+    /// and not two — a second implementation here is precisely how a
+    /// recovered Work would come to be reported clean while the same disk
+    /// state assessed at retirement read dirty.
+    #[test]
+    fn a_crash_recovered_teardown_records_the_same_integrity_assessment() {
+        use crate::domain::work::KIND_WORK_COMPLETED;
+        use crate::runtime::integrity::IntegrityDisposition;
+        use crate::runtime::surface::{
+            KIND_SURFACE_MATERIALIZED, KIND_SURFACE_TORN_DOWN, materialize,
+        };
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(data.path());
+        let engine = Engine::new(Arc::new(BackendRegistry::new()), None, data.path());
+
+        let work_id = "01RECOVEREDTEARDOWN00";
+        let spec = repo(&dir.path().join("solo"));
+        let surface =
+            materialize(data.path(), work_id, std::slice::from_ref(&spec)).expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        testing::submit(&mut core, work_id, "crashed before its teardown landed");
+        testing::commit(
+            &mut core,
+            work_id,
+            KIND_SURFACE_MATERIALIZED,
+            json!({"surface": surface}),
+        );
+        testing::commit(&mut core, work_id, KIND_WORK_COMPLETED, json!({}));
+
+        // The run ended on another branch, and the crash landed before
+        // teardown could say so.
+        let output = std::process::Command::new("git")
+            .args(["checkout", "-b", "renegade"])
+            .current_dir(&worktree)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .output()
+            .expect("git");
+        assert!(output.status.success(), "checkout: {output:?}");
+
+        let report = reconcile(&engine, &mut core).expect("recovery");
+        assert_eq!(report.surfaces_retired, vec![work_id.to_string()]);
+
+        let torn = events(&core, work_id, KIND_SURFACE_TORN_DOWN);
+        assert_eq!(torn.len(), 1, "exactly one teardown is recorded");
+        assert_eq!(
+            torn[0]["recovered"], true,
+            "the trail shows when the teardown was recorded, not that it \
+             landed with the completion: {}",
+            torn[0]
+        );
+        assert_eq!(
+            torn[0]["integrity"], "dirty",
+            "a recovered teardown carries the same assessment a live one \
+             would have: {}",
+            torn[0]
+        );
+        assert_eq!(
+            torn[0]["report"]["bindings"][0]["findings"][0]["finding"], "assigned_branch_mismatch",
+            "{}",
+            torn[0]
+        );
+        assert_eq!(
+            core.registry
+                .state()
+                .run_view(work_id)
+                .expect("run")
+                .integrity,
+            Some(IntegrityDisposition::Dirty),
+            "and the projection folds it the same way the live path's does"
+        );
+        assert_eq!(
+            core.registry.state().works[work_id].state,
+            WorkState::Completed,
+            "integrity never moves Work state (§11.5)"
+        );
+    }
+
     /// Payloads of one work's events of one kind, in journal order.
     fn events(core: &Core, work_id: &str, kind: &str) -> Vec<serde_json::Value> {
         core.journal

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -32,6 +32,9 @@ use serde::{Deserialize, Serialize};
 use crate::domain::workspace::RepositorySpec;
 use crate::runtime::fsutil::create_dir_all_durable;
 use crate::runtime::git::{GitError, git, git_submodule_update, git_succeeds};
+use crate::runtime::integrity::{
+    DriftAttribution, EstateDriftObservation, IntegrityDisposition, IntegrityFinding, ObservedHead,
+};
 
 /// Directory under the data dir holding all work surfaces.
 pub const SURFACES_DIR: &str = "surfaces";
@@ -252,6 +255,24 @@ pub enum BindingDisposition {
         /// Why removal failed.
         detail: String,
     },
+    /// §11.7: the worktree's HEAD was detached at a commit no named ref in
+    /// the source repository is *proven* to reach. Removing it would leave
+    /// that commit unreferenced — reachable from nothing, and so a candidate
+    /// for git's own garbage collection — so teardown retains the worktree
+    /// instead. A retained worktree's HEAD is itself a gc root, which is
+    /// precisely what makes retention the fail-closed answer here.
+    ///
+    /// Distinct from [`RetainedError`](Self::RetainedError) on purpose: no
+    /// git command refused anything: sergeant *chose* not to remove this,
+    /// and an operator resolving it gives the commit a branch rather than
+    /// debugging a git failure. Additive on replay in the direction that
+    /// matters (C3): no event journaled before this phase can carry it.
+    RetainedUnreferenced {
+        /// The commit HEAD was detached at.
+        head_sha: String,
+        /// What was checked, and why removal was refused.
+        evidence: String,
+    },
 }
 
 /// Teardown outcome for one binding.
@@ -277,6 +298,21 @@ pub struct BindingTeardown {
     /// commit; otherwise it is whatever the branch already pointed at.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub final_sha: Option<String>,
+    /// §11.7: what the worktree's HEAD **actually** pointed at when teardown
+    /// looked, as opposed to the `work_branch` just above, which is only what
+    /// this binding was assigned. `None` means *not assessed* — a vanished
+    /// worktree, a git that could not answer, or a `surface.torn_down`
+    /// journaled before this field existed (C3: additive, and absence never
+    /// reads as agreement).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_head: Option<ObservedHead>,
+    /// §11.3's directly attributable findings for this binding, in the order
+    /// teardown observed them. Empty means teardown found nothing to
+    /// attribute — which is not the same as "not assessed"; that is what an
+    /// absent `observed_head` says. `#[serde(default)]` so an old event
+    /// replays with no findings and no integrity assessment at all.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<IntegrityFinding>,
     /// What happened.
     #[serde(flatten)]
     pub disposition: BindingDisposition,
@@ -292,6 +328,50 @@ pub struct TeardownReport {
     /// Whether every worktree was removed cleanly. `false` means something
     /// was retained and is described in `bindings` — never silently dropped.
     pub clean: bool,
+    /// §11.4 (bounded by amendment C6): every bound repository mount whose
+    /// committed HEAD moved between this Work's binding base and its
+    /// retirement. Reported, never attributed, and never part of
+    /// [`TeardownReport::integrity`] — a mount moving during the Work window
+    /// is not evidence the Work moved it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub drift: Vec<EstateDriftObservation>,
+}
+
+impl TeardownReport {
+    /// §11.5's orthogonal axis for this teardown.
+    ///
+    /// Dirty when either half of "core can account for this surface" fails:
+    ///
+    /// - any binding carries a §11.3 finding (the attributable half), or
+    /// - any binding was not retired cleanly — `!clean` (the *retirement*
+    ///   half). Every §11.3-nameable cause already yields its own finding, so
+    ///   this second clause only ever fires alone for a retention §11.3 has
+    ///   no vocabulary for: a `RetainedError` where `git status` itself
+    ///   refused, so teardown could not establish anything at all. Reporting
+    ///   that as clean would be the one answer the closed enum must not force
+    ///   — fail closed instead.
+    ///
+    /// Estate drift is deliberately absent from both clauses (§11.4).
+    ///
+    /// Computed, never stored on the report: `teardown` also runs as
+    /// `materialize`'s partial-failure *rollback*, which is not a retirement
+    /// and must not be journaled as an integrity assessment at all. The one
+    /// caller that applies this is the retirement path in
+    /// `Engine::settle_surface`.
+    pub fn integrity(&self) -> IntegrityDisposition {
+        if self.clean && self.bindings.iter().all(|b| b.findings.is_empty()) {
+            IntegrityDisposition::Clean
+        } else {
+            IntegrityDisposition::Dirty
+        }
+    }
+
+    /// Every binding's findings, flattened in binding order — what a view
+    /// renders when it wants "what was found", not "what happened per
+    /// repository".
+    pub fn findings(&self) -> impl Iterator<Item = &IntegrityFinding> {
+        self.bindings.iter().flat_map(|b| b.findings.iter())
+    }
 }
 
 /// Failure materializing a surface.
@@ -787,14 +867,21 @@ fn attach_one(
 /// honest outcome is a recorded report, which is what the caller journals.
 pub fn teardown(surface: &WorkSurface) -> TeardownReport {
     let mut bindings = Vec::with_capacity(surface.bindings.len());
+    let mut drift = Vec::new();
     for binding in &surface.bindings {
-        let (disposition, final_sha) = teardown_binding(binding);
+        // §11.4/C6: read the mount before this binding's own teardown
+        // touches anything, so `observed` is the estate as the Work left it
+        // rather than as teardown left it.
+        drift.extend(observe_estate_drift(binding));
+        let outcome = teardown_binding(binding);
         bindings.push(BindingTeardown {
             repository: binding.repository.clone(),
             worktree_path: binding.worktree_path.clone(),
             work_branch: binding.work_branch.clone(),
-            final_sha,
-            disposition,
+            final_sha: outcome.final_sha,
+            observed_head: outcome.observed_head,
+            findings: outcome.findings,
+            disposition: outcome.disposition,
         });
     }
     // The worktrees live one level *below* the surface root, so removing them
@@ -809,6 +896,7 @@ pub fn teardown(surface: &WorkSurface) -> TeardownReport {
         work_id: surface.work_id.clone(),
         bindings,
         clean,
+        drift,
     }
 }
 
@@ -894,6 +982,18 @@ pub fn retained_bindings(teardown: &TeardownReport) -> Vec<RetainedBinding> {
                     path: b.worktree_path.clone(),
                     reason: "retained_error",
                     detail: detail.clone(),
+                    bytes: directory_size(&b.worktree_path),
+                })
+            }
+            BindingDisposition::RetainedUnreferenced { evidence, .. } => {
+                if !b.worktree_path.exists() {
+                    return None;
+                }
+                Some(RetainedBinding {
+                    repository: b.repository.clone(),
+                    path: b.worktree_path.clone(),
+                    reason: "retained_unreferenced",
+                    detail: evidence.clone(),
                     bytes: directory_size(&b.worktree_path),
                 })
             }
@@ -1031,6 +1131,18 @@ fn reap_binding(surface: &WorkSurface, binding: &BindingTeardown) -> ReapOutcome
             reason: format!(
                 "teardown could not establish this worktree was clean ({detail}); resolve the \
                  underlying git error and retry teardown instead of reaping"
+            ),
+        },
+        // §11.7: reaping this would do exactly what teardown refused to do —
+        // drop the last reference to commits no named ref reaches. `reap` is
+        // an explicit operator action, but it is a *disk reclamation* verb,
+        // not a "destroy possible output" one, so it stops here and names the
+        // one-line remedy that makes the worktree ordinary again.
+        BindingDisposition::RetainedUnreferenced { head_sha, .. } => ReapOutcome::Skipped {
+            reason: format!(
+                "this worktree holds a detached HEAD at {head_sha} that no named ref reaches; \
+                 give the commit a branch (`git branch <name> {head_sha}`) and retry teardown \
+                 instead of reaping"
             ),
         },
         BindingDisposition::Removed | BindingDisposition::Missing => ReapOutcome::NothingRetained,
@@ -1195,7 +1307,150 @@ pub fn directory_size(path: &Path) -> u64 {
         .sum()
 }
 
-fn teardown_binding(binding: &RepositoryBinding) -> (BindingDisposition, Option<String>) {
+/// What teardown observed and did for one binding: the disposition, plus the
+/// §11 evidence [`teardown`] folds into the [`BindingTeardown`] record.
+struct BindingOutcome {
+    /// What happened to the worktree.
+    disposition: BindingDisposition,
+    /// The retained branch's tip.
+    final_sha: Option<String>,
+    /// Where the worktree's HEAD actually was, when it could be read.
+    observed_head: Option<ObservedHead>,
+    /// §11.3 findings attributable to this binding.
+    findings: Vec<IntegrityFinding>,
+}
+
+/// Read what a worktree's HEAD actually points at (§11.7's first question).
+///
+/// A resolvable branch name is an attached HEAD; otherwise a resolvable
+/// commit is a detached one. If *neither* resolves, this returns `None`
+/// rather than inventing a classification: a worktree whose git cannot answer
+/// either question is not "detached", it is unreadable, and teardown's own
+/// `git status --porcelain` check below already fails that closed as a
+/// `RetainedError` carrying git's diagnostic.
+fn observe_head(worktree: &Path) -> Option<ObservedHead> {
+    match git(worktree, &["symbolic-ref", "--quiet", "--short", "HEAD"]) {
+        Ok(branch) if !branch.is_empty() => Some(ObservedHead::Branch {
+            branch,
+            sha: git(worktree, &["rev-parse", "HEAD"]).ok(),
+        }),
+        _ => git(worktree, &["rev-parse", "HEAD"])
+            .ok()
+            .map(|sha| ObservedHead::Detached { sha }),
+    }
+}
+
+/// Whether any named ref in the source repository is **proven** to reach
+/// `sha` (§11.7's detached-HEAD test).
+///
+/// `git branch --contains` answers it directly for local branches. The
+/// second check is the same question asked of this binding's own work branch,
+/// which `--contains` would also have answered — kept because it is the ref
+/// §11.7 names explicitly and because it still answers if the first call
+/// fails for a reason that has nothing to do with reachability.
+///
+/// Every failure path returns `false`. "Not proven reachable" is the
+/// fail-closed answer, and the caller's response to `false` is to *keep* the
+/// worktree, so an error here can only ever cost a retained directory —
+/// never a lost commit.
+fn reachable_from_a_named_ref(binding: &RepositoryBinding, sha: &str) -> bool {
+    if matches!(
+        git(&binding.source_path, &["branch", "--contains", sha]),
+        Ok(ref out) if !out.is_empty()
+    ) {
+        return true;
+    }
+    git_succeeds(
+        &binding.source_path,
+        &[
+            "merge-base",
+            "--is-ancestor",
+            sha,
+            &format!("refs/heads/{}", binding.work_branch),
+        ],
+    )
+}
+
+/// `git rev-parse --path-format=absolute --git-common-dir`, canonicalized.
+///
+/// Canonicalized because the comparison this feeds is about *identity*, not
+/// spelling: a source path reached through a symlink (`/tmp` → `/private/tmp`
+/// on macOS, an estate mount behind a symlinked parent) would otherwise
+/// answer differently from the worktree that shares its object store, and
+/// report a mismatch where there is none.
+fn common_dir(dir: &Path) -> Option<PathBuf> {
+    let raw = git(
+        dir,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )
+    .ok()?;
+    let path = PathBuf::from(raw);
+    Some(std::fs::canonicalize(&path).unwrap_or(path))
+}
+
+/// §11.3's `assigned_common_dir_mismatch`: the worktree and the checkout it
+/// is journaled against must agree on the Git common directory — the identity
+/// §2.7 locks on and the one that says these two paths really do share an
+/// object store.
+///
+/// Phase A asks the question at teardown, from both sides, which needs no
+/// binding schema change. Phase B pins the canonical common dir at admission,
+/// at which point the expected side comes from the binding rather than from
+/// re-asking the source checkout.
+///
+/// A read that fails on either side yields no finding: this is the *identity*
+/// check, and an unanswerable git is a different failure, already handled
+/// fail-closed by the status/removal path below.
+fn common_dir_finding(binding: &RepositoryBinding) -> Option<IntegrityFinding> {
+    let expected = common_dir(&binding.source_path)?;
+    let observed = common_dir(&binding.worktree_path)?;
+    if expected == observed {
+        return None;
+    }
+    Some(IntegrityFinding::AssignedCommonDirMismatch {
+        repository: binding.repository.clone(),
+        evidence: format!(
+            "the assigned worktree reports git common directory {} while its journaled source \
+             checkout {} reports {}",
+            observed.display(),
+            binding.source_path.display(),
+            expected.display()
+        ),
+        expected_common_dir: expected,
+        observed_common_dir: observed,
+    })
+}
+
+/// §11.4, bounded by amendment C6: one `git rev-parse HEAD` against this
+/// binding's declared mount, compared with the commit the binding was cut
+/// from. One call per bound repository, at retirement only — no worktree
+/// walking, no `git status`, no unselected-repository reads, no polling.
+///
+/// Only `BindingOrigin::Cut` bindings are compared. For an `Attached`
+/// binding, `base_sha` is carried over from the *target* Work's binding
+/// (see [`BindingOrigin`]) and is therefore not this Work's own record of
+/// what the mount was at admission — reporting a `before` that was never
+/// this Work's base would be a worse answer than reporting nothing.
+///
+/// Drift in repositories this Work never selected is out of scope here by
+/// construction: it needs the estate-bound daemon, and is Phase D's work.
+fn observe_estate_drift(binding: &RepositoryBinding) -> Option<EstateDriftObservation> {
+    if binding.origin != BindingOrigin::Cut {
+        return None;
+    }
+    let observed = git(&binding.source_path, &["rev-parse", "HEAD"]).ok()?;
+    if observed == binding.base_sha {
+        return None;
+    }
+    Some(EstateDriftObservation {
+        repository: binding.repository.clone(),
+        before: binding.base_sha.clone(),
+        observed,
+        attribution: DriftAttribution::Unknown,
+    })
+}
+
+fn teardown_binding(binding: &RepositoryBinding) -> BindingOutcome {
     // Read the retained branch's tip **before** taking the per-repository lock.
     // This call reads from ref storage only — it does not access the worktree
     // registry (`.git/worktrees/`) that `with_repository` protects, so running
@@ -1212,6 +1467,8 @@ fn teardown_binding(binding: &RepositoryBinding) -> (BindingDisposition, Option<
     )
     .ok();
 
+    let mut findings = Vec::new();
+
     if !binding.worktree_path.exists() {
         // The directory is gone, but the source repository still lists it;
         // unregister it now so a later rematerialize at the same path is
@@ -1219,7 +1476,92 @@ fn teardown_binding(binding: &RepositoryBinding) -> (BindingDisposition, Option<
         with_repository(&binding.source_path, || {
             prune_stale_worktrees(&binding.source_path);
         });
-        return (BindingDisposition::Missing, final_sha);
+        findings.push(IntegrityFinding::AssignedWorktreeMissing {
+            repository: binding.repository.clone(),
+            worktree_path: binding.worktree_path.clone(),
+            evidence: format!(
+                "the assigned worktree {} did not exist when teardown ran",
+                binding.worktree_path.display()
+            ),
+        });
+        return BindingOutcome {
+            disposition: BindingDisposition::Missing,
+            final_sha,
+            // Nothing left to read a HEAD from: not assessed, not agreed.
+            observed_head: None,
+            findings,
+        };
+    }
+
+    // §11.7's actual-vs-expected reconciliation, **before** the dirty check
+    // below, because the dirty check cannot see any of it: `git status
+    // --porcelain` answers "is there uncommitted content here", never "is
+    // this still the branch the binding was assigned" (§2.6 / #173). Both
+    // reads run in the worktree and touch only `.git/HEAD` and ref storage,
+    // not the `.git/worktrees/` registry `with_repository` protects, so they
+    // stay outside the lock like every other read on this path.
+    let observed_head = observe_head(&binding.worktree_path);
+    findings.extend(common_dir_finding(binding));
+    match &observed_head {
+        // A clean worktree on the *wrong* named branch is recorded and then
+        // removed exactly like any other clean worktree (§11.7). Both named
+        // branches stay durable: teardown deletes neither the expected
+        // `sergeant/<work-id>` nor the one that was actually used, so the
+        // commits on the observed branch remain reachable after the worktree
+        // that pointed at them is gone — which is what makes recording the
+        // branch and its tip here the whole fix rather than half of one.
+        Some(ObservedHead::Branch { branch, sha }) if *branch != binding.work_branch => {
+            findings.push(IntegrityFinding::AssignedBranchMismatch {
+                repository: binding.repository.clone(),
+                worktree_path: binding.worktree_path.clone(),
+                expected_branch: binding.work_branch.clone(),
+                expected_sha: final_sha.clone(),
+                observed_branch: branch.clone(),
+                observed_sha: sha.clone(),
+                evidence: format!(
+                    "the assigned worktree ended on branch {branch} rather than {}; both \
+                     branches are retained",
+                    binding.work_branch
+                ),
+            });
+        }
+        Some(ObservedHead::Detached { sha }) => {
+            let reachable = reachable_from_a_named_ref(binding, sha);
+            let evidence = format!(
+                "the assigned worktree ended with HEAD detached at {sha}; \
+                 `git branch --contains` and `merge-base --is-ancestor {}` \
+                 {} a named ref that reaches it",
+                binding.work_branch,
+                if reachable { "found" } else { "found no" }
+            );
+            findings.push(IntegrityFinding::AssignedHeadDetachedOrUnreferenced {
+                repository: binding.repository.clone(),
+                worktree_path: binding.worktree_path.clone(),
+                expected_branch: binding.work_branch.clone(),
+                observed_sha: sha.clone(),
+                reachable,
+                evidence: evidence.clone(),
+            });
+            if !reachable {
+                // Fail closed, and *before* the dirty check on purpose: the
+                // dirty path removes the worktree with `--force` once its
+                // content is captured as a patch, and a patch captures
+                // uncommitted content, never commits. Removing this worktree
+                // would leave the detached commits reachable from nothing at
+                // all. Retaining it keeps its HEAD as a gc root, so nothing
+                // possible output is destroyed.
+                return BindingOutcome {
+                    disposition: BindingDisposition::RetainedUnreferenced {
+                        head_sha: sha.clone(),
+                        evidence,
+                    },
+                    final_sha,
+                    observed_head,
+                    findings,
+                };
+            }
+        }
+        _ => {}
     }
 
     // Check whether the worktree is clean **before** taking the per-repository
@@ -1237,19 +1579,40 @@ fn teardown_binding(binding: &RepositoryBinding) -> (BindingDisposition, Option<
             // Dirty: `retain_dirty` captures a patch and calls `git worktree
             // remove --force`, which does touch the registry.  Hold the lock
             // for that entire path.
+            //
+            // The finding rides *alongside* the existing retention machinery
+            // rather than replacing any of it (§11.7's first bullet): the
+            // disposition still says what was done with the content, the
+            // finding says what it means for the Work.
+            findings.push(IntegrityFinding::AssignedWorktreeUncommitted {
+                repository: binding.repository.clone(),
+                worktree_path: binding.worktree_path.clone(),
+                evidence: changes.clone(),
+            });
             let disposition =
                 with_repository(&binding.source_path, || retain_dirty(binding, changes));
-            return (disposition, final_sha);
+            return BindingOutcome {
+                disposition,
+                final_sha,
+                observed_head,
+                findings,
+            };
         }
         Ok(_) => {} // clean — proceed to the removal below
         Err(e) => {
-            // Cannot establish that it is clean ⇒ must not remove it.
-            return (
-                BindingDisposition::RetainedError {
+            // Cannot establish that it is clean ⇒ must not remove it. No
+            // §11.3 finding: the closed vocabulary has no kind for "git
+            // could not answer", and inventing `assigned_worktree_uncommitted`
+            // here would report content nothing observed. `TeardownReport::
+            // integrity` still fails this closed through `clean`.
+            return BindingOutcome {
+                disposition: BindingDisposition::RetainedError {
                     detail: e.to_string(),
                 },
                 final_sha,
-            );
+                observed_head,
+                findings,
+            };
         }
     }
 
@@ -1289,7 +1652,12 @@ fn teardown_binding(binding: &RepositoryBinding) -> (BindingDisposition, Option<
             },
         }
     });
-    (disposition, final_sha)
+    BindingOutcome {
+        disposition,
+        final_sha,
+        observed_head,
+        findings,
+    }
 }
 
 /// Ensure the parent directory of `worktree` exists and return the path as a
@@ -1963,25 +2331,31 @@ mod tests {
         );
     }
 
-    /// #173: today, teardown is blind to a worktree that switched off its
-    /// own `work_branch` before it was torn down. `final_sha` is read from
-    /// `refs/heads/<work_branch>` — deliberately, so it resolves even for a
-    /// `Missing` binding (see
+    /// #173, closed: a worktree that switched off its own `work_branch`
+    /// before teardown is reconciled and reported, not silently absorbed.
+    ///
+    /// This was Phase 0's contract pin. Teardown used to read `final_sha`
+    /// from `refs/heads/<work_branch>` — deliberately, so it resolves even
+    /// for a `Missing` binding (see
     /// `teardown_captures_the_retained_branchs_tip_as_the_finalize_commit`
-    /// above) — and `git status --porcelain` only asks "is the worktree
-    /// dirty", not "is it still on the branch this binding claims". A
+    /// above) — and ask `git status --porcelain` only "is the worktree
+    /// dirty", never "is it still on the branch this binding claims". A
     /// worktree that checks out a different branch and commits there is
-    /// clean by that check (nothing uncommitted) and leaves `work_branch`
-    /// itself exactly where it started, so teardown reports the base SHA
-    /// and a clean `Removed` disposition — indistinguishable from a surface
-    /// nothing ever touched — while `git worktree remove` deletes the
-    /// worktree that was the only record of which branch it had actually
-    /// ended up on. Phase A adds actual-vs-expected branch/HEAD/status
-    /// reconciliation at teardown and a closed integrity-finding enum so
-    /// this divergence is reported instead of silently absorbed.
-    // CONTRACT PIN (estate-root Phase A): teardown reports actual-vs-expected branch/HEAD divergence instead of a clean disposition at the base SHA.
+    /// clean by that check and leaves `work_branch` exactly where it
+    /// started, so the report was a clean `Removed` at the base SHA:
+    /// indistinguishable from a surface nothing ever touched, while
+    /// `git worktree remove` deleted the only record of where the run had
+    /// actually ended up.
+    ///
+    /// §11.7's answer, asserted below: the removal still happens (a clean
+    /// worktree on the wrong branch is still clean), but the divergence is
+    /// recorded first — `observed_head` names the branch and its tip, an
+    /// `assigned_branch_mismatch` finding carries expected-vs-observed, and
+    /// the report's integrity disposition is `dirty`. Both named branches
+    /// survive (§12.1), which is what makes recording the observed one a
+    /// usable pointer rather than an epitaph.
     #[test]
-    fn contract_pin_teardown_is_blind_to_a_worktree_switched_off_its_work_branch() {
+    fn teardown_reports_a_worktree_that_switched_off_its_work_branch() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
@@ -2008,40 +2382,368 @@ mod tests {
         );
 
         let report = teardown(&surface);
+        let binding = &report.bindings[0];
 
-        // The defect, pinned: a clean `Removed` disposition and the base
-        // SHA, as if nothing had ever happened in this worktree.
+        // A clean worktree on the wrong branch is still removed (§11.7): the
+        // content is committed and both branches are durable, so there is
+        // nothing here to fail closed over.
+        assert_eq!(binding.disposition, BindingDisposition::Removed);
+        assert!(!worktree.exists(), "a clean worktree is still removed");
+
+        // What used to be lost with it: where HEAD actually was.
         assert_eq!(
-            report.bindings[0].disposition,
-            BindingDisposition::Removed,
-            "today, switching branches inside the worktree does not stop teardown from \
-             reporting a clean removal"
+            binding.observed_head,
+            Some(ObservedHead::Branch {
+                branch: "renegade".to_string(),
+                sha: Some(renegade_commit.clone()),
+            }),
+            "teardown must record the branch the worktree actually ended on, and its tip"
         );
+
+        // `final_sha` keeps its documented meaning — the *retained branch's*
+        // tip, still at the base SHA because nothing advanced it — and the
+        // finding is what carries the divergence rather than overloading it.
+        assert_eq!(binding.final_sha.as_deref(), Some(base_sha.as_str()));
+        let [
+            IntegrityFinding::AssignedBranchMismatch {
+                repository,
+                expected_branch,
+                expected_sha,
+                observed_branch,
+                observed_sha,
+                ..
+            },
+        ] = binding.findings.as_slice()
+        else {
+            panic!("expected exactly one branch-mismatch finding: {binding:?}");
+        };
+        assert_eq!(repository, "solo");
+        assert_eq!(expected_branch, &work_branch_name);
+        assert_eq!(expected_sha.as_deref(), Some(base_sha.as_str()));
+        assert_eq!(observed_branch, "renegade");
+        assert_eq!(observed_sha.as_deref(), Some(renegade_commit.as_str()));
+
         assert_eq!(
-            report.bindings[0].final_sha.as_deref(),
-            Some(base_sha.as_str()),
-            "today, final_sha is the untouched work_branch ref — still at the base SHA — \
-             not the divergent commit the worktree actually ended up on"
+            report.integrity(),
+            IntegrityDisposition::Dirty,
+            "a branch mismatch makes the Work terminal-dirty (§11.5)"
         );
-        assert!(
-            !worktree.exists(),
-            "today, the worktree (the only record of the renegade branch's checkout) is removed"
-        );
-        // The renegade branch itself survives in the source repository's
-        // refs (worktrees share one ref store) — the commit is not
-        // destroyed — but nothing in the teardown report names it, and the
-        // work_branch this binding is journaled against never pointed at
-        // it, so no reconciliation done today can connect the two.
-        assert!(
-            git_succeeds(
-                &spec.path,
-                &["rev-parse", "--verify", "refs/heads/renegade"]
-            ),
-            "the renegade commit itself survives, orphaned from anything teardown reported"
-        );
+
+        // §11.7/§12.1: both named branches remain durable. Teardown deletes
+        // neither the expected one nor the one that was actually used, so
+        // the commit stays reachable and the report names the ref it is on.
+        for branch in [work_branch_name.as_str(), "renegade"] {
+            assert!(
+                git_succeeds(
+                    &spec.path,
+                    &["rev-parse", "--verify", &format!("refs/heads/{branch}")]
+                ),
+                "{branch} must still exist in the source repository after teardown"
+            );
+        }
         assert_ne!(
             work_branch_name, "renegade",
             "sanity: the binding's own work_branch was never the one switched to"
+        );
+    }
+
+    /// The baseline the rest of §11 is measured against: a surface that did
+    /// what it was asked reports `clean`, no findings, and a HEAD sitting on
+    /// exactly the branch the binding named.
+    ///
+    /// Worth its own test because "clean" is now a *computed* claim rather
+    /// than the absence of one — a reconciliation that produced spurious
+    /// findings would make every ordinary Work terminal-dirty, which is the
+    /// failure mode that turns a signal into noise (#94's own lesson).
+    #[test]
+    fn an_ordinary_teardown_reports_clean_integrity_on_the_expected_branch() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface =
+            materialize(data.path(), "01CLEAN", std::slice::from_ref(&spec)).expect("materialize");
+        let base_sha = surface.bindings[0].base_sha.clone();
+
+        let report = teardown(&surface);
+        let binding = &report.bindings[0];
+
+        assert_eq!(binding.disposition, BindingDisposition::Removed);
+        assert_eq!(
+            binding.observed_head,
+            Some(ObservedHead::Branch {
+                branch: work_branch("01CLEAN"),
+                sha: Some(base_sha),
+            })
+        );
+        assert!(
+            binding.findings.is_empty(),
+            "an untouched surface must produce no findings: {:?}",
+            binding.findings
+        );
+        assert!(report.drift.is_empty(), "the mount never moved");
+        assert_eq!(report.integrity(), IntegrityDisposition::Clean);
+    }
+
+    /// §11.7's fail-closed case: a detached HEAD carrying commits no named
+    /// ref reaches **retains** the worktree.
+    ///
+    /// Removing it would drop the last reference to those commits — a
+    /// worktree's HEAD is a gc root, a removed worktree's is not — and
+    /// teardown never destroys possible output. The patch capture the dirty
+    /// path uses is no substitute here: it captures uncommitted content, and
+    /// these commits are exactly the opposite. `sgt work reap` must decline
+    /// for the same reason, with the remedy named rather than a refusal an
+    /// operator has to decode.
+    #[test]
+    fn teardown_retains_a_worktree_whose_detached_head_no_named_ref_reaches() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface = materialize(data.path(), "01DETACHED", std::slice::from_ref(&spec))
+            .expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        // Detach, then commit: the commit belongs to no branch at all.
+        git_as_test_identity(&worktree, &["checkout", "--detach"]);
+        std::fs::write(worktree.join("orphan.txt"), "unreferenced output\n").expect("write orphan");
+        git_as_test_identity(&worktree, &["add", "."]);
+        git_as_test_identity(&worktree, &["commit", "-m", "committed off any branch"]);
+        let orphan = git(&worktree, &["rev-parse", "HEAD"]).expect("orphan commit");
+        assert!(
+            git(&spec.path, &["branch", "--contains", &orphan])
+                .expect("branch --contains")
+                .is_empty(),
+            "the fixture must actually produce a commit no branch contains"
+        );
+
+        let report = teardown(&surface);
+        let binding = &report.bindings[0];
+
+        assert!(
+            matches!(
+                &binding.disposition,
+                BindingDisposition::RetainedUnreferenced { head_sha, .. } if head_sha == &orphan
+            ),
+            "expected the worktree to be retained: {:?}",
+            binding.disposition
+        );
+        assert!(
+            worktree.exists(),
+            "the worktree must survive — its HEAD is the only thing referencing the commit"
+        );
+        assert!(
+            git_succeeds(&spec.path, &["cat-file", "-e", &orphan]),
+            "the orphaned commit must still be in the object store"
+        );
+        let [
+            IntegrityFinding::AssignedHeadDetachedOrUnreferenced {
+                observed_sha,
+                reachable,
+                ..
+            },
+        ] = binding.findings.as_slice()
+        else {
+            panic!("expected one detached-HEAD finding: {binding:?}");
+        };
+        assert_eq!(observed_sha, &orphan);
+        assert!(!reachable, "no named ref reaches it");
+        assert_eq!(report.integrity(), IntegrityDisposition::Dirty);
+
+        // #109's inspect verb sees it, and reap declines rather than doing
+        // the one thing teardown refused to do.
+        let retained = retained_bindings(&report);
+        assert_eq!(retained.len(), 1);
+        assert_eq!(retained[0].reason, "retained_unreferenced");
+        let reaped = reap(&surface, &report);
+        assert!(
+            matches!(
+                &reaped.bindings[0].outcome,
+                ReapOutcome::Skipped { reason } if reason.contains(&orphan)
+            ),
+            "reap must decline and name the commit: {:?}",
+            reaped.bindings[0].outcome
+        );
+        assert!(worktree.exists(), "reap must not have removed it either");
+    }
+
+    /// The other half of §11.7's detached-HEAD rule: detachment is always a
+    /// finding, but a commit a named ref still reaches is not at risk, so the
+    /// worktree is removed exactly as any other clean one is.
+    ///
+    /// Without this half the fail-closed rule would retain every worktree a
+    /// workflow happened to leave detached at its own branch tip — honest
+    /// but useless, and #109's 30 GB of retained surfaces all over again.
+    #[test]
+    fn teardown_removes_a_worktree_whose_detached_head_is_still_reachable() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface = materialize(data.path(), "01REACHABLE", std::slice::from_ref(&spec))
+            .expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        // Detached, but at the work branch's own tip: nothing is at risk.
+        git_as_test_identity(&worktree, &["checkout", "--detach"]);
+
+        let report = teardown(&surface);
+        let binding = &report.bindings[0];
+
+        assert_eq!(binding.disposition, BindingDisposition::Removed);
+        assert!(!worktree.exists());
+        let [IntegrityFinding::AssignedHeadDetachedOrUnreferenced { reachable, .. }] =
+            binding.findings.as_slice()
+        else {
+            panic!("expected one detached-HEAD finding: {binding:?}");
+        };
+        assert!(reachable, "the work branch itself reaches this commit");
+        assert_eq!(
+            report.integrity(),
+            IntegrityDisposition::Dirty,
+            "a detached HEAD is still attributable, even when nothing was lost"
+        );
+    }
+
+    /// A worktree that vanished before teardown reached it keeps its
+    /// `Missing` disposition — and now maps to the §11.3 finding for it, so
+    /// "the surface was not where it was supposed to be" is reportable rather
+    /// than only inferable from a disposition tag.
+    #[test]
+    fn a_vanished_worktree_maps_to_the_missing_finding_and_reads_dirty() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface = materialize(data.path(), "01VANISHED", std::slice::from_ref(&spec))
+            .expect("materialize");
+        std::fs::remove_dir_all(&surface.bindings[0].worktree_path).expect("simulate vanished");
+
+        let report = teardown(&surface);
+        let binding = &report.bindings[0];
+
+        assert_eq!(binding.disposition, BindingDisposition::Missing);
+        assert!(
+            binding.observed_head.is_none(),
+            "there is no HEAD left to read: not assessed, not agreed"
+        );
+        assert!(matches!(
+            binding.findings.as_slice(),
+            [IntegrityFinding::AssignedWorktreeMissing { .. }]
+        ));
+        assert_eq!(report.integrity(), IntegrityDisposition::Dirty);
+    }
+
+    /// #109's retention machinery is untouched by §11: an uncommitted
+    /// worktree still captures its patch and still reports `retained_dirty`.
+    /// The finding rides *alongside* it — the disposition says what was done
+    /// with the content, the finding says what it means for the Work.
+    #[test]
+    fn an_uncommitted_worktree_yields_the_finding_beside_the_existing_retention() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface =
+            materialize(data.path(), "01DIRTY", std::slice::from_ref(&spec)).expect("materialize");
+        std::fs::write(surface.bindings[0].worktree_path.join("wip.rs"), "//\n").expect("dirty");
+
+        let report = teardown(&surface);
+        let binding = &report.bindings[0];
+
+        assert!(
+            matches!(
+                binding.disposition,
+                BindingDisposition::RetainedDirty { patch: Some(_), .. }
+            ),
+            "#109's patch capture must be unchanged: {:?}",
+            binding.disposition
+        );
+        let [IntegrityFinding::AssignedWorktreeUncommitted { evidence, .. }] =
+            binding.findings.as_slice()
+        else {
+            panic!("expected one uncommitted finding: {binding:?}");
+        };
+        assert!(
+            evidence.contains("wip.rs"),
+            "the finding carries git's own porcelain evidence: {evidence}"
+        );
+        assert_eq!(report.integrity(), IntegrityDisposition::Dirty);
+    }
+
+    /// §11.3's `assigned_common_dir_mismatch`: a worktree that answers with a
+    /// different canonical Git common directory than the checkout it is
+    /// journaled against is not the worktree the binding thinks it is — the
+    /// same identity §2.7/§9.4 needs the interprocess lock keyed on.
+    ///
+    /// Reproduced by handing teardown a binding whose `source_path` names a
+    /// *different* repository than the worktree actually belongs to, which is
+    /// exactly the shape a mis-journaled or aliased mount would have.
+    #[test]
+    fn a_worktree_whose_common_dir_disagrees_with_its_source_checkout_is_a_finding() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let mine = repo(&dir.path().join("mine"));
+        let stranger = repo(&dir.path().join("stranger"));
+        let surface = materialize(data.path(), "01COMMONDIR", std::slice::from_ref(&mine))
+            .expect("materialize");
+
+        let mut misbound = surface.clone();
+        misbound.bindings[0].source_path = stranger.path.clone();
+
+        let report = teardown(&misbound);
+        let binding = &report.bindings[0];
+
+        assert!(
+            binding
+                .findings
+                .iter()
+                .any(|f| matches!(f, IntegrityFinding::AssignedCommonDirMismatch { .. })),
+            "expected a common-dir mismatch: {:?}",
+            binding.findings
+        );
+        assert_eq!(report.integrity(), IntegrityDisposition::Dirty);
+        // Fail closed all the way through: the worktree belongs to a
+        // repository this teardown was not pointed at, so nothing removed it.
+        assert!(surface.bindings[0].worktree_path.exists());
+    }
+
+    /// §11.4, bounded by amendment C6: a mount whose committed HEAD moved
+    /// during the Work window is *observed* — one `rev-parse` per bound
+    /// repository, at retirement — and attributed to nobody.
+    ///
+    /// The assertion that matters most is the negative one: drift does not
+    /// make the Work dirty. Captain, an editor, another Work, or an unrelated
+    /// process may have advanced that mount, and reporting a Work dirty for
+    /// something it cannot be shown to have done is exactly the false signal
+    /// §11.4 exists to prevent.
+    #[test]
+    fn estate_drift_is_observed_at_teardown_and_never_makes_the_work_dirty() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface =
+            materialize(data.path(), "01DRIFT", std::slice::from_ref(&spec)).expect("materialize");
+        let base_sha = surface.bindings[0].base_sha.clone();
+
+        // Somebody else advances the mount while the Work runs.
+        std::fs::write(spec.path.join("unrelated.txt"), "not this work\n").expect("write");
+        git_as_test_identity(&spec.path, &["add", "."]);
+        git_as_test_identity(&spec.path, &["commit", "-m", "somebody else's commit"]);
+        let moved = git(&spec.path, &["rev-parse", "HEAD"]).expect("moved head");
+
+        let report = teardown(&surface);
+
+        assert_eq!(
+            report.drift,
+            vec![EstateDriftObservation {
+                repository: "solo".to_string(),
+                before: base_sha,
+                observed: moved,
+                attribution: DriftAttribution::Unknown,
+            }]
+        );
+        assert!(report.bindings[0].findings.is_empty());
+        assert_eq!(
+            report.integrity(),
+            IntegrityDisposition::Clean,
+            "estate drift is reported, never attributed, and never dirty (§11.4)"
         );
     }
 
@@ -2925,6 +3627,8 @@ mod tests {
             worktree_path: dir.path().join("some-other-worktree"),
             work_branch: "sergeant/01INSPECT".to_string(),
             final_sha: None,
+            observed_head: None,
+            findings: Vec::new(),
             disposition: BindingDisposition::RetainedError {
                 detail: "fatal: could not read status".to_string(),
             },
@@ -3006,6 +3710,8 @@ mod tests {
             worktree_path: dir.path().join("untouched"),
             work_branch: "sergeant/01REAP".to_string(),
             final_sha: None,
+            observed_head: None,
+            findings: Vec::new(),
             disposition: BindingDisposition::RetainedError {
                 detail: "fatal: could not read status".to_string(),
             },

--- a/src/tui/work_view.rs
+++ b/src/tui/work_view.rs
@@ -732,6 +732,53 @@ impl WorkScreen {
         }
         blank(&mut lines);
 
+        // §11 (C5): the integrity axis is orthogonal to the reported state
+        // above, so it gets its own card rather than being folded into it.
+        // A null `integrity` key is *not assessed* — a Work whose surface
+        // never retired, or a teardown journaled before the axis existed —
+        // and says so rather than rendering "clean".
+        heading("Integrity (§11)", &mut lines);
+        let integrity = &self.work["integrity"];
+        if integrity.is_null() {
+            lines.push(kv("disposition", "not assessed"));
+        } else {
+            lines.push(kv("disposition", &field_text(&integrity["disposition"])));
+            match integrity["findings"].as_array() {
+                Some(findings) if !findings.is_empty() => {
+                    for finding in findings {
+                        lines.push(kv(
+                            &field_text(&finding["finding"]),
+                            &format!(
+                                "{}  {}",
+                                field_text(&finding["repository"]),
+                                field_text(&finding["evidence"]),
+                            ),
+                        ));
+                    }
+                }
+                _ => lines.push(kv("findings", "-")),
+            }
+            // §11.4: drift is reported, never attributed, and never part of
+            // the disposition above.
+            match integrity["drift"].as_array() {
+                Some(drift) if !drift.is_empty() => {
+                    for observation in drift {
+                        lines.push(kv(
+                            &format!("drift {}", field_text(&observation["repository"])),
+                            &format!(
+                                "{} -> {}  attribution {}",
+                                field_text(&observation["before"]),
+                                field_text(&observation["observed"]),
+                                field_text(&observation["attribution"]),
+                            ),
+                        ));
+                    }
+                }
+                _ => lines.push(kv("estate drift", "-")),
+            }
+        }
+        blank(&mut lines);
+
         heading("Output (§13.8)", &mut lines);
         match self.work["output"]["repositories"].as_array() {
             Some(repos) if !repos.is_empty() => {
@@ -1504,6 +1551,72 @@ mod tests {
         assert!(
             text.contains("respond"),
             "action matrix names respond: {text}"
+        );
+    }
+
+    /// §11 (C5): the integrity axis is visible in the Details pane, and an
+    /// unassessed Work says so rather than reading as clean.
+    ///
+    /// The negative half is the one worth pinning. A pane that rendered a
+    /// missing `integrity` key as "clean" would be the TUI inventing the
+    /// exact fact amendment C3 forbids the journal from inventing.
+    #[test]
+    fn the_details_pane_shows_the_integrity_axis_and_its_findings() {
+        let text = |screen: &WorkScreen| {
+            screen
+                .details_lines()
+                .iter()
+                .map(|l| l.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        let unassessed = text(&screen_with("completed", Vec::new()));
+        assert!(unassessed.contains("Integrity"), "{unassessed}");
+        assert!(
+            unassessed.contains("not assessed"),
+            "an absent assessment must not read as clean: {unassessed}"
+        );
+
+        let mut body = work_body("completed_dirty");
+        body["integrity"] = json!({
+            "disposition": "dirty",
+            "findings": [{
+                "finding": "assigned_branch_mismatch",
+                "repository": "svc-a",
+                "worktree_path": "/data/surfaces/01WORK/svc-a",
+                "expected_branch": "sergeant/01WORK",
+                "expected_sha": "abc123",
+                "observed_branch": "renegade",
+                "observed_sha": "def456",
+                "evidence": "the assigned worktree ended on branch renegade",
+            }],
+            "drift": [{
+                "repository": "svc-a",
+                "before": "abc123",
+                "observed": "999999",
+                "attribution": "unknown",
+            }],
+        });
+        let assessed = text(&WorkScreen::from_parts(
+            "01WORK".to_string(),
+            body,
+            Vec::new(),
+            Vec::new(),
+            None,
+        ));
+        assert!(assessed.contains("dirty"), "{assessed}");
+        assert!(
+            assessed.contains("assigned_branch_mismatch"),
+            "the finding kind is named: {assessed}"
+        );
+        assert!(
+            assessed.contains("renegade"),
+            "and its evidence with it: {assessed}"
+        );
+        assert!(
+            assessed.contains("unknown"),
+            "§11.4's drift keeps its unknown attribution on screen: {assessed}"
         );
     }
 

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -2598,6 +2598,141 @@ async fn a_stranded_completion_is_not_reported_as_plain_completed() {
     handle.shutdown().await;
 }
 
+/// #173 / §11.7 end to end: a run whose worktree ends on a *different* branch
+/// completes, and says so.
+///
+/// The defect this closes was silent by construction. `final_sha` is read
+/// from `refs/heads/sergeant/<work-id>` and `git status --porcelain` only
+/// asks whether anything is uncommitted, so a worktree that checked out
+/// another branch and committed there was clean by both measures: teardown
+/// reported `removed` at the base SHA, `sgt work show` reported plain
+/// `completed`, and `git worktree remove` deleted the only record of where
+/// the output had actually gone. §17's acceptance line — a worktree ending on
+/// another branch can no longer be reported clean, nor represented as though
+/// the expected branch contains its output — is what these assertions are.
+///
+/// Driven through the real daemon rather than `surface::teardown` directly,
+/// because the claim is about what an operator is told: the finding has to
+/// survive the journal, the projection fold, and both read paths (`work show`
+/// and `work list`) to be worth anything.
+#[tokio::test]
+async fn a_run_that_ends_on_the_wrong_branch_completes_dirty_and_keeps_both_branches() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let repo = repos.path().join("solo");
+    let base_sha = init_repo(&repo);
+    write_two_stage_workflow(&repo);
+
+    let (registry, _fake) = one_fake([
+        FakeStep::waiting("parks so the fixture can move the worktree"),
+        FakeStep::complete_with("first done"),
+        FakeStep::complete_with("second done"),
+    ]);
+    let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
+    let client = http();
+
+    let (_, body) = submit(
+        &client,
+        &handle,
+        &repo,
+        "commits somewhere else entirely",
+        json!({"workflow": "tiny"}),
+    )
+    .await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    let work_branch = format!("sergeant/{work_id}");
+    let worktree = PathBuf::from(
+        body["surface"]["bindings"][0]["worktree_path"]
+            .as_str()
+            .expect("worktree"),
+    );
+
+    // What an actor that mis-drives git does: switch off the assigned branch
+    // and commit the run's output there instead.
+    git(&worktree, &["checkout", "-b", "renegade"]);
+    std::fs::write(worktree.join("output.rs"), "fn main() {}\n").expect("write output");
+    git(&worktree, &["add", "."]);
+    git(&worktree, &["commit", "-m", "output, on the wrong branch"]);
+    let renegade_sha = git(&worktree, &["rev-parse", "HEAD"]);
+
+    // Retry re-enters the parked stage and the scripted run completes every
+    // remaining stage, driving the whole run through teardown.
+    let (status, body) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/retry"),
+        json!({"command_id": ulid()}),
+    )
+    .await;
+    assert_eq!(status, 200, "retry rejected: {body}");
+
+    // A clean worktree on the wrong branch is still removed — the content is
+    // committed and both branches are durable — but the report names where
+    // it actually was.
+    assert_eq!(
+        body["teardown"]["bindings"][0]["disposition"], "removed",
+        "{body}"
+    );
+    assert_eq!(
+        body["teardown"]["bindings"][0]["observed_head"],
+        json!({"head": "branch", "branch": "renegade", "sha": renegade_sha}),
+        "{body}"
+    );
+
+    // §11.5's axis, and the §11.3 finding behind it.
+    assert_eq!(body["integrity"]["disposition"], "dirty", "{body}");
+    let finding = &body["integrity"]["findings"][0];
+    assert_eq!(finding["finding"], "assigned_branch_mismatch", "{body}");
+    assert_eq!(finding["expected_branch"], work_branch, "{body}");
+    assert_eq!(finding["expected_sha"], base_sha, "{body}");
+    assert_eq!(finding["observed_branch"], "renegade", "{body}");
+    assert_eq!(finding["observed_sha"], renegade_sha, "{body}");
+
+    // Work state is untouched (§11.5: no new transition target); only the
+    // reported label carries the axis.
+    assert_eq!(body["work"]["state"], "completed_dirty", "{body}");
+    let (status, _) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/retry"),
+        json!({"command_id": ulid()}),
+    )
+    .await;
+    assert_eq!(
+        status, 409,
+        "still `Completed` underneath — terminal, not retryable"
+    );
+
+    // C5: distinguishable from `sgt work list`, not only from `work show`.
+    let list = get(&client, &handle, "/v1/work").await;
+    let row = list["works"]
+        .as_array()
+        .expect("works")
+        .iter()
+        .find(|w| w["id"] == work_id)
+        .expect("the work is listed");
+    assert_eq!(row["state"], "completed_dirty", "{list}");
+    assert_eq!(row["integrity"]["disposition"], "dirty", "{list}");
+
+    // §11.7 / §12.1: both named branches survive in the source repository,
+    // so the commit the run actually made is still reachable by name.
+    assert!(
+        branch_exists(&repo, &work_branch),
+        "the expected branch is always retained, advanced or not"
+    );
+    assert!(
+        branch_exists(&repo, "renegade"),
+        "the branch the run actually used is never deleted either"
+    );
+    assert_eq!(
+        git(&repo, &["rev-parse", "refs/heads/renegade"]),
+        renegade_sha,
+        "and it still points at the run's output"
+    );
+
+    handle.shutdown().await;
+}
+
 /// A multi-repository submission where a later repository cannot be
 /// materialized: the earlier ones already have a real branch and worktree in
 /// the user's own checkouts. Those are rolled back and the report is


### PR DESCRIPTION
Phase A of the estate-root integration (spec: specs/phase-a.md; proposal §11, amendments C2/C3/C5/C6). Closes the #173 class: teardown now reconciles the worktree's ACTUAL branch/HEAD against the binding before removal; a wrong-branch or unreachable-detached result can never be reported clean or lose commits.

- New `runtime/integrity.rs`: closed §11.3 finding enum (adapter kinds defined, emission-gated per C2, zero construction sites), `IntegrityDisposition` orthogonal to WorkState (ADR 0007b pattern — no state-machine change, pinned by the untouched transition-table test).
- `surface.torn_down` gains an additive sibling `integrity` key; old-shape payloads replay as not-assessed (tested via hand-built JSON), never clean.
- Estate drift observed per bound mount (Cut bindings only), attribution unknown, never dirties.
- New `RetainedUnreferenced` disposition retains detached-unreachable output fail-closed; reap skips it.
- Mandatory dirty visibility (C5): `integrity` sibling key in API views, `failed/dirty`·`canceled/dirty` list labels, TUI integrity card.
- 7 design decisions documented in commit messages/module docs; all survived the spec-fidelity axis.

Gauntlet: 4-axis panel → 1 confirmed warning (untested list-label branch) → fixed with mutation-verified unit tests. Gates green (fmt, clippy -D warnings, 526 lib + full integration, 0 failures). Deferred findings: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4