### PR TITLE
Phase C: explicit Work scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,12 @@ released before a release can proceed.
   one-repository estate is unaffected: it still infers its sole repository
   on an empty scope. Group expansion is no longer CLI-side: the daemon
   resolves `--group`/`--repo`/`--all` against its own bound manifest, so
-  every client (CLI, TUI, or a direct API caller) reaches the identical
-  resolution. `sgt run --all` is new — an explicit, journaled selection of
+  every client submitting the same scope — CLI, TUI, or a direct API caller
+  — reaches the identical resolution. The TUI's New Work form submits that
+  same structured scope: its dead `workspace` field is replaced by a
+  `group` field, and both it and `repositories` are forwarded unexpanded,
+  so naming a group in the TUI resolves exactly as `sgt run --group` does.
+  `sgt run --all` is new — an explicit, journaled selection of
   the whole estate. A submitted Work now records both the request form
   (`scope_request`: repos/group/all as submitted) and the resolved
   repository list, so a later manifest edit cannot rewrite what an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,34 @@ released before a release can proceed.
   Journal changes are additive. A `surface.torn_down` recorded before this
   release replays unchanged and reads as *not assessed* — never as clean.
 
+- **Explicit Work scope is now required for a multi-repository estate
+  (estate-root proposal §7).** Submitting `sgt run` with no `--repo`,
+  `--group`, or `--all` used to silently expand to every declared
+  repository; it is now refused with a structured 422 naming the repo
+  count, the declared repositories and groups, and the three ways to
+  select — `--repo <name>` (repeatable), `--group <name>`, or `--all`. A
+  one-repository estate is unaffected: it still infers its sole repository
+  on an empty scope. Group expansion is no longer CLI-side: the daemon
+  resolves `--group`/`--repo`/`--all` against its own bound manifest, so
+  every client (CLI, TUI, or a direct API caller) reaches the identical
+  resolution. `sgt run --all` is new — an explicit, journaled selection of
+  the whole estate. A submitted Work now records both the request form
+  (`scope_request`: repos/group/all as submitted) and the resolved
+  repository list, so a later manifest edit cannot rewrite what an
+  already-journaled Work meant.
+
+### Removed
+
+- **`--workspace` is gone, from the CLI and the wire.** The daemon is bound
+  to exactly one estate; a client-supplied workspace label had no role left
+  to play. `Work.workspace` is no longer written by any new submission —
+  `scope_request` and the resolved `repositories` list are its replacement
+  — but the field itself still deserializes so a pre-existing journal (the
+  live estate journals 150+ Works carrying it) keeps replaying unchanged.
+  Analytics and the provenance graph now read the estate label off the
+  plan-time `workflow.bound` event instead of the submission, and tolerate
+  its absence for a Work that never reached a workspace at all.
+
 ### Documentation
 
 - **Corrected: the shell installer does not verify downloads.** `dist`'s

--- a/src/api.rs
+++ b/src/api.rs
@@ -43,7 +43,8 @@ use crate::domain::manifest::{self, ManifestError};
 use crate::domain::work::{
     EnvelopeRequest, IntentDetail, KIND_COMMAND_ACCEPTED, KIND_COMMAND_REJECTED, KIND_WORK_BLOCKED,
     KIND_WORK_CANCELED, KIND_WORK_COMPLETED, KIND_WORK_FAILED, KIND_WORK_NEEDS_INPUT,
-    KIND_WORK_RESUMED, KIND_WORK_STARTED, KIND_WORK_SUBMITTED, KIND_WORK_WAITING, Work, WorkState,
+    KIND_WORK_RESUMED, KIND_WORK_STARTED, KIND_WORK_SUBMITTED, KIND_WORK_WAITING, ScopeRequest,
+    Work, WorkState,
 };
 use crate::domain::workflow::{
     self, KIND_STAGE_BLOCKED, KIND_STAGE_CANCELED, KIND_STAGE_COMPLETED, KIND_STAGE_ENTERED,
@@ -775,7 +776,46 @@ fn engine_error_body(e: &EngineError) -> Value {
     if let Some(available) = e.available_backends() {
         body["error"]["available_backends"] = json!(available);
     }
+    // estate-root §7.1/§15: a missing-scope refusal carries its remedy as
+    // data too — repo count, declared repos, declared groups, and the three
+    // example invocations (--repo/--group/--all) — so a client never has to
+    // regex the message to build the "select repositories" prompt.
+    if let EngineError::MissingScope {
+        repo_count,
+        repos,
+        groups,
+    } = e
+    {
+        body["error"]["repo_count"] = json!(repo_count);
+        body["error"]["repos"] = json!(repos);
+        body["error"]["groups"] = json!(groups);
+        body["error"]["examples"] = missing_scope_examples(repos, groups);
+    }
+    // §15: an unknown group is refused naming the available ones.
+    if let EngineError::UnknownGroup { available, .. } = e {
+        body["error"]["available_groups"] = json!(available);
+    }
     body
+}
+
+/// §7.1's three example invocations for a missing-scope refusal, using real
+/// declared names when the estate has any (more useful than a placeholder),
+/// falling back to a generic `<repo>`/`<group>` when it does not.
+fn missing_scope_examples(repos: &[String], groups: &[String]) -> Value {
+    let repo_example = match repos {
+        [] => "sgt run \"<intent>\" --repo <repo>".to_string(),
+        [one] => format!("sgt run \"<intent>\" --repo {one}"),
+        many => format!("sgt run \"<intent>\" --repo {} --repo {}", many[0], many[1]),
+    };
+    let group_example = match groups.first() {
+        Some(g) => format!("sgt run \"<intent>\" --group {g}"),
+        None => "sgt run \"<intent>\" --group <group>".to_string(),
+    };
+    json!({
+        "repo": repo_example,
+        "group": group_example,
+        "all": "sgt run \"<intent>\" --all",
+    })
 }
 
 /// HTTP status for an engine failure: 4xx where the client can fix it, 500
@@ -1014,10 +1054,12 @@ fn internal_error(e: impl std::fmt::Display) -> Response {
 struct SubmitRequest {
     command_id: String,
     intent: String,
+    /// estate-root proposal §7/§13.3's structured scope request
+    /// (`--repo`/`--group`/`--all`). §7.4: `workspace` no longer exists as
+    /// a wire field at all — the daemon is bound to exactly one estate, and
+    /// this is its replacement.
     #[serde(default)]
-    workspace: Option<String>,
-    #[serde(default)]
-    repositories: Vec<String>,
+    scope: ScopeRequest,
     #[serde(default)]
     workflow: Option<String>,
     #[serde(default)]
@@ -1029,9 +1071,9 @@ struct SubmitRequest {
     #[serde(default)]
     origin: Option<Origin>,
     /// R-MVP1-6's structured-intent schema slot. Progressive elaboration of
-    /// `intent`, checked for agreement against `workflow`/`repositories`
-    /// above (§13's one-source-of-truth rule) and journaled verbatim
-    /// otherwise — nothing here drives routing.
+    /// `intent`, checked for agreement against `workflow`/`scope.repos`/
+    /// `scope.group` above (§13's one-source-of-truth rule) and journaled
+    /// verbatim otherwise — nothing here drives routing.
     #[serde(default)]
     intent_detail: Option<IntentDetail>,
     /// MVP-3's submit-time envelope override (`--turns`/`--ceiling-secs`):
@@ -1067,12 +1109,12 @@ fn envelope_out_of_range(req: &SubmitRequest) -> Option<String> {
 }
 
 /// R-MVP1-6's submit-time agreement check: a structured elaboration that
-/// names a `workflow`/`repos` different from what the submission's own
-/// flags say is two answers to "what is this Work about" in one Work, and
-/// §13 requires exactly one source of truth. Absent on either side is not a
-/// disagreement — only *both present and different* is. Repository sets are
-/// compared unordered (a client naming the same repos in a different order
-/// has not disagreed with itself).
+/// names a `workflow`/`repos`/`group` different from what the submission's
+/// own flags say is two answers to "what is this Work about" in one Work,
+/// and §13 requires exactly one source of truth. Absent on either side is
+/// not a disagreement — only *both present and different* is. Repository
+/// sets are compared unordered (a client naming the same repos in a
+/// different order has not disagreed with itself).
 fn intent_detail_disagreement(req: &SubmitRequest) -> Option<String> {
     let detail = req.intent_detail.as_ref()?;
     if let (Some(declared), Some(flag)) = (detail.workflow.as_deref(), req.workflow.as_deref())
@@ -1084,25 +1126,33 @@ fn intent_detail_disagreement(req: &SubmitRequest) -> Option<String> {
         ));
     }
     if let Some(declared) = detail.repos.as_ref()
-        && !req.repositories.is_empty()
+        && !req.scope.repos.is_empty()
     {
         let declared_set: std::collections::BTreeSet<&str> =
             declared.iter().map(String::as_str).collect();
         let flag_set: std::collections::BTreeSet<&str> =
-            req.repositories.iter().map(String::as_str).collect();
+            req.scope.repos.iter().map(String::as_str).collect();
         if declared_set != flag_set {
             return Some(format!(
-                "intent_detail.repos is {declared:?}, but the submission's repositories are \
+                "intent_detail.repos is {declared:?}, but the submission's scope.repos are \
                  {:?}; the two must agree",
-                req.repositories
+                req.scope.repos
             ));
         }
     }
-    // `detail.group` is deliberately not checked here (I3): R-MVP1-5(b)
-    // gives group membership "no new engine surface" in MVP-1 — there is no
-    // `--group` flag yet for it to disagree with, and expanding it into a
-    // repository set to compare is MVP-3's CLI-side job. Revisit this
-    // function when `--group` lands, not before.
+    // estate-root Phase C: `scope.group` is now a real wire field (§13.3),
+    // so `detail.group` gets the same one-source-of-truth check `repos`
+    // and `workflow` already get above — the comment this replaces (I3)
+    // predates `--group` existing as anything but MVP-3's CLI-side-only
+    // expansion, which is exactly what Phase C retires.
+    if let (Some(declared), Some(group)) = (detail.group.as_deref(), req.scope.group.as_deref())
+        && declared != group
+    {
+        return Some(format!(
+            "intent_detail.group is {declared:?}, but the submission's scope.group is \
+             {group:?}; the two must agree"
+        ));
+    }
     None
 }
 
@@ -1158,7 +1208,7 @@ async fn submit_work(
         let backend = req.backend.clone();
         let workflow = req.workflow.clone();
         let profile = req.profile.clone();
-        let repositories = req.repositories.clone();
+        let scope = req.scope.clone();
         let origin_cwd = origin.cwd.clone();
         let origin_client = origin.client.clone();
         Some(
@@ -1169,7 +1219,9 @@ async fn submit_work(
                     backend: backend.as_deref(),
                     workflow: workflow.as_deref(),
                     profile: profile.as_deref(),
-                    repositories: &repositories,
+                    repos: &scope.repos,
+                    group: scope.group.as_deref(),
+                    all: scope.all,
                 })
             })
             .await,
@@ -1290,13 +1342,29 @@ async fn submit_work(
         }
     };
 
+    // §7.3: journaled twice — `scope_request` is exactly what was submitted;
+    // `repositories` is what `plan` (when there was a workspace to resolve
+    // against at all) actually resolved it to. When there was no workspace
+    // (`plan` is `None` — the client offered no repository context at all),
+    // there is nothing to resolve against, so the raw request is the best
+    // honest answer for `repositories` too, same as before this field had a
+    // resolution step in front of it.
+    let scope_request = req.scope.clone();
+    let resolved_repositories = plan
+        .as_ref()
+        .map(|p| p.repositories.iter().map(|r| r.name.clone()).collect())
+        .unwrap_or_else(|| scope_request.repos.clone());
+
     let work = Work {
         id: ulid::Ulid::generate().to_string(),
-        workspace: req
-            .workspace
-            .or_else(|| plan.as_ref().map(|p| p.workspace.name.clone())),
+        // §7.4: `--workspace`/`SubmitRequest.workspace` no longer exist.
+        // `Work.workspace` is kept only so a pre-Phase-C journal event still
+        // deserializes (`Work::workspace`'s doc comment); every new Work
+        // leaves it `None`.
+        workspace: None,
         intent: req.intent,
-        repositories: req.repositories,
+        repositories: resolved_repositories,
+        scope_request,
         workflow: req.workflow,
         backend: req.backend,
         origin_client: origin.client,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,20 +93,24 @@ enum Command {
         /// Launch profile (§14).
         #[arg(long)]
         profile: Option<String>,
-        /// Targeted repository (repeatable).
+        /// Targeted repository (repeatable). §7.2: forwarded verbatim as
+        /// `scope.repos` — the daemon resolves scope against its own bound
+        /// estate; the CLI performs no expansion of its own.
         #[arg(long = "repo")]
         repositories: Vec<String>,
-        /// A declared `[group.<name>]`'s repositories, expanded client-side
-        /// into the same selection `--repo` builds (R-MVP1-5(b): group
-        /// membership gets no new engine surface — this is pure CLI-side
-        /// flag expansion over the existing `repositories` field). Combines
-        /// with any `--repo` flags given alongside it (union, declaration
-        /// order, duplicates dropped).
+        /// A declared `[group.<name>]`, forwarded verbatim as `scope.group`
+        /// (§7.2's core-owned resolution: the daemon expands group
+        /// membership against its own bound manifest, not the CLI — this
+        /// lets the TUI or a direct API caller submit the identical scope
+        /// JSON without reimplementing group semantics). May combine with
+        /// `--repo` (union, dedup, decided by the daemon).
         #[arg(long)]
         group: Option<String>,
-        /// Workspace to scope the work to.
+        /// Explicit whole-estate selection (§7.1's third scope form,
+        /// forwarded as `scope.all`) — required to target every repository
+        /// in a multi-repository estate; the daemon never infers it.
         #[arg(long)]
-        workspace: Option<String>,
+        all: bool,
         /// R-MVP1-7's turn envelope, overridden for this one Work
         /// (checkpoint-friction item — the daemon-wide `Engine::turn_cap`/
         /// `SGT_TURN_CAP` default applies otherwise). Journaled with the
@@ -616,51 +620,22 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             workflow,
             backend,
             profile,
-            mut repositories,
+            repositories,
             group,
-            workspace,
+            all,
             turns,
             ceiling_secs,
         } => {
-            // R-MVP1-5(b): group membership gets no new engine surface —
-            // `--group` is pure CLI-side expansion into the same
-            // `repositories` selection `--repo` already builds, over the
-            // estate discovered from the current directory (bounded at this
-            // daemon's own data dir, mirroring every other client-side
-            // workspace read in this binary).
-            //
-            // MVP-3 invariants finding MVP3-C2: this reads group membership
-            // through the on-disk-free structural parser
-            // (`declared_groups_scoped`), not the strict `discover_scoped`
-            // (which resolves every declared `[[repo]]` through git) — group
-            // membership is just declared names, so an unrelated missing
-            // repository must not block a group whose own members are all
-            // fine, the same coupling `domain::manifest`'s edit pens no
-            // longer have (MVP3-C1).
-            if let Some(group_name) = &group {
-                let cwd = std::env::current_dir()?;
-                let groups = crate::domain::workspace::Workspace::declared_groups_scoped(
-                    &cwd,
-                    Some(&data_dir),
-                )?;
-                let members = groups.get(group_name).ok_or_else(|| {
-                    let available: Vec<&str> = groups.keys().map(String::as_str).collect();
-                    CliError::new(format!(
-                        "no group {group_name:?} declared in this estate (declared: {}); \
-                         declare it first with `sgt group add {group_name} <repo>...`",
-                        if available.is_empty() {
-                            "none".to_string()
-                        } else {
-                            available.join(", ")
-                        }
-                    ))
-                })?;
-                for repo in &members.repos {
-                    if !repositories.contains(repo) {
-                        repositories.push(repo.clone());
-                    }
-                }
-            }
+            // estate-root proposal §7.2: scope resolution is core-owned. The
+            // CLI forwards `--repo`/`--group`/`--all` verbatim as
+            // `scope.{repos,group,all}` and does no expansion of its own —
+            // the daemon resolves them against its own bound manifest
+            // (`runtime::engine::Engine::resolve_scope`), the same function
+            // a direct API caller or the TUI submitting the identical scope
+            // JSON reaches. Before this, `--group` was pure CLI-side
+            // expansion (MVP-3 finding MVP3-C2, R-MVP1-5(b)); §7.2's own
+            // rule — "a client surface adds usability, never functionality"
+            // — is exactly what retires that.
             let client = ensure_daemon(&data_dir).await?;
             let envelope = if turns.is_some() || ceiling_secs.is_some() {
                 Some(json!({"turn_cap": turns, "ceiling_secs": ceiling_secs}))
@@ -673,8 +648,11 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                 "workflow": workflow,
                 "backend": backend,
                 "profile": profile,
-                "repositories": repositories,
-                "workspace": workspace,
+                "scope": {
+                    "repos": repositories,
+                    "group": group,
+                    "all": all,
+                },
                 "envelope": envelope,
                 "created_by": "cli",
                 "origin": origin(),

--- a/src/domain/work.rs
+++ b/src/domain/work.rs
@@ -122,6 +122,42 @@ impl EnvelopeRequest {
     }
 }
 
+/// estate-root proposal §7.3/§13.3's structured scope request: exactly what
+/// the client asked for (`--repo`/`--group`/`--all`, as submitted), kept
+/// distinct from [`Work::repositories`] below — the *resolved* list a
+/// core-owned lookup against the bound estate's `groups` produced from this
+/// request (`runtime::engine::Engine::resolve_scope`). §7.3's whole point is
+/// that both survive: a later manifest edit (a group's membership changes, a
+/// repository is renamed) cannot retroactively rewrite what an already
+/// journaled Work was scoped to, because the resolved list is pinned here
+/// too, permanently, beside the request that produced it.
+///
+/// `#[serde(default)]` on [`Work::scope_request`] is what lets every Work
+/// journaled before this field existed replay: it has no `scope_request` key
+/// at all, and defaults to this type's all-empty [`Default`] — the honest
+/// reading for a Work that predates the concept of a structured scope
+/// request.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScopeRequest {
+    /// Explicit `--repo`/`scope.repos` names, as submitted (repeatable,
+    /// declaration order, not yet deduplicated against `group`'s members —
+    /// that union happens during resolution, not here).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repos: Vec<String>,
+    /// `--group`/`scope.group`, as submitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    /// `--all`/`scope.all`: an explicit whole-estate selection (§7.1's third
+    /// scope form). Journaled as the request form even though it resolves to
+    /// the same repository list a future `--repo` naming every repository
+    /// would — §7.3's "a later manifest edit cannot rewrite the meaning of
+    /// an existing Work" needs to know the client asked for *everything*,
+    /// not for the specific repositories the estate happened to declare that
+    /// day.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub all: bool,
+}
+
 /// Event kind: a work item was accepted and entered `pending`.
 pub const KIND_WORK_SUBMITTED: &str = "work.submitted";
 /// Event kind: a work item was canceled.
@@ -255,21 +291,42 @@ impl std::fmt::Display for WorkState {
     }
 }
 
-/// A Work record per §10: id, workspace, intent, targeted repositories,
-/// workflow, state, created_by, created_at. `workflow` and `backend` are
-/// recorded for M3/M4 but not executed in M2.
+/// A Work record per §10: id, intent, targeted repositories (`scope_request`
+/// and its resolution, §7.3), workflow, state, created_by, created_at.
+/// `workflow` and `backend` are recorded for M3/M4 but not executed in M2.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Work {
     /// ULID identifying this work item.
     pub id: String,
-    /// Workspace this work belongs to, when the client scoped it.
+    /// **Deprecated, never written (estate-root Phase C, §7.4).** Before
+    /// Phase C this carried a free-form client-supplied workspace label (or,
+    /// later, the discovered estate's name as a submit-time fallback). The
+    /// daemon is bound to exactly one estate now, so the field has no role
+    /// left to play in submission or Work identity — every Work journaled
+    /// from Phase C onward leaves this `None`. It stays in the struct, still
+    /// `#[serde(default)]`, purely so a pre-Phase-C `work.submitted` event
+    /// (the live dogfood estate journals 150+ of them) still deserializes;
+    /// nothing new should ever read or write it. [`Work::scope_request`] and
+    /// [`Work::repositories`] are its replacement (§7.3).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace: Option<String>,
     /// The human intent this work exists to satisfy.
     pub intent: String,
-    /// Targeted repositories (recorded; nothing acts on them until M3).
+    /// The *resolved* repositories this Work targets — `scope_request`
+    /// (below), as core-owned resolution against the bound estate's
+    /// `groups`/declared repositories actually expanded it. `Engine::
+    /// resolve_scope` computes this once, at submit; a later manifest edit
+    /// (a group's membership changes) cannot retroactively change what an
+    /// already-journaled Work meant (§7.3).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repositories: Vec<String>,
+    /// estate-root proposal §7.3/§13.3's request form: exactly what the
+    /// client asked for (`--repo`/`--group`/`--all`), before resolution.
+    /// `#[serde(default)]`: absent on every Work journaled before this field
+    /// existed, which replays as [`ScopeRequest::default`] — the honest
+    /// reading for a Work that predates the concept.
+    #[serde(default)]
+    pub scope_request: ScopeRequest,
     /// Requested workflow (recorded for M3; not executed in M2).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow: Option<String>,

--- a/src/domain/workspace.rs
+++ b/src/domain/workspace.rs
@@ -1115,14 +1115,31 @@ impl Workspace {
     }
 
     /// Restrict the workspace to the named repositories (the submit request's
-    /// `repositories` selection). An unknown name is an error rather than a
-    /// silently empty surface, and a name repeated in the selection is an
-    /// error too — two identical bindings would send `materialize` at the
-    /// same worktree path and branch twice, the second `git worktree add`
-    /// failing after the first has already touched the user's repository.
+    /// resolved scope — see `runtime::engine::Engine::resolve_scope`, the
+    /// caller that turns `--repo`/`--group`/`--all` into this exact name
+    /// list). An unknown name is an error rather than a silently empty
+    /// surface, and a name repeated in the selection is an error too — two
+    /// identical bindings would send `materialize` at the same worktree path
+    /// and branch twice, the second `git worktree add` failing after the
+    /// first has already touched the user's repository.
+    ///
+    /// **An empty `names` is refused, not "every repository" (estate-root
+    /// Phase C, §7.1).** Before Phase C this returned every declared
+    /// repository — the "zero-config" reading of no selection. §7.1 replaces
+    /// that with an explicit refusal: a one-repository estate's sole-repo
+    /// inference and a multi-repository estate's structured remedy both
+    /// belong to the *resolution* layer above this one
+    /// (`Engine::resolve_scope`), which decides what an empty scope request
+    /// means before ever reaching here — this domain-level call now only
+    /// ever sees a nonempty, already-decided name list.
     pub fn select(&self, names: &[String]) -> Result<Vec<RepositorySpec>, String> {
         if names.is_empty() {
-            return Ok(self.repositories.clone());
+            return Err(format!(
+                "no repositories selected for workspace {:?}; an empty selection is refused, \
+                 not expanded to every declared repository (estate-root Phase C, §7.1) — \
+                 select explicitly with --repo, --group, or --all",
+                self.name
+            ));
         }
         let mut seen = BTreeSet::new();
         let mut selected = Vec::with_capacity(names.len());
@@ -1392,14 +1409,14 @@ mod tests {
         assert!(err.contains("api, web"), "got {err}");
     }
 
-    /// `select` with an empty name list returns every declared repository —
-    /// the caller-convenience reading of "no selection". Phase C replaces
-    /// this with structured scope requests (`--repo`/`--group`/`--all`) and
-    /// an explicit empty-scope refusal with the §7.1 remedy text (C7b); an
-    /// empty list will then no longer mean "all".
-    // CONTRACT PIN (estate-root Phase C): empty selection refuses instead of meaning "all".
+    /// `select` with an empty name list is refused, not "every declared
+    /// repository" — the Phase 0 pin's flip (estate-root Phase C, §7.1).
+    /// Single-repo inference and the multi-repo structured remedy are
+    /// `Engine::resolve_scope`'s job, decided before this is ever called
+    /// with an empty list; this domain-layer regression test only pins that
+    /// `select` itself no longer papers over an undecided scope.
     #[test]
-    fn contract_pin_empty_selection_currently_means_every_repository() {
+    fn empty_selection_is_refused_at_the_domain_layer() {
         let workspace = Workspace {
             name: "payments".to_string(),
             root: PathBuf::from("/nowhere"),
@@ -1424,13 +1441,12 @@ mod tests {
             repository_origin: BTreeMap::new(),
         };
 
-        let selected = workspace
+        let err = workspace
             .select(&[])
-            .expect("an empty selection succeeds today");
-        assert_eq!(
-            selected.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
-            ["api", "web"],
-            "today, an empty selection silently expands to every declared repository"
+            .expect_err("an empty selection must now be refused, not expanded to \"all\"");
+        assert!(
+            err.contains("payments") && err.contains("--all"),
+            "the refusal should name the workspace and the remedy vocabulary, got: {err}"
         );
     }
 

--- a/src/runtime/analytics.rs
+++ b/src/runtime/analytics.rs
@@ -457,6 +457,12 @@ impl Appended {
 struct WorkRow {
     work_id: String,
     intent: Option<String>,
+    /// estate-root Phase C, §7.4: seeded from `work.submitted`'s
+    /// (pre-Phase-C-only, now always absent for a new Work) `workspace`
+    /// field, then overwritten by `workflow.bound`'s plan-time estate name
+    /// once that fires — see the two folds below. `None` for a `pending`
+    /// Work that never reached `workflow.bound` is an honest "not yet
+    /// resolved to an estate", not a lost fact.
     workspace: Option<String>,
     workflow: Option<String>,
     backend: Option<String>,

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -75,8 +75,20 @@ pub struct SubmitContext<'a> {
     pub workflow: Option<&'a str>,
     /// Requested profile name (§14).
     pub profile: Option<&'a str>,
-    /// Requested repository subset; empty means the whole workspace.
-    pub repositories: &'a [String],
+    /// §7.1/§13.3's structured scope request, the CLI/API's `scope.repos` —
+    /// explicit repository names, as submitted. Combined with `group`
+    /// (union, dedup) by [`Engine::resolve_scope`]; never expanded by any
+    /// client, per §7.2's "a client surface adds usability, never
+    /// functionality".
+    pub repos: &'a [String],
+    /// `scope.group` — a declared `[group.<name>]` to expand, resolved
+    /// against *this* daemon's own bound manifest (§7.2), not by the caller.
+    pub group: Option<&'a str>,
+    /// `scope.all` — an explicit whole-estate selection (§7.1's third scope
+    /// form). Wins over `repos`/`group` when set: [`Engine::resolve_scope`]
+    /// resolves to every declared repository and does not also require
+    /// `repos`/`group` to be empty.
+    pub all: bool,
 }
 
 /// A resolved, side-effect-free plan for starting a run.
@@ -730,6 +742,34 @@ pub enum EngineError {
     /// The requested repository subset does not match the workspace.
     #[error("{0}")]
     RepositorySelection(String),
+    /// estate-root proposal §7.1: a multi-repository estate was submitted to
+    /// with no scope selected at all — Sergeant refuses rather than
+    /// silently expanding to every repository. `repo_count`/`repos`/`groups`
+    /// are exactly what the API's structured 422 body names as the remedy
+    /// (§15: "list declared repos/groups and show `--repo`, `--group`,
+    /// `--all`").
+    #[error(
+        "this estate contains {repo_count} repositories, but no Work scope was selected; \
+         select repositories with --repo, a declared group with --group, or the whole estate \
+         explicitly with --all (declared repos: {repos:?}; declared groups: {groups:?})"
+    )]
+    MissingScope {
+        /// How many repositories the estate declares.
+        repo_count: usize,
+        /// Every declared repository's name.
+        repos: Vec<String>,
+        /// Every declared group's name.
+        groups: Vec<String>,
+    },
+    /// §15: `scope.group`/`--group` named a group this estate has not
+    /// declared.
+    #[error("no group named {requested:?} in this estate (declared: {available:?})")]
+    UnknownGroup {
+        /// The group name that was requested.
+        requested: String,
+        /// Every group name the estate does declare.
+        available: Vec<String>,
+    },
     /// R-MVP1-4: the selected repositories disagree on `instructions`
     /// policy. One process, one `--setting-sources` — there is nowhere for
     /// two policies to both take effect, so the submission is refused
@@ -879,6 +919,8 @@ impl EngineError {
             EngineError::Backend(_) => "backend_error",
             EngineError::Core(_) => "internal",
             EngineError::RepositorySelection(_) => "unknown_repository",
+            EngineError::MissingScope { .. } => "missing_scope",
+            EngineError::UnknownGroup { .. } => "unknown_group",
             EngineError::InstructionPolicyConflict { .. } => "instruction_policy_conflict",
             EngineError::ProfileNotFound { .. } => "profile_not_found",
             EngineError::ProfileBackendMismatch { .. } => "profile_backend_mismatch",
@@ -1110,9 +1152,7 @@ impl Engine {
             self.check_selection_is_honourable(context)?;
             return Ok(None);
         };
-        let repositories = workspace
-            .select(context.repositories)
-            .map_err(EngineError::RepositorySelection)?;
+        let repositories = Self::resolve_scope(&workspace, context)?;
 
         // R-MVP1-4: one process, one policy. Resolved and refused here, at
         // submit, before a Work record or a worktree exists — the same
@@ -1175,6 +1215,92 @@ impl Engine {
             profile,
             stage_bindings,
         }))
+    }
+
+    /// estate-root proposal §7.2/§7.1: turn a submission's `{repos, group,
+    /// all}` scope request into the exact repository list to materialize,
+    /// resolved against *this daemon's own* already-discovered `workspace`
+    /// — never by a client. §7.2's whole point is that the CLI, the TUI, or
+    /// a direct API caller submitting the identical scope JSON all reach
+    /// this one function and get the identical answer; no client surface
+    /// reimplements group-membership or empty-scope semantics.
+    ///
+    /// Order of decisions, per §7.1:
+    ///
+    /// 1. `all` wins outright: every declared repository, regardless of
+    ///    whatever `repos`/`group` also said (§7.3 still journals the
+    ///    request form separately, so *why* it resolved to everything is
+    ///    never lost even though the resolved list alone couldn't say).
+    /// 2. Otherwise, the union of `repos` and — when `group` names a
+    ///    declared group — that group's members, `repos`-order first, new
+    ///    group members appended, duplicates dropped. An undeclared `group`
+    ///    is refused by name, listing the estate's declared groups (§15).
+    /// 3. An empty union is not "select everything" (§7.1 replaces that
+    ///    reading): a one-repository estate infers its sole repository; a
+    ///    multi-repository estate is refused with the full §7.1 remedy body
+    ///    (repo count, declared repos, declared groups).
+    /// 4. A nonempty selection still goes through [`Workspace::select`] for
+    ///    its own checks (unknown name, duplicate name) — this function only
+    ///    decides *what* the name list is, not whether every name in it is
+    ///    valid.
+    ///
+    /// Historical note (MVP3-C2): before this, `run --group`'s expansion was
+    /// pure CLI-side convenience that read group membership through an
+    /// on-disk-free structural parser (`Workspace::declared_groups_scoped`)
+    /// specifically so an unrelated broken repository elsewhere in the
+    /// estate could not block a group whose own members were all fine. That
+    /// carve-out does not survive moving resolution here: `workspace` above
+    /// is already the strictly-discovered estate (`Workspace::
+    /// discover_scoped`, the same call `plan` makes for routing and
+    /// instruction-policy regardless of scope), so a `--group` submission
+    /// now fails on an unrelated broken repository exactly the way a plain
+    /// `--repo` submission always has — discovery, not group lookup, is
+    /// what requires the whole estate to resolve. `declared_groups_scoped`
+    /// remains in use for the CLI's own local, non-submitting `sgt group
+    /// list` family, untouched by this change.
+    fn resolve_scope(
+        workspace: &Workspace,
+        context: &SubmitContext<'_>,
+    ) -> Result<Vec<RepositorySpec>, EngineError> {
+        if context.all {
+            return Ok(workspace.repositories.clone());
+        }
+
+        let mut names: Vec<String> = context.repos.to_vec();
+        if let Some(group_name) = context.group {
+            let group =
+                workspace
+                    .groups
+                    .get(group_name)
+                    .ok_or_else(|| EngineError::UnknownGroup {
+                        requested: group_name.to_string(),
+                        available: workspace.groups.keys().cloned().collect(),
+                    })?;
+            for repo in &group.repos {
+                if !names.contains(repo) {
+                    names.push(repo.clone());
+                }
+            }
+        }
+
+        if names.is_empty() {
+            if workspace.repositories.len() == 1 {
+                return Ok(workspace.repositories.clone());
+            }
+            return Err(EngineError::MissingScope {
+                repo_count: workspace.repositories.len(),
+                repos: workspace
+                    .repositories
+                    .iter()
+                    .map(|r| r.name.clone())
+                    .collect(),
+                groups: workspace.groups.keys().cloned().collect(),
+            });
+        }
+
+        workspace
+            .select(&names)
+            .map_err(EngineError::RepositorySelection)
     }
 
     /// R-MVP1-4's submit-time policy check: every selected repository must
@@ -4173,6 +4299,173 @@ mod tests {
         );
     }
 
+    // ------------------------- estate-root Phase C: Engine::resolve_scope
+
+    /// A workspace fixture for exercising [`Engine::resolve_scope`] directly
+    /// — resolution never touches the filesystem, so `/nowhere` placeholders
+    /// are fine (mirrors `domain::workspace::tests`' own fixture pattern).
+    fn scope_fixture(repos: &[&str], groups: &[(&str, &[&str])]) -> Workspace {
+        Workspace {
+            name: "payments".to_string(),
+            root: PathBuf::from("/nowhere"),
+            repositories: repos
+                .iter()
+                .map(|name| RepositorySpec {
+                    name: name.to_string(),
+                    path: PathBuf::from(format!("/nowhere/{name}")),
+                })
+                .collect(),
+            default_backend: None,
+            default_workflow: None,
+            profiles: Vec::new(),
+            config_path: None,
+            surfaces_dir: None,
+            data_dir: None,
+            repository_policy: BTreeMap::new(),
+            groups: groups
+                .iter()
+                .map(|(name, members)| {
+                    (
+                        name.to_string(),
+                        crate::domain::workspace::GroupSpec {
+                            repos: members.iter().map(|m| m.to_string()).collect(),
+                            brief: None,
+                        },
+                    )
+                })
+                .collect(),
+            repository_origin: BTreeMap::new(),
+        }
+    }
+
+    /// §7.1: `--all` wins outright, regardless of whatever `repos`/`group`
+    /// also said.
+    #[test]
+    fn resolve_scope_all_selects_every_declared_repository_regardless_of_repos_or_group() {
+        let workspace = scope_fixture(&["api", "web"], &[("pair", &["api", "web"])]);
+        let resolved = Engine::resolve_scope(
+            &workspace,
+            &SubmitContext {
+                repos: &["api".to_string()],
+                group: Some("pair"),
+                all: true,
+                ..SubmitContext::default()
+            },
+        )
+        .expect("all must resolve");
+        let mut names: Vec<&str> = resolved.iter().map(|r| r.name.as_str()).collect();
+        names.sort();
+        assert_eq!(names, ["api", "web"]);
+    }
+
+    /// §7.1: a one-repository estate infers its sole repository on an empty
+    /// scope request.
+    #[test]
+    fn resolve_scope_infers_the_sole_repository_of_a_one_repository_estate_on_empty_scope() {
+        let workspace = scope_fixture(&["solo"], &[]);
+        let resolved = Engine::resolve_scope(&workspace, &SubmitContext::default())
+            .expect("a one-repository estate infers its sole repository");
+        assert_eq!(
+            resolved.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
+            ["solo"]
+        );
+    }
+
+    /// §7.1: a multi-repository estate refuses an empty scope, and the
+    /// refusal carries the full remedy body — repo count, declared repos,
+    /// declared groups.
+    #[test]
+    fn resolve_scope_refuses_an_empty_scope_on_a_multi_repository_estate() {
+        let workspace = scope_fixture(&["api", "web"], &[("pair", &["api", "web"])]);
+        let err = Engine::resolve_scope(&workspace, &SubmitContext::default())
+            .expect_err("a multi-repository estate must refuse an empty scope");
+        match err {
+            EngineError::MissingScope {
+                repo_count,
+                repos,
+                groups,
+            } => {
+                assert_eq!(repo_count, 2);
+                assert_eq!(repos, vec!["api".to_string(), "web".to_string()]);
+                assert_eq!(groups, vec!["pair".to_string()]);
+            }
+            other => panic!("expected MissingScope, got {other}"),
+        }
+    }
+
+    /// §7.1: `--group` may combine with explicit `--repo` additions — union,
+    /// dedup, `repos` first in declaration order, new group members
+    /// appended.
+    #[test]
+    fn resolve_scope_unions_group_members_with_explicit_repos_and_dedups() {
+        let workspace = scope_fixture(&["api", "web", "docs"], &[("pair", &["api", "web"])]);
+        let resolved = Engine::resolve_scope(
+            &workspace,
+            &SubmitContext {
+                repos: &["web".to_string(), "docs".to_string()],
+                group: Some("pair"),
+                ..SubmitContext::default()
+            },
+        )
+        .expect("union must resolve");
+        assert_eq!(
+            resolved.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
+            ["web", "docs", "api"],
+            "explicit --repo first (declaration order), then new group members appended, with \
+             no duplicate for the repo already named by both"
+        );
+    }
+
+    /// §15: an undeclared `--group` is refused by name, listing the estate's
+    /// declared groups.
+    #[test]
+    fn resolve_scope_refuses_an_undeclared_group_naming_the_declared_ones() {
+        let workspace = scope_fixture(&["api", "web"], &[("pair", &["api", "web"])]);
+        let err = Engine::resolve_scope(
+            &workspace,
+            &SubmitContext {
+                group: Some("ghost"),
+                ..SubmitContext::default()
+            },
+        )
+        .expect_err("an undeclared group must refuse");
+        match err {
+            EngineError::UnknownGroup {
+                requested,
+                available,
+            } => {
+                assert_eq!(requested, "ghost");
+                assert_eq!(available, vec!["pair".to_string()]);
+            }
+            other => panic!("expected UnknownGroup, got {other}"),
+        }
+    }
+
+    /// §15: an unknown `--repo` name is refused by [`Workspace::select`],
+    /// naming the estate's declared repositories.
+    #[test]
+    fn resolve_scope_refuses_an_unknown_repository_naming_the_declared_ones() {
+        let workspace = scope_fixture(&["api", "web"], &[]);
+        let err = Engine::resolve_scope(
+            &workspace,
+            &SubmitContext {
+                repos: &["ghost".to_string()],
+                ..SubmitContext::default()
+            },
+        )
+        .expect_err("an unknown repository must refuse");
+        match err {
+            EngineError::RepositorySelection(message) => {
+                assert!(message.contains("ghost"), "got: {message}");
+                assert!(
+                    message.contains("api") && message.contains("web"),
+                    "got: {message}"
+                );
+            }
+            other => panic!("expected RepositorySelection, got {other}"),
+        }
+    }
+
     /// Every `EngineError`'s wire code, in one table.
     ///
     /// `code()` is the vocabulary `/v1` answers with and the thing a client
@@ -4307,6 +4600,21 @@ mod tests {
                     index: 9,
                 },
                 "no_such_stage",
+            ),
+            (
+                EngineError::MissingScope {
+                    repo_count: 2,
+                    repos: vec!["api".to_string(), "web".to_string()],
+                    groups: vec![],
+                },
+                "missing_scope",
+            ),
+            (
+                EngineError::UnknownGroup {
+                    requested: "ghost".to_string(),
+                    available: vec!["payments".to_string()],
+                },
+                "unknown_group",
             ),
         ];
         let mut seen = std::collections::BTreeSet::new();
@@ -4988,6 +5296,7 @@ mod tests {
                 workspace: None,
                 intent: "review this".to_string(),
                 repositories: Vec::new(),
+                scope_request: Default::default(),
                 workflow: None,
                 backend: None,
                 origin_client: None,

--- a/src/runtime/graph.rs
+++ b/src/runtime/graph.rs
@@ -157,6 +157,13 @@ impl GraphContext {
                     delta.node(&node, "client", client, None, seq);
                     delta.edge("submitted", &node, &work_node_id, Some(work_id), seq);
                 }
+                // estate-root Phase C, §7.4: `work["workspace"]` is a
+                // pre-Phase-C submission field, never written by a new
+                // `work.submitted` — so this branch only ever fires for a
+                // legacy journal replay now. The `workflow.bound` branch
+                // below is the label's live source for every Work
+                // journaled from Phase C onward (plan-time estate name,
+                // not a client-supplied one).
                 if let Some(workspace) = work["workspace"].as_str() {
                     let node = format!("workspace:{workspace}");
                     delta.node(&node, "workspace", workspace, None, seq);
@@ -179,6 +186,19 @@ impl GraphContext {
                     let node = format!("profile:{profile}");
                     delta.node(&node, "profile", profile, None, seq);
                     delta.edge("uses_profile", &work_node_id, &node, Some(work_id), seq);
+                }
+                // estate-root Phase C, §7.4: the discovered estate name at
+                // plan time (`StartPlan.workspace.name`, journaled here
+                // since before Phase C existed) is the label's live source
+                // now that `Work.workspace` is never written for a new
+                // submission — analytics.rs's `WorkRow` already prefers
+                // this same field over the submission-time one; this is
+                // that same "tolerate absence, prefer plan-time name"
+                // reading for the graph's `workspace` node/edge.
+                if let Some(workspace) = event.payload["workspace"].as_str() {
+                    let node = format!("workspace:{workspace}");
+                    delta.node(&node, "workspace", workspace, None, seq);
+                    delta.edge("scoped_to", &work_node_id, &node, Some(work_id), seq);
                 }
             }
             KIND_SURFACE_MATERIALIZED => {

--- a/src/runtime/projection.rs
+++ b/src/runtime/projection.rs
@@ -1438,3 +1438,109 @@ mod rule_a_eviction_tests {
         assert_eq!(rebuilt.state().works[work_id].state, WorkState::Completed);
     }
 }
+
+#[cfg(test)]
+mod estate_root_phase_c_scope_replay_tests {
+    //! estate-root proposal §7.4: `Work` gained `scope_request` and stopped
+    //! writing `workspace` in Phase C. Neither change may take back a
+    //! journal a pre-Phase-C daemon already wrote — the live dogfood estate
+    //! alone carries 150+ `work.submitted` events with a literal `workspace`
+    //! key and no `scope_request` key at all. This is that replay contract,
+    //! pinned through the real fold (`work_registry_reducer`, not just
+    //! `serde_json::from_value` in isolation) so a future change to either
+    //! field's `#[serde(default)]` discipline fails here first.
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::domain::work::ScopeRequest;
+    use crate::runtime::testing;
+
+    /// A `work.submitted` payload in exactly the pre-Phase-C shape: a
+    /// `workspace` string, a `repositories` list, and no `scope_request`
+    /// key — must still fold into a valid, complete `Work`.
+    #[test]
+    fn a_pre_phase_c_work_submitted_event_replays_with_scope_request_defaulted() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+        let work_id = "01LEGACYWORK0000000";
+
+        testing::commit(
+            &mut core,
+            work_id,
+            KIND_WORK_SUBMITTED,
+            json!({"work": {
+                "id": work_id,
+                "workspace": "payments",
+                "intent": "legacy submission from before Phase C",
+                "repositories": ["api", "web"],
+                "workflow": "software-change",
+                "backend": "claude",
+                "state": "pending",
+                "created_by": "cli",
+                "created_at": "2026-01-01T00:00:00Z",
+            }}),
+        );
+
+        let work = core
+            .registry
+            .state()
+            .works
+            .get(work_id)
+            .expect("a pre-Phase-C work.submitted event must still replay into a Work");
+        assert_eq!(
+            work.workspace.as_deref(),
+            Some("payments"),
+            "the legacy workspace key must still deserialize, even though nothing writes it \
+             anymore"
+        );
+        assert_eq!(work.repositories, vec!["api", "web"]);
+        assert_eq!(
+            work.scope_request,
+            ScopeRequest::default(),
+            "an event with no scope_request key must default, not fail to replay"
+        );
+    }
+
+    /// A `work.submitted` payload in the current (Phase C) shape — a real
+    /// `scope_request` and no `workspace` key at all — replays identically,
+    /// and the two shapes stay distinguishable (a legacy Work still reports
+    /// its `workspace` label; a new one reports `None`, per §7.4).
+    #[test]
+    fn a_current_shape_work_submitted_event_replays_with_no_workspace_label() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+        let work_id = "01CURRENTWORK000000";
+
+        testing::commit(
+            &mut core,
+            work_id,
+            KIND_WORK_SUBMITTED,
+            json!({"work": {
+                "id": work_id,
+                "intent": "current-shape submission",
+                "repositories": ["api", "web"],
+                "scope_request": {"repos": ["api", "web"], "group": null, "all": false},
+                "state": "pending",
+                "created_by": "cli",
+                "created_at": "2026-01-01T00:00:00Z",
+            }}),
+        );
+
+        let work = core
+            .registry
+            .state()
+            .works
+            .get(work_id)
+            .expect("a current-shape work.submitted event must replay");
+        assert_eq!(work.workspace, None, "§7.4: never written for a new Work");
+        assert_eq!(
+            work.scope_request,
+            ScopeRequest {
+                repos: vec!["api".to_string(), "web".to_string()],
+                group: None,
+                all: false,
+            }
+        );
+    }
+}

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -29,7 +29,7 @@ enum Field {
     Workflow,
     Backend,
     Profile,
-    Workspace,
+    Group,
     Repositories,
     TurnCap,
     CeilingSecs,
@@ -41,7 +41,7 @@ const FIELDS: [Field; 9] = [
     Field::Workflow,
     Field::Backend,
     Field::Profile,
-    Field::Workspace,
+    Field::Group,
     Field::Repositories,
     Field::TurnCap,
     Field::CeilingSecs,
@@ -55,7 +55,7 @@ impl Field {
             Field::Workflow => "workflow",
             Field::Backend => "backend",
             Field::Profile => "profile",
-            Field::Workspace => "workspace",
+            Field::Group => "group",
             Field::Repositories => "repositories",
             Field::TurnCap => "turns",
             Field::CeilingSecs => "ceiling",
@@ -97,16 +97,21 @@ pub struct NewWorkForm {
     pub workflow: String,
     pub backend: String,
     pub profile: String,
-    pub workspace: String,
-    /// Free text, split on whitespace/commas at submission — §9.1 names a
-    /// group-expansion path shared with `sgt run --group`, but that path
-    /// reads the estate manifest from local disk
-    /// (`Workspace::declared_groups_scoped`), which no TUI module may do:
-    /// the TUI reaches the crate only through `crate::api` (§30, `t5`/`t5b`),
-    /// and the daemon does not expose declared repositories/groups over the
-    /// API yet — that is T3's job (§20.4, the `/v1/estate/*` routes). Until
-    /// then this field takes explicit repository names, exactly what
-    /// `sgt run --repo` already accepts without `--group`.
+    /// One declared group name, forwarded verbatim as `scope.group` —
+    /// exactly what `sgt run --group` sends. estate-root proposal §7.2 moved
+    /// expansion into the daemon, so naming a group here costs the TUI no
+    /// local manifest read (`Workspace::declared_groups_scoped`), which no
+    /// module under this tree may do anyway: the TUI reaches the crate only
+    /// through `crate::api` (§30, `t5`/`t5b`). The daemon still does not
+    /// expose the declared repositories/groups over the API — that is T3's
+    /// job (§20.4, the `/v1/estate/*` routes) — so the name is typed rather
+    /// than chosen from a catalog, and an unknown one comes back as §15's
+    /// 422 naming the available groups.
+    pub group: String,
+    /// Free text, split on whitespace/commas at submission, forwarded as
+    /// `scope.repos` — exactly what `sgt run --repo` sends. Combines with
+    /// [`NewWorkForm::group`] above (§7.2's union, deduplicated during
+    /// resolution).
     pub repositories: String,
     pub turn_cap: String,
     pub ceiling_secs: String,
@@ -203,7 +208,7 @@ impl NewWorkForm {
             Field::Workflow => Some(&mut self.workflow),
             Field::Backend => Some(&mut self.backend),
             Field::Profile => Some(&mut self.profile),
-            Field::Workspace => Some(&mut self.workspace),
+            Field::Group => Some(&mut self.group),
             Field::Repositories => Some(&mut self.repositories),
             Field::TurnCap => Some(&mut self.turn_cap),
             Field::CeilingSecs => Some(&mut self.ceiling_secs),
@@ -227,7 +232,15 @@ impl NewWorkForm {
     }
 
     /// §9.1's field mapping onto current submission semantics — the same
-    /// body shape `sgt run` already sends to `POST /v1/work`.
+    /// body shape `sgt run` already sends to `POST /v1/work`, including
+    /// estate-root proposal §13.3's structured `scope`: the form forwards
+    /// what the operator named and expands nothing, so a group typed here
+    /// resolves through the daemon's `Engine::resolve_scope` — the very
+    /// function `sgt run --group` reaches (§7.2's "a client surface adds
+    /// usability, never functionality"). There is no `--all` control:
+    /// leaving both scope fields empty on a multi-repository estate is
+    /// refused with §7.1's remedy, which lands in `last_error` beside the
+    /// form.
     fn body(&self) -> Value {
         let repositories: Vec<String> = self
             .repositories
@@ -251,8 +264,11 @@ impl NewWorkForm {
             "workflow": non_empty(&self.workflow),
             "backend": non_empty(&self.backend),
             "profile": non_empty(&self.profile),
-            "repositories": repositories,
-            "workspace": non_empty(&self.workspace),
+            "scope": {
+                "repos": repositories,
+                "group": non_empty(&self.group),
+                "all": false,
+            },
             "envelope": envelope,
             "created_by": "tui",
             "origin": {"client": "tui", "cwd": std::env::current_dir().ok()},
@@ -279,7 +295,7 @@ impl Default for NewWorkForm {
             workflow: String::new(),
             backend: String::new(),
             profile: String::new(),
-            workspace: String::new(),
+            group: String::new(),
             repositories: String::new(),
             turn_cap: String::new(),
             ceiling_secs: String::new(),
@@ -382,7 +398,7 @@ fn field_line<'a>(form: &'a NewWorkForm, field: Field, focused: bool) -> Line<'a
         Field::Workflow => form.workflow.as_str(),
         Field::Backend => form.backend.as_str(),
         Field::Profile => form.profile.as_str(),
-        Field::Workspace => form.workspace.as_str(),
+        Field::Group => form.group.as_str(),
         Field::Repositories => form.repositories.as_str(),
         Field::TurnCap => form.turn_cap.as_str(),
         Field::CeilingSecs => form.ceiling_secs.as_str(),
@@ -571,11 +587,34 @@ mod tests {
         };
         assert_eq!(body["intent"], "fix the thing");
         assert_eq!(body["workflow"], "implement");
-        assert_eq!(body["repositories"], json!(["svc-a", "svc-b"]));
+        assert_eq!(body["scope"]["repos"], json!(["svc-a", "svc-b"]));
         assert_eq!(body["envelope"]["turn_cap"], 12);
         assert_eq!(body["created_by"], "tui");
         assert_eq!(body["origin"]["client"], "tui");
         assert!(form.last_error.is_none());
+    }
+
+    /// estate-root proposal §13.3/§7.2: scope travels in exactly one place,
+    /// the structured `scope` block the daemon resolves — never as the
+    /// pre-§7 top-level `repositories`/`workspace` keys, which no longer
+    /// exist on the wire and would be silently ignored on deserialize,
+    /// dropping the operator's selection without a word.
+    #[test]
+    fn scope_is_the_only_place_the_form_expresses_a_selection() {
+        let mut form = NewWorkForm {
+            group: "core".to_string(),
+            repositories: "svc-a".to_string(),
+            ..NewWorkForm::default()
+        };
+        form.intent.set_text("scope me");
+        let body = form.body();
+        assert_eq!(body["scope"]["repos"], json!(["svc-a"]));
+        assert_eq!(body["scope"]["group"], "core");
+        assert_eq!(body["scope"]["all"], false);
+        assert!(
+            body.get("repositories").is_none() && body.get("workspace").is_none(),
+            "the pre-§7 wire keys are gone, not sent alongside: {body}"
+        );
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -18,12 +18,16 @@
 //!
 //! > If the TUI needs a private shortcut, the API is incomplete.
 //!
-//! — and it is why `Home`'s New Work form takes explicit repository names
-//! rather than expanding a declared group the way `sgt run --group` does:
-//! that expansion reads the estate manifest from local disk
+//! — and it is why `Home`'s New Work form forwards its scope fields
+//! verbatim (`scope.repos`/`scope.group`) and expands nothing: group
+//! membership is resolved by the daemon against its own bound manifest
+//! (estate-root proposal §7.2), so the form reaches the identical
+//! resolution `sgt run --repo`/`--group` does without ever reading the
+//! estate from local disk
 //! (`crate::domain::workspace::Workspace::declared_groups_scoped`), which no
-//! module here may reach for, and the daemon does not expose declared
-//! groups over the API yet (T3's job, §20.4).
+//! module here may reach for. What is still missing is the *catalog*: the
+//! daemon does not expose declared repositories and groups over the API yet
+//! (T3's job, §20.4), so both fields are typed rather than chosen.
 //!
 //! Liveness is the same SSE tail every other client uses, resumed from the
 //! `journal_head` the first fetch reported, so attaching does not replay

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -3679,7 +3679,7 @@ async fn r_mvp1_6_all_five_intent_detail_fields_journal_and_display() {
             "command_id": ulid(),
             "intent": "free text stays primary",
             "workflow": "software-change",
-            "repositories": ["api", "web"],
+            "scope": {"repos": ["api", "web"]},
             "intent_detail": {
                 "objective": "ship the thing",
                 "repos": ["api", "web"],
@@ -3799,7 +3799,7 @@ async fn r_mvp1_6_a_disagreeing_repos_refuses_naming_both_sources() {
         .json(&json!({
             "command_id": ulid(),
             "intent": "two answers to one question",
-            "repositories": ["api"],
+            "scope": {"repos": ["api"]},
             "intent_detail": {"repos": ["web"]},
         }))
         .send()
@@ -3815,7 +3815,7 @@ async fn r_mvp1_6_a_disagreeing_repos_refuses_naming_both_sources() {
         .json(&json!({
             "command_id": ulid(),
             "intent": "same repos, different order",
-            "repositories": ["api", "web"],
+            "scope": {"repos": ["api", "web"]},
             "intent_detail": {"repos": ["web", "api"]},
         }))
         .send()
@@ -3860,7 +3860,7 @@ async fn r_mvp1_6_repos_named_only_in_intent_detail_is_inert_not_a_disagreement(
     assert_eq!(
         resp.status(),
         201,
-        "no `repositories` flag means nothing for intent_detail.repos to \
+        "no `scope.repos` means nothing for intent_detail.repos to \
          disagree with: {:?}",
         resp.text().await
     );

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -398,7 +398,14 @@ async fn t1_zero_config_submit_materializes_a_real_worktree() {
     assert_eq!(status, 201, "submit failed: {body}");
     let work_id = body["work"]["id"].as_str().expect("work id").to_string();
     assert_eq!(body["work"]["state"], "active");
-    assert_eq!(body["work"]["workspace"], "solo");
+    // estate-root §7.1/§7.4: no scope was submitted at all, and a
+    // one-repository estate infers its sole repository — `Work.workspace`
+    // is never written for a new Work (`workflow.bound`'s own `workspace`
+    // field, journaled separately, is its replacement — see
+    // `r_mvp1_4_workflow_bound_carries_repositories_and_instruction_identities`
+    // below for that assertion).
+    assert_eq!(body["work"]["workspace"], Value::Null);
+    assert_eq!(body["work"]["repositories"], json!(["solo"]));
 
     // The binding records everything §11 asks for.
     let bindings = body["surface"]["bindings"]
@@ -499,9 +506,21 @@ path = "../payments-web"
     let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
     let client = http();
 
-    let (status, body) = submit(&client, &handle, &api, "multi repo", json!({})).await;
+    // estate-root §7.1: "payments" declares two repositories, so this test's
+    // whole point (one surface, two bindings) needs an explicit scope now —
+    // `--all` is the least-assuming choice that still selects both.
+    let (status, body) = submit(
+        &client,
+        &handle,
+        &api,
+        "multi repo",
+        json!({"scope": {"all": true}}),
+    )
+    .await;
     assert_eq!(status, 201, "submit failed: {body}");
-    assert_eq!(body["work"]["workspace"], "payments");
+    // §7.4: `Work.workspace` is never written for a new Work; §7.3's
+    // resolved-list replacement is asserted via `bindings` below.
+    assert_eq!(body["work"]["workspace"], Value::Null);
 
     let bindings = body["surface"]["bindings"].as_array().expect("bindings");
     assert_eq!(bindings.len(), 2, "one binding per declared repository");
@@ -598,7 +617,17 @@ async fn r_mvp1_4_mixed_instructions_policy_refuses_at_submit_naming_both_repos(
     let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
     let client = http();
 
-    let (status, body) = submit(&client, &handle, &api, "mixed policy", json!({})).await;
+    // estate-root §7.1: an explicit `--all` selects both repositories, so
+    // this test still reaches the instruction-policy check it means to pin
+    // rather than tripping the (now separate) missing-scope refusal first.
+    let (status, body) = submit(
+        &client,
+        &handle,
+        &api,
+        "mixed policy",
+        json!({"scope": {"all": true}}),
+    )
+    .await;
     assert_eq!(status, 422, "a mixed policy must refuse at submit: {body}");
     assert_eq!(body["error"]["code"], "instruction_policy_conflict");
     let message = body["error"]["message"].as_str().expect("message");
@@ -739,7 +768,18 @@ async fn r_mvp1_4_workflow_bound_carries_repositories_and_instruction_identities
     let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
     let client = http();
 
-    let (status, body) = submit(&client, &handle, &api, "uniform policy", json!({})).await;
+    // estate-root §7.1: "payments" declares two repositories, so an empty
+    // scope is refused now — `--all` is this test's explicit request for
+    // both, which is what it actually wants to pin (uniform policy across a
+    // multi-repository bind), orthogonal to which scope form asked for it.
+    let (status, body) = submit(
+        &client,
+        &handle,
+        &api,
+        "uniform policy",
+        json!({"scope": {"all": true}}),
+    )
+    .await;
     assert_eq!(status, 201, "submit failed: {body}");
     let work_id = body["work"]["id"].as_str().expect("work id").to_string();
     assert_eq!(body["work"]["state"], "active");
@@ -2798,7 +2838,17 @@ async fn a_repository_that_cannot_be_materialized_rolls_back_the_ones_that_could
     let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
     let client = http();
 
-    let (status, body) = submit(&client, &handle, &api, "half a surface", json!({})).await;
+    // estate-root §7.1: "payments" declares two repositories; `--all`
+    // selects both so materialization is actually attempted against `web`
+    // and can fail the way this test means to pin.
+    let (status, body) = submit(
+        &client,
+        &handle,
+        &api,
+        "half a surface",
+        json!({"scope": {"all": true}}),
+    )
+    .await;
     assert_eq!(status, 201, "submit failed: {body}");
     let work_id = body["work"]["id"].as_str().expect("work id").to_string();
     assert_eq!(
@@ -3868,6 +3918,111 @@ async fn a_submission_with_no_workspace_is_captured_but_still_routed() {
     handle.shutdown().await;
 }
 
+/// estate-root proposal §7.1: a multi-repository estate refuses an empty
+/// scope with the full remedy body — repo count, declared repos, declared
+/// groups, and the three example invocations — rather than silently
+/// expanding to every repository.
+#[tokio::test]
+async fn a_multi_repo_estate_refuses_an_empty_scope_with_the_7_1_remedy() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let api = repos.path().join("payments-api");
+    let web = repos.path().join("payments-web");
+    init_repo(&api);
+    init_repo(&web);
+    std::fs::write(
+        api.join("sergeant.toml"),
+        "[estate]\nname = \"payments\"\n\n\
+         [[repo]]\nname = \"api\"\npath = \".\"\n\n\
+         [[repo]]\nname = \"web\"\npath = \"../payments-web\"\n\n\
+         [group.pair]\nrepos = [\"api\", \"web\"]\n",
+    )
+    .expect("sergeant.toml");
+
+    let (registry, fake) = one_fake([FakeStep::hang()]);
+    let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
+    let client = http();
+
+    let (status, body) = submit(&client, &handle, &api, "no scope at all", json!({})).await;
+    assert_eq!(status, 422, "an empty scope must refuse: {body}");
+    assert_eq!(body["error"]["code"], "missing_scope");
+    assert_eq!(body["error"]["repo_count"], 2);
+    assert_eq!(body["error"]["repos"], json!(["api", "web"]));
+    assert_eq!(body["error"]["groups"], json!(["pair"]));
+    assert!(
+        body["error"]["examples"]["repo"].as_str().is_some(),
+        "must offer a --repo example: {body}"
+    );
+    assert!(
+        body["error"]["examples"]["group"]
+            .as_str()
+            .is_some_and(|s| s.contains("pair")),
+        "must offer a --group example naming a real declared group: {body}"
+    );
+    assert_eq!(
+        body["error"]["examples"]["all"],
+        "sgt run \"<intent>\" --all"
+    );
+    let message = body["error"]["message"].as_str().expect("message");
+    assert!(message.contains("2 repositories"), "got: {message}");
+    assert!(
+        fake.starts().is_empty(),
+        "a missing-scope refusal must never reach a backend"
+    );
+
+    handle.shutdown().await;
+}
+
+/// estate-root proposal §7.1: `--all` is explicit and journaled as the
+/// request form even though it resolves to the same list every declared
+/// repository would — `scope_request.all` must be `true`, not merely a
+/// side effect inferred from `repositories` matching every declared name.
+#[tokio::test]
+async fn run_all_resolves_every_repository_and_journals_the_request_form() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let api = repos.path().join("payments-api");
+    let web = repos.path().join("payments-web");
+    init_repo(&api);
+    init_repo(&web);
+    std::fs::write(
+        api.join("sergeant.toml"),
+        "[estate]\nname = \"payments\"\n\n\
+         [[repo]]\nname = \"api\"\npath = \".\"\n\n\
+         [[repo]]\nname = \"web\"\npath = \"../payments-web\"\n",
+    )
+    .expect("sergeant.toml");
+
+    let (registry, _fake) = one_fake([FakeStep::hang()]);
+    let handle = start_with(data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
+    let client = http();
+
+    let (status, body) = submit(
+        &client,
+        &handle,
+        &api,
+        "everything, explicitly",
+        json!({"scope": {"all": true}}),
+    )
+    .await;
+    assert_eq!(status, 201, "submit failed: {body}");
+    let mut repositories: Vec<String> = body["work"]["repositories"]
+        .as_array()
+        .expect("repositories")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    repositories.sort();
+    assert_eq!(repositories, vec!["api", "web"]);
+    assert_eq!(
+        body["work"]["scope_request"],
+        json!({"all": true}),
+        "the request form (all: true) must be journaled, not just its resolution: {body}"
+    );
+
+    handle.shutdown().await;
+}
+
 /// The submit crash window (§25's fail-closed rule applied to sergeant's own
 /// bookkeeping). Submitting is several fsynced appends, and a daemon that
 /// dies inside that sequence leaves a `pending` work no verb can move:
@@ -4369,6 +4524,181 @@ fn cli_respond_and_retry_through_the_binary() {
     );
 
     stop_daemon(data.path());
+}
+
+/// Write a `sergeant.toml` declaring three repositories (`api`, `web`,
+/// `docs`) and one group `pair` = `[api, web]`, at `root` (which must be
+/// `api`'s own checkout, `path = "."`).
+fn write_three_repo_estate_with_a_group(repos_dir: &Path) {
+    let api = repos_dir.join("payments-api");
+    let web = repos_dir.join("payments-web");
+    let docs = repos_dir.join("payments-docs");
+    init_repo(&api);
+    init_repo(&web);
+    init_repo(&docs);
+    std::fs::write(
+        api.join("sergeant.toml"),
+        "[estate]\nname = \"payments\"\n\n\
+         [[repo]]\nname = \"api\"\npath = \".\"\n\n\
+         [[repo]]\nname = \"web\"\npath = \"../payments-web\"\n\n\
+         [[repo]]\nname = \"docs\"\npath = \"../payments-docs\"\n\n\
+         [group.pair]\nrepos = [\"api\", \"web\"]\n",
+    )
+    .expect("sergeant.toml");
+}
+
+/// estate-root proposal §7.1/§7.2, through the real spawned binary: `--all`
+/// forwards `scope.all` verbatim and the daemon resolves it to every
+/// declared repository; `--group` combined with `--repo` forwards both and
+/// the daemon unions them (dedup) — the CLI performs no expansion of its
+/// own (§7.2's "a client surface adds usability, never functionality").
+#[test]
+fn cli_run_all_and_run_group_plus_repo_wire_shapes() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    write_three_repo_estate_with_a_group(repos.path());
+    let api = repos.path().join("payments-api");
+
+    let output = sgt(&api, &data, &["--json", "run", "--all", "everything"]);
+    assert!(
+        output.status.success(),
+        "sgt run --all failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: Value = serde_json::from_slice(&output.stdout).expect("run --json");
+    let mut repositories: Vec<String> = body["work"]["repositories"]
+        .as_array()
+        .expect("repositories")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    repositories.sort();
+    assert_eq!(repositories, vec!["api", "docs", "web"]);
+    assert_eq!(body["work"]["scope_request"], json!({"all": true}));
+
+    let output = sgt(
+        &api,
+        &data,
+        &[
+            "--json", "run", "--group", "pair", "--repo", "docs", "union",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "sgt run --group pair --repo docs failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: Value = serde_json::from_slice(&output.stdout).expect("run --json");
+    let mut repositories: Vec<String> = body["work"]["repositories"]
+        .as_array()
+        .expect("repositories")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    repositories.sort();
+    assert_eq!(repositories, vec!["api", "docs", "web"]);
+    assert_eq!(
+        body["work"]["scope_request"],
+        json!({"repos": ["docs"], "group": "pair"}),
+        "the request form must carry --repo and --group exactly as submitted, not their union"
+    );
+
+    stop_daemon(data.path());
+}
+
+/// estate-root proposal §7.4: `--workspace` is gone from the CLI entirely —
+/// clap refuses the flag itself, before any daemon could ever be asked
+/// about it.
+#[test]
+fn cli_run_rejects_the_removed_workspace_flag() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let repo = repos.path().join("solo");
+    init_repo(&repo);
+
+    let output = sgt(
+        &repo,
+        &data,
+        &["run", "--workspace", "payments", "do the thing"],
+    );
+    assert!(
+        !output.status.success(),
+        "--workspace must be rejected, not silently accepted"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("workspace") || stderr.to_lowercase().contains("unexpected argument"),
+        "clap's own diagnostic must name the flag: {stderr}"
+    );
+    assert!(
+        data.daemon_pids().is_empty(),
+        "a clap parse failure must never reach ensure_daemon: {stderr}"
+    );
+}
+
+/// estate-root proposal §7.2: scope resolution is core-owned, so a
+/// `scope.group` submitted straight to the API (bypassing the CLI entirely)
+/// and the equivalent `--group` submitted through the real spawned binary
+/// resolve to the identical repository list — proof that the CLI reaches
+/// the same resolution rather than reimplementing it.
+#[tokio::test]
+async fn scope_resolution_is_identical_across_the_cli_and_a_direct_api_submission() {
+    // Leg 1: a direct API submission, no CLI involved at all.
+    let api_repos = TempDir::new().expect("tempdir");
+    let api_data = TempDir::new().expect("tempdir");
+    write_three_repo_estate_with_a_group(api_repos.path());
+    let api_root = api_repos.path().join("payments-api");
+    let (registry, _fake) = one_fake([FakeStep::hang()]);
+    let handle = start_with(api_data.path(), registry, Some(FAKE_BACKEND_NAME)).await;
+    let client = http();
+    let (status, api_body) = submit(
+        &client,
+        &handle,
+        &api_root,
+        "direct api scope.group",
+        json!({"scope": {"group": "pair"}}),
+    )
+    .await;
+    assert_eq!(status, 201, "direct API submit failed: {api_body}");
+    let mut api_repositories: Vec<String> = api_body["work"]["repositories"]
+        .as_array()
+        .expect("repositories")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    api_repositories.sort();
+    handle.shutdown().await;
+
+    // Leg 2: the identical scope, through the real CLI binary.
+    let cli_repos = TempDir::new().expect("tempdir");
+    let cli_data = DataDir::new();
+    write_three_repo_estate_with_a_group(cli_repos.path());
+    let cli_root = cli_repos.path().join("payments-api");
+    let output = sgt(
+        &cli_root,
+        &cli_data,
+        &["--json", "run", "--group", "pair", "cli --group scope"],
+    );
+    assert!(
+        output.status.success(),
+        "sgt run --group pair failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let cli_body: Value = serde_json::from_slice(&output.stdout).expect("run --json");
+    let mut cli_repositories: Vec<String> = cli_body["work"]["repositories"]
+        .as_array()
+        .expect("repositories")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    cli_repositories.sort();
+    stop_daemon(cli_data.path());
+
+    assert_eq!(
+        api_repositories, cli_repositories,
+        "the CLI's --group and a direct API scope.group submission must resolve identically"
+    );
+    assert_eq!(api_repositories, vec!["api", "web"]);
 }
 
 /// Run the sgt binary from `cwd` against `data_dir`.

--- a/tests/m5_projections.rs
+++ b/tests/m5_projections.rs
@@ -862,14 +862,27 @@ impl Provenance {
                         )
                     && to == submitted_work
             }
+            // estate-root Phase C, §7.4: `scoped_to` has two justifying
+            // shapes now — `work.submitted`'s `workspace` field (legacy
+            // journal replay only; a new Work never carries it) and
+            // `workflow.bound`'s own `workspace` field (the live source, the
+            // plan-time estate name — same field `analytics.rs`'s `WorkRow`
+            // already prefers).
             "scoped_to" => {
-                event.kind == "work.submitted"
+                (event.kind == "work.submitted"
                     && from == submitted_work
                     && to
                         == format!(
                             "workspace:{}",
                             payload["work"]["workspace"].as_str().unwrap_or_default()
-                        )
+                        ))
+                    || (event.kind == "workflow.bound"
+                        && from == work
+                        && to
+                            == format!(
+                                "workspace:{}",
+                                payload["workspace"].as_str().unwrap_or_default()
+                            ))
             }
             "targets" => {
                 event.kind == "surface.materialized"

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -398,7 +398,7 @@ async fn t1_the_tui_renders_and_drives_the_fleet_over_the_api() {
     for c in "submitted from the tui".chars() {
         app.on_key(ratatui::crossterm::event::KeyCode::Char(c));
     }
-    // Tab past workflow/backend/profile/workspace/repositories/turns/ceiling
+    // Tab past workflow/backend/profile/group/repositories/turns/ceiling
     // to the `[ Run Work ]` control, then submit.
     for _ in 0..8 {
         app.on_key(ratatui::crossterm::event::KeyCode::Tab);
@@ -429,6 +429,32 @@ async fn t1_the_tui_renders_and_drives_the_fleet_over_the_api() {
             .iter()
             .any(|w| w["intent"] == "submitted from the tui"),
         "the TUI's New Work form must actually reach the daemon: {fleet}"
+    );
+
+    // …and so does the scope the operator typed (estate-root proposal
+    // §13.3): a repository this estate never declared must come back as
+    // §15's refusal naming it, which can only happen if the Repositories
+    // field actually reaches `scope.repos` and the daemon's own
+    // `Engine::resolve_scope` — the same resolution `sgt run --repo` gets.
+    // A form that dropped the field would be accepted here instead, since a
+    // one-repository estate infers its sole repository on an empty scope.
+    app.home.intent.set_text("scoped from the tui");
+    app.home.repositories = "not-a-declared-repo".to_string();
+    let action = app.on_key(ratatui::crossterm::event::KeyCode::Enter);
+    let Action::Submit(scoped) = action else {
+        panic!("expected a submission, got {action:?}");
+    };
+    assert_eq!(scoped["scope"]["repos"], json!(["not-a-declared-repo"]));
+    let outcome = app.execute(&client, Action::Submit(scoped)).await;
+    assert_eq!(outcome, Action::Refresh);
+    let refused = app
+        .home
+        .last_error
+        .clone()
+        .expect("an undeclared repository must be refused");
+    assert!(
+        refused.contains("not-a-declared-repo"),
+        "the refusal must name what the form actually sent: {refused}"
     );
 
     handle.shutdown().await;

--- a/tests/m8_estate_cli.rs
+++ b/tests/m8_estate_cli.rs
@@ -4,17 +4,22 @@
 //! `sgt init` (scaffold + idempotency) · `sgt repo add/remove/list`
 //! (populate-or-verify, atomic validated writes, group-membership refusal)
 //! · `sgt group add/remove/list` (mkdir-p union semantics, declared-member
-//! validation) · `sgt run --group` (R-MVP1-5(b): pure client-side expansion
-//! into the existing `--repo` selection, zero new engine surface) · the
-//! estate-resolved data-dir default (U-R2, R-MVP1-12's own walk reused for
-//! `--data-dir`/`SGT_DATA_DIR` precedence, unchanged).
+//! validation) · `sgt run --group` (estate-root proposal §7.2: the CLI
+//! forwards `--repo`/`--group`/`--all` verbatim as `scope.{repos,group,all}`
+//! and the *daemon* resolves group membership against its own bound
+//! manifest — superseding MVP-3's original R-MVP1-5(b) CLI-side expansion)
+//! · the estate-resolved data-dir default (U-R2, R-MVP1-12's own walk reused
+//! for `--data-dir`/`SGT_DATA_DIR` precedence, unchanged).
 //!
 //! Every non-daemon verb here (`init`, `repo *`, `group *`, `doctor`) is
 //! pure manifest/filesystem plumbing (§9: "sergeant.toml ... never stores
 //! transient work state") — no daemon is spawned, so these run against a
 //! bare `&Path`, matching `m6_surfaces.rs`'s own `doctor(...)` helper.
 //! `sgt run --group` is the one verb here that submits real work and so
-//! auto-spawns a daemon; that test alone goes through `support::DataDir`.
+//! auto-spawns a daemon; that test (and its "unrelated broken repo" sibling)
+//! alone go through `support::DataDir` — and, since Phase C, *always* spawn
+//! one, because scope resolution (including an undeclared group's refusal)
+//! now happens on the daemon side rather than before `ensure_daemon` runs.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -820,17 +825,18 @@ fn workflow_fork_refuses_to_overwrite_an_existing_local_package() {
 
 // --------------------------------------------------------- run --group
 
-/// guard-map: `sgt run --group <name>` expands client-side into the exact
-/// same `repositories` selection `--repo` (repeated) would produce —
-/// R-MVP1-5(b)'s ruling, pinned end to end through a real (fake-backend)
-/// submission. An undeclared group name is refused before any daemon is
-/// even spawned. Mutation this kills: `--group` sending the group *name*
-/// to the API instead of its expanded members (the engine has no group
-/// concept at all — `NORTH-STAR.md`'s R-NS-4 — so that would silently
-/// submit work bound to zero repositories, or fail server-side without
-/// naming the group like this test's second assertion does).
+/// guard-map: `sgt run --group <name>` submits `scope.group = <name>`
+/// verbatim, and the *daemon* resolves it into the exact same repository
+/// list `--repo` (repeated) would produce — estate-root §7.2's ruling,
+/// pinned end to end through a real (fake-backend) submission. An
+/// undeclared group name is refused by the daemon's own 422 (§15), naming
+/// it — no longer a client-side pre-check, so a real daemon spawns for this
+/// case too. Mutation this kills: `--group` sending the group *name* to the
+/// API but resolution silently expanding to zero repositories or the whole
+/// estate instead of the daemon's structured refusal/expansion this test
+/// pins on both sides of the undeclared-group boundary.
 #[test]
-fn run_group_expands_client_side_into_repositories() {
+fn run_group_resolves_server_side_into_repositories() {
     let data_dir = DataDir::new();
     let estate = tempfile::TempDir::new().expect("tempdir");
     run(estate.path(), Some(data_dir.path()), &[], &["init"]).assert_ok("init");
@@ -852,7 +858,9 @@ fn run_group_expands_client_side_into_repositories() {
     )
     .assert_ok("group add");
 
-    // An undeclared group is refused before any daemon spawns.
+    // An undeclared group is refused by the daemon's own scope resolution
+    // (§7.2) — the CLI no longer looks group membership up itself, so
+    // `ensure_daemon` runs and a real daemon answers this 422.
     let bad = run(
         estate.path(),
         Some(data_dir.path()),
@@ -862,8 +870,10 @@ fn run_group_expands_client_side_into_repositories() {
     bad.assert_fails("undeclared group");
     assert!(bad.stderr.contains("ghost"), "got: {}", bad.stderr);
     assert!(
-        data_dir.daemon_pids().is_empty(),
-        "an undeclared --group must be refused before ensure_daemon ever spawns one"
+        !data_dir.daemon_pids().is_empty(),
+        "server-side --group resolution means a daemon must actually spawn and reach its own \
+         scope resolution for the undeclared-group refusal to happen at all: {}",
+        bad.stderr
     );
 
     let submitted = run(
@@ -885,22 +895,26 @@ fn run_group_expands_client_side_into_repositories() {
     data_dir.reap();
 }
 
-/// MVP-3 invariants finding MVP3-C2: `--group`'s *client-side* expansion
-/// reads group membership through the on-disk-free structural parser, so an
-/// unrelated declared repository missing from disk no longer refuses the
-/// command before a daemon is even spawned — the same "wrongness scoped
-/// per-entry" contract `repo add`/`group add` already hold (MVP3-C1). The
-/// daemon's own submit-time estate resolution is a *separate*, pre-existing,
-/// accepted coupling (matches plain `--repo` too, per the B4 register entry
-/// C2's own basis cites) and is deliberately left alone here — so the
-/// command as a whole still fails once `ghost` is missing, but *how* it
-/// fails is the proof: client-side no longer refuses first.
+/// Historical note, MVP3-C2: before estate-root Phase C, `--group`'s
+/// *client-side* expansion read group membership through an on-disk-free
+/// structural parser specifically so an unrelated declared repository
+/// missing from disk would not refuse the command before a daemon was even
+/// spawned. Phase C retires that CLI-side lookup entirely (§7.2: resolution
+/// is core-owned), so this test's outcome is no longer "the client-side
+/// carve-out and the daemon's own strict bind disagree" — it is the plain
+/// consequence of `Engine::plan` unconditionally discovering the *whole*
+/// estate (`Workspace::discover_scoped`) before scope resolution ever runs,
+/// exactly the coupling a plain `--repo` submission has always had (matches
+/// the B4 register entry MVP3-C2's own basis cites). `ghost` being outside
+/// the requested group no longer matters: the command still fails, and the
+/// daemon's own 422 is what names `ghost` as the actual defect.
 ///
-/// guard-map: reverting the group lookup back to the strict
-/// `Workspace::discover_scoped` makes this fail identically to the
-/// "undeclared group" case above — refused before `ensure_daemon` ever
-/// spawns one — instead of a daemon actually starting and the *daemon's*
-/// preflight (a 422 naming `ghost`) being what rejects the submission.
+/// guard-map: a resolution path that somehow skipped or lightened workspace
+/// discovery for a `--group` submission (say, resolving groups against a
+/// separately-read, on-disk-free manifest instead of the same `workspace`
+/// `plan` already discovered) would make this pass with no daemon-side
+/// evidence of `ghost` at all — the `daemon_pids` assertion below is what
+/// catches that regression.
 #[test]
 fn run_group_expansion_itself_survives_an_unrelated_declared_repo_missing_from_disk() {
     let data_dir = DataDir::new();
@@ -942,9 +956,9 @@ fn run_group_expansion_itself_survives_an_unrelated_declared_repo_missing_from_d
     );
     assert!(
         !data_dir.daemon_pids().is_empty(),
-        "client-side --group expansion must not have refused first — a daemon must have \
-         actually spawned and reached its own bind-time preflight for this to be *that* \
-         refusal rather than the client-side one: {}",
+        "a daemon must have actually spawned and reached its own bind-time preflight for this \
+         to be the daemon's own full-estate discovery failing on ghost, not some earlier \
+         client-side check: {}",
         submitted.stderr
     );
 


### PR DESCRIPTION
Phase C of the estate-root integration (spec: specs/phase-c.md; proposal §7/§13.3, amendments C7b/C8).

- Structured `scope: {repos, group, all}` on the wire; group expansion moved from CLI into core (`Engine::resolve_scope`); CLI/TUI forward verbatim.
- Empty scope: one-repo estate infers its sole repo; multi-repo estate gets the §7.1 structured 422 (repo count, declared repos/groups, three example invocations). Unknown repo/group refusals name available values.
- `--all` explicit and journaled; scope journaled twice (request form + resolved list, §7.3).
- `--workspace` removed from CLI and wire; `Work.workspace` deprecated, never written, replay-tolerant (old-journal replay tested — the live estate's 150+ Works still fold).
- Phase 0 pin flipped: empty selection now errors at the domain layer.

Gauntlet: 4-axis panel → 2 warnings CONFIRMED AND FIXED (the TUI composer still sent the pre-C wire shape, silently emptying every TUI submission's scope — now emits `scope` with a test; CHANGELOG claim corrected), 2 info findings deferred with reasons:
- `--all` silently wins over combined `--repo`/`--group` (journaled verbatim, §7.1 silent on combining — flagged for owner taste).
- MVP3-C2 lenient group lookup retired: an unrelated broken repo now blocks `--group` (deliberate, documented in engine.rs, pinned by a guard-map test; consistent with strict discovery).

Gates green (fmt, clippy -D warnings, 546 lib + 18 integration binaries, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4