### PR TITLE
Phase B: common-dir interprocess locking, binding enrichment, backend binding summary

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -4848,6 +4848,7 @@ mod tests {
             profile: None,
             execute: None,
             instruction_policy: crate::domain::workspace::InstructionPolicy::default(),
+            bindings: Vec::new(),
         };
         let handle = {
             use crate::backend::Backend;

--- a/src/api.rs
+++ b/src/api.rs
@@ -2546,7 +2546,11 @@ async fn reap_work(
     // its duration. Reap is rare and explicit, never on a hot path, so this
     // is accepted rather than plumbed through the async effect system the
     // way `teardown` itself is.
-    let report = blocking_sync(|| reap(&surface, &teardown));
+    // `state.data_dir` is this daemon's own storage — where §9.4's
+    // interprocess repository locks live. Reap's one guarded span (a `git
+    // worktree remove --force` on a retained-dirty binding) takes the same
+    // lock every other registry mutation in the surface module does.
+    let report = blocking_sync(|| reap(&state.data_dir, &surface, &teardown));
     let result = json!({"report": report});
     record_and_respond(
         &mut core,

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -124,9 +124,9 @@ use std::sync::{Arc, Mutex, OnceLock};
 use serde_json::{Value, json};
 
 use super::{
-    Backend, BackendError, BackendSignal, Capabilities, Completion, EventSink, ExecutionHandle,
-    NativeEvent, NativeState, Observation, PreparedExecution, ProbeReport, ResumeRequest,
-    RuntimeScope, StartRequest,
+    Backend, BackendError, BackendSignal, BindingSummary, Capabilities, Completion, EventSink,
+    ExecutionHandle, NativeEvent, NativeState, Observation, PreparedExecution, ProbeReport,
+    ResumeRequest, RuntimeScope, StartRequest,
 };
 use crate::domain::event::{Event, EventDraft, EventSource};
 use crate::domain::profile::Profile;
@@ -208,6 +208,94 @@ does not hold for a daemon reached any other way: a terminal that never went thr
 <harness>` inherits whatever environment it happened to have. If a tool you expect is missing, \
 that is more likely an unenriched PATH than a permissions fault — run `sgt doctor` to check what \
 this installation's environment actually guarantees before assuming otherwise.";
+
+/// Opening line of §10.1's mutation-surface section, composed after
+/// [`ENVIRONMENT_CONTRACT`] by [`compose_launch_prompt`] whenever the request
+/// carries a binding summary.
+///
+/// §10.1 names exactly what is outside the Work's mutation authority — the
+/// estate root, the `repos/` mounts, unselected repositories, other Work
+/// surfaces, sergeant's runtime state, unrelated checkouts — and the shortest
+/// true statement of all of it is "the listed worktrees, and nothing else".
+/// The mounts get their own clause because they are the one exclusion an actor
+/// is actively likely to get wrong: `repos/<name>` is where the repository
+/// *looks* like it lives, and a linked worktree of it is easy to mistake for a
+/// view rather than the thing itself.
+///
+/// **Factual, not exhortative.** This states where the Work's authority
+/// begins and ends and what each worktree was bound to; it does not
+/// editorialize about consequences or add rules of its own. §12's "procedure
+/// is data" belongs to the stage's CONTEXT.md, which is composed after this
+/// and stays verbatim.
+const MUTATION_SURFACE_HEADER: &str = "\
+Mutation surface: this Work may modify exactly the worktree(s) listed below, and nothing else. \
+The estate root, the `repos/` mounts those worktrees were cut from, unselected repositories, \
+other Works' surfaces, and any other path on this machine are outside what this Work is \
+authorized to change. Each worktree is already checked out on its own branch at its own base \
+commit:";
+
+/// The full first-turn prompt for a LAUNCH, in fixed section order.
+///
+/// ```text
+/// 1  EXECUTION_MODEL_CONTRACT      ADR 0007(a), sergeant's own statement
+/// 2  ENVIRONMENT_CONTRACT          ADR 0007(a), sergeant's own statement
+/// 3  mutation surface (§10.1)      sergeant's own statement, from the bindings
+/// 4  intent                        §12: data, verbatim
+/// 5  CONTEXT.md                    §12: data, verbatim
+/// ```
+///
+/// ADR 0007(a)'s two statements precede everything: they are sergeant's own
+/// execution-model and environment guarantees, not stage content, so neither
+/// is subject to §12's "verbatim, uninterpreted" rule the way intent and
+/// CONTEXT.md are. §10.1's mutation surface joins them for the same reason —
+/// it is a fact about the Work sergeant admitted, not procedure — and sits
+/// third, after the guarantees the actor needs to read everything else
+/// correctly and before the work it is being asked to do.
+///
+/// Section 3 is omitted entirely when the request carries no bindings, rather
+/// than emitted empty: a `StartRequest` replayed from before §10.1 existed has
+/// nothing to say here, and "you may modify nothing" is a claim its silence
+/// does not make.
+///
+/// A free function, not a method, and the reason is testability: composition
+/// used to happen inline in `launch`, where the only way to observe it was to
+/// spawn a real `claude` process. This is the seam
+/// `the_launch_prompt_states_the_mutation_surface_after_the_two_contracts`
+/// pins.
+fn compose_launch_prompt(request: &StartRequest) -> String {
+    let mut sections = vec![
+        EXECUTION_MODEL_CONTRACT.to_string(),
+        ENVIRONMENT_CONTRACT.to_string(),
+    ];
+    if !request.bindings.is_empty() {
+        sections.push(mutation_surface_section(&request.bindings));
+    }
+    sections.push(request.intent.clone());
+    sections.push(request.context.clone());
+    sections.join("\n\n")
+}
+
+/// §10.1's section body: the header, then one line per bound repository.
+///
+/// One line each, in the Work's own scope order, naming the four facts §10.1
+/// asks for — path, expected branch, base branch, base SHA. The SHA is
+/// carried in full rather than abbreviated: it is the Work's pin, and a
+/// short form is a value an actor would have to resolve before it could use
+/// it for anything.
+fn mutation_surface_section(bindings: &[BindingSummary]) -> String {
+    let mut section = String::from(MUTATION_SURFACE_HEADER);
+    for binding in bindings {
+        section.push_str(&format!(
+            "\n- {}: {} (branch {}, cut from {} at {})",
+            binding.repository,
+            binding.worktree_path.display(),
+            binding.work_branch,
+            binding.base_branch,
+            binding.base_sha,
+        ));
+    }
+    section
+}
 
 /// The actor's question from one `post_turn_summary` line, when it asked one.
 ///
@@ -1632,18 +1720,7 @@ impl Backend for ClaudeBackend {
                 },
             );
         }
-        // ADR 0007(a) precedes both: sergeant's own execution-model and
-        // environment-guarantee statements, not stage content, so neither is
-        // ever subject to §12's "verbatim, uninterpreted" rule the way
-        // intent and CONTEXT.md are. §12 itself: procedure is data — intent
-        // plus the stage's CONTEXT.md, verbatim, uninterpreted. The two
-        // contracts are composed together, in this fixed order, so a test
-        // can pin that adding one never overwrites the other.
-        let prompt = format!(
-            "{EXECUTION_MODEL_CONTRACT}\n\n{ENVIRONMENT_CONTRACT}\n\n{}\n\n{}",
-            request.intent, request.context
-        );
-        if let Err(e) = self.spawn_turn(&request.execution_id, prompt) {
+        if let Err(e) = self.spawn_turn(&request.execution_id, compose_launch_prompt(request)) {
             // A failed launch must not leave a phantom execution that
             // OBSERVE would misread as an interrupted-but-resumable turn.
             self.lock().executions.remove(&request.execution_id);
@@ -2299,6 +2376,111 @@ fn new_session_uuid() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A `StartRequest` carrying `bindings`, for the prompt-composition
+    /// tests. Everything else is the minimum a request needs.
+    fn prompt_request(bindings: Vec<BindingSummary>) -> StartRequest {
+        StartRequest {
+            work_id: "01PROMPT".to_string(),
+            execution_id: "e-prompt".to_string(),
+            stage_id: "00-only".to_string(),
+            attempt: 1,
+            cwd: PathBuf::from("/data/surfaces/01PROMPT"),
+            intent: "the human intent".to_string(),
+            context: "the stage's CONTEXT.md".to_string(),
+            model: None,
+            profile: None,
+            execute: None,
+            instruction_policy: crate::domain::workspace::InstructionPolicy::default(),
+            bindings,
+        }
+    }
+
+    fn binding(repository: &str, sha: &str) -> BindingSummary {
+        BindingSummary {
+            repository: repository.to_string(),
+            worktree_path: PathBuf::from(format!("/data/surfaces/01PROMPT/{repository}")),
+            work_branch: "sergeant/01PROMPT".to_string(),
+            base_branch: "main".to_string(),
+            base_sha: sha.to_string(),
+        }
+    }
+
+    /// §10.1: the launched turn is told the exact worktrees the Work may
+    /// modify, the branch each is expected to be on, and the commit each was
+    /// cut from — and that everything else, the `repos/` mounts included, is
+    /// outside its authority.
+    ///
+    /// The order is the contract as much as the content is (ADR 0007(a)'s two
+    /// statements, then this, then §12's verbatim data), so it is asserted
+    /// positionally rather than by "contains".
+    #[test]
+    fn the_launch_prompt_states_the_mutation_surface_after_the_two_contracts() {
+        let api_sha = "a".repeat(40);
+        let web_sha = "b".repeat(40);
+        let request = prompt_request(vec![binding("api", &api_sha), binding("web", &web_sha)]);
+        let prompt = compose_launch_prompt(&request);
+
+        let sections: Vec<&str> = prompt.split("\n\n").collect();
+        assert_eq!(
+            sections.len(),
+            5,
+            "five sections in fixed order: {sections:#?}"
+        );
+        assert_eq!(sections[0], EXECUTION_MODEL_CONTRACT);
+        assert_eq!(sections[1], ENVIRONMENT_CONTRACT);
+        assert_eq!(
+            sections[3], "the human intent",
+            "§12's data is carried verbatim and is not disturbed by the new section"
+        );
+        assert_eq!(sections[4], "the stage's CONTEXT.md");
+
+        let surface = sections[2];
+        assert!(
+            surface.starts_with(MUTATION_SURFACE_HEADER),
+            "the mutation surface is the third section: {surface}"
+        );
+        // Every fact §10.1 names, per repository, exactly as journaled.
+        assert!(
+            surface.contains(
+                "- api: /data/surfaces/01PROMPT/api (branch sergeant/01PROMPT, cut from main at "
+            ),
+            "{surface}"
+        );
+        assert!(
+            surface.contains(&api_sha),
+            "the full base SHA, not a prefix"
+        );
+        assert!(
+            surface.contains("- web: /data/surfaces/01PROMPT/web (branch sergeant/01PROMPT"),
+            "{surface}"
+        );
+        assert!(surface.contains(&web_sha));
+        // Scope order, not alphabetical-by-accident: api was bound first.
+        assert!(surface.find("- api:") < surface.find("- web:"));
+        // And the exclusions §10.1 lists, with the mounts named explicitly.
+        assert!(surface.contains("`repos/`"), "{surface}");
+        assert!(surface.contains("and nothing else"), "{surface}");
+    }
+
+    /// C2/C3: a request with no binding summary — a `StartRequest` replayed
+    /// from before §10.1, or any caller that does not supply one — still
+    /// launches, and says nothing about a mutation surface rather than
+    /// claiming an empty one.
+    #[test]
+    fn a_start_request_without_bindings_composes_the_prompt_it_always_did() {
+        let prompt = compose_launch_prompt(&prompt_request(Vec::new()));
+        let sections: Vec<&str> = prompt.split("\n\n").collect();
+        assert_eq!(sections.len(), 4, "the pre-§10.1 shape: {sections:#?}");
+        assert_eq!(sections[0], EXECUTION_MODEL_CONTRACT);
+        assert_eq!(sections[1], ENVIRONMENT_CONTRACT);
+        assert_eq!(sections[2], "the human intent");
+        assert_eq!(sections[3], "the stage's CONTEXT.md");
+        assert!(
+            !prompt.contains("Mutation surface:"),
+            "silence, not a claim that the Work may modify nothing: {prompt}"
+        );
+    }
 
     /// The measured 2.1.226 result envelope for an honored haiku pin
     /// (verbatim fields that matter, recorded 2026-08-08 in this container).

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -1355,6 +1355,7 @@ mod tests {
                 env: BTreeMap::new(),
             }),
             instruction_policy: InstructionPolicy::default(),
+            bindings: Vec::new(),
         };
         let prepared = backend
             .prepare(&request)
@@ -1468,6 +1469,7 @@ mod tests {
                 profile: None,
                 execute: None,
                 instruction_policy: InstructionPolicy::default(),
+                bindings: Vec::new(),
             };
             let spec = ExecuteSpec {
                 image: "alpine:3".into(),
@@ -1504,6 +1506,7 @@ mod tests {
             profile: None,
             execute: None,
             instruction_policy: InstructionPolicy::default(),
+            bindings: Vec::new(),
         };
         let err = backend.prepare(&request).expect_err("must refuse");
         assert!(matches!(err, BackendError::Failed { .. }));

--- a/src/backend/fake.rs
+++ b/src/backend/fake.rs
@@ -1072,6 +1072,7 @@ mod tests {
             profile: None,
             execute: None,
             instruction_policy: crate::domain::workspace::InstructionPolicy::default(),
+            bindings: Vec::new(),
         }
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -179,6 +179,34 @@ pub struct ProbeReport {
     pub detail: Option<String>,
 }
 
+/// One selected repository, as the backend needs to see it (§10.1).
+///
+/// §10.1: "the backend receives the complete binding summary, not only a cwd,
+/// so its prompt/launch grammar can state exact repository paths, expected
+/// branches, and base SHAs". A `cwd` alone cannot say any of that — for a
+/// multi-repo Work it is the surface *root*, and even for a single-repo Work
+/// it names a directory without naming the branch the actor is expected to be
+/// on or the commit it started from.
+///
+/// Every field is a fact sergeant already journaled about the Work's own
+/// [`RepositoryBinding`](crate::runtime::surface::RepositoryBinding). Nothing
+/// here is policy or instruction: what an adapter *does* with it is the
+/// adapter's business, and an adapter that ignores the field entirely still
+/// runs (C2 — core reports only what it can prove).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BindingSummary {
+    /// Repository name within the Work's scope.
+    pub repository: String,
+    /// The linked worktree this Work may modify — the mutation surface.
+    pub worktree_path: PathBuf,
+    /// Branch the Work executes on in that worktree.
+    pub work_branch: String,
+    /// Branch the work branch was cut from (`(detached)` if HEAD was).
+    pub base_branch: String,
+    /// Exact commit it was cut from.
+    pub base_sha: String,
+}
+
 /// Everything a backend needs to START one execution for one stage attempt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StartRequest {
@@ -222,6 +250,16 @@ pub struct StartRequest {
     /// is exactly what every such request's actual launch grammar was.
     #[serde(default)]
     pub instruction_policy: InstructionPolicy,
+    /// §10.1's complete binding summary: one entry per repository in the
+    /// Work's scope, in the Work's own scope order.
+    ///
+    /// `#[serde(default)]` to an empty vec, so a `StartRequest` journaled
+    /// before this field existed replays as "no summary supplied" — which is
+    /// exactly what it was. An empty summary is not a claim that the Work has
+    /// no repositories; it is the absence of a claim, and an adapter must not
+    /// read it as a mutation surface of nothing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bindings: Vec<BindingSummary>,
 }
 
 /// Everything a backend needs to RESUME an execution it no longer remembers
@@ -264,6 +302,16 @@ pub struct ResumeRequest {
     /// (`Suppress`) whether or not it actually had one to re-supply.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instruction_policy: Option<InstructionPolicy>,
+    /// §10.1's binding summary, re-supplied on RESUME for the same reason the
+    /// model pin and the profile are: a restarted adapter has lost whatever it
+    /// derived from it, and re-deriving the Work's mutation surface from a
+    /// bare `cwd` would be the fabrication this type's contract forbids.
+    ///
+    /// `#[serde(default)]` to empty, exactly as on
+    /// [`StartRequest::bindings`], and read the same way — absence of a
+    /// claim, not a claim of absence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bindings: Vec<BindingSummary>,
 }
 
 impl ResumeRequest {
@@ -281,6 +329,7 @@ impl ResumeRequest {
             model: None,
             profile: None,
             instruction_policy: None,
+            bindings: Vec::new(),
         }
     }
 }

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -2755,6 +2755,11 @@ impl Engine {
             model: stage_profile.as_ref().and_then(|p| p.default_model.clone()),
             profile: stage_profile,
             instruction_policy: Some(Self::run_instruction_policy(run)),
+            // §10.1, re-supplied from the journaled surface for the same
+            // reason the pin and the profile are: a restarted adapter has
+            // lost whatever it derived from it, and the Work's mutation
+            // surface is not something it may re-invent from a bare cwd.
+            bindings: surface.binding_summary(),
         })
     }
 
@@ -2990,6 +2995,11 @@ impl Engine {
             // MVP-2 D2 item 1: the policy `workflow.bound` pinned, not
             // re-derived from the live manifest.
             instruction_policy: Self::run_instruction_policy(&run),
+            // §10.1: the complete binding summary, not only a cwd. Taken from
+            // the surface this stage is actually about to run in, so the paths
+            // and refs an adapter states are the ones sergeant journaled —
+            // never re-derived from the manifest or from the filesystem.
+            bindings: surface.binding_summary(),
         };
         let prepared = match backend.prepare(&request) {
             Ok(prepared) => prepared,
@@ -4875,6 +4885,7 @@ mod tests {
             profile: None,
             execute: None,
             instruction_policy: InstructionPolicy::default(),
+            bindings: Vec::new(),
         };
         let handle = fake.start(&start_request).expect("fake backend start");
         testing::commit(

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -548,6 +548,12 @@ pub struct InterruptOutcome {
 /// included, queueing behind someone else's checkout.
 pub struct PendingSurface {
     work_id: String,
+    /// The daemon's data dir, carried so [`Self::perform`] can locate the
+    /// interprocess repository locks (§9.4). Deliberately separate from
+    /// `SurfaceEffect::Materialize`'s `surfaces_root`, which R-MVP1-1 unbound
+    /// from the data dir: an estate may put its surfaces anywhere, and the
+    /// locks still live in the daemon's own storage.
+    data_dir: PathBuf,
     effect: SurfaceEffect,
 }
 
@@ -610,6 +616,7 @@ impl PendingSurface {
                 surfaces_root,
                 plan,
             } => SurfaceOutcome::Materialized(materialize(
+                &self.data_dir,
                 surfaces_root,
                 &self.work_id,
                 &plan.repositories,
@@ -621,9 +628,11 @@ impl PendingSurface {
                 if surface.bindings.iter().all(|b| b.worktree_path.exists()) {
                     return SurfaceOutcome::Rematerialized(Ok(None));
                 }
-                SurfaceOutcome::Rematerialized(rematerialize(surface).map(Some))
+                SurfaceOutcome::Rematerialized(rematerialize(&self.data_dir, surface).map(Some))
             }
-            SurfaceEffect::Teardown { surface, .. } => SurfaceOutcome::TornDown(teardown(surface)),
+            SurfaceEffect::Teardown { surface, .. } => {
+                SurfaceOutcome::TornDown(teardown(&self.data_dir, surface))
+            }
         }
     }
 }
@@ -1520,6 +1529,7 @@ impl Engine {
         Ok(Step {
             next: Next::Surface(Box::new(PendingSurface {
                 work_id: work.id.clone(),
+                data_dir: self.data_dir.clone(),
                 effect: SurfaceEffect::Materialize {
                     surfaces_root: plan.surfaces_root.clone(),
                     plan: Box::new(plan.clone()),
@@ -1936,6 +1946,7 @@ impl Engine {
             return Ok(Step {
                 next: Next::Surface(Box::new(PendingSurface {
                     work_id: work_id.to_string(),
+                    data_dir: self.data_dir.clone(),
                     effect: SurfaceEffect::Rematerialize {
                         surface,
                         index: current.index,
@@ -3896,6 +3907,7 @@ impl Engine {
         }
         Next::Surface(Box::new(PendingSurface {
             work_id: work_id.to_string(),
+            data_dir: self.data_dir.clone(),
             effect: SurfaceEffect::Teardown { surface, recovered },
         }))
     }
@@ -4987,6 +4999,8 @@ mod tests {
                 work_branch: format!("sergeant/{work_id}"),
                 head_sha: "1".repeat(40),
                 origin: BindingOrigin::Cut,
+                canonical_top_level: Some(PathBuf::from("/repos/solo")),
+                canonical_common_dir: Some(PathBuf::from("/repos/solo/.git")),
             }
         }
 

--- a/src/runtime/git.rs
+++ b/src/runtime/git.rs
@@ -65,6 +65,53 @@ pub enum GitError {
     },
 }
 
+/// `git rev-parse --path-format=absolute --git-common-dir` in `dir`,
+/// canonicalized: the identity §2.7/§9.4 locks on.
+///
+/// The *common* directory, not the git dir: a linked worktree's own
+/// `.git/worktrees/<name>` is private to it, while the common dir is the
+/// shared object store, the ref storage, and the linked-worktree registry —
+/// the state two concurrent mutators actually collide in. A primary checkout
+/// and every `git worktree add` of it answer with one and the same path,
+/// which is precisely what a lock keyed on the checkout *path* could never
+/// see (proposal §2.7: "different linked worktree paths may share one Git
+/// common directory and therefore one ref/worktree registry while receiving
+/// different locks").
+///
+/// Canonicalized because this is about identity, not spelling: a repository
+/// reached through a symlink (`/tmp` → `/private/tmp` on macOS, an estate
+/// mount behind a symlinked parent) would otherwise answer differently from
+/// the same repository reached directly, and hand two names to one thing.
+/// When canonicalization fails — a path that raced away underneath us — the
+/// absolute answer Git gave is kept as-is rather than discarded: a slightly
+/// less normalized identity still serializes correctly against every other
+/// caller that resolves it the same way, and refusing outright would fail an
+/// operation over a spelling.
+pub fn canonical_git_common_dir(dir: &Path) -> Result<std::path::PathBuf, GitError> {
+    let raw = git(
+        dir,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?;
+    let path = std::path::PathBuf::from(raw);
+    Ok(std::fs::canonicalize(&path).unwrap_or(path))
+}
+
+/// `git rev-parse --path-format=absolute --show-toplevel` in `dir`,
+/// canonicalized the same way [`canonical_git_common_dir`] is.
+///
+/// §3.5's "canonical Git top level" half of a repository binding: what the
+/// declared mount path actually resolves to as a working tree, recorded at
+/// admission so later readers compare against what was admitted rather than
+/// re-asking a checkout that may have moved.
+pub fn canonical_git_top_level(dir: &Path) -> Result<std::path::PathBuf, GitError> {
+    let raw = git(
+        dir,
+        &["rev-parse", "--path-format=absolute", "--show-toplevel"],
+    )?;
+    let path = std::path::PathBuf::from(raw);
+    Ok(std::fs::canonicalize(&path).unwrap_or(path))
+}
+
 /// Run `git <args>` in `dir` and return trimmed stdout, or a [`GitError`].
 pub fn git(dir: &Path, args: &[&str]) -> Result<String, GitError> {
     let output = command(dir, args)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,5 @@
-//! Runtime: journal, projections, git, surfaces, integrity, routing, engine,
-//! recovery.
+//! Runtime: journal, projections, git, surfaces, integrity, repository
+//! locking, routing, engine, recovery.
 
 pub mod analytics;
 pub mod blob;
@@ -11,6 +11,7 @@ pub mod integrity;
 pub mod journal;
 pub mod projection;
 pub mod recovery;
+pub mod repolock;
 pub mod router;
 pub mod surface;
 

--- a/src/runtime/recovery.rs
+++ b/src/runtime/recovery.rs
@@ -582,8 +582,13 @@ mod tests {
 
         let work_id = "01RECOVEREDTEARDOWN00";
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), work_id, std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            work_id,
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let worktree = surface.bindings[0].worktree_path.clone();
 
         testing::submit(&mut core, work_id, "crashed before its teardown landed");

--- a/src/runtime/repolock.rs
+++ b/src/runtime/repolock.rs
@@ -1,0 +1,350 @@
+//! Interprocess repository lock, keyed by canonical Git common directory
+//! (proposal §9.4, amendment C4).
+//!
+//! §9.4: *every* operation mutating a repository's linked-worktree registry or
+//! its Work refs takes its lock identity from the canonical result of `git
+//! rev-parse --path-format=absolute --git-common-dir`, and that lock is
+//! **interprocess** — "the implementation may retain an in-process mutex for
+//! efficiency, but the filesystem lock is the correctness boundary".
+//!
+//! # Why this is a new primitive and not `fsutil::take_exclusive_lock`
+//!
+//! [`crate::runtime::fsutil::take_exclusive_lock`] is a *self-leak
+//! workaround*, not a blocking primitive (C4). It answers "does someone else
+//! really own the daemon data dir right now", waits at most one second and
+//! only when this process has held that same path before, records every path
+//! it ever locked in a process-lifetime set, and is designed to fail closed
+//! immediately for a rival daemon. Repository locking needs the opposite
+//! shape: a contender is *expected*, must wait for the holder rather than
+//! refuse, must be able to take and release the same lock many times over a
+//! process's life, and must never consult a process-lifetime memo. Widening
+//! `take_exclusive_lock` to cover both would have made the daemon-identity
+//! refusal wait, which is the one thing it must not do.
+//!
+//! # Where the lock file lives, and why that is complete (§6.2)
+//!
+//! `<data_dir>/locks/repo/<blake3-hex of the canonical common dir>.lock`.
+//!
+//! **Never inside the user's `.git`.** Surface doctrine is that Sergeant does
+//! not write into a source checkout: it creates linked worktrees and branches
+//! through Git's own porcelain and otherwise leaves the repository alone. A
+//! lock file dropped into `.git/` would be Sergeant state living in a
+//! directory the user owns, surviving uninstall, and visible to every other
+//! tool that walks that repository.
+//!
+//! That raises the obvious question: if the file is not next to the thing it
+//! protects, do two mutators actually meet on it? Under §6.2 they do. "One
+//! checkout belongs to one estate" — separate estates use separate clones,
+//! there are no manifest aliases into another estate, no `../repo` paths, no
+//! symlinked shared mounts, and a Work's linked worktree may not itself be
+//! declared as a repository source. One checkout therefore has exactly one
+//! estate, one estate has exactly one data dir, and every legitimate mutator
+//! of that checkout resolves that same data dir. Keying the *directory* on the
+//! data dir and the *file* on the Git common directory is complete for the
+//! ownership model the product actually has, and it keeps Sergeant's state
+//! inside Sergeant's own storage where the rest of it already is.
+//!
+//! The hash follows [`crate::runtime::blob`]'s existing precedent for
+//! identity-keyed filenames (`<data_dir>/blobs/b3/<hex>`): a blake3 digest of
+//! the canonical path bytes, so an arbitrarily deep or oddly spelled path
+//! becomes one fixed-length, filesystem-safe name — and so that two spellings
+//! that canonicalize to one directory cannot produce two lock files.
+//!
+//! # Bounded wait, never an infinite one
+//!
+//! Surface operations are synchronous and reach the async runtime through
+//! `api::blocking`, which uses `block_in_place` on a multi-thread runtime but
+//! **runs the closure inline on a current-thread one**. An unbounded
+//! `File::lock()` there would park the reactor itself. So acquisition is a
+//! bounded retry loop over `try_lock` with backoff and a [`LOCK_BUDGET`]
+//! deadline; exhausting it returns [`RepoLockError::Timeout`], which names the
+//! lock path and the repository it stands for. Failing closed with evidence is
+//! an outcome an operator can act on; a hung daemon is not.
+//!
+//! The budget is also what absorbs the fork/exec window
+//! `fsutil::take_exclusive_lock` documents: Sergeant shells out to Git while
+//! holding this lock, and between a child's `fork` and its `exec` that child
+//! holds a duplicate of every descriptor the parent had open. Rust opens files
+//! `O_CLOEXEC`, so such a duplicate cannot outlive the `exec` — waiting is what
+//! resolves it, and the retry loop waits by construction.
+
+use std::fs::{File, OpenOptions, TryLockError};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::runtime::fsutil::create_dir_all_durable;
+
+/// Directory under the data dir holding every repository lock file.
+pub const LOCKS_DIR: &str = "locks";
+/// Subdirectory of [`LOCKS_DIR`] for locks keyed by Git common directory.
+pub const REPO_LOCKS_DIR: &str = "repo";
+
+/// How long [`acquire`] waits for a holder before failing closed.
+///
+/// Generous relative to what the guarded spans actually cost — a `git worktree
+/// add --no-checkout` was measured at ~43 ms of lock-held time, so this is
+/// roughly 700 such operations queued ahead of us — and still finite, because
+/// the caller may be the reactor thread itself. A wait this long means
+/// something is genuinely wrong (a crashed holder on a filesystem that leaked
+/// the lock, a foreign process sitting on the file), and saying so with the
+/// path in hand beats waiting forever.
+pub const LOCK_BUDGET: Duration = Duration::from_secs(30);
+
+/// Longest pause between attempts. Backoff starts far below it, so ordinary
+/// contention — the common case, one short registry write ahead of us —
+/// clears on the first or second retry rather than paying the ceiling.
+const LOCK_MAX_DELAY: Duration = Duration::from_millis(50);
+
+/// Failure taking a repository's interprocess lock.
+#[derive(Debug, thiserror::Error)]
+pub enum RepoLockError {
+    /// The lock file (or its directory) could not be created or opened.
+    #[error(
+        "cannot open the repository lock {path} for git common directory {common_dir}: {source}"
+    )]
+    Io {
+        /// Lock file this was about.
+        path: String,
+        /// Git common directory the lock stands for.
+        common_dir: String,
+        /// Underlying filesystem failure.
+        source: std::io::Error,
+    },
+    /// Someone else held the lock for longer than the budget allows. Fail
+    /// closed with evidence: which lock, which repository identity, how long
+    /// we waited. The holder is deliberately reported as unknown — an
+    /// advisory `flock` names no owner, and inventing one (by writing a pid
+    /// into the file) would be a fact this primitive cannot keep true across
+    /// a crash.
+    #[error(
+        "the repository lock {path} for git common directory {common_dir} is held by another \
+         process (holder unknown: an advisory lock names no owner); waited {waited:?} and gave \
+         up rather than block indefinitely"
+    )]
+    Timeout {
+        /// Lock file this was about.
+        path: String,
+        /// Git common directory the lock stands for.
+        common_dir: String,
+        /// How long acquisition actually waited before giving up.
+        waited: Duration,
+    },
+}
+
+/// An exclusive hold on one repository's interprocess lock.
+///
+/// Released on drop — by closing the file, which is what releases the advisory
+/// lock. Nothing is deleted: the lock file itself is a durable rendezvous
+/// point, and unlinking it would let a later acquirer create a *different*
+/// inode at the same path and lock that instead, which is the classic way to
+/// end up with two "holders" of one lock.
+#[derive(Debug)]
+pub struct RepositoryLock {
+    /// Kept solely for its side effect: closing it unlocks.
+    _file: File,
+    path: PathBuf,
+}
+
+impl RepositoryLock {
+    /// The lock file this hold is on. Evidence for callers that report it.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// The lock file for `common_dir` under `data_dir`.
+///
+/// Pure: makes no filesystem calls and creates nothing. `common_dir` is
+/// expected to be already canonical — [`acquire`]'s callers derive it once per
+/// operation through `git::canonical_git_common_dir` — because canonicalizing
+/// here would make an identity function that sometimes hits the disk and
+/// sometimes does not.
+pub fn lock_path(data_dir: &Path, common_dir: &Path) -> PathBuf {
+    let digest = blake3::hash(common_dir.as_os_str().as_encoded_bytes()).to_hex();
+    data_dir
+        .join(LOCKS_DIR)
+        .join(REPO_LOCKS_DIR)
+        .join(format!("{digest}.lock"))
+}
+
+/// Take the exclusive interprocess lock for `common_dir`, waiting up to
+/// [`LOCK_BUDGET`] for a current holder.
+///
+/// Re-acquirable: this keeps no process-lifetime memory of what it has locked,
+/// so the same repository may be locked and released as many times as there
+/// are guarded spans.
+pub fn acquire(data_dir: &Path, common_dir: &Path) -> Result<RepositoryLock, RepoLockError> {
+    acquire_within(data_dir, common_dir, LOCK_BUDGET)
+}
+
+/// [`acquire`] with an explicit budget.
+///
+/// Public so the multi-process acceptance test can assert the *timeout* arm
+/// without spending [`LOCK_BUDGET`] of wall clock to do it: the budget is the
+/// one parameter of this primitive that a test cannot otherwise vary, and
+/// pinning the structured refusal is worth more than keeping the knob private.
+pub fn acquire_within(
+    data_dir: &Path,
+    common_dir: &Path,
+    budget: Duration,
+) -> Result<RepositoryLock, RepoLockError> {
+    let path = lock_path(data_dir, common_dir);
+    let io = |source: std::io::Error| RepoLockError::Io {
+        path: path.display().to_string(),
+        common_dir: common_dir.display().to_string(),
+        source,
+    };
+    if let Some(parent) = path.parent() {
+        create_dir_all_durable(parent).map_err(io)?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(io)?;
+
+    let started = Instant::now();
+    let deadline = started + budget;
+    let mut delay = Duration::from_millis(1);
+    loop {
+        match file.try_lock() {
+            Ok(()) => return Ok(RepositoryLock { _file: file, path }),
+            Err(TryLockError::WouldBlock) => {}
+            Err(TryLockError::Error(e)) => return Err(io(e)),
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(RepoLockError::Timeout {
+                path: path.display().to_string(),
+                common_dir: common_dir.display().to_string(),
+                waited: started.elapsed(),
+            });
+        }
+        std::thread::sleep(delay.min(deadline - now));
+        delay = (delay * 2).min(LOCK_MAX_DELAY);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two spellings of one directory must not produce two lock files — the
+    /// whole defect §2.7 names, expressed at the level of the filename.
+    #[test]
+    fn the_lock_file_is_a_pure_function_of_the_common_directory() {
+        let data = Path::new("/data");
+        let common = Path::new("/repos/api/.git");
+        assert_eq!(lock_path(data, common), lock_path(data, common));
+        assert_ne!(
+            lock_path(data, common),
+            lock_path(data, Path::new("/repos/web/.git"))
+        );
+        // Under the data dir, never under the repository.
+        let path = lock_path(data, common);
+        assert!(path.starts_with(data.join(LOCKS_DIR).join(REPO_LOCKS_DIR)));
+        assert!(!path.starts_with(common));
+        assert_eq!(path.extension().and_then(|e| e.to_str()), Some("lock"));
+    }
+
+    #[test]
+    fn acquire_creates_the_lock_file_under_the_data_dir_and_releases_on_drop() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = dir.path().join("data");
+        let common = dir.path().join("repo/.git");
+
+        let held = acquire(&data, &common).expect("first acquisition");
+        let path = held.path().to_path_buf();
+        assert!(path.is_file(), "the lock file is created on demand");
+        assert_eq!(path, lock_path(&data, &common));
+        drop(held);
+
+        // Re-acquirable: nothing here is process-lifetime state.
+        let again = acquire(&data, &common).expect("reacquisition after release");
+        assert_eq!(again.path(), path);
+        drop(again);
+        assert!(
+            path.is_file(),
+            "release closes the file; it does not unlink the rendezvous point"
+        );
+    }
+
+    /// Different repositories do not contend: the point of keying on identity
+    /// rather than serializing all git behind one gate.
+    #[test]
+    fn two_repositories_hold_their_locks_independently() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = dir.path().join("data");
+        let api = acquire(&data, &dir.path().join("api/.git")).expect("api");
+        let web = acquire(&data, &dir.path().join("web/.git")).expect("web");
+        assert_ne!(api.path(), web.path());
+    }
+
+    /// A holder that goes away is waited out rather than refused — the shape
+    /// `fsutil::take_exclusive_lock` deliberately does *not* have.
+    #[test]
+    fn a_holder_that_releases_is_waited_out_rather_than_refused() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = dir.path().join("data");
+        let common = dir.path().join("repo/.git");
+
+        let held = acquire(&data, &common).expect("first acquisition");
+        let hold_for = Duration::from_millis(60);
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(hold_for);
+            drop(held);
+        });
+
+        let started = Instant::now();
+        let taken = acquire(&data, &common).expect("the contender must wait, not fail");
+        assert!(
+            started.elapsed() >= hold_for,
+            "it really waited for the release rather than racing it"
+        );
+        drop(taken);
+        releaser.join().expect("releaser");
+    }
+
+    /// The budget is a real ceiling, and exhausting it produces evidence: the
+    /// lock path, the repository identity, and an explicit holder-unknown.
+    #[test]
+    fn a_holder_that_stays_produces_a_bounded_structured_timeout() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = dir.path().join("data");
+        let common = dir.path().join("repo/.git");
+
+        let _held = acquire(&data, &common).expect("first acquisition");
+        let budget = Duration::from_millis(120);
+        let started = Instant::now();
+        let err =
+            acquire_within(&data, &common, budget).expect_err("a held lock must not be taken");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= budget,
+            "it must spend its whole budget: {elapsed:?}"
+        );
+        assert!(
+            elapsed < budget * 20,
+            "and then give up, not block indefinitely: {elapsed:?}"
+        );
+        let RepoLockError::Timeout {
+            path, common_dir, ..
+        } = &err
+        else {
+            panic!("a contended lock must time out, not fail some other way: {err:?}");
+        };
+        assert_eq!(Path::new(path), lock_path(&data, &common));
+        assert_eq!(Path::new(common_dir), common);
+        let text = err.to_string();
+        assert!(
+            text.contains("holder unknown"),
+            "the refusal is honest about what it cannot know: {text}"
+        );
+        assert!(
+            text.contains(&common.display().to_string()),
+            "and names the repository: {text}"
+        );
+    }
+}

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -31,16 +31,81 @@ use serde::{Deserialize, Serialize};
 
 use crate::domain::workspace::RepositorySpec;
 use crate::runtime::fsutil::create_dir_all_durable;
-use crate::runtime::git::{GitError, git, git_submodule_update, git_succeeds};
+use crate::runtime::git::{
+    GitError, canonical_git_common_dir, canonical_git_top_level, git, git_submodule_update,
+    git_succeeds,
+};
 use crate::runtime::integrity::{
     DriftAttribution, EstateDriftObservation, IntegrityDisposition, IntegrityFinding, ObservedHead,
 };
+use crate::runtime::repolock::{self, RepoLockError};
 
 /// Directory under the data dir holding all work surfaces.
 pub const SURFACES_DIR: &str = "surfaces";
 
-/// One lock per source repository, held across every worktree mutation this
-/// module makes against that repository.
+/// The lock identity for one repository, derived **once per operation** and
+/// carried to every guarded span that operation opens.
+///
+/// Deriving is a `git rev-parse` — a process spawn — so it happens at the
+/// entry to `materialize`/`attach`/`rematerialize`/`teardown`/`reap`, per
+/// repository, and never inside a span. A binding that already records its
+/// canonical common directory (§3.5, journaled from Phase B onward) skips the
+/// spawn entirely; only a pre-enrichment binding pays for one.
+///
+/// `identity` is the canonical git common directory (§2.7/§9.4), which is what
+/// **both** locking layers key on. Fallback when git cannot answer — a source
+/// path that is not a repository, or a git that will not run — is the
+/// canonicalized source path: the pre-Phase-B key, which is strictly better
+/// than no key at all, and whose one weakness (aliasing a checkout against its
+/// own linked worktree) can only bite where git was already unable to tell us
+/// they were the same repository.
+#[derive(Debug, Clone)]
+struct RepositoryGate {
+    /// Data dir whose `locks/repo/` holds the interprocess lock file.
+    data_dir: PathBuf,
+    /// Canonical git common directory: one identity, both layers.
+    identity: PathBuf,
+}
+
+impl RepositoryGate {
+    /// Derive the gate for `source` by asking git for its common directory.
+    /// One spawn; call once per repository per operation.
+    fn derive(data_dir: &Path, source: &Path) -> Self {
+        Self::from_common_dir(data_dir, canonical_git_common_dir(source).ok(), source)
+    }
+
+    /// The gate for a common directory already in hand — the shape
+    /// `materialize_one` and `attach_one` use, because they need that same
+    /// reading for the binding they are about to journal (§3.5) and must not
+    /// spawn `git rev-parse` twice to get it.
+    fn from_common_dir(data_dir: &Path, common_dir: Option<PathBuf>, source: &Path) -> Self {
+        let identity = common_dir.unwrap_or_else(|| {
+            std::fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf())
+        });
+        Self {
+            data_dir: data_dir.to_path_buf(),
+            identity,
+        }
+    }
+
+    /// The gate for a journaled binding, preferring the identity recorded at
+    /// admission (§3.5) over re-asking the checkout. Beyond saving a spawn,
+    /// this is the more honest answer: the lock a teardown takes is the one
+    /// the materialization that created these worktrees took, even if the
+    /// source path has since been moved or replaced underneath us.
+    fn for_binding(data_dir: &Path, binding: &RepositoryBinding) -> Self {
+        match &binding.canonical_common_dir {
+            Some(identity) => Self {
+                data_dir: data_dir.to_path_buf(),
+                identity: identity.clone(),
+            },
+            None => Self::derive(data_dir, &binding.source_path),
+        }
+    }
+}
+
+/// One in-process lock per repository identity, held across every worktree
+/// mutation this module makes against that repository.
 ///
 /// **Not the core lock, and that is the point.** N3 moved git out from under
 /// the daemon's single writer (§22.6), which is what the budget asks for — and
@@ -52,30 +117,60 @@ pub const SURFACES_DIR: &str = "surfaces";
 /// *retained*, journaled and left on disk, which is honest and still wrong.
 ///
 /// So concurrency against one repository is serialized here, at the narrowest
-/// scope that fixes it: per source path, for the duration of the git calls
-/// that touch its registry. Two works in different repositories still proceed
-/// in parallel, and no request anywhere queues behind the core lock for it.
-fn repository_lock(source: &Path) -> Arc<Mutex<()>> {
+/// scope that fixes it: per repository identity, for the duration of the git
+/// calls that touch its registry. Two works in different repositories still
+/// proceed in parallel, and no request anywhere queues behind the core lock
+/// for it.
+///
+/// **Keyed on the git common directory since Phase B**, not the source
+/// checkout path. §2.7: different linked worktree paths may share one common
+/// directory — and therefore one ref and worktree registry — while receiving
+/// different locks, and a lock two mutators do not share is not a lock. This
+/// stays as §9.4's permitted "fast local layer"; the file lock
+/// [`with_repository`] takes inside it is the correctness boundary.
+fn repository_lock(identity: &Path) -> Arc<Mutex<()>> {
     static LOCKS: OnceLock<Mutex<BTreeMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
     let table = LOCKS.get_or_init(|| Mutex::new(BTreeMap::new()));
-    // Keyed on the canonical path: two workspaces can reach one repository by
-    // different routes, and a lock they do not share is not a lock.
-    let key = std::fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf());
     let mut table = table.lock().unwrap_or_else(|e| e.into_inner());
-    Arc::clone(table.entry(key).or_default())
+    Arc::clone(table.entry(identity.to_path_buf()).or_default())
 }
 
-/// Run `f` with this repository's worktree registry to itself.
+/// Run `f` with this repository's worktree registry to itself — against every
+/// thread in this process, and against every other process on the machine.
 ///
-/// Poisoning is deliberately ignored: the guard protects git's on-disk
+/// Two layers, in this order (§9.4: "the implementation may retain an
+/// in-process mutex for efficiency, but the filesystem lock is the correctness
+/// boundary"):
+///
+/// 1. [`repository_lock`], the in-process mutex. Cheap, and it means the
+///    common case — a burst of submissions inside one daemon — never reaches
+///    the filesystem to discover it must wait.
+/// 2. [`repolock::acquire`], the interprocess file lock. Taken *inside* the
+///    mutex, so exactly one thread of this process ever contends for it, which
+///    is also what makes the bounded wait a wait for a genuinely foreign
+///    holder rather than for ourselves.
+///
+/// Both are released in reverse order when this function returns.
+///
+/// **The span is not widened by any of this.** The asymmetric hold pattern
+/// this module measured (reads, status and worktree population *outside*;
+/// registry mutation inside a narrow span) is unchanged — the file lock is
+/// taken and dropped in exactly the eight places the mutex already was, and no
+/// read acquired a guard before this change or acquires one after it.
+///
+/// Mutex poisoning is deliberately ignored: the guard protects git's on-disk
 /// registry, not an in-memory invariant, so a panic in one caller leaves
 /// nothing for the next one to be confused by — and refusing every later
 /// worktree operation for the daemon's lifetime would be a far worse failure
-/// than the one being guarded against.
-fn with_repository<T>(source: &Path, f: impl FnOnce() -> T) -> T {
-    let lock = repository_lock(source);
-    let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
-    f()
+/// than the one being guarded against. A *file* lock failure is different and
+/// is returned: it means another process may be mutating this registry right
+/// now, which is precisely the condition this function exists to prevent
+/// running under.
+fn with_repository<T>(gate: &RepositoryGate, f: impl FnOnce() -> T) -> Result<T, SurfaceError> {
+    let local = repository_lock(&gate.identity);
+    let _local_guard = local.lock().unwrap_or_else(|e| e.into_inner());
+    let _file_guard = repolock::acquire(&gate.data_dir, &gate.identity)?;
+    Ok(f())
 }
 
 /// Event kind: a work surface is about to be materialized. Appended *before*
@@ -149,6 +244,29 @@ pub struct RepositoryBinding {
     /// shape that could exist then — deserializes as exactly that.
     #[serde(default)]
     pub origin: BindingOrigin,
+    /// §3.5's "canonical Git top level": what `source_path` actually resolved
+    /// to as a working tree at admission (`git rev-parse --show-toplevel`,
+    /// canonicalized).
+    ///
+    /// `Option` + `#[serde(default)]` (amendment C3: journal changes are
+    /// additive): a binding journaled before Phase B replays as `None`, which
+    /// is the truthful reading — nothing observed this at the time — and
+    /// every consumer treats it as "re-derive or do without", never as a
+    /// value to invent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_top_level: Option<PathBuf>,
+    /// §3.5's "canonical Git common directory", and §2.7's lock identity:
+    /// `git rev-parse --path-format=absolute --git-common-dir`, canonicalized,
+    /// pinned at admission.
+    ///
+    /// Recording it is what lets a later teardown lock the *same* repository
+    /// the materialization did without re-asking a checkout that may since
+    /// have moved — and what lets `common_dir_finding` compare the worktree's
+    /// answer against what was admitted rather than against a second live
+    /// reading of the source. `None` for a pre-Phase-B binding, exactly like
+    /// [`Self::canonical_top_level`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_common_dir: Option<PathBuf>,
 }
 
 /// What materialization is about to create, recorded before it creates any of
@@ -380,6 +498,13 @@ pub enum SurfaceError {
     /// Git refused.
     #[error(transparent)]
     Git(#[from] GitError),
+    /// The repository's interprocess lock (§9.4) could not be taken, so the
+    /// registry mutation it guards was never attempted. Carried transparently:
+    /// [`RepoLockError`] already names the lock file, the git common directory
+    /// it stands for, and how long acquisition waited — everything an operator
+    /// needs, and nothing this layer can add to it.
+    #[error(transparent)]
+    RepositoryLock(#[from] RepoLockError),
     /// Filesystem failure preparing the surface directory.
     #[error("surface io error at {path}: {source}")]
     Io {
@@ -457,7 +582,15 @@ pub fn surface_root(surfaces_root: &Path, work_id: &str) -> PathBuf {
 /// exactly the same recorded teardown a later repository's failure always
 /// got, instead of silently stranding the worktree `materialize_one` had
 /// already created for it.
+///
+/// `data_dir` is the daemon's own storage, and is *not* assumed to be the
+/// parent of `surfaces_root` (R-MVP1-1 unbound the two). It is here for one
+/// reason: it locates the interprocess repository locks §9.4 requires
+/// (`<data_dir>/locks/repo/`; see [`crate::runtime::repolock`] for why that
+/// key is complete under §6.2). Every entry point in this module takes it for
+/// the same reason and uses it for nothing else.
 pub fn materialize(
+    data_dir: &Path,
     surfaces_root: &Path,
     work_id: &str,
     repositories: &[RepositorySpec],
@@ -478,7 +611,7 @@ pub fn materialize(
 
     let mut bindings: Vec<RepositoryBinding> = Vec::with_capacity(repositories.len());
     for repository in repositories {
-        let outcome = match materialize_one(&root, &canonical_root, &branch, repository) {
+        let outcome = match materialize_one(data_dir, &root, &canonical_root, &branch, repository) {
             Ok(binding) => init_submodules_if_present(&binding.worktree_path)
                 .map(|()| binding.clone())
                 .map_err(|err| (Some(binding), err)),
@@ -502,7 +635,7 @@ pub fn materialize(
                     root,
                     bindings,
                 };
-                let report = teardown(&partial);
+                let report = teardown(data_dir, &partial);
                 return Err(SurfaceError::PartialFailure {
                     source: Box::new(err),
                     teardown: report,
@@ -518,6 +651,7 @@ pub fn materialize(
 }
 
 fn materialize_one(
+    data_dir: &Path,
     root: &Path,
     canonical_root: &Path,
     branch: &str,
@@ -558,6 +692,17 @@ fn materialize_one(
     )
     .unwrap_or_else(|_| "(detached)".to_string());
 
+    // §3.5's two canonical identities, read here — once, outside the lock,
+    // alongside the other admission facts — and then used for both purposes
+    // they exist for: the lock key below, and the binding's own record of what
+    // this repository *was* at admission.  Deriving them here rather than
+    // inside the span is the whole point: `with_repository` must never spawn
+    // a `git rev-parse` while holding a registry lock.
+    let canonical_top_level = canonical_git_top_level(&repository.path).ok();
+    let canonical_common_dir = canonical_git_common_dir(&repository.path).ok();
+    let gate =
+        RepositoryGate::from_common_dir(data_dir, canonical_common_dir.clone(), &repository.path);
+
     // Only `git worktree add` touches `.git/worktrees/` — the operation the
     // per-repository lock exists to serialize.  Hold it for exactly that span
     // and nothing more.
@@ -574,9 +719,9 @@ fn materialize_one(
     // below populates exactly the same content as a full add would have.  The
     // checkout completes before `materialize_one` returns, so no caller ever
     // sees a worktree with its branch set but its files absent.
-    with_repository(&repository.path, || {
+    with_repository(&gate, || {
         add_worktree_no_checkout(&repository.path, &worktree_path, branch, &base_sha)
-    })?;
+    })??;
     // Outside the per-repository lock: populate the working tree.
     //
     // `git reset --hard HEAD` is used rather than `git checkout HEAD` for two
@@ -610,7 +755,7 @@ fn materialize_one(
     if let Err(checkout_err) = checkout_worktree(&worktree_path) {
         let path = worktree_path.display().to_string();
         // Remove registry entry first so the branch is unreferenced.
-        let _ = with_repository(&repository.path, || {
+        let _ = with_repository(&gate, || {
             git(&repository.path, &["worktree", "remove", "--force", &path]).map(|_| ())
         });
         // Delete the branch so a retry can re-create it with `-b`.
@@ -634,6 +779,12 @@ fn materialize_one(
         work_branch: branch.to_string(),
         head_sha,
         origin: BindingOrigin::Cut,
+        canonical_top_level,
+        // The `Option` is carried, not the gate's `identity`: the gate falls
+        // back to the canonicalized source path when git cannot answer, and
+        // that path is not a common directory — journaling it as one would
+        // record a value that only usually means what the field says.
+        canonical_common_dir,
     })
 }
 
@@ -658,15 +809,31 @@ fn materialize_one(
 /// this change opens. Left alone rather than folded into this pass: the fix
 /// belongs to `settle_rematerialize`'s error handling in general, not to
 /// submodules specifically.
-pub fn rematerialize(surface: &WorkSurface) -> Result<WorkSurface, SurfaceError> {
+///
+/// §3.5/C3: both canonical identities are **re-derived** here rather than
+/// carried forward. A retry can land days after admission, and this is the
+/// one path that re-establishes the worktree from the branch — if the mount
+/// has been re-cloned or moved in between, the identity that matters is the
+/// one the re-attachment actually used. A pre-Phase-B binding that replayed
+/// with `None` therefore gains its identities on first retry, rather than
+/// staying blank forever.
+pub fn rematerialize(data_dir: &Path, surface: &WorkSurface) -> Result<WorkSurface, SurfaceError> {
     create_dir_all_durable(&surface.root).map_err(|source| SurfaceError::Io {
         path: surface.root.display().to_string(),
         source,
     })?;
     let mut bindings = Vec::with_capacity(surface.bindings.len());
     for binding in &surface.bindings {
+        // One derivation per binding per operation, before any span opens.
+        let canonical_common_dir = canonical_git_common_dir(&binding.source_path).ok();
+        let canonical_top_level = canonical_git_top_level(&binding.source_path).ok();
+        let gate = RepositoryGate::from_common_dir(
+            data_dir,
+            canonical_common_dir.clone(),
+            &binding.source_path,
+        );
         if !binding.worktree_path.exists() {
-            with_repository(&binding.source_path, || {
+            with_repository(&gate, || {
                 // Whatever removed the directory may not have unregistered it
                 // — teardown only prunes on the paths it walks, and a worktree
                 // can vanish long after that (a retained-dirty one deleted by
@@ -697,11 +864,15 @@ pub fn rematerialize(surface: &WorkSurface) -> Result<WorkSurface, SurfaceError>
                     !branch_exists,
                 )?;
                 init_submodules_if_present(&binding.worktree_path)
-            })?;
+            })??;
         }
         let head_sha = git(&binding.worktree_path, &["rev-parse", "HEAD"])?;
         bindings.push(RepositoryBinding {
             head_sha,
+            canonical_top_level: canonical_top_level
+                .or_else(|| binding.canonical_top_level.clone()),
+            canonical_common_dir: canonical_common_dir
+                .or_else(|| binding.canonical_common_dir.clone()),
             ..binding.clone()
         });
     }
@@ -740,7 +911,11 @@ pub fn rematerialize(surface: &WorkSurface) -> Result<WorkSurface, SurfaceError>
 /// gate-surface attach never leaves an orphaned worktree in the caller's
 /// repositories — same as an ordinary `materialize` failure, and using the
 /// identical [`SurfaceError::PartialFailure`] shape.
+///
+/// `data_dir` locates the interprocess repository locks, exactly as in
+/// [`materialize`].
 pub fn attach(
+    data_dir: &Path,
     surfaces_root: &Path,
     work_id: &str,
     target_work_id: &str,
@@ -761,7 +936,7 @@ pub fn attach(
 
     let mut bindings: Vec<RepositoryBinding> = Vec::with_capacity(target_bindings.len());
     for target in target_bindings {
-        let outcome = match attach_one(&root, &canonical_root, target_work_id, target) {
+        let outcome = match attach_one(data_dir, &root, &canonical_root, target_work_id, target) {
             Ok(binding) => init_submodules_if_present(&binding.worktree_path)
                 .map(|()| binding.clone())
                 .map_err(|err| (Some(binding), err)),
@@ -787,7 +962,7 @@ pub fn attach(
                     root,
                     bindings,
                 };
-                let report = teardown(&partial);
+                let report = teardown(data_dir, &partial);
                 return Err(SurfaceError::PartialFailure {
                     source: Box::new(err),
                     teardown: report,
@@ -803,6 +978,7 @@ pub fn attach(
 }
 
 fn attach_one(
+    data_dir: &Path,
     root: &Path,
     canonical_root: &Path,
     target_work_id: &str,
@@ -820,7 +996,19 @@ fn attach_one(
             source_repo: target.source_path.display().to_string(),
         });
     }
-    let head_sha = with_repository(&target.source_path, || -> Result<String, SurfaceError> {
+    // §3.5, derived once and outside the span, exactly as `materialize_one`
+    // does. An attached binding shares the target's *branch*, but its own
+    // identities are read fresh here: this Work is admitting this repository
+    // now, and "what the mount was when the target was admitted" is a
+    // different fact, already recorded on the target's own binding.
+    let canonical_top_level = canonical_git_top_level(&target.source_path).ok();
+    let canonical_common_dir = canonical_git_common_dir(&target.source_path).ok();
+    let gate = RepositoryGate::from_common_dir(
+        data_dir,
+        canonical_common_dir.clone(),
+        &target.source_path,
+    );
+    let head_sha = with_repository(&gate, || -> Result<String, SurfaceError> {
         // `create_branch: false`: the git-level operation `rematerialize`
         // already performs in a different context (re-attaching a surface's
         // own retained branch), invoked here from a new caller with a
@@ -843,7 +1031,7 @@ fn attach_one(
             false,
         )?;
         Ok(git(&worktree_path, &["rev-parse", "HEAD"])?)
-    })?;
+    })??;
 
     Ok(RepositoryBinding {
         repository: target.repository.clone(),
@@ -856,6 +1044,8 @@ fn attach_one(
         origin: BindingOrigin::Attached {
             target_work_id: target_work_id.to_string(),
         },
+        canonical_top_level,
+        canonical_common_dir,
     })
 }
 
@@ -865,7 +1055,13 @@ fn attach_one(
 /// This never returns an error. Teardown runs on the way to a terminal state,
 /// and a Work does not stop being canceled because a worktree was dirty — the
 /// honest outcome is a recorded report, which is what the caller journals.
-pub fn teardown(surface: &WorkSurface) -> TeardownReport {
+/// That includes a repository lock this daemon could not take: it becomes a
+/// `RetainedError` disposition with the timeout as its detail, which is the
+/// same fail-closed shape a git refusal already produces.
+///
+/// `data_dir` locates the interprocess repository locks, exactly as in
+/// [`materialize`].
+pub fn teardown(data_dir: &Path, surface: &WorkSurface) -> TeardownReport {
     let mut bindings = Vec::with_capacity(surface.bindings.len());
     let mut drift = Vec::new();
     for binding in &surface.bindings {
@@ -873,7 +1069,7 @@ pub fn teardown(surface: &WorkSurface) -> TeardownReport {
         // touches anything, so `observed` is the estate as the Work left it
         // rather than as teardown left it.
         drift.extend(observe_estate_drift(binding));
-        let outcome = teardown_binding(binding);
+        let outcome = teardown_binding(data_dir, binding);
         bindings.push(BindingTeardown {
             repository: binding.repository.clone(),
             worktree_path: binding.worktree_path.clone(),
@@ -1068,13 +1264,16 @@ pub struct ReapReport {
 /// Scoped to `RetainedDirty` only, matching [`ReapOutcome::Skipped`]'s
 /// reasoning: a `RetainedError` binding has no evidence backing a forced
 /// removal, so it is reported, not touched.
-pub fn reap(surface: &WorkSurface, teardown: &TeardownReport) -> ReapReport {
+///
+/// `data_dir` locates the interprocess repository locks, exactly as in
+/// [`materialize`].
+pub fn reap(data_dir: &Path, surface: &WorkSurface, teardown: &TeardownReport) -> ReapReport {
     let bindings = teardown
         .bindings
         .iter()
         .map(|b| BindingReap {
             repository: b.repository.clone(),
-            outcome: reap_binding(surface, b),
+            outcome: reap_binding(data_dir, surface, b),
         })
         .collect();
     remove_surface_root(&surface.root);
@@ -1084,7 +1283,7 @@ pub fn reap(surface: &WorkSurface, teardown: &TeardownReport) -> ReapReport {
     }
 }
 
-fn reap_binding(surface: &WorkSurface, binding: &BindingTeardown) -> ReapOutcome {
+fn reap_binding(data_dir: &Path, surface: &WorkSurface, binding: &BindingTeardown) -> ReapOutcome {
     match &binding.disposition {
         BindingDisposition::RetainedDirty {
             patch: Some(info), ..
@@ -1104,11 +1303,10 @@ fn reap_binding(surface: &WorkSurface, binding: &BindingTeardown) -> ReapOutcome
             // through git rather than a raw recursive delete keeps the
             // source repository's own worktree registry consistent, the
             // same as every other removal this module ever does.
-            let Some(source) = surface
+            let Some(surface_binding) = surface
                 .bindings
                 .iter()
                 .find(|b| b.repository == binding.repository)
-                .map(|b| b.source_path.clone())
             else {
                 return ReapOutcome::Failed {
                     detail: "no surface binding recorded for this repository; cannot resolve \
@@ -1116,12 +1314,22 @@ fn reap_binding(surface: &WorkSurface, binding: &BindingTeardown) -> ReapOutcome
                         .to_string(),
                 };
             };
+            let source = surface_binding.source_path.clone();
+            // Derived once, outside the span, from the binding's own record —
+            // the same rule every other guarded span in this module follows.
+            let gate = RepositoryGate::for_binding(data_dir, surface_binding);
             let bytes = directory_size(&binding.worktree_path);
             let path = binding.worktree_path.display().to_string();
-            match with_repository(&source, || {
+            // Two failure layers flattened into one `Failed`: a lock we could
+            // not take and a removal git refused are both "this was not
+            // reaped, here is why", and reap's report has one place to say so.
+            match with_repository(&gate, || {
                 git(&source, &["worktree", "remove", "--force", &path])
             }) {
-                Ok(_) => ReapOutcome::Reaped { bytes },
+                Ok(Ok(_)) => ReapOutcome::Reaped { bytes },
+                Ok(Err(e)) => ReapOutcome::Failed {
+                    detail: e.to_string(),
+                },
                 Err(e) => ReapOutcome::Failed {
                     detail: e.to_string(),
                 },
@@ -1371,39 +1579,29 @@ fn reachable_from_a_named_ref(binding: &RepositoryBinding, sha: &str) -> bool {
     )
 }
 
-/// `git rev-parse --path-format=absolute --git-common-dir`, canonicalized.
-///
-/// Canonicalized because the comparison this feeds is about *identity*, not
-/// spelling: a source path reached through a symlink (`/tmp` → `/private/tmp`
-/// on macOS, an estate mount behind a symlinked parent) would otherwise
-/// answer differently from the worktree that shares its object store, and
-/// report a mismatch where there is none.
-fn common_dir(dir: &Path) -> Option<PathBuf> {
-    let raw = git(
-        dir,
-        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
-    )
-    .ok()?;
-    let path = PathBuf::from(raw);
-    Some(std::fs::canonicalize(&path).unwrap_or(path))
-}
-
 /// §11.3's `assigned_common_dir_mismatch`: the worktree and the checkout it
 /// is journaled against must agree on the Git common directory — the identity
 /// §2.7 locks on and the one that says these two paths really do share an
 /// object store.
 ///
-/// Phase A asks the question at teardown, from both sides, which needs no
+/// Phase A asked the question at teardown, from both sides, which needed no
 /// binding schema change. Phase B pins the canonical common dir at admission,
-/// at which point the expected side comes from the binding rather than from
-/// re-asking the source checkout.
+/// so the *expected* side now comes from the binding — a genuinely stronger
+/// check, because it compares the worktree against what was admitted rather
+/// than against a second live reading that would move with the mount. A
+/// pre-enrichment binding (`None`, C3) falls back to Phase A's behaviour and
+/// re-asks the source checkout, which is exactly as good an answer as it ever
+/// was for those bindings.
 ///
 /// A read that fails on either side yields no finding: this is the *identity*
 /// check, and an unanswerable git is a different failure, already handled
 /// fail-closed by the status/removal path below.
 fn common_dir_finding(binding: &RepositoryBinding) -> Option<IntegrityFinding> {
-    let expected = common_dir(&binding.source_path)?;
-    let observed = common_dir(&binding.worktree_path)?;
+    let expected = match &binding.canonical_common_dir {
+        Some(admitted) => admitted.clone(),
+        None => canonical_git_common_dir(&binding.source_path).ok()?,
+    };
+    let observed = canonical_git_common_dir(&binding.worktree_path).ok()?;
     if expected == observed {
         return None;
     }
@@ -1450,7 +1648,11 @@ fn observe_estate_drift(binding: &RepositoryBinding) -> Option<EstateDriftObserv
     })
 }
 
-fn teardown_binding(binding: &RepositoryBinding) -> BindingOutcome {
+fn teardown_binding(data_dir: &Path, binding: &RepositoryBinding) -> BindingOutcome {
+    // One lock identity for this whole teardown, resolved before any span
+    // opens — from the binding's own admission record when it has one, so the
+    // lock released here is the lock materialization took.
+    let gate = RepositoryGate::for_binding(data_dir, binding);
     // Read the retained branch's tip **before** taking the per-repository lock.
     // This call reads from ref storage only — it does not access the worktree
     // registry (`.git/worktrees/`) that `with_repository` protects, so running
@@ -1473,7 +1675,13 @@ fn teardown_binding(binding: &RepositoryBinding) -> BindingOutcome {
         // The directory is gone, but the source repository still lists it;
         // unregister it now so a later rematerialize at the same path is
         // possible.  `git worktree prune` modifies the registry → lock.
-        with_repository(&binding.source_path, || {
+        //
+        // Best-effort, and already was: `prune_stale_worktrees` discards its
+        // own git failures. A lock we cannot take is one more way this prune
+        // does not happen, and it changes nothing about the disposition below
+        // — the worktree is `Missing` either way, and the next teardown or
+        // rematerialize against this repository prunes what this one skipped.
+        let _ = with_repository(&gate, || {
             prune_stale_worktrees(&binding.source_path);
         });
         findings.push(IntegrityFinding::AssignedWorktreeMissing {
@@ -1589,8 +1797,15 @@ fn teardown_binding(binding: &RepositoryBinding) -> BindingOutcome {
                 worktree_path: binding.worktree_path.clone(),
                 evidence: changes.clone(),
             });
-            let disposition =
-                with_repository(&binding.source_path, || retain_dirty(binding, changes));
+            // A lock we cannot take means the `--force` removal `retain_dirty`
+            // ends with must not be attempted at all: another process may be
+            // rewriting this registry right now. Fail closed exactly as an
+            // unanswerable `git status` does below — retained, with the
+            // refusal itself as the recorded evidence.
+            let disposition = with_repository(&gate, || retain_dirty(binding, changes))
+                .unwrap_or_else(|e| BindingDisposition::RetainedError {
+                    detail: e.to_string(),
+                });
             return BindingOutcome {
                 disposition,
                 final_sha,
@@ -1618,7 +1833,7 @@ fn teardown_binding(binding: &RepositoryBinding) -> BindingOutcome {
 
     // Clean path: only `git worktree remove` touches the registry.
     let path = binding.worktree_path.display().to_string();
-    let disposition = with_repository(&binding.source_path, || {
+    let disposition = with_repository(&gate, || {
         match git(&binding.source_path, &["worktree", "remove", &path]) {
             Ok(_) => BindingDisposition::Removed,
             // #22: git unconditionally refuses to remove a worktree that
@@ -1651,6 +1866,11 @@ fn teardown_binding(binding: &RepositoryBinding) -> BindingOutcome {
                 detail: e.to_string(),
             },
         }
+    })
+    // Same fail-closed rule as every other arm here: a removal that was never
+    // attempted retains the worktree and records why.
+    .unwrap_or_else(|e| BindingDisposition::RetainedError {
+        detail: e.to_string(),
     });
     BindingOutcome {
         disposition,
@@ -1775,6 +1995,40 @@ mod tests {
     use super::*;
     use std::process::Command;
 
+    /// The data dir a fixture surface belongs to.
+    ///
+    /// Every fixture in this module hands `materialize` one tempdir as *both*
+    /// the data dir and the surfaces root — the daemon's own default
+    /// relationship (`<data_dir>/surfaces`) collapsed by one level, which
+    /// keeps a fixture to a single directory. A surface root is
+    /// `<surfaces_root>/<work-id>`, so its parent is that directory.
+    ///
+    /// The two being genuinely independent (R-MVP1-1: an estate may put its
+    /// surfaces anywhere, and §9.4's locks still live in the daemon's own
+    /// storage) is pinned separately, by
+    /// [`the_repository_lock_lives_under_the_data_dir_not_the_surfaces_root`].
+    fn fixture_data_dir(surface: &WorkSurface) -> &Path {
+        surface
+            .root
+            .parent()
+            .expect("a fixture surface root always has a parent")
+    }
+
+    /// [`teardown`] against the data dir this fixture surface belongs to.
+    fn teardown_of(surface: &WorkSurface) -> TeardownReport {
+        teardown(fixture_data_dir(surface), surface)
+    }
+
+    /// [`rematerialize`] against the data dir this fixture surface belongs to.
+    fn rematerialize_of(surface: &WorkSurface) -> Result<WorkSurface, SurfaceError> {
+        rematerialize(fixture_data_dir(surface), surface)
+    }
+
+    /// [`reap`] against the data dir this fixture surface belongs to.
+    fn reap_of(surface: &WorkSurface, report: &TeardownReport) -> ReapReport {
+        reap(fixture_data_dir(surface), surface, report)
+    }
+
     /// Concurrent surfaces against **one** repository all materialize and all
     /// tear down cleanly.
     ///
@@ -1803,7 +2057,13 @@ mod tests {
     #[test]
     fn concurrent_surfaces_on_one_repository_all_materialize_and_retire_cleanly() {
         let dir = tempfile::TempDir::new().expect("tempdir");
+        // Unlike the rest of this module's fixtures, the data dir and the
+        // surfaces root are kept apart here: the emptiness assertion below is
+        // about the *surfaces* root, and §9.4's `locks/repo/` lives in the
+        // daemon's storage. This is also the production relationship, one
+        // level flattened (`<data_dir>/surfaces`).
         let data = dir.path().join("data");
+        let surfaces = dir.path().join("surfaces");
         let spec = repo(&dir.path().join("solo"));
         // Enough overlap that adds and removes interleave inside git's own
         // `.git/worktrees` registry, which is where the measured failure was.
@@ -1817,12 +2077,18 @@ mod tests {
                 let handles: Vec<_> = (0..WORKS)
                     .map(|i| {
                         let data = data.clone();
+                        let surfaces = surfaces.clone();
                         let spec = spec.clone();
                         scope.spawn(move || {
                             let work_id = format!("01CONCURRENT{round}{i:03}");
-                            let surface = materialize(&data, &work_id, std::slice::from_ref(&spec))
-                                .unwrap_or_else(|e| panic!("materialize {work_id}: {e}"));
-                            teardown(&surface)
+                            let surface = materialize(
+                                &data,
+                                &surfaces,
+                                &work_id,
+                                std::slice::from_ref(&spec),
+                            )
+                            .unwrap_or_else(|e| panic!("materialize {work_id}: {e}"));
+                            teardown(&data, &surface)
                         })
                     })
                     .collect();
@@ -1839,13 +2105,13 @@ mod tests {
                      removed (round {round} of {ROUNDS}): {report:?}"
                 );
             }
-            // `data` is handed to `materialize` directly as the surfaces
+            // `surfaces` is handed to `materialize` directly as the surfaces
             // root (R-MVP1-1: no implicit `SURFACES_DIR` nesting inside this
             // module any more — that join happens once, at `Engine`'s
             // default computation, not here).
             assert!(
-                !data.exists()
-                    || std::fs::read_dir(&data)
+                !surfaces.exists()
+                    || std::fs::read_dir(&surfaces)
                         .expect("surfaces root")
                         .next()
                         .is_none(),
@@ -1854,24 +2120,28 @@ mod tests {
         }
     }
 
-    /// §2.7/Phase B (C4): `repository_lock` keys on the canonical *checkout
-    /// path* handed to it, not the git common directory the checkout
-    /// actually shares with others. A primary checkout and a `git worktree
-    /// add` of it are two different, canonicalize-stable paths pointing at
-    /// one shared `.git` (a linked worktree's `commondir` file points back
-    /// to it) — the same "two workspaces can reach one repository by
-    /// different routes" hazard `repository_lock`'s own doc comment already
-    /// names for symlinks, just reached through a worktree instead. Today
-    /// that means concurrent mutations against a checkout and its own
-    /// linked worktree are not serialized against each other at all,
-    /// defeating the guard this module's header describes (measured
-    /// burst-50 fatal: `.git/worktrees/<other-work>/commondir`). Phase B's
-    /// blocking interprocess lock keys on canonical `git rev-parse
-    /// --path-format=absolute --git-common-dir` instead, closing this.
-    // CONTRACT PIN (estate-root Phase B): repository_lock keys on the git common directory, so a checkout and its own linked worktree share one lock.
+    /// §2.7 (Phase 0 pin #5, flipped by Phase B): a checkout and its own
+    /// linked worktree are **one** lock identity, at both layers.
+    ///
+    /// A primary checkout and a `git worktree add` of it are two different,
+    /// canonicalize-stable paths pointing at one shared `.git` — a linked
+    /// worktree's `commondir` file points back to it — so a lock keyed on the
+    /// checkout *path* handed the module gave them one lock each, which is the
+    /// same "two workspaces can reach one repository by different routes"
+    /// hazard `repository_lock`'s own doc comment already named for symlinks,
+    /// just reached through a worktree instead. Nothing serialized concurrent
+    /// registry mutations between them, defeating the guard this module's
+    /// header describes (measured burst-50 fatal: `.git/worktrees/<other-
+    /// work>/commondir`).
+    ///
+    /// Both halves are asserted, because the fix has two halves: the
+    /// in-process mutex is now keyed on the common directory (one `Arc`), and
+    /// the interprocess lock file derived from that identity is one file. A
+    /// regression in either would let the two paths past each other.
     #[test]
-    fn contract_pin_repository_lock_aliases_a_checkout_and_its_own_linked_worktree() {
+    fn a_checkout_and_its_own_linked_worktree_are_one_repository_lock() {
         let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = dir.path().join("data");
         let primary = repo(&dir.path().join("primary"));
         let linked = dir.path().join("linked-worktree");
         let output = Command::new("git")
@@ -1893,33 +2163,98 @@ mod tests {
             .expect("git worktree add");
         assert!(output.status.success(), "worktree add: {output:?}");
 
-        // Both paths do genuinely share one git common directory — the fact
-        // Phase B's fix will key on.
-        let common_from_primary = git(
-            &primary.path,
-            &["rev-parse", "--path-format=absolute", "--git-common-dir"],
-        )
-        .expect("common dir from the primary checkout");
-        let common_from_linked = git(
-            &linked,
-            &["rev-parse", "--path-format=absolute", "--git-common-dir"],
-        )
-        .expect("common dir from the linked worktree");
+        // The fixture premise: these two paths really do share one git common
+        // directory. Without this the rest of the test would pass vacuously.
         assert_eq!(
-            common_from_primary, common_from_linked,
+            canonical_git_common_dir(&primary.path).expect("common dir from the primary checkout"),
+            canonical_git_common_dir(&linked).expect("common dir from the linked worktree"),
             "the fixture must actually share one git common directory"
         );
 
-        let primary_lock = repository_lock(&primary.path);
-        let linked_lock = repository_lock(&linked);
+        let primary_gate = RepositoryGate::derive(&data, &primary.path);
+        let linked_gate = RepositoryGate::derive(&data, &linked);
 
+        // Layer 1: the in-process fast layer resolves to the same mutex.
         assert!(
-            !Arc::ptr_eq(&primary_lock, &linked_lock),
-            "today, repository_lock is keyed on the canonical checkout path rather than the \
-             shared git common directory, so a primary checkout and its own linked worktree \
-             yield two distinct lock Arcs — nothing serializes worktree-registry mutations \
-             against each other between them"
+            Arc::ptr_eq(
+                &repository_lock(&primary_gate.identity),
+                &repository_lock(&linked_gate.identity),
+            ),
+            "a primary checkout and its own linked worktree share one worktree registry, so \
+             they must share one in-process lock: keyed on the canonical git common directory, \
+             not on the checkout path each caller happened to name"
         );
+
+        // Layer 2: and the correctness boundary — one lock file, so the same
+        // holds against another process, not merely another thread.
+        assert_eq!(
+            repolock::lock_path(&data, &primary_gate.identity),
+            repolock::lock_path(&data, &linked_gate.identity),
+            "and one interprocess lock file, which is what makes this hold across processes"
+        );
+
+        // A genuinely different repository still gets its own lock: the point
+        // is one identity per registry, not one gate for all of git.
+        let other = repo(&dir.path().join("other"));
+        let other_gate = RepositoryGate::derive(&data, &other.path);
+        assert!(
+            !Arc::ptr_eq(
+                &repository_lock(&primary_gate.identity),
+                &repository_lock(&other_gate.identity),
+            ),
+            "unrelated repositories must still proceed in parallel"
+        );
+        assert_ne!(
+            repolock::lock_path(&data, &primary_gate.identity),
+            repolock::lock_path(&data, &other_gate.identity),
+        );
+    }
+
+    /// R-MVP1-1 left the surfaces root free to live anywhere; §9.4's locks
+    /// still belong to the daemon's own storage. The two are separate
+    /// parameters and this is the test that keeps them separate — every other
+    /// fixture in this module collapses them into one tempdir.
+    #[test]
+    fn the_repository_lock_lives_under_the_data_dir_not_the_surfaces_root() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = dir.path().join("data");
+        let surfaces = dir.path().join("somewhere-else/surfaces");
+        let spec = repo(&dir.path().join("solo"));
+
+        let surface = materialize(
+            &data,
+            &surfaces,
+            "01SPLITROOTS",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+        assert!(
+            surface.root.starts_with(&surfaces),
+            "the surface goes where the surfaces root says: {}",
+            surface.root.display()
+        );
+
+        let common = surface.bindings[0]
+            .canonical_common_dir
+            .clone()
+            .expect("a freshly materialized binding records its common directory");
+        let lock = repolock::lock_path(&data, &common);
+        assert!(
+            lock.is_file(),
+            "materializing takes the repository lock, so its file exists under the data dir: {}",
+            lock.display()
+        );
+        assert!(
+            !lock.starts_with(&surfaces),
+            "and not under the surfaces root"
+        );
+        assert!(
+            !lock.starts_with(&spec.path),
+            "and never inside the user's checkout (§6.2 / surface doctrine)"
+        );
+
+        let report = teardown(&data, &surface);
+        assert!(report.clean, "teardown across split roots: {report:?}");
     }
 
     /// Run one git command in `dir` with a fixture identity, same shape as
@@ -1980,8 +2315,13 @@ mod tests {
         let spec = repo(&source);
         let data_dir_inside = source.join(".sergeant-data");
 
-        let err = materialize(&data_dir_inside, "01WORKID", std::slice::from_ref(&spec))
-            .expect_err("must refuse");
+        let err = materialize(
+            &data_dir_inside,
+            &data_dir_inside,
+            "01WORKID",
+            std::slice::from_ref(&spec),
+        )
+        .expect_err("must refuse");
         assert!(
             matches!(err, SurfaceError::InsideSourceCheckout { .. }),
             "expected a refusal, got {err}"
@@ -1994,8 +2334,13 @@ mod tests {
 
         // The same repository outside the checkout materializes fine.
         let data = tempfile::TempDir::new().expect("tempdir");
-        let surface = materialize(data.path(), "01WORKID", std::slice::from_ref(&spec))
-            .expect("materialize outside the checkout");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01WORKID",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize outside the checkout");
         assert_eq!(surface.bindings.len(), 1);
         // Single-repo work executes in the worktree itself, not the root.
         assert_eq!(surface.execution_cwd(), surface.bindings[0].worktree_path);
@@ -2011,8 +2356,13 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01GONE", std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01GONE",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
 
         let worktree = surface.bindings[0].worktree_path.display().to_string();
         std::fs::remove_dir_all(&surface.bindings[0].worktree_path).expect("remove worktree");
@@ -2023,7 +2373,7 @@ mod tests {
             "git still lists the vanished worktree until something unregisters it"
         );
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         assert!(!report.clean, "a missing worktree is not a clean teardown");
         assert_eq!(report.bindings[0].disposition, BindingDisposition::Missing);
         assert_eq!(report.bindings[0].work_branch, work_branch("01GONE"));
@@ -2037,7 +2387,7 @@ mod tests {
                 .contains(&worktree),
             "teardown must unregister the worktree it recorded as missing"
         );
-        let rebuilt = rematerialize(&surface)
+        let rebuilt = rematerialize_of(&surface)
             .expect("a recorded-missing worktree must not wedge the path forever");
         assert!(rebuilt.bindings[0].worktree_path.is_dir());
     }
@@ -2065,14 +2415,19 @@ mod tests {
         let outer = repo(&dir.path().join("outer"));
         declare_submodule(&outer.path, &inner.path, "vendored");
 
-        let surface = materialize(data.path(), "01STALE", std::slice::from_ref(&outer))
-            .expect("materialize a repository with a submodule");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01STALE",
+            std::slice::from_ref(&outer),
+        )
+        .expect("materialize a repository with a submodule");
         let worktree = surface.bindings[0].worktree_path.clone();
 
         // Uncommitted work: teardown retains it whole, and therefore never
         // prunes.
         std::fs::write(worktree.join("half-done.rs"), "fn main() {}\n").expect("dirty");
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         assert!(matches!(
             report.bindings[0].disposition,
             BindingDisposition::RetainedDirty { patch: None, .. }
@@ -2085,7 +2440,7 @@ mod tests {
         // ...and then it is deleted by something that is not sergeant.
         std::fs::remove_dir_all(&worktree).expect("delete out of band");
 
-        let rebuilt = rematerialize(&surface).expect("retry must still be able to rebuild");
+        let rebuilt = rematerialize_of(&surface).expect("retry must still be able to rebuild");
         assert!(rebuilt.bindings[0].worktree_path.is_dir());
         assert_eq!(
             git(&worktree, &["rev-parse", "--abbrev-ref", "HEAD"]).expect("head"),
@@ -2095,7 +2450,7 @@ mod tests {
         // And it is repeatable: a second rebuild after a second deletion
         // works too, so nothing accumulates that eventually wedges it.
         std::fs::remove_dir_all(&worktree).expect("delete again");
-        rematerialize(&surface).expect("still rebuildable");
+        rematerialize_of(&surface).expect("still rebuildable");
     }
 
     /// A later repository failing must not leave the earlier ones' branches
@@ -2115,8 +2470,13 @@ mod tests {
         let branch = work_branch("01PARTIAL");
         git(&second.path, &["branch", &branch]).expect("pre-create the colliding branch");
 
-        let err = materialize(data.path(), "01PARTIAL", &[first.clone(), second])
-            .expect_err("the second repository must fail");
+        let err = materialize(
+            data.path(),
+            data.path(),
+            "01PARTIAL",
+            &[first.clone(), second],
+        )
+        .expect_err("the second repository must fail");
         let SurfaceError::PartialFailure { source, teardown } = err else {
             panic!("expected a partial failure, got {err}");
         };
@@ -2171,8 +2531,13 @@ mod tests {
         std::os::unix::fs::symlink(&source, &link).expect("symlink");
         let data_dir_via_link = link.join(".sergeant-data");
 
-        let err = materialize(&data_dir_via_link, "01LINK", std::slice::from_ref(&spec))
-            .expect_err("the symlinked route is still inside the checkout");
+        let err = materialize(
+            &data_dir_via_link,
+            &data_dir_via_link,
+            "01LINK",
+            std::slice::from_ref(&spec),
+        )
+        .expect_err("the symlinked route is still inside the checkout");
         assert!(
             matches!(err, SurfaceError::InsideSourceCheckout { .. }),
             "expected a refusal, got {err}"
@@ -2204,11 +2569,16 @@ mod tests {
         second.name = "second".to_string();
 
         // One repository: the root is empty after the worktree goes.
-        let solo = materialize(data.path(), "01ROOT", std::slice::from_ref(&first))
-            .expect("materialize solo");
+        let solo = materialize(
+            data.path(),
+            data.path(),
+            "01ROOT",
+            std::slice::from_ref(&first),
+        )
+        .expect("materialize solo");
         let root = solo.root.clone();
         assert!(root.is_dir(), "materialize created the root");
-        let report = teardown(&solo);
+        let report = teardown_of(&solo);
         assert!(report.clean);
         assert!(
             !root.exists(),
@@ -2225,26 +2595,27 @@ mod tests {
         // …and tearing the same surface down again is a no-op, not an error:
         // the crash window between the removal and the `surface.torn_down`
         // append is re-run, not repaired (L6).
-        let again = teardown(&solo);
+        let again = teardown_of(&solo);
         assert_eq!(again.bindings[0].disposition, BindingDisposition::Missing);
         assert!(!root.exists());
 
         // Two repositories: the root survives until the last worktree is
         // gone. Tearing down a surface that names only the first binding
         // leaves the second worktree — and therefore the root — untouched.
-        let pair = materialize(data.path(), "01PAIR", &[first, second]).expect("materialize pair");
+        let pair = materialize(data.path(), data.path(), "01PAIR", &[first, second])
+            .expect("materialize pair");
         let pair_root = pair.root.clone();
         let partial = WorkSurface {
             bindings: pair.bindings[..1].to_vec(),
             ..pair.clone()
         };
-        teardown(&partial);
+        teardown_of(&partial);
         assert!(
             pair_root.is_dir(),
             "a root still holding another repository's worktree must be kept"
         );
         assert!(pair.bindings[1].worktree_path.is_dir(), "untouched");
-        teardown(&pair);
+        teardown_of(&pair);
         assert!(
             !pair_root.exists(),
             "the last binding's removal takes the root with it"
@@ -2255,10 +2626,15 @@ mod tests {
         // directory — that gets reclaimed once its dirty state is captured
         // as a patch, which is exactly what keeps the root non-empty.
         let dirty_spec = repo(&dir.path().join("dirty"));
-        let dirty = materialize(data.path(), "01DIRTY", std::slice::from_ref(&dirty_spec))
-            .expect("materialize dirty");
+        let dirty = materialize(
+            data.path(),
+            data.path(),
+            "01DIRTY",
+            std::slice::from_ref(&dirty_spec),
+        )
+        .expect("materialize dirty");
         std::fs::write(dirty.bindings[0].worktree_path.join("wip.rs"), "//\n").expect("dirty");
-        let report = teardown(&dirty);
+        let report = teardown_of(&dirty);
         let BindingDisposition::RetainedDirty { patch, .. } = &report.bindings[0].disposition
         else {
             panic!(
@@ -2291,8 +2667,13 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface = materialize(data.path(), "01FINALIZE", std::slice::from_ref(&spec))
-            .expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01FINALIZE",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let worktree = &surface.bindings[0].worktree_path;
         let base_sha = surface.bindings[0].base_sha.clone();
 
@@ -2306,7 +2687,7 @@ mod tests {
             "the fixture must actually advance the branch"
         );
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         assert_eq!(report.bindings[0].disposition, BindingDisposition::Removed);
         assert_eq!(
             report.bindings[0].final_sha.as_deref(),
@@ -2317,10 +2698,15 @@ mod tests {
 
         // A worktree the repository never had (Missing) still resolves the
         // branch tip: it lives on the branch, not the worktree.
-        let again = materialize(data.path(), "01FINALIZE2", std::slice::from_ref(&spec))
-            .expect("materialize again");
+        let again = materialize(
+            data.path(),
+            data.path(),
+            "01FINALIZE2",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize again");
         std::fs::remove_dir_all(&again.bindings[0].worktree_path).expect("simulate vanished");
-        let missing_report = teardown(&again);
+        let missing_report = teardown_of(&again);
         assert_eq!(
             missing_report.bindings[0].disposition,
             BindingDisposition::Missing
@@ -2359,8 +2745,13 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01SWITCH", std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01SWITCH",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let worktree = surface.bindings[0].worktree_path.clone();
         let work_branch_name = surface.bindings[0].work_branch.clone();
         let base_sha = surface.bindings[0].base_sha.clone();
@@ -2381,7 +2772,7 @@ mod tests {
             "the fixture must actually produce a divergent commit"
         );
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         let binding = &report.bindings[0];
 
         // A clean worktree on the wrong branch is still removed (§11.7): the
@@ -2460,11 +2851,16 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01CLEAN", std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01CLEAN",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let base_sha = surface.bindings[0].base_sha.clone();
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         let binding = &report.bindings[0];
 
         assert_eq!(binding.disposition, BindingDisposition::Removed);
@@ -2499,8 +2895,13 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface = materialize(data.path(), "01DETACHED", std::slice::from_ref(&spec))
-            .expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01DETACHED",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let worktree = surface.bindings[0].worktree_path.clone();
 
         // Detach, then commit: the commit belongs to no branch at all.
@@ -2516,7 +2917,7 @@ mod tests {
             "the fixture must actually produce a commit no branch contains"
         );
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         let binding = &report.bindings[0];
 
         assert!(
@@ -2554,7 +2955,7 @@ mod tests {
         let retained = retained_bindings(&report);
         assert_eq!(retained.len(), 1);
         assert_eq!(retained[0].reason, "retained_unreferenced");
-        let reaped = reap(&surface, &report);
+        let reaped = reap_of(&surface, &report);
         assert!(
             matches!(
                 &reaped.bindings[0].outcome,
@@ -2578,14 +2979,19 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface = materialize(data.path(), "01REACHABLE", std::slice::from_ref(&spec))
-            .expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01REACHABLE",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let worktree = surface.bindings[0].worktree_path.clone();
 
         // Detached, but at the work branch's own tip: nothing is at risk.
         git_as_test_identity(&worktree, &["checkout", "--detach"]);
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         let binding = &report.bindings[0];
 
         assert_eq!(binding.disposition, BindingDisposition::Removed);
@@ -2612,11 +3018,16 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface = materialize(data.path(), "01VANISHED", std::slice::from_ref(&spec))
-            .expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01VANISHED",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         std::fs::remove_dir_all(&surface.bindings[0].worktree_path).expect("simulate vanished");
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         let binding = &report.bindings[0];
 
         assert_eq!(binding.disposition, BindingDisposition::Missing);
@@ -2640,11 +3051,16 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01DIRTY", std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01DIRTY",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         std::fs::write(surface.bindings[0].worktree_path.join("wip.rs"), "//\n").expect("dirty");
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         let binding = &report.bindings[0];
 
         assert!(
@@ -2672,22 +3088,37 @@ mod tests {
     /// journaled against is not the worktree the binding thinks it is — the
     /// same identity §2.7/§9.4 needs the interprocess lock keyed on.
     ///
-    /// Reproduced by handing teardown a binding whose `source_path` names a
-    /// *different* repository than the worktree actually belongs to, which is
-    /// exactly the shape a mis-journaled or aliased mount would have.
+    /// Reproduced by handing teardown a binding that names a *different*
+    /// repository than the worktree actually belongs to, which is exactly the
+    /// shape a mis-journaled or aliased mount would have.
+    ///
+    /// Since Phase B the expected side is the identity the binding *recorded
+    /// at admission* (§3.5), not a second live reading of `source_path` — a
+    /// stronger check, because it compares the worktree against what was
+    /// admitted rather than against a mount that may have moved since. The
+    /// mis-binding here therefore rewrites both halves of the binding's
+    /// repository identity, which is what a mis-journaled binding really
+    /// looks like.
     #[test]
     fn a_worktree_whose_common_dir_disagrees_with_its_source_checkout_is_a_finding() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let mine = repo(&dir.path().join("mine"));
         let stranger = repo(&dir.path().join("stranger"));
-        let surface = materialize(data.path(), "01COMMONDIR", std::slice::from_ref(&mine))
-            .expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01COMMONDIR",
+            std::slice::from_ref(&mine),
+        )
+        .expect("materialize");
 
         let mut misbound = surface.clone();
         misbound.bindings[0].source_path = stranger.path.clone();
+        misbound.bindings[0].canonical_common_dir =
+            Some(canonical_git_common_dir(&stranger.path).expect("stranger common dir"));
 
-        let report = teardown(&misbound);
+        let report = teardown_of(&misbound);
         let binding = &report.bindings[0];
 
         assert!(
@@ -2704,6 +3135,162 @@ mod tests {
         assert!(surface.bindings[0].worktree_path.exists());
     }
 
+    /// The same finding, from a binding journaled before Phase B existed
+    /// (C3: `canonical_common_dir` replays as `None`).
+    ///
+    /// With nothing admitted to compare against, the check falls back to
+    /// Phase A's behaviour — re-ask the journaled `source_path` — which is
+    /// exactly as good an answer as it ever was for those bindings, and is
+    /// the guarantee that widening the binding did not quietly switch off a
+    /// finding for every Work that predates the widening.
+    #[test]
+    fn a_pre_enrichment_binding_still_gets_the_common_dir_finding_from_its_source_path() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let mine = repo(&dir.path().join("mine"));
+        let stranger = repo(&dir.path().join("stranger"));
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01OLDCOMMONDIR",
+            std::slice::from_ref(&mine),
+        )
+        .expect("materialize");
+
+        let mut misbound = surface.clone();
+        misbound.bindings[0].source_path = stranger.path.clone();
+        // The shape an old journal replays as: no admitted identity at all.
+        misbound.bindings[0].canonical_common_dir = None;
+        misbound.bindings[0].canonical_top_level = None;
+
+        let report = teardown_of(&misbound);
+        assert!(
+            report.bindings[0]
+                .findings
+                .iter()
+                .any(|f| matches!(f, IntegrityFinding::AssignedCommonDirMismatch { .. })),
+            "expected a common-dir mismatch from the source-path fallback: {:?}",
+            report.bindings[0].findings
+        );
+        assert_eq!(report.integrity(), IntegrityDisposition::Dirty);
+    }
+
+    /// §3.5 + C3: what a fresh binding records, and what an old one replays
+    /// as.
+    ///
+    /// The two canonical identities are additive `Option` fields, so a
+    /// `surface.materialized` payload written before Phase B — the exact JSON
+    /// shape this test embeds — must still deserialize, and must come back
+    /// saying *nothing observed this*, never a fabricated path.
+    #[test]
+    fn a_binding_records_its_canonical_identities_and_an_old_payload_replays_without_them() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01IDENTITY",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+        let binding = &surface.bindings[0];
+
+        assert_eq!(
+            binding.canonical_top_level.as_deref(),
+            Some(
+                canonical_git_top_level(&spec.path)
+                    .expect("top level")
+                    .as_path()
+            ),
+            "a fresh binding records §3.5's canonical top level"
+        );
+        assert_eq!(
+            binding.canonical_common_dir.as_deref(),
+            Some(
+                canonical_git_common_dir(&spec.path)
+                    .expect("common dir")
+                    .as_path()
+            ),
+            "and the canonical common directory §2.7 locks on"
+        );
+
+        // A `surface.materialized` payload from before Phase B: every field
+        // the old shape had, and neither of the new ones.
+        let old = serde_json::json!({
+            "repository": "solo",
+            "source_path": "/repos/solo",
+            "base_branch": "main",
+            "base_sha": "0".repeat(40),
+            "worktree_path": "/data/surfaces/01OLD/solo",
+            "work_branch": "sergeant/01OLD",
+            "head_sha": "1".repeat(40),
+        });
+        let replayed: RepositoryBinding =
+            serde_json::from_value(old).expect("an old binding must still replay");
+        assert_eq!(replayed.repository, "solo");
+        assert_eq!(replayed.origin, BindingOrigin::Cut);
+        assert_eq!(
+            replayed.canonical_top_level, None,
+            "nothing observed this at the time; it must not be invented"
+        );
+        assert_eq!(replayed.canonical_common_dir, None);
+
+        // And the enriched shape round-trips as itself.
+        let round_tripped: RepositoryBinding =
+            serde_json::from_value(serde_json::to_value(binding).expect("serialize"))
+                .expect("deserialize");
+        assert_eq!(&round_tripped, binding);
+
+        let report = teardown_of(&surface);
+        assert!(report.clean, "{report:?}");
+    }
+
+    /// C3, the other half: a whole `surface.materialized` payload in the
+    /// pre-enrichment shape replays into a `WorkSurface` that teardown can
+    /// still act on — and a teardown driven from it locks the right
+    /// repository, because [`RepositoryGate::for_binding`] falls back to
+    /// deriving from `source_path` when the binding admitted nothing.
+    #[test]
+    fn an_old_shape_materialized_payload_replays_and_tears_down() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01OLDREPLAY",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+
+        // Journal it, then strip the fields Phase B added — byte-for-byte the
+        // payload a pre-Phase-B daemon would have written.
+        let mut payload = serde_json::to_value(&surface).expect("serialize surface");
+        for binding in payload["bindings"]
+            .as_array_mut()
+            .expect("bindings array")
+            .iter_mut()
+        {
+            let binding = binding.as_object_mut().expect("binding object");
+            binding.remove("canonical_top_level");
+            binding.remove("canonical_common_dir");
+            binding.remove("origin");
+        }
+
+        let replayed: WorkSurface =
+            serde_json::from_value(payload).expect("an old surface payload must still replay");
+        assert_eq!(replayed.bindings[0].canonical_common_dir, None);
+        assert_eq!(replayed.bindings[0].origin, BindingOrigin::Cut);
+
+        let report = teardown(data.path(), &replayed);
+        assert!(
+            report.clean,
+            "a surface replayed from an old payload still tears down cleanly: {report:?}"
+        );
+        assert!(!surface.bindings[0].worktree_path.exists());
+    }
+
     /// §11.4, bounded by amendment C6: a mount whose committed HEAD moved
     /// during the Work window is *observed* — one `rev-parse` per bound
     /// repository, at retirement — and attributed to nobody.
@@ -2718,8 +3305,13 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01DRIFT", std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01DRIFT",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let base_sha = surface.bindings[0].base_sha.clone();
 
         // Somebody else advances the mount while the Work runs.
@@ -2728,7 +3320,7 @@ mod tests {
         git_as_test_identity(&spec.path, &["commit", "-m", "somebody else's commit"]);
         let moved = git(&spec.path, &["rev-parse", "HEAD"]).expect("moved head");
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
 
         assert_eq!(
             report.drift,
@@ -2752,7 +3344,7 @@ mod tests {
     fn a_surface_needs_at_least_one_repository() {
         let data = tempfile::TempDir::new().expect("tempdir");
         assert!(matches!(
-            materialize(data.path(), "01EMPTY", &[]),
+            materialize(data.path(), data.path(), "01EMPTY", &[]),
             Err(SurfaceError::NoRepositories)
         ));
     }
@@ -2813,8 +3405,13 @@ mod tests {
         let outer = repo(&dir.path().join("outer"));
         declare_submodule(&outer.path, &inner.path, "vendored");
 
-        let surface = materialize(data.path(), "01SUBMODULE", std::slice::from_ref(&outer))
-            .expect("materialize a repository with a submodule");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01SUBMODULE",
+            std::slice::from_ref(&outer),
+        )
+        .expect("materialize a repository with a submodule");
         let worktree = &surface.bindings[0].worktree_path;
         assert_eq!(
             std::fs::read_to_string(worktree.join("vendored").join("payload.txt"))
@@ -2829,7 +3426,7 @@ mod tests {
             "the submodule must report initialized: {status:?}"
         );
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         assert!(
             report.clean,
             "an untouched submodule worktree is clean: {report:?}"
@@ -2890,8 +3487,13 @@ mod tests {
         );
         git_as_test_identity(&outer.path, &["commit", "-m", "an unreachable submodule"]);
 
-        let err = materialize(data.path(), "01BADSUBMODULE", std::slice::from_ref(&outer))
-            .expect_err("a disallowed submodule transport must refuse materialization");
+        let err = materialize(
+            data.path(),
+            data.path(),
+            "01BADSUBMODULE",
+            std::slice::from_ref(&outer),
+        )
+        .expect_err("a disallowed submodule transport must refuse materialization");
         let SurfaceError::PartialFailure { source, teardown } = err else {
             panic!(
                 "expected the same rolled-back-and-reported shape a later repository's \
@@ -3009,8 +3611,13 @@ mod tests {
         // First attempt: add_worktree_no_checkout succeeds (no checkout →
         // smudge filter not triggered), checkout_worktree fails (smudge
         // filter exits 1), cleanup runs.
-        let err = materialize(data.path(), "01CHECKFAIL", std::slice::from_ref(&spec))
-            .expect_err("checkout_worktree failure must propagate as an error");
+        let err = materialize(
+            data.path(),
+            data.path(),
+            "01CHECKFAIL",
+            std::slice::from_ref(&spec),
+        )
+        .expect_err("checkout_worktree failure must propagate as an error");
         assert!(
             matches!(err, SurfaceError::Git { .. }),
             "expected a git error from the reset --hard, got: {err}"
@@ -3047,12 +3654,18 @@ mod tests {
         }
 
         // Retry: must succeed because the branch slot was freed.
-        let surface = materialize(data.path(), "01CHECKFAIL", std::slice::from_ref(&spec)).expect(
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01CHECKFAIL",
+            std::slice::from_ref(&spec),
+        )
+        .expect(
             "retry must succeed — branch was deleted so it can be recreated with -b; \
                  if this fails with 'branch already exists', the cleanup is missing",
         );
         assert!(surface.bindings[0].worktree_path.is_dir());
-        teardown(&surface);
+        teardown_of(&surface);
     }
 
     /// The force-retry `teardown_binding` uses for git's blanket "containing
@@ -3075,6 +3688,7 @@ mod tests {
 
         let surface = materialize(
             data.path(),
+            data.path(),
             "01DIRTYSUBMODULE",
             std::slice::from_ref(&outer),
         )
@@ -3088,7 +3702,7 @@ mod tests {
         )
         .expect("simulate uncommitted submodule content");
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         assert!(
             !report.clean,
             "uncommitted content inside a submodule must block teardown: {report:?}"
@@ -3142,8 +3756,13 @@ mod tests {
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
 
-        let target = materialize(data.path(), "01TARGET", std::slice::from_ref(&spec))
-            .expect("materialize target");
+        let target = materialize(
+            data.path(),
+            data.path(),
+            "01TARGET",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize target");
         let target_branch = target.bindings[0].work_branch.clone();
         assert_eq!(target_branch, work_branch("01TARGET"));
 
@@ -3161,14 +3780,20 @@ mod tests {
         let pre_gate_tip =
             git(&target.bindings[0].worktree_path, &["rev-parse", "HEAD"]).expect("target head");
 
-        let target_report = teardown(&target);
+        let target_report = teardown_of(&target);
         assert!(
             target_report.clean,
             "the fixture must reach the clean-teardown precondition: {target_report:?}"
         );
 
-        let gate = attach(data.path(), "01GATE", "01TARGET", &target.bindings)
-            .expect("attach must succeed once the target has torn down clean");
+        let gate = attach(
+            data.path(),
+            data.path(),
+            "01GATE",
+            "01TARGET",
+            &target.bindings,
+        )
+        .expect("attach must succeed once the target has torn down clean");
         assert_eq!(gate.bindings.len(), 1);
         assert_eq!(gate.bindings[0].work_branch, target_branch);
         assert_eq!(
@@ -3207,7 +3832,7 @@ mod tests {
             "a commit made in the attached worktree must land on the target's real branch"
         );
 
-        let gate_report = teardown(&gate);
+        let gate_report = teardown_of(&gate);
         assert!(gate_report.clean, "gate teardown: {gate_report:?}");
         // Teardown always retains the branch — including one it only ever
         // attached to, never minted.
@@ -3237,12 +3862,23 @@ mod tests {
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
 
-        let target = materialize(data.path(), "01LIVE", std::slice::from_ref(&spec))
-            .expect("materialize target");
+        let target = materialize(
+            data.path(),
+            data.path(),
+            "01LIVE",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize target");
         // No teardown: the target's worktree is still live on its branch.
 
-        let err = attach(data.path(), "01GATE", "01LIVE", &target.bindings)
-            .expect_err("attach must refuse while the target's worktree still holds the branch");
+        let err = attach(
+            data.path(),
+            data.path(),
+            "01GATE",
+            "01LIVE",
+            &target.bindings,
+        )
+        .expect_err("attach must refuse while the target's worktree still holds the branch");
         assert!(
             matches!(err, SurfaceError::Git(_)),
             "expected git's own exclusivity refusal, got {err}"
@@ -3256,10 +3892,16 @@ mod tests {
         // exactly the race Mechanism A's precondition exists to prevent —
         // pin it the other way too: once the target *does* tear down clean,
         // the identical call succeeds.
-        let report = teardown(&target);
+        let report = teardown_of(&target);
         assert!(report.clean);
-        attach(data.path(), "01GATE2", "01LIVE", &target.bindings)
-            .expect("attach must succeed once the target's worktree is actually gone");
+        attach(
+            data.path(),
+            data.path(),
+            "01GATE2",
+            "01LIVE",
+            &target.bindings,
+        )
+        .expect("attach must succeed once the target's worktree is actually gone");
     }
 
     /// A branch that no longer exists — deleted out of band after a clean
@@ -3272,16 +3914,27 @@ mod tests {
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
 
-        let target = materialize(data.path(), "01GONEBRANCH", std::slice::from_ref(&spec))
-            .expect("materialize target");
-        let report = teardown(&target);
+        let target = materialize(
+            data.path(),
+            data.path(),
+            "01GONEBRANCH",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize target");
+        let report = teardown_of(&target);
         assert!(report.clean);
 
         let branch = target.bindings[0].work_branch.clone();
         git(&spec.path, &["branch", "-D", &branch]).expect("delete the branch out of band");
 
-        let err = attach(data.path(), "01GATE", "01GONEBRANCH", &target.bindings)
-            .expect_err("attach must refuse when the branch no longer exists");
+        let err = attach(
+            data.path(),
+            data.path(),
+            "01GATE",
+            "01GONEBRANCH",
+            &target.bindings,
+        )
+        .expect_err("attach must refuse when the branch no longer exists");
         assert!(
             matches!(err, SurfaceError::Git(_)),
             "expected a git refusal naming the missing branch, got {err}"
@@ -3299,9 +3952,14 @@ mod tests {
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
 
-        let target = materialize(data.path(), "01COLLIDE", std::slice::from_ref(&spec))
-            .expect("materialize target");
-        let report = teardown(&target);
+        let target = materialize(
+            data.path(),
+            data.path(),
+            "01COLLIDE",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize target");
+        let report = teardown_of(&target);
         assert!(report.clean);
 
         let colliding_path = data.path().join("01GATE").join("solo");
@@ -3309,8 +3967,14 @@ mod tests {
         std::fs::write(colliding_path.join("occupied.txt"), "already here\n")
             .expect("occupy the path");
 
-        let err = attach(data.path(), "01GATE", "01COLLIDE", &target.bindings)
-            .expect_err("attach must refuse a worktree path collision");
+        let err = attach(
+            data.path(),
+            data.path(),
+            "01GATE",
+            "01COLLIDE",
+            &target.bindings,
+        )
+        .expect_err("attach must refuse a worktree path collision");
         assert!(
             matches!(err, SurfaceError::Git(_)),
             "expected git's own refusal to add a worktree onto a non-empty path, got {err}"
@@ -3337,11 +4001,12 @@ mod tests {
 
         let target = materialize(
             data.path(),
+            data.path(),
             "01PARTIALATTACH",
             &[first.clone(), second.clone()],
         )
         .expect("materialize target");
-        let report = teardown(&target);
+        let report = teardown_of(&target);
         assert!(report.clean);
 
         // The second repository's branch is gone by the time the gate
@@ -3350,8 +4015,14 @@ mod tests {
         let branch = work_branch("01PARTIALATTACH");
         git(&second.path, &["branch", "-D", &branch]).expect("delete second's branch");
 
-        let err = attach(data.path(), "01GATE", "01PARTIALATTACH", &target.bindings)
-            .expect_err("the second repository's attach must fail");
+        let err = attach(
+            data.path(),
+            data.path(),
+            "01GATE",
+            "01PARTIALATTACH",
+            &target.bindings,
+        )
+        .expect_err("the second repository's attach must fail");
         let SurfaceError::PartialFailure {
             teardown: rollback, ..
         } = err
@@ -3398,8 +4069,13 @@ mod tests {
         let inner = repo(&dir.path().join("inner"));
         let spec = repo(&dir.path().join("solo"));
 
-        let target = materialize(data.path(), "01SUBTARGET", std::slice::from_ref(&spec))
-            .expect("materialize target");
+        let target = materialize(
+            data.path(),
+            data.path(),
+            "01SUBTARGET",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize target");
         let worktree = target.bindings[0].worktree_path.clone();
 
         // Declare a submodule over a transport `init_submodules_if_present`'s
@@ -3427,14 +4103,20 @@ mod tests {
         );
         git_as_test_identity(&worktree, &["commit", "-m", "an unreachable submodule"]);
 
-        let target_report = teardown(&target);
+        let target_report = teardown_of(&target);
         assert!(
             target_report.clean,
             "the fixture must reach the clean-teardown precondition: {target_report:?}"
         );
 
-        let err = attach(data.path(), "01GATE", "01SUBTARGET", &target.bindings)
-            .expect_err("a disallowed submodule transport must refuse the takeover");
+        let err = attach(
+            data.path(),
+            data.path(),
+            "01GATE",
+            "01SUBTARGET",
+            &target.bindings,
+        )
+        .expect_err("a disallowed submodule transport must refuse the takeover");
         let SurfaceError::PartialFailure {
             source,
             teardown: rollback,
@@ -3472,7 +4154,7 @@ mod tests {
     fn attach_needs_at_least_one_target_binding() {
         let data = tempfile::TempDir::new().expect("tempdir");
         assert!(matches!(
-            attach(data.path(), "01EMPTY", "01TARGET", &[]),
+            attach(data.path(), data.path(), "01EMPTY", "01TARGET", &[]),
             Err(SurfaceError::NoRepositories)
         ));
     }
@@ -3492,8 +4174,13 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01SCOPE", std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01SCOPE",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let worktree = surface.bindings[0].worktree_path.clone();
 
         std::fs::write(worktree.join(".gitignore"), "target/\n").expect(".gitignore");
@@ -3509,7 +4196,7 @@ mod tests {
         std::fs::write(worktree.join("target").join("big.bin"), "compiled output")
             .expect("build artifact");
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         let BindingDisposition::RetainedDirty { patch, .. } = &report.bindings[0].disposition
         else {
             panic!(
@@ -3552,8 +4239,13 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01LOCKED", std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01LOCKED",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         let worktree = surface.bindings[0].worktree_path.clone();
 
         std::fs::write(worktree.join("half-done.rs"), "fn main() {}\n").expect("dirty");
@@ -3567,7 +4259,7 @@ mod tests {
         )
         .expect("lock the worktree");
 
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
         let BindingDisposition::RetainedDirty { patch, .. } = &report.bindings[0].disposition
         else {
             panic!(
@@ -3617,10 +4309,15 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface = materialize(data.path(), "01INSPECT", std::slice::from_ref(&spec))
-            .expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01INSPECT",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         std::fs::write(surface.bindings[0].worktree_path.join("wip.rs"), "//\n").expect("dirty");
-        let report = teardown(&surface);
+        let report = teardown_of(&surface);
 
         let error_binding = BindingTeardown {
             repository: "other".to_string(),
@@ -3687,10 +4384,15 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let data = tempfile::TempDir::new().expect("tempdir");
         let spec = repo(&dir.path().join("solo"));
-        let surface =
-            materialize(data.path(), "01REAP", std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01REAP",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         std::fs::write(surface.bindings[0].worktree_path.join("wip.rs"), "//\n").expect("dirty");
-        let mut report = teardown(&surface);
+        let mut report = teardown_of(&surface);
         let BindingDisposition::RetainedDirty {
             patch: Some(before),
             ..
@@ -3717,7 +4419,7 @@ mod tests {
             },
         });
 
-        let reaped = reap(&surface, &report);
+        let reaped = reap_of(&surface, &report);
         assert_eq!(reaped.work_id, "01REAP");
 
         let solo = reaped

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -29,6 +29,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
 
+use crate::backend::BindingSummary;
 use crate::domain::workspace::RepositorySpec;
 use crate::runtime::fsutil::create_dir_all_durable;
 use crate::runtime::git::{
@@ -325,6 +326,27 @@ impl WorkSurface {
             [only] => only.worktree_path.clone(),
             _ => self.root.clone(),
         }
+    }
+
+    /// §10.1's binding summary: the exact worktrees this Work may modify,
+    /// with the branch and base commit each was bound to, in scope order.
+    ///
+    /// [`Self::execution_cwd`] answers "where does the process start", which
+    /// for a multi-repo Work is the surface root — a directory the Work may
+    /// *not* write to. This answers the different and more important question
+    /// a backend's launch grammar needs: which directories are the mutation
+    /// surface, and what is each one supposed to be.
+    pub fn binding_summary(&self) -> Vec<BindingSummary> {
+        self.bindings
+            .iter()
+            .map(|b| BindingSummary {
+                repository: b.repository.clone(),
+                worktree_path: b.worktree_path.clone(),
+                work_branch: b.work_branch.clone(),
+                base_branch: b.base_branch.clone(),
+                base_sha: b.base_sha.clone(),
+            })
+            .collect()
     }
 }
 

--- a/tests/c4_repo_lock.rs
+++ b/tests/c4_repo_lock.rs
@@ -1,0 +1,301 @@
+//! Amendment C4 acceptance: the repository lock is *interprocess*.
+//!
+//! §9.4 makes the filesystem lock the correctness boundary and the in-process
+//! mutex a mere optimization, and §17 asks that registry operations serialize
+//! by Git common directory **across processes**. Neither claim can be tested
+//! from inside one process: a `Mutex` and a `flock` are indistinguishable to a
+//! single-process test, which is exactly how a rekey that quietly dropped the
+//! file lock would slip through a green suite.
+//!
+//! So this file spawns a **real second process** and makes it hold the lock.
+//!
+//! # The rig
+//!
+//! Rather than reach for `CARGO_BIN_EXE_sgt` — which would need a CLI verb
+//! whose only purpose is to sit on a lock, i.e. product surface invented for a
+//! test — the helper is a `#[test]` in this same binary, re-executed through
+//! `std::env::current_exe()`. It does nothing unless [`HELPER_COMMON_DIR`] is
+//! set in its environment, so it is an ordinary (trivially passing) test in a
+//! normal run and a lock-holding daemon-shaped process when this file drives
+//! it. Two files carry the handshake, because pipes would need the helper to
+//! flush at exactly the right moments and a sleep would make the test a race:
+//!
+//! - the helper creates its `ready` file *after* it holds the lock;
+//! - the helper exits (releasing the lock by dropping it) once its `release`
+//!   file appears.
+//!
+//! # What is asserted
+//!
+//! 1. A contender **waits** for a foreign holder and then succeeds — the lock
+//!    is genuinely shared across processes, and it is a wait rather than a
+//!    refusal (the shape `fsutil::take_exclusive_lock` deliberately does not
+//!    have).
+//! 2. A holder that stays produces the **bounded structured timeout**, with
+//!    the lock path and the repository identity in it, instead of hanging.
+//! 3. Two different *source paths* that share one Git common directory — a
+//!    checkout and a linked worktree of it — contend on **one** lock file
+//!    (§18, and the flipped Phase 0 pin's cross-process half).
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+use sergeant_rs::runtime::git::canonical_git_common_dir;
+use sergeant_rs::runtime::repolock::{self, RepoLockError};
+
+/// Set in the helper's environment: the git checkout whose common directory
+/// it should lock. Absent in an ordinary run, which is what makes the helper
+/// test inert.
+const HELPER_COMMON_DIR: &str = "SGT_TEST_LOCK_SOURCE";
+/// Set in the helper's environment: the data dir the lock file lives under.
+const HELPER_DATA_DIR: &str = "SGT_TEST_LOCK_DATA_DIR";
+/// The helper creates this once it holds the lock.
+const HELPER_READY: &str = "SGT_TEST_LOCK_READY";
+/// The helper exits once this appears.
+const HELPER_RELEASE: &str = "SGT_TEST_LOCK_RELEASE";
+
+/// The lock-holding second process. Inert unless driven by [`hold_lock_in_a_second_process`].
+///
+/// It deliberately goes through the *same* public entry points the daemon
+/// does — `canonical_git_common_dir` then `repolock::acquire` — rather than
+/// opening the lock file by a path this test computed. A rig that computed the
+/// path itself would still pass if the daemon's own derivation drifted, which
+/// is the one thing this file exists to catch.
+#[test]
+fn repository_lock_helper_process() {
+    let Ok(source) = std::env::var(HELPER_COMMON_DIR) else {
+        return; // an ordinary run: nothing to do
+    };
+    let data_dir = PathBuf::from(std::env::var(HELPER_DATA_DIR).expect("helper data dir"));
+    let ready = PathBuf::from(std::env::var(HELPER_READY).expect("helper ready path"));
+    let release = PathBuf::from(std::env::var(HELPER_RELEASE).expect("helper release path"));
+
+    let common_dir =
+        canonical_git_common_dir(Path::new(&source)).expect("helper: git common directory");
+    let held = repolock::acquire(&data_dir, &common_dir).expect("helper: acquire the lock");
+    std::fs::write(&ready, held.path().display().to_string()).expect("helper: signal ready");
+
+    // Hold it until told otherwise. Bounded so a parent that dies mid-test
+    // cannot leave this process sitting on a lock forever.
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while !release.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    drop(held);
+}
+
+/// A live handle on the helper process, with the paths that talk to it.
+struct Helper {
+    child: Child,
+    release: PathBuf,
+    /// The lock file the helper reported holding.
+    lock_path: PathBuf,
+}
+
+impl Helper {
+    /// Let the helper go and wait for it to actually exit — the lock is not
+    /// released until the process is gone, so a test that asserted
+    /// availability without this would be racing the kernel.
+    fn release_and_wait(mut self) {
+        std::fs::write(&self.release, b"go").expect("signal release");
+        let status = self.child.wait().expect("helper exit");
+        assert!(status.success(), "helper process failed: {status}");
+    }
+}
+
+/// Spawn the helper against `source` and block until it holds the lock.
+fn hold_lock_in_a_second_process(data_dir: &Path, source: &Path, scratch: &Path) -> Helper {
+    let ready = scratch.join("ready");
+    let release = scratch.join("release");
+    let child = Command::new(std::env::current_exe().expect("current test binary"))
+        .args(["--exact", "repository_lock_helper_process", "--nocapture"])
+        .env(HELPER_COMMON_DIR, source)
+        .env(HELPER_DATA_DIR, data_dir)
+        .env(HELPER_READY, &ready)
+        .env(HELPER_RELEASE, &release)
+        .spawn()
+        .expect("spawn the lock-holding helper");
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while !ready.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "the helper process never reported holding the lock"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let lock_path = PathBuf::from(std::fs::read_to_string(&ready).expect("read ready"));
+    Helper {
+        child,
+        release,
+        lock_path,
+    }
+}
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "sergeant tests")
+        .env("GIT_AUTHOR_EMAIL", "tests@example.invalid")
+        .env("GIT_COMMITTER_NAME", "sergeant tests")
+        .env("GIT_COMMITTER_EMAIL", "tests@example.invalid")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}: {}",
+        dir.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// A checkout with one commit, plus a linked worktree of it. Both paths share
+/// one Git common directory; that is the whole point of the fixture.
+fn checkout_with_linked_worktree(root: &Path) -> (PathBuf, PathBuf) {
+    let primary = root.join("primary");
+    std::fs::create_dir_all(&primary).expect("repo dir");
+    git(&primary, &["init", "-b", "main"]);
+    std::fs::write(primary.join("README.md"), "# fixture\n").expect("write");
+    git(&primary, &["add", "."]);
+    git(&primary, &["commit", "-m", "initial"]);
+
+    let linked = root.join("linked");
+    git(
+        &primary,
+        &[
+            "worktree",
+            "add",
+            linked.to_str().expect("utf8 path"),
+            "-b",
+            "linked-branch",
+        ],
+    );
+    (primary, linked)
+}
+
+/// (1) and (3): a contender waits out a foreign holder and then succeeds —
+/// and the two processes met on one lock despite naming *different* source
+/// paths, because those paths share one Git common directory (§18).
+#[test]
+fn a_second_process_holding_the_repository_lock_is_waited_out_not_refused() {
+    let dir = TempDir::new().expect("tempdir");
+    let data = dir.path().join("data");
+    let (primary, linked) = checkout_with_linked_worktree(dir.path());
+
+    // The helper locks via the *linked worktree*; this process contends via
+    // the *primary checkout*. Different paths, one registry, one lock.
+    let helper = hold_lock_in_a_second_process(&data, &linked, dir.path());
+
+    let common_from_primary = canonical_git_common_dir(&primary).expect("common dir");
+    assert_eq!(
+        helper.lock_path,
+        repolock::lock_path(&data, &common_from_primary),
+        "two source paths sharing one git common directory must resolve to one lock file"
+    );
+    assert!(
+        helper.lock_path.starts_with(&data),
+        "the lock lives in the daemon's data dir: {}",
+        helper.lock_path.display()
+    );
+    assert!(
+        !helper.lock_path.starts_with(&primary),
+        "and never inside the user's checkout"
+    );
+
+    // Release the holder shortly, from this process, while the acquisition
+    // below is already waiting on it.
+    let hold_for = Duration::from_millis(400);
+    let releaser = std::thread::spawn(move || {
+        std::thread::sleep(hold_for);
+        helper.release_and_wait();
+    });
+
+    let started = Instant::now();
+    let taken = repolock::acquire(&data, &common_from_primary)
+        .expect("a foreign holder that goes away must be waited out, not refused");
+    let waited = started.elapsed();
+    releaser.join().expect("releaser thread");
+
+    assert!(
+        waited >= hold_for,
+        "it must actually have waited for the other process to release: {waited:?}"
+    );
+    assert_eq!(
+        taken.path(),
+        repolock::lock_path(&data, &common_from_primary),
+        "and it is the very lock file the other process was holding"
+    );
+    drop(taken);
+}
+
+/// (2): a holder that never lets go produces the bounded, structured refusal
+/// rather than a hang.
+///
+/// This is the property the whole primitive is shaped around: surface
+/// operations reach the runtime through `api::blocking`, which runs them
+/// inline on the reactor under a current-thread runtime, so an unbounded
+/// `File::lock()` would park the daemon instead of failing it. The budget is
+/// passed explicitly here so the assertion costs a fraction of a second
+/// rather than the production 30.
+#[test]
+fn a_second_process_that_keeps_the_lock_produces_a_bounded_structured_timeout() {
+    let dir = TempDir::new().expect("tempdir");
+    let data = dir.path().join("data");
+    let (primary, linked) = checkout_with_linked_worktree(dir.path());
+    let common_dir = canonical_git_common_dir(&primary).expect("common dir");
+
+    let helper = hold_lock_in_a_second_process(&data, &linked, dir.path());
+
+    let budget = Duration::from_millis(250);
+    let started = Instant::now();
+    let err = repolock::acquire_within(&data, &common_dir, budget)
+        .expect_err("a lock held by another process must not be taken");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed >= budget,
+        "the whole budget is spent waiting: {elapsed:?}"
+    );
+    assert!(
+        elapsed < budget * 20,
+        "and then it gives up rather than blocking: {elapsed:?}"
+    );
+
+    let RepoLockError::Timeout {
+        path,
+        common_dir: reported,
+        waited,
+    } = &err
+    else {
+        panic!("a contended lock must fail as a timeout, not otherwise: {err:?}");
+    };
+    assert_eq!(
+        Path::new(path),
+        repolock::lock_path(&data, &common_dir),
+        "the refusal names the lock file"
+    );
+    assert_eq!(
+        Path::new(reported),
+        common_dir,
+        "and the repository identity it stands for"
+    );
+    assert!(*waited >= budget);
+    let text = err.to_string();
+    assert!(
+        text.contains("holder unknown"),
+        "an advisory lock names no owner, and the error says so rather than guessing: {text}"
+    );
+
+    // And once the other process really is gone, the lock is available again
+    // — the refusal was about contention, not about a lock left poisoned.
+    helper.release_and_wait();
+    let taken = repolock::acquire(&data, &common_dir)
+        .expect("the lock is free once the holding process exits");
+    drop(taken);
+}

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -532,6 +532,44 @@ path = "../payments-web"
     assert_eq!(starts.len(), 1);
     assert_eq!(starts[0].cwd, root);
 
+    // §10.1: and the backend is handed the complete binding summary, not
+    // only that cwd — which for a multi-repo Work is precisely the case
+    // where the cwd is a directory the Work may *not* write to. Every field
+    // is the one sergeant journaled for that binding.
+    let summary = &starts[0].bindings;
+    assert_eq!(
+        summary.len(),
+        2,
+        "one summary entry per bound repository: {summary:?}"
+    );
+    for (entry, journaled) in summary.iter().zip(bindings) {
+        assert_eq!(entry.repository, journaled["repository"].as_str().unwrap());
+        assert_eq!(
+            entry.worktree_path,
+            PathBuf::from(journaled["worktree_path"].as_str().unwrap()),
+            "the exact worktree path the Work may modify"
+        );
+        assert_eq!(
+            entry.work_branch,
+            journaled["work_branch"].as_str().unwrap()
+        );
+        assert_eq!(
+            entry.base_branch,
+            journaled["base_branch"].as_str().unwrap()
+        );
+        assert_eq!(
+            entry.base_sha,
+            journaled["base_sha"].as_str().unwrap(),
+            "the exact base SHA, pinned"
+        );
+        assert_ne!(
+            entry.worktree_path, root,
+            "no entry names the surface root: it is not part of the mutation surface"
+        );
+    }
+    assert_eq!(summary[0].base_sha, api_head, "declaration order, again");
+    assert_eq!(summary[1].base_sha, web_head);
+
     handle.shutdown().await;
 }
 

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -801,6 +801,7 @@ fn start_request(
         profile: None,
         execute: None,
         instruction_policy: InstructionPolicy::default(),
+        bindings: Vec::new(),
     }
 }
 
@@ -2619,6 +2620,7 @@ fn resume_launches_later_turns_under_the_re_supplied_configuration() {
                         .collect(),
                 }),
                 instruction_policy: Some(InstructionPolicy::default()),
+                bindings: Vec::new(),
             },
         )
         .expect("re-adopt");
@@ -3219,6 +3221,7 @@ fn resume_refuses_a_pin_that_could_never_be_honored() {
                 model: Some("anthropic/claude-haiku-4-5".to_string()),
                 profile: None,
                 instruction_policy: Some(InstructionPolicy::default()),
+                bindings: Vec::new(),
             },
         )
         .expect_err("a provider-qualified pin is refused pre-flight at RESUME too");
@@ -3239,6 +3242,7 @@ fn resume_refuses_a_pin_that_could_never_be_honored() {
                 model: Some("haiku".to_string()),
                 profile: None,
                 instruction_policy: Some(InstructionPolicy::default()),
+                bindings: Vec::new(),
             },
         )
         .expect("re-adopt");
@@ -3501,6 +3505,7 @@ fn a4_restart_reattaches_a_surviving_session_and_blocks_with_resumable_evidence(
                 model: Some("haiku".to_string()),
                 profile: None,
                 instruction_policy: Some(InstructionPolicy::default()),
+                bindings: Vec::new(),
             },
         )
         .expect("re-adopt is idempotent");
@@ -5299,6 +5304,7 @@ fn a1_real_claude_session_identity_survives_turns_and_restart() {
                 model: Some("haiku".to_string()),
                 profile: None,
                 instruction_policy: Some(InstructionPolicy::default()),
+                bindings: Vec::new(),
             },
         )
         .expect("re-adopt from session evidence");
@@ -6156,6 +6162,7 @@ fn n9_the_ask_capability_is_paired_with_what_the_backend_can_actually_report() {
         profile: None,
         execute: None,
         instruction_policy: InstructionPolicy::default(),
+        bindings: Vec::new(),
     };
     let handle = fake.start(&request).expect("start");
     assert_eq!(
@@ -6269,6 +6276,19 @@ fn n17_an_actor_ask_survives_a_daemon_restart_and_the_answer_still_lands() {
     assert_eq!(resumes.len(), 1, "exactly one re-adoption: {resumes:?}");
     assert_eq!(resumes[0].0, execution_id);
     assert_eq!(resumes[0].1.work_id, work_id);
+    // §10.1's binding summary is re-supplied too, from the journaled surface
+    // — and note the surface `journal_surface` wrote is deliberately in the
+    // *pre-enrichment* shape (no `canonical_*` fields), so this also proves
+    // C3: an old `surface.materialized` payload replays and still yields a
+    // complete summary, because every field the summary needs predates the
+    // widening.
+    let summary = &resumes[0].1.bindings;
+    assert_eq!(summary.len(), 1, "one bound repository: {summary:?}");
+    assert_eq!(summary[0].repository, "solo");
+    assert_eq!(summary[0].work_branch, format!("sergeant/{work_id}"));
+    assert_eq!(summary[0].base_branch, "main");
+    assert_eq!(summary[0].base_sha, "0".repeat(40));
+    assert_eq!(summary[0].worktree_path, data.path());
     let reconciled = events_of(core, work_id, KIND_EXECUTION_RECONCILED);
     assert_eq!(
         reconciled.len(),
@@ -6461,6 +6481,7 @@ fn a5_real_claude_reports_an_actor_authored_question_as_needs_input() {
         profile: None,
         execute: None,
         instruction_policy: InstructionPolicy::default(),
+        bindings: Vec::new(),
     };
     let handle = backend.start(&request).expect("start");
 
@@ -6601,6 +6622,7 @@ fn bs2_default_mode_headless_turn_cannot_write_without_an_explicit_permission_mo
         profile: None,
         execute: None,
         instruction_policy: InstructionPolicy::default(),
+        bindings: Vec::new(),
     };
     let handle = backend.start(&request).expect("start");
     let observation = wait_settled(&backend, &handle, Duration::from_secs(180));
@@ -6894,6 +6916,7 @@ fn n12_windows3_and_4_identity_created_and_process_started_are_one_window() {
                 profile: None,
                 execute: None,
                 instruction_policy: InstructionPolicy::default(),
+                bindings: Vec::new(),
             })
             .expect("prepare");
         fake.launch(&prepared).expect("launch");
@@ -6991,6 +7014,7 @@ fn n13_window5_result_observed_before_the_result_append() {
             profile: None,
             execute: None,
             instruction_policy: InstructionPolicy::default(),
+            bindings: Vec::new(),
         })
         .expect("prepare");
     fake.launch(&prepared).expect("launch");
@@ -7076,6 +7100,7 @@ fn n14_window6_result_appended_before_the_transition() {
             profile: None,
             execute: None,
             instruction_policy: InstructionPolicy::default(),
+            bindings: Vec::new(),
         })
         .expect("prepare");
     fake.launch(&prepared).expect("launch");

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -3832,8 +3832,13 @@ fn a4_a_crash_between_completion_and_teardown_is_swept_on_restart() {
             path: repo.clone(),
         };
         // A real surface, materialized exactly as the engine materializes it.
-        let surface =
-            materialize(data.path(), work_id, std::slice::from_ref(&spec)).expect("materialize");
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            work_id,
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
         submit_work(&mut core, work_id, "completed just before the crash");
         commit(
             &mut core,
@@ -3976,7 +3981,13 @@ fn a4_a_swept_surface_that_cannot_be_removed_is_retained_named_and_not_re_swept(
         name: "dirty".to_string(),
         path: repo.clone(),
     };
-    let surface = materialize(data.path(), work_id, std::slice::from_ref(&spec)).expect("surface");
+    let surface = materialize(
+        data.path(),
+        data.path(),
+        work_id,
+        std::slice::from_ref(&spec),
+    )
+    .expect("surface");
     submit_work(&mut core, work_id, "canceled with work still in the tree");
     commit(
         &mut core,

--- a/tests/m7_docker_executor.rs
+++ b/tests/m7_docker_executor.rs
@@ -202,6 +202,7 @@ fn request(work_id: &str, execution_id: &str, cwd: &Path, exec: ExecuteSpec) -> 
         profile: None,
         execute: Some(exec),
         instruction_policy: sergeant_rs::domain::workspace::InstructionPolicy::default(),
+        bindings: Vec::new(),
     }
 }
 


### PR DESCRIPTION
Phase B of the estate-root integration (spec: specs/phase-b.md; proposal §9.4/§3.5/§10.1, amendments C3/C4).

- New `runtime/repolock.rs`: blocking interprocess file lock at `<data_dir>/locks/repo/<blake3-of-canonical-common-dir>.lock`; bounded 30s wait with structured Timeout/Io errors; release-on-drop; never inside the user's .git (§6.2 ownership reasoning documented).
- Both lock layers (in-process mutex + file lock, file lock inside the mutex) rekeyed by canonical git common directory — a checkout and its linked worktree now contend on ONE lock across processes (Phase 0 pin flipped; real two-process acceptance test via re-exec helper).
- Asymmetric hold pattern preserved: no reads moved inside spans, no registry mutation escaped.
- `RepositoryBinding` gains `canonical_top_level`/`canonical_common_dir` (additive; old journal payloads replay as None).
- `StartRequest`/`ResumeRequest` carry a `BindingSummary` list; the claude launch prompt gains a fixed-order mutation-surface section (composition extracted and pinned by test; omitted entirely when empty).
- Teardown lock-timeout fails closed to `RetainedError`; work branch retained.

Gauntlet: 4-axis panel, ZERO findings confirmed. Gates green (fmt, clippy -D warnings, 537 lib + all integration, incl. the 24-thread burst test). Deferred findings: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4