### PR TITLE
Phase E: Git admission preflight and bounded override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,75 @@ released before a release can proceed.
 
 ### Changed
 
+- **Every Work is now admitted against a complete Git preflight before it
+  exists (estate-root proposal §8).** Submitting used to read each mount's
+  HEAD with no judgment at all: a dirty mount, a detached HEAD, an
+  unresolvable commit, an existing `sergeant/<work-id>` ref, an occupied or
+  still-registered surface path, or a repository whose lock could not be
+  taken all became a durable Work record first and a problem afterwards.
+  Core now checks all eleven §8.1 facts for **every** selected repository
+  before `work.submitted` is journaled and before any Git mutation, and
+  refuses with a structured 422 when any of them is unresolved — so there
+  is nothing to clean up, in the journal or in your checkouts.
+
+  Each check has its own stable error code, the evidence observed, and a
+  named remedy: `git_preflight_mount_missing`, `_mount_aliased`,
+  `_top_level_mismatch`, `_linked_worktree_source`,
+  `_common_dir_unlockable`, `_detached_head`, `_unresolvable_head`,
+  `_dirty_mount`, `_work_branch_collision`, `_worktree_path_collision`,
+  `_incomplete_plan`. A refusal reports every unresolved finding across the
+  whole scope, so a multi-repository submission is fixed in one pass rather
+  than one submission per repository; when part of a scope cannot be
+  planned, the refusal says so explicitly and **no** repository is
+  materialized, including the ones that were fine.
+
+  The base a Work runs on is now an *admitted* fact: `base_branch` and
+  `base_sha` are what preflight judged, not what the mount happens to say
+  by the time `git worktree add` runs. Sergeant still performs no automatic
+  network or branch-changing Git command on any admission path — no fetch,
+  pull, push, rebase, switch, checkout or remote-default inference — which
+  is now asserted against a recording Git binary across a whole real
+  admission rather than only stated.
+
+  **Upgrade note:** a mount with uncommitted changes, or on a detached
+  HEAD, is refused where it previously ran. Commit or stash, check the
+  mount out onto the branch the Work should be based on, or use the new
+  bounded override below.
+
+- **`sgt run --override-git-preflight`** waives exactly two of those
+  cautions, and only because an exact commit can still be pinned in both
+  (§8.3):
+
+  - a **dirty** mount — the Work is based on the committed `HEAD`, the full
+    `git status --porcelain` output is journaled as evidence, and the
+    record states explicitly that the uncommitted changes are excluded from
+    the Work base (they stay in your mount, untouched);
+  - a **detached** mount — the exact `HEAD` is pinned and **no** named base
+    branch is recorded.
+
+  It never waives anything else: not an invalid estate, unresolved or
+  unknown scope, an unknown or aliased repository, an unresolvable top
+  level / common directory / commit, a lock conflict, an existing Work ref
+  or surface path, a failed surface construction, or a
+  backend/workflow/profile failure. An unresolvable `HEAD` says so
+  explicitly — the override is unavailable there because no exact base can
+  be pinned. Override may waive policy caution; it may not replace a
+  missing fact or overcome mechanical impossibility.
+
+  It is available **only** as a flag on `sgt run` (and the matching
+  `override_git_preflight` request field). There is no configuration key,
+  no `[estate]` key, no profile field and no run template that can set it:
+  the operator types it for that submission or it is not set. The
+  authorization and every waived finding are journaled with the Work.
+
+- **A repository binding records no base branch when there is none.**
+  `base_branch` on a `RepositoryBinding` (and on the `BindingSummary`
+  backends receive) is now nullable, and a detached admission records an
+  explicit `null` rather than the old `"(detached)"` sentinel — a value
+  that read like a branch name in the field every consumer branches on. A
+  binding journaled before this change replays exactly what it recorded,
+  sentinel included.
+
 - **An estate is now exactly the current directory (estate-root proposal
   §4).** Every estate-scoped command — `run`, `status`, `work *`,
   `respond`/`retry`/`extend`/`cancel`, `watch`, `analytics`, `tui`,

--- a/src/api.rs
+++ b/src/api.rs
@@ -795,6 +795,38 @@ fn engine_error_body(e: &EngineError) -> Value {
     if let EngineError::UnknownGroup { available, .. } = e {
         body["error"]["available_groups"] = json!(available);
     }
+    // estate-root §8.1/§15: a Git admission refusal carries its whole
+    // taxonomy as data. `error.code` is already the *first* failed check's
+    // stable code (`EngineError::code`), which is what a client branches on;
+    // `findings` is every unresolved check across the whole selected scope,
+    // each naming its repository, its §8.1 check number, its own code, the
+    // evidence, and its remedy — so a multi-repository scope is fixed in one
+    // pass rather than one submission per repository.
+    //
+    // `override_available` is §15's dirty/detached row ("mention the bounded
+    // --override-git-preflight escape hatch") answered as a boolean rather
+    // than left for a client to infer from the code — and answered `false`
+    // for exactly the row that must not offer it: an unresolvable HEAD, where
+    // no exact base can be pinned at all.
+    if let EngineError::GitPreflight(refusal) = e {
+        body["error"]["findings"] = json!(
+            refusal
+                .findings
+                .iter()
+                .map(|finding| json!({
+                    "repository": finding.repository,
+                    "check": finding.check,
+                    "check_number": finding.check.number(),
+                    "code": finding.code(),
+                    "detail": finding.detail,
+                    "remedy": finding.remedy(),
+                    "waivable": finding.check.waivable(),
+                    "porcelain": finding.porcelain,
+                }))
+                .collect::<Vec<Value>>()
+        );
+        body["error"]["override_available"] = json!(refusal.override_would_help());
+    }
     body
 }
 
@@ -1082,6 +1114,18 @@ struct SubmitRequest {
     /// nothing here drives routing, exactly like `intent_detail` above.
     #[serde(default)]
     envelope: Option<EnvelopeRequest>,
+    /// estate-root §8.3's one bounded override, as `sgt run
+    /// --override-git-preflight` sends it.
+    ///
+    /// **It has exactly one source: this field, on this request.** §8.3: "it
+    /// is never available from run defaults or a run template; the operator
+    /// must type it for that submission." There is deliberately no daemon
+    /// config key, no `[estate]` manifest key, and no profile field that can
+    /// set it — `#[serde(default)]` means a submission that does not say so
+    /// is not overriding anything, and nothing else in the process can make
+    /// this `true`.
+    #[serde(default)]
+    override_git_preflight: bool,
 }
 
 /// R-MVP1-7's envelope override, sanity-checked at submit: a turn cap of 0
@@ -1202,6 +1246,14 @@ async fn submit_work(
     // same single-writer decision it always was — just made after the reading
     // rather than around it.
     let origin = req.origin.clone().unwrap_or_default();
+    // §8.1 checks 9 and 10 are questions about `sergeant/<work-id>` and this
+    // Work's own surface directory, so the id has to exist before the record
+    // does. Minting it here — side-effect free, and *not* durable until the
+    // `work.submitted` append far below — is what lets the whole Git
+    // admission contract run "before a Work record exists". Every path that
+    // does not reach that append (a preflight refusal, a replayed
+    // `command_id`, an empty intent) simply discards it.
+    let work_id_candidate = ulid::Ulid::generate().to_string();
     let planned = if req.intent.trim().is_empty() {
         None
     } else {
@@ -1212,6 +1264,8 @@ async fn submit_work(
         let scope = req.scope.clone();
         let origin_cwd = origin.cwd.clone();
         let origin_client = origin.client.clone();
+        let candidate = work_id_candidate.clone();
+        let override_git_preflight = req.override_git_preflight;
         Some(
             blocking(move || {
                 engine.plan(&SubmitContext {
@@ -1223,6 +1277,8 @@ async fn submit_work(
                     repos: &scope.repos,
                     group: scope.group.as_deref(),
                     all: scope.all,
+                    work_id: Some(&candidate),
+                    override_git_preflight,
                 })
             })
             .await,
@@ -1357,7 +1413,8 @@ async fn submit_work(
         .unwrap_or_else(|| scope_request.repos.clone());
 
     let work = Work {
-        id: ulid::Ulid::generate().to_string(),
+        // The id §8.1's checks 9 and 10 were already asked about, above.
+        id: work_id_candidate,
         // §7.4: `--workspace`/`SubmitRequest.workspace` no longer exist.
         // `Work.workspace` is kept only so a pre-Phase-C journal event still
         // deserializes (`Work::workspace`'s doc comment, which also says why
@@ -1378,6 +1435,8 @@ async fn submit_work(
         // I3's own rule, reused: an empty `{}` override is the same fact as
         // sending nothing.
         envelope: req.envelope.filter(|e| !e.is_empty()),
+        // §8.3: the authorization the operator gave for this one submission.
+        git_preflight_override: req.override_git_preflight,
         state: WorkState::Pending,
         created_by: req.created_by.unwrap_or_else(|| "api".to_string()),
         created_at: rfc3339_utc_now(),

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -2469,6 +2469,43 @@ mod tests {
         assert!(surface.contains("and nothing else"), "{surface}");
     }
 
+    /// §8.3's bounded override admits a detached mount, which records an exact
+    /// `base_sha` and no named base branch. The actor is told that in words —
+    /// not a `None`-shaped placeholder it would have to interpret — and the
+    /// pin itself is still carried in full, because the SHA is the only base
+    /// fact such a binding has.
+    #[test]
+    fn a_detached_admission_says_it_has_no_named_base_branch_and_still_names_the_sha() {
+        let api_sha = "c".repeat(40);
+        let web_sha = "d".repeat(40);
+        let mut detached = binding("web", &web_sha);
+        detached.base_branch = None;
+        let request = prompt_request(vec![binding("api", &api_sha), detached]);
+        let prompt = compose_launch_prompt(&request);
+
+        let sections: Vec<&str> = prompt.split("\n\n").collect();
+        let surface = sections[2];
+        assert!(
+            surface.contains(&format!(
+                "- web: /data/surfaces/01PROMPT/web (branch sergeant/01PROMPT, \
+                 cut from no named base branch (detached admission) at {web_sha})"
+            )),
+            "{surface}"
+        );
+        // The named-base arm is unaffected by the detached one beside it.
+        assert!(
+            surface.contains(&format!(
+                "- api: /data/surfaces/01PROMPT/api (branch sergeant/01PROMPT, \
+                 cut from main at {api_sha})"
+            )),
+            "{surface}"
+        );
+        assert!(
+            !surface.contains("None"),
+            "no Rust-shaped placeholder reaches the actor: {surface}"
+        );
+    }
+
     /// C2/C3: a request with no binding summary — a `StartRequest` replayed
     /// from before §10.1, or any caller that does not supply one — still
     /// launches, and says nothing about a mutation surface rather than

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -290,7 +290,13 @@ fn mutation_surface_section(bindings: &[BindingSummary]) -> String {
             binding.repository,
             binding.worktree_path.display(),
             binding.work_branch,
-            binding.base_branch,
+            // A detached admission (§8.3's bounded override) has no named
+            // base branch; say so rather than print a `None`-shaped
+            // placeholder the actor would have to interpret.
+            binding
+                .base_branch
+                .as_deref()
+                .unwrap_or("no named base branch (detached admission)"),
             binding.base_sha,
         ));
     }
@@ -2401,7 +2407,7 @@ mod tests {
             repository: repository.to_string(),
             worktree_path: PathBuf::from(format!("/data/surfaces/01PROMPT/{repository}")),
             work_branch: "sergeant/01PROMPT".to_string(),
-            base_branch: "main".to_string(),
+            base_branch: Some("main".to_string()),
             base_sha: sha.to_string(),
         }
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -201,8 +201,12 @@ pub struct BindingSummary {
     pub worktree_path: PathBuf,
     /// Branch the Work executes on in that worktree.
     pub work_branch: String,
-    /// Branch the work branch was cut from (`(detached)` if HEAD was).
-    pub base_branch: String,
+    /// Branch the work branch was cut from — `None` when the mount was
+    /// admitted detached under §8.3's bounded override, which pins an exact
+    /// `base_sha` and records no named base branch. `#[serde(default)]` so a
+    /// summary journaled before the field became optional still replays.
+    #[serde(default)]
+    pub base_branch: Option<String>,
     /// Exact commit it was cut from.
     pub base_sha: String,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,6 +132,27 @@ enum Command {
         /// applies otherwise).
         #[arg(long)]
         ceiling_secs: Option<u64>,
+        /// estate-root §8.3's one bounded override of the Git admission
+        /// preflight. Waives exactly two normal cautions, and only because an
+        /// exact commit can still be pinned in both: a **dirty** mount (the
+        /// Work is based on the committed HEAD, the full porcelain evidence
+        /// is journaled, and the uncommitted changes are explicitly excluded)
+        /// and a **detached** mount (the exact HEAD is pinned and no named
+        /// base branch is recorded).
+        ///
+        /// It never waives an invalid estate, unresolved scope, an unknown
+        /// repository, an aliased mount, an unresolvable top level/common
+        /// dir/commit, a lock conflict, an existing Work ref or path, a
+        /// failed surface construction, or a backend/workflow/profile
+        /// failure. "Override may waive policy caution. It may not replace a
+        /// missing fact or overcome mechanical impossibility."
+        ///
+        /// Deliberately a flag on this one verb and nothing else: §8.3 makes
+        /// it unavailable from run defaults and run templates, so there is no
+        /// config key, no `[estate]` key and no profile field that can supply
+        /// it — the operator types it for that submission or it is not set.
+        #[arg(long)]
+        override_git_preflight: bool,
     },
     /// Inspect work items.
     Work {
@@ -700,6 +721,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             all,
             turns,
             ceiling_secs,
+            override_git_preflight,
         } => {
             // estate-root proposal §7.2: scope resolution is core-owned. The
             // CLI forwards `--repo`/`--group`/`--all` verbatim as
@@ -729,6 +751,10 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                     "all": all,
                 },
                 "envelope": envelope,
+                // §8.3: forwarded verbatim from the flag, with no default
+                // layer of any kind between the two — the daemon reads it off
+                // this one request field.
+                "override_git_preflight": override_git_preflight,
                 "created_by": "cli",
                 "origin": origin(),
             });

--- a/src/domain/estate.rs
+++ b/src/domain/estate.rs
@@ -822,7 +822,15 @@ fn check_removed_repo_path(text: &str, file: &str) -> Result<(), EstateError> {
 ///
 /// Returns the canonical mount on success, so callers record the resolved
 /// path rather than the declared one.
-fn validate_mount(file: &str, name: &str, mount: &Path) -> Result<PathBuf, EstateError> {
+///
+/// **Public because §8.4 makes the daemon repeat this, not because two
+/// implementations of it exist.** `Estate::resolve` calls it while parsing the
+/// manifest; [`crate::runtime::preflight`] calls this same function again per
+/// *selected* repository at admission — "the API/daemon repeats and
+/// authoritatively enforces the mechanical contract" — and maps the three
+/// error variants it can return onto §8.1's checks 1–4 rather than re-deriving
+/// the same three questions from git a second way.
+pub fn validate_mount(file: &str, name: &str, mount: &Path) -> Result<PathBuf, EstateError> {
     // Check 2, first half, and the one case a canonical comparison alone
     // cannot see: the mount *itself* being a symlink. `canonicalize` would
     // happily follow it and then agree with git that the target is the top

--- a/src/domain/work.rs
+++ b/src/domain/work.rs
@@ -359,6 +359,21 @@ pub struct Work {
     /// existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub envelope: Option<EnvelopeRequest>,
+    /// estate-root §8.3: whether the operator typed
+    /// `--override-git-preflight` for *this* submission.
+    ///
+    /// Journaled on the Work itself, not only on the surface plan that
+    /// records what it waived, because the two are different facts and §8.3
+    /// asks for both: an override that turned out to waive nothing is still
+    /// an operator authorization that was given, and `work.submitted` is
+    /// where the submission's own request form lives (beside
+    /// [`Self::scope_request`], for the same §7.3-shaped reason).
+    ///
+    /// `#[serde(default)]`, skipped when false, on [`ScopeRequest::all`]'s
+    /// precedent: absent means not overridden, which is what every Work
+    /// journaled before Phase E recorded.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub git_preflight_override: bool,
     /// Current state (only mutated by folding journal events).
     pub state: WorkState,
     /// Who submitted it.

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -5344,7 +5344,7 @@ mod tests {
             RepositoryBinding {
                 repository: "solo".to_string(),
                 source_path: PathBuf::from("/repos/solo"),
-                base_branch: "main".to_string(),
+                base_branch: Some("main".to_string()),
                 base_sha: "0".repeat(40),
                 worktree_path: PathBuf::from(format!("/data/surfaces/{work_id}/solo")),
                 work_branch: format!("sergeant/{work_id}"),

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -52,12 +52,13 @@ use crate::domain::workflow::{
     KIND_STAGE_RESUMED, KIND_STAGE_WAITING, KIND_WORKFLOW_BOUND, StageBinding, StageDefinition,
     StageKind, StageStatus, WorkflowDefinition, WorkflowError,
 };
+use crate::runtime::preflight::{self, GitPreflight, PreflightRefusal};
 use crate::runtime::projection::{WorkRegistry, WorkRun, is_absorbing};
 use crate::runtime::router::{Route, RouteError, RouteInputs, route, route_stage};
 use crate::runtime::surface::{
     KIND_SURFACE_MATERIALIZED, KIND_SURFACE_MATERIALIZING, KIND_SURFACE_TORN_DOWN,
     RepositoryBinding, SURFACES_DIR, SurfaceError, SurfacePlan, TeardownReport, WorkSurface,
-    materialize, rematerialize, teardown,
+    materialize_admitted, rematerialize, teardown,
 };
 
 /// Everything a submission says about how it wants to run.
@@ -89,6 +90,25 @@ pub struct SubmitContext<'a> {
     /// resolves to every declared repository and does not also require
     /// `repos`/`group` to be empty.
     pub all: bool,
+    /// The id the Work *would* be given, for §8.1's checks 9 and 10 — both
+    /// of which are questions about `sergeant/<work-id>` and
+    /// `<surfaces_root>/<work-id>/<repo>`, so the id has to exist before the
+    /// record does. The caller mints it and reuses it for the `Work` it
+    /// creates when planning succeeds; a refusal discards it, which costs
+    /// nothing and is the whole point of asking here.
+    ///
+    /// `None` skips §8.1 entirely: no id, no checks 9/10, nothing admitted.
+    /// That is the shape every non-submission caller of
+    /// [`Engine::plan`](Self) has (routing probes, the runtime's own
+    /// fixtures), and it must not silently become an unadmitted submission —
+    /// which is why [`StartPlan::preflight`] is an `Option`, not an empty
+    /// `Vec` that would read as "admitted, nothing found".
+    pub work_id: Option<&'a str>,
+    /// §8.3's `--override-git-preflight`, exactly as the submission carried
+    /// it. **Never a default and never read from configuration**: this is a
+    /// borrowed request field with no other source, so there is nowhere for a
+    /// run template or an estate manifest to set it from.
+    pub override_git_preflight: bool,
 }
 
 /// A resolved, side-effect-free plan for starting a run.
@@ -120,6 +140,15 @@ pub struct StartPlan {
     /// Pinned into `workflow.bound` and read by every later stage entry, so a
     /// retry and a restart reconstruct the same decision.
     pub stage_bindings: Vec<StageBinding>,
+    /// §8.1's Git admission, when this plan was made for a real submission
+    /// (`SubmitContext::work_id` was set).
+    ///
+    /// `None` means no admission was performed — never "admitted and found
+    /// nothing". Materialization reads the pinned base out of this rather
+    /// than re-asking each mount, so the distinction decides whether a Work
+    /// is based on the commit that was *judged* or on whatever HEAD says by
+    /// the time `git worktree add` runs.
+    pub preflight: Option<GitPreflight>,
 }
 
 /// Why `target_work_id`'s branch cannot (yet) be taken over by a gate Work
@@ -627,11 +656,18 @@ impl PendingSurface {
             SurfaceEffect::Materialize {
                 surfaces_root,
                 plan,
-            } => SurfaceOutcome::Materialized(materialize(
+            } => SurfaceOutcome::Materialized(materialize_admitted(
                 &self.data_dir,
                 surfaces_root,
                 &self.work_id,
                 &plan.repositories,
+                // §8.2: the base each repository was *admitted* on, not
+                // whatever its HEAD says now. An empty slice (a plan made
+                // without admission) leaves the live read in place, which is
+                // the only thing it could do.
+                plan.preflight
+                    .as_ref()
+                    .map_or(&[][..], |p| p.repositories.as_slice()),
             )),
             SurfaceEffect::Rematerialize { surface, .. } => {
                 // A retry whose worktrees are all still on disk needs no git
@@ -895,6 +931,12 @@ pub enum EngineError {
         /// The backend the stage resolved to.
         backend: String,
     },
+    /// §8.1: Git admission preflight refused this submission, before a Work
+    /// record existed and before any Git mutation. Carries every unresolved
+    /// finding, each with its own §15 code and remedy — see
+    /// [`crate::runtime::preflight`].
+    #[error("{0}")]
+    GitPreflight(PreflightRefusal),
     /// §17.5: a workflow declares a `kind = "execute"` stage, but the
     /// `"docker"` backend is not registered or its probe reports
     /// unavailable. Refused before Work or worktree side effects, exactly
@@ -945,6 +987,10 @@ impl EngineError {
             EngineError::NoSuchStage { .. } => "no_such_stage",
             EngineError::AskCapabilityUnavailable { .. } => "ask_capability_unavailable",
             EngineError::ExecuteBackendUnavailable { .. } => "execute_backend_unavailable",
+            // §15: the code names the *check*, not the phase — "preflight
+            // failed" would tell a client nothing it could act on. Every
+            // other finding travels in the body beside it.
+            EngineError::GitPreflight(refusal) => refusal.code(),
         }
     }
 
@@ -1242,6 +1288,35 @@ impl Engine {
         // "reject the submission" rather than "a work that dies at stage 2".
         let stage_bindings = self.bind_stages(&estate, &workflow, &route, profile.as_ref())?;
 
+        // §8.1/§8.4, last: the Git admission contract, run for every selected
+        // repository before `work.submitted` and before any Git mutation.
+        //
+        // Last, deliberately. Everything above is a question about
+        // configuration — is this estate readable, is that group declared, can
+        // this workflow route — and every one of those is on §8.3's
+        // never-bypass list too. Answering them first means a submission that
+        // was going to be refused for an unroutable backend is refused for the
+        // unroutable backend, rather than for the dirty mount preflight would
+        // also have found; it also keeps the ~6 git spawns per repository off
+        // submissions that were never going to run.
+        //
+        // Still strictly before the Work exists: `plan` has created nothing at
+        // this point and its caller mints the `Work` only from an `Ok`.
+        let preflight = match context.work_id {
+            None => None,
+            Some(work_id) => Some(
+                preflight::run(
+                    &estate,
+                    &self.data_dir,
+                    &surfaces_root,
+                    work_id,
+                    &repositories,
+                    context.override_git_preflight,
+                )
+                .map_err(EngineError::GitPreflight)?,
+            ),
+        };
+
         Ok(Some(StartPlan {
             estate,
             repositories,
@@ -1250,6 +1325,7 @@ impl Engine {
             route,
             profile,
             stage_bindings,
+            preflight,
         }))
     }
 
@@ -1649,6 +1725,21 @@ impl Engine {
         self.run_inline(core, step)
     }
 
+    /// The [`SurfacePlan`] `surface.materializing` records for `plan`,
+    /// carrying §8.1's admission when the plan has one.
+    ///
+    /// Split out rather than inlined so the "with admission" and "without"
+    /// shapes are one decision in one place: a plan made for a real
+    /// submission always has a [`GitPreflight`], and one made without a
+    /// `work_id` (routing probes, fixtures) never does.
+    fn surface_plan(plan: &StartPlan, work_id: &str) -> SurfacePlan {
+        let base = SurfacePlan::new(&plan.surfaces_root, work_id, &plan.repositories);
+        match &plan.preflight {
+            Some(preflight) => base.with_admission(preflight),
+            None => base,
+        }
+    }
+
     /// [`Engine::start`]'s first phase: journal the intent to materialize, and
     /// hand the git back to the caller.
     ///
@@ -1682,7 +1773,11 @@ impl Engine {
             core,
             &work.id,
             KIND_SURFACE_MATERIALIZING,
-            json!({"plan": SurfacePlan::new(&plan.surfaces_root, &work.id, &plan.repositories)}),
+            // §8.3: "the override and every waived finding are journaled with
+            // the Work" — carried on the plan, so the authorization is durable
+            // strictly before the effect it authorized, exactly like the paths
+            // and branches beside it.
+            json!({"plan": Self::surface_plan(plan, &work.id)}),
         )?;
         Ok(Step {
             next: Next::Surface(Box::new(PendingSurface {
@@ -4733,6 +4828,8 @@ mod tests {
             profile: None,
             // N3 (§12.5): one binding per stage, and this plan has no stages.
             stage_bindings: Vec::new(),
+            // No admission: this plan was built by hand, not by `plan`.
+            preflight: None,
         };
 
         engine
@@ -5334,6 +5431,7 @@ mod tests {
                 profile: None,
                 intent_detail: None,
                 envelope: None,
+                git_preflight_override: false,
                 state,
                 created_by: "test".to_string(),
                 created_at: "2026-01-01T00:00:00Z".to_string(),
@@ -5352,6 +5450,7 @@ mod tests {
                 origin: BindingOrigin::Cut,
                 canonical_top_level: Some(PathBuf::from("/repos/solo")),
                 canonical_common_dir: Some(PathBuf::from("/repos/solo/.git")),
+                preflight: None,
             }
         }
 

--- a/src/runtime/git.rs
+++ b/src/runtime/git.rs
@@ -132,6 +132,37 @@ pub fn git(dir: &Path, args: &[&str]) -> Result<String, GitError> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// [`git`] without the trim: stdout exactly as Git wrote it.
+///
+/// Necessary for `status --porcelain`, whose leading whitespace *is* the
+/// answer — ` M file` (modified, unstaged) and `M  file` (modified, staged)
+/// differ only there, and trimming turns the first into the second. §8.3
+/// requires an override to "record full porcelain evidence"; evidence with
+/// its first status column removed is not that.
+///
+/// Only the trailing newline Git terminates its last record with is dropped,
+/// so a clean tree still answers with an empty string.
+pub fn git_verbatim(dir: &Path, args: &[&str]) -> Result<String, GitError> {
+    let output = command(dir, args)
+        .output()
+        .map_err(|source| GitError::Spawn {
+            args: owned(args),
+            dir: dir.display().to_string(),
+            source,
+        })?;
+    if !output.status.success() {
+        return Err(GitError::Failed {
+            args: owned(args),
+            dir: dir.display().to_string(),
+            status: output.status.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .trim_end_matches('\n')
+        .to_string())
+}
+
 /// Whether `git <args>` in `dir` exits zero. Used for existence questions
 /// (`is this a work tree?`, `does this branch exist?`) where the failing case
 /// is an answer, not an error.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,5 @@
 //! Runtime: journal, projections, git, surfaces, integrity, repository
-//! locking, routing, engine, recovery.
+//! locking, git admission preflight, routing, engine, recovery.
 
 pub mod analytics;
 pub mod blob;
@@ -9,6 +9,7 @@ pub mod git;
 pub mod graph;
 pub mod integrity;
 pub mod journal;
+pub mod preflight;
 pub mod projection;
 pub mod recovery;
 pub mod repolock;

--- a/src/runtime/preflight.rs
+++ b/src/runtime/preflight.rs
@@ -1,0 +1,904 @@
+//! Git admission preflight (proposal §8, §15; estate-root Phase E).
+//!
+//! §8.1 is a list of eleven facts that must hold for *every* selected
+//! repository "before `work.submitted` or any Git mutation", and §8.4 says who
+//! owns checking them:
+//!
+//! > AGENTS.md teaches Captain what state to prepare and reconcile, but
+//! > correctness does not depend on Captain remembering a checklist. The
+//! > API/daemon repeats and authoritatively enforces the mechanical contract.
+//!
+//! So this module is core-owned and runs from [`Engine::plan`](
+//! crate::runtime::engine::Engine::plan) — the one place a submission is fully
+//! resolved and nothing has been created yet. Its refusal is an
+//! [`EngineError`](crate::runtime::engine::EngineError), which the API already
+//! answers as a structured 422; the Work record is minted only if this
+//! returns `Ok`.
+//!
+//! # What it does not do
+//!
+//! §6.4: "Sergeant does not fetch, pull, reset, rebase, switch to main, or
+//! infer a remote default during Work admission." Every git invocation below
+//! is a question — `rev-parse`, `symbolic-ref`, `status --porcelain`,
+//! `show-ref`, `worktree list` — and there is no verb here that writes to the
+//! mounted checkout at all. `tests/e_admission_uses_no_network_git.rs` holds
+//! that claim to a recording git shim across a whole real admission rather
+//! than to this comment.
+//!
+//! # Reuse, not a second opinion
+//!
+//! Checks 1–4 are exactly what [`estate::validate_mount`] already decides
+//! while resolving a manifest (Phase D); this calls that same function per
+//! *selected* repository and maps its three error variants onto the four
+//! checks, so there is one implementation of "is this mount really this
+//! estate's own ordinary checkout" and not two that can drift. Check 5 is
+//! Phase B's [`repolock::acquire`] plus the same
+//! [`fs_locking::detect_for_path`] reliability gate the daemon applies to its
+//! own data dir (amendment C4). Only checks 6–11 are new here.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::estate::{Estate, EstateError, MANIFEST_FILE, RepositorySpec, validate_mount};
+use crate::platform::fs_locking::{self, Reliability};
+use crate::runtime::git::{canonical_git_common_dir, git, git_succeeds};
+use crate::runtime::repolock;
+use crate::runtime::surface::{surface_root, work_branch};
+
+/// The eleven §8.1 checks, one variant each.
+///
+/// The taxonomy is the deliverable, not an implementation detail: §15 requires
+/// "stable structured API codes plus human remedies", and a refusal that could
+/// only say "preflight failed" would name no remedy at all. Every variant
+/// carries its own [`code`](Self::code) — the string a client branches on —
+/// and its own [`remedy`](Self::remedy).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreflightCheck {
+    /// 1. The derived mount path exists.
+    MountPresent,
+    /// 2. The path is not a symlink or alias outside the estate-owned mount.
+    MountNotAliased,
+    /// 3. `git rev-parse --show-toplevel` resolves exactly to the canonical
+    ///    mount.
+    MountTopLevel,
+    /// 4. The mount is an ordinary primary checkout, not a linked worktree
+    ///    admitted as a repository source.
+    MountPrimaryCheckout,
+    /// 5. The canonical Git common directory is resolvable and lockable.
+    CommonDirLockable,
+    /// 6. HEAD is attached to a named local branch. **Waivable** (§8.3).
+    HeadAttached,
+    /// 7. HEAD resolves to a full commit SHA.
+    HeadFullSha,
+    /// 8. `git status --porcelain` is empty for index and working tree.
+    ///    **Waivable** (§8.3).
+    WorktreeClean,
+    /// 9. `sergeant/<work-id>` does not already exist in that repository.
+    WorkBranchAbsent,
+    /// 10. The planned linked-worktree path is absent and not registered.
+    WorktreePathAbsent,
+    /// 11. All selected repositories can be planned before the first
+    ///     materialization side effect occurs.
+    AllRepositoriesPlanned,
+}
+
+impl PreflightCheck {
+    /// The stable wire code §15 requires. Prefixed so a client can tell a
+    /// preflight refusal from every other 422 without a lookup table.
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::MountPresent => "git_preflight_mount_missing",
+            Self::MountNotAliased => "git_preflight_mount_aliased",
+            Self::MountTopLevel => "git_preflight_top_level_mismatch",
+            Self::MountPrimaryCheckout => "git_preflight_linked_worktree_source",
+            Self::CommonDirLockable => "git_preflight_common_dir_unlockable",
+            Self::HeadAttached => "git_preflight_detached_head",
+            Self::HeadFullSha => "git_preflight_unresolvable_head",
+            Self::WorktreeClean => "git_preflight_dirty_mount",
+            Self::WorkBranchAbsent => "git_preflight_work_branch_collision",
+            Self::WorktreePathAbsent => "git_preflight_worktree_path_collision",
+            Self::AllRepositoriesPlanned => "git_preflight_incomplete_plan",
+        }
+    }
+
+    /// §8.1's own numbering, carried so a refusal can cite the check the
+    /// proposal names rather than only this crate's spelling of it.
+    pub fn number(self) -> u8 {
+        match self {
+            Self::MountPresent => 1,
+            Self::MountNotAliased => 2,
+            Self::MountTopLevel => 3,
+            Self::MountPrimaryCheckout => 4,
+            Self::CommonDirLockable => 5,
+            Self::HeadAttached => 6,
+            Self::HeadFullSha => 7,
+            Self::WorktreeClean => 8,
+            Self::WorkBranchAbsent => 9,
+            Self::WorktreePathAbsent => 10,
+            Self::AllRepositoriesPlanned => 11,
+        }
+    }
+
+    /// §8.3's table, as a predicate: exactly two conditions may be waived by
+    /// `--override-git-preflight`, and only because an exact commit can still
+    /// be pinned in both.
+    ///
+    /// Everything else is on the never-bypass list, and the reason is one
+    /// sentence of the proposal's own:
+    ///
+    /// > Override may waive policy caution. It may not replace a missing fact
+    /// > or overcome mechanical impossibility.
+    ///
+    /// [`Self::HeadFullSha`] is the sharpest case and deliberately `false`:
+    /// an unresolvable HEAD is precisely a missing fact — there is no commit
+    /// to pin — so §15 requires the refusal to say the override is
+    /// unavailable rather than to offer it.
+    pub fn waivable(self) -> bool {
+        matches!(self, Self::WorktreeClean | Self::HeadAttached)
+    }
+
+    /// §15's "named remedy": what the operator does about it.
+    pub fn remedy(self) -> &'static str {
+        match self {
+            Self::MountPresent => {
+                "clone or place the repository at <estate-root>/repos/<name>, or `sgt repo add \
+                 <name> --origin <url>`"
+            }
+            Self::MountNotAliased => {
+                "replace the symlink with the estate's own checkout at \
+                 <estate-root>/repos/<name>; separate estates use separate clones, even for the \
+                 same upstream repository (§6.2)"
+            }
+            Self::MountTopLevel => {
+                "make <estate-root>/repos/<name> the repository's own top level — a `../` alias \
+                 or another estate's clone reached through it is refused (§6.2)"
+            }
+            Self::MountPrimaryCheckout => {
+                "clone the repository into <estate-root>/repos/<name>; a linked worktree owns \
+                 neither its branches nor its worktree registry and may not be a repository \
+                 source (§6.2)"
+            }
+            Self::CommonDirLockable => {
+                "wait for whatever holds this repository's lock to finish, or move the estate to \
+                 a filesystem where advisory locking is reliable"
+            }
+            Self::HeadAttached => {
+                "check the mount out onto the branch this Work should be based on (`git -C \
+                 <mount> switch <branch>`), or re-submit with --override-git-preflight to pin \
+                 the exact detached HEAD and record no named base branch"
+            }
+            Self::HeadFullSha => {
+                "give the mount a commit to be based on (`git -C <mount> commit`, or check out a \
+                 branch that has one); --override-git-preflight is unavailable here because no \
+                 exact base can be pinned"
+            }
+            Self::WorktreeClean => {
+                "commit or stash the mount's changes (`git -C <mount> status`), or re-submit \
+                 with --override-git-preflight to base the Work on the committed HEAD and \
+                 exclude the uncommitted changes"
+            }
+            Self::WorkBranchAbsent => {
+                "this ref belongs to the Work named in it and is never deleted or reused \
+                 automatically (§9.1); inspect it with `sgt work show <work-id>` and resolve it \
+                 yourself if it is genuinely stale"
+            }
+            Self::WorktreePathAbsent => {
+                "the path belongs to the Work named in it; inspect it with `sgt work show \
+                 <work-id>` — sergeant never removes or reuses another Work's surface \
+                 automatically"
+            }
+            Self::AllRepositoriesPlanned => {
+                "resolve every named repository's finding above, or narrow the scope with --repo \
+                 so the submission covers only repositories that can be planned"
+            }
+        }
+    }
+}
+
+/// One §8.1 check that did not hold, for one repository.
+///
+/// Carried whether it was refused or waived: §8.3 requires "the override and
+/// every waived finding are journaled with the Work", so a waived finding is
+/// exactly this value stored on the admission record rather than raised.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreflightFinding {
+    /// Repository this was found in. `AllRepositoriesPlanned` is the one
+    /// scope-level finding and names the whole selection instead.
+    pub repository: String,
+    /// Which §8.1 check.
+    pub check: PreflightCheck,
+    /// What was actually observed — the evidence half of §15's "show
+    /// branch/HEAD/status", never a restatement of the check's name.
+    pub detail: String,
+    /// §8.3's dirty-mount evidence: the *full* `git status --porcelain`
+    /// output, recorded verbatim so a waived dirty admission journals exactly
+    /// what was excluded from the Work base rather than a count of it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub porcelain: Option<String>,
+}
+
+impl PreflightFinding {
+    fn new(repository: &str, check: PreflightCheck, detail: impl Into<String>) -> Self {
+        Self {
+            repository: repository.to_string(),
+            check,
+            detail: detail.into(),
+            porcelain: None,
+        }
+    }
+
+    /// The stable API code for this finding (§15).
+    pub fn code(&self) -> &'static str {
+        self.check.code()
+    }
+
+    /// The named remedy for this finding (§15).
+    pub fn remedy(&self) -> &'static str {
+        self.check.remedy()
+    }
+}
+
+impl std::fmt::Display for PreflightFinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} (§8.1 check {}, {}): {} — {}",
+            self.repository,
+            self.check.number(),
+            self.check.code(),
+            self.detail,
+            self.check.remedy()
+        )
+    }
+}
+
+/// What §8.3 authorized for one repository, journaled with its binding.
+///
+/// Present on an admitted repository whether or not anything was waived: the
+/// honest record of a clean admission is "the override was not requested and
+/// nothing was waived", which is a different fact from "no preflight ran"
+/// (what a `None` on a pre-Phase-E binding means).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreflightEvidence {
+    /// Whether the submission carried `--override-git-preflight` at all. Note
+    /// this is the *submission's* flag, not "something was waived": an
+    /// override that turned out to waive nothing still records that the
+    /// operator typed it.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub override_authorized: bool,
+    /// Every §8.1 finding the override waived, with its evidence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub waived: Vec<PreflightFinding>,
+    /// §8.3's required explicit statement, when a dirty mount was waived:
+    /// which uncommitted changes are *excluded* from the Work base. `None`
+    /// when nothing was excluded, which is the ordinary case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uncommitted_excluded: Option<String>,
+}
+
+impl PreflightEvidence {
+    /// Whether this admission waived anything at all.
+    pub fn waived_anything(&self) -> bool {
+        !self.waived.is_empty()
+    }
+}
+
+/// One repository, admitted: every §8.1 fact resolved, and the §8.2 base
+/// pinned.
+///
+/// This is what makes §8.2's base an *admitted* fact rather than an ambient
+/// one. Materialization reads `base_sha`/`base_branch` from here instead of
+/// re-asking the mount, so the commit the Work is based on is the commit
+/// preflight judged — not whatever HEAD happens to be by the time
+/// `git worktree add` runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdmittedRepository {
+    /// Repository name within the estate.
+    pub repository: String,
+    /// The canonical derived mount `<estate-root>/repos/<name>`.
+    pub mount_path: PathBuf,
+    /// §3.5's canonical Git top level.
+    pub canonical_top_level: PathBuf,
+    /// §3.5's canonical Git common directory — §2.7/§9.4's lock identity.
+    pub canonical_common_dir: PathBuf,
+    /// §8.2's base branch: the mount's current local branch. `None` only for
+    /// a detached mount admitted under §8.3's override, which records no
+    /// named base branch.
+    #[serde(default)]
+    pub base_branch: Option<String>,
+    /// §8.2's base commit: the mount's exact HEAD, always a full SHA.
+    pub base_sha: String,
+    /// The `sergeant/<work-id>` branch check 9 found absent.
+    pub work_branch: String,
+    /// The linked-worktree path check 10 found absent and unregistered.
+    pub worktree_path: PathBuf,
+    /// §8.3's override record for this repository.
+    #[serde(default)]
+    pub evidence: PreflightEvidence,
+}
+
+/// The whole scope, admitted (§8.1 check 11).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GitPreflight {
+    /// The Work this admission is for — the id checks 9 and 10 are about.
+    pub work_id: String,
+    /// Whether the submission carried `--override-git-preflight`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub override_requested: bool,
+    /// One record per selected repository, in scope order.
+    pub repositories: Vec<AdmittedRepository>,
+}
+
+impl GitPreflight {
+    /// Every finding §8.3 waived across the whole scope, in scope order.
+    pub fn waived(&self) -> impl Iterator<Item = &PreflightFinding> {
+        self.repositories
+            .iter()
+            .flat_map(|r| r.evidence.waived.iter())
+    }
+
+    /// The admission record for one repository by name.
+    pub fn repository(&self, name: &str) -> Option<&AdmittedRepository> {
+        self.repositories.iter().find(|r| r.repository == name)
+    }
+}
+
+/// A submission refused by §8.1, before a Work record exists.
+///
+/// Holds *every* unresolved finding rather than the first, because §15's
+/// remedy for a multi-repository scope is not "fix this one and resubmit to
+/// discover the next": check 11 is a scope-level fact, and an operator who
+/// has to iterate one repository per submission is being told a fraction of
+/// what preflight already knows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreflightRefusal {
+    /// At least one finding, in scope order, with check 11's scope-level
+    /// finding last when the scope had more than one repository.
+    pub findings: Vec<PreflightFinding>,
+}
+
+impl PreflightRefusal {
+    /// The primary structured code (§15): the first repository-level finding,
+    /// which is the most specific thing an operator can act on. Every other
+    /// finding travels in the body beside it.
+    pub fn code(&self) -> &'static str {
+        self.findings
+            .first()
+            .map_or(PreflightCheck::AllRepositoriesPlanned.code(), |f| f.code())
+    }
+
+    /// Whether any refused finding would have been waivable by
+    /// `--override-git-preflight` — what §15's dirty/detached row means by
+    /// "mention the bounded escape hatch", and deliberately *not* mentioned
+    /// when nothing here is waivable.
+    pub fn override_would_help(&self) -> bool {
+        self.findings.iter().any(|f| f.check.waivable())
+    }
+}
+
+impl std::fmt::Display for PreflightRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "git admission preflight refused this submission (§8.1): "
+        )?;
+        for (index, finding) in self.findings.iter().enumerate() {
+            if index > 0 {
+                f.write_str("; ")?;
+            }
+            write!(f, "{finding}")?;
+        }
+        if self.override_would_help() {
+            f.write_str(
+                ". --override-git-preflight waives a dirty or detached mount — and nothing else",
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Run §8.1 for every selected repository.
+///
+/// `work_id` is the id the Work *would* get: checks 9 and 10 are questions
+/// about `sergeant/<work-id>` and `<surfaces_root>/<work-id>/<repo>`, so the
+/// id has to exist before the record does. Minting a ULID costs nothing and
+/// has no side effect, so a refusal simply discards it — which is the whole
+/// point of running here, "before a Work record exists".
+///
+/// `data_dir` is where §9.4's repository locks live, and is the only reason
+/// this function takes it (check 5).
+///
+/// Ordering within a repository is deliberate: the mount identity checks
+/// (1–4) come first because every later question is meaningless if the path
+/// is not the repository we think it is, and check 7 is evaluated even when
+/// check 6 fails, because a detached HEAD still has a commit and §8.3 can
+/// only waive the detachment if that commit exists.
+///
+/// **A repository stops at its first finding.** Reporting "detached *and*
+/// dirty *and* colliding" for a mount whose top level is not even the
+/// declared path is noise, not evidence — but every *repository* is
+/// evaluated, so a two-repository scope with a problem in each is refused
+/// naming both.
+pub fn run(
+    estate: &Estate,
+    data_dir: &Path,
+    surfaces_root: &Path,
+    work_id: &str,
+    repositories: &[RepositorySpec],
+    override_requested: bool,
+) -> Result<GitPreflight, PreflightRefusal> {
+    let manifest = estate.root.join(MANIFEST_FILE).display().to_string();
+    let branch = work_branch(work_id);
+    let root = surface_root(surfaces_root, work_id);
+
+    let mut admitted = Vec::with_capacity(repositories.len());
+    let mut refused = Vec::new();
+    let mut unplannable = Vec::new();
+
+    for repository in repositories {
+        let worktree_path = root.join(&repository.name);
+        match check_one(
+            &manifest,
+            data_dir,
+            repository,
+            &branch,
+            &worktree_path,
+            override_requested,
+        ) {
+            Ok(record) => admitted.push(record),
+            Err(finding) => {
+                unplannable.push(finding.repository.clone());
+                refused.push(finding);
+            }
+        }
+    }
+
+    if refused.is_empty() {
+        return Ok(GitPreflight {
+            work_id: work_id.to_string(),
+            override_requested,
+            repositories: admitted,
+        });
+    }
+
+    // Check 11, as a finding rather than an invariant nobody can see fail.
+    // Only for a multi-repository scope: for a single repository "1 of 1
+    // could not be planned" restates the finding above it, while for a scope
+    // it is the fact that decides the outcome — no repository was
+    // materialized, including the ones that were fine.
+    if repositories.len() > 1 {
+        refused.push(PreflightFinding::new(
+            &unplannable.join(", "),
+            PreflightCheck::AllRepositoriesPlanned,
+            format!(
+                "{} of {} selected repositories could not be planned ({}); no repository was \
+                 materialized — §8.1 requires the whole scope to plan before the first \
+                 materialization side effect",
+                unplannable.len(),
+                repositories.len(),
+                unplannable.join(", ")
+            ),
+        ));
+    }
+    Err(PreflightRefusal { findings: refused })
+}
+
+/// §8.1 for one repository. `Ok` is an admission; `Err` is its first
+/// unresolved finding.
+fn check_one(
+    manifest: &str,
+    data_dir: &Path,
+    repository: &RepositorySpec,
+    branch: &str,
+    worktree_path: &Path,
+    override_requested: bool,
+) -> Result<AdmittedRepository, PreflightFinding> {
+    let name = repository.name.as_str();
+    let mount = repository.path.as_path();
+
+    // Checks 1–4, decided by the one function that already decides them.
+    let canonical_top_level = validate_mount(manifest, name, mount).map_err(|e| {
+        let (check, detail) = classify_mount_error(mount, &e);
+        PreflightFinding::new(name, check, detail)
+    })?;
+
+    // Check 5: resolvable, on a filesystem whose advisory locks mean
+    // something, and actually lockable.
+    let canonical_common_dir = canonical_git_common_dir(mount).map_err(|e| {
+        PreflightFinding::new(
+            name,
+            PreflightCheck::CommonDirLockable,
+            format!(
+                "git cannot resolve a common directory for {}: {e}",
+                mount.display()
+            ),
+        )
+    })?;
+    // C4's disposition: the same gate `daemon::start_with` applies to its own
+    // data dir, applied here to the mount's filesystem. `Unknown` never
+    // refuses — an inconclusive probe must not brick a platform whose
+    // detection is unmeasured (`fs_locking`'s own asymmetry).
+    if let Reliability::Unreliable { filesystem } =
+        fs_locking::detect_for_path(&canonical_common_dir)
+    {
+        return Err(PreflightFinding::new(
+            name,
+            PreflightCheck::CommonDirLockable,
+            format!(
+                "{} is on a {filesystem} filesystem: {}",
+                canonical_common_dir.display(),
+                fs_locking::remedy(&filesystem)
+            ),
+        ));
+    }
+    // Taken and released: this asks "can this repository be locked at all",
+    // not "is it free forever". A holder is *waited out* rather than refused
+    // (§9.4's contender semantics, which `repolock::acquire` implements), so
+    // an ordinary concurrent materialization does not turn into an admission
+    // refusal — only exhausting the budget does, and that is a structured
+    // failure naming the lock.
+    drop(
+        repolock::acquire(data_dir, &canonical_common_dir).map_err(|e| {
+            PreflightFinding::new(name, PreflightCheck::CommonDirLockable, e.to_string())
+        })?,
+    );
+
+    // Check 6: attached HEAD. Waivable — but only once check 7 has proved
+    // there is a commit to pin, so the finding is held rather than raised.
+    let base_branch = git(mount, &["symbolic-ref", "--quiet", "--short", "HEAD"]).ok();
+
+    // Check 7: a full commit SHA. Evaluated even when 6 failed, because a
+    // detached HEAD still has one — and because §8.3 may only waive the
+    // detachment when "an exact commit can still be pinned".
+    let head = git(mount, &["rev-parse", "--verify", "HEAD"]).map_err(|e| {
+        PreflightFinding::new(
+            name,
+            PreflightCheck::HeadFullSha,
+            format!(
+                "HEAD in {} does not resolve to a commit (an unborn branch, or a repository with \
+                 no commits yet): {e}",
+                mount.display()
+            ),
+        )
+    })?;
+    if !is_full_object_id(&head) {
+        return Err(PreflightFinding::new(
+            name,
+            PreflightCheck::HeadFullSha,
+            format!(
+                "HEAD in {} resolved to {head:?}, which is not a full object id",
+                mount.display()
+            ),
+        ));
+    }
+
+    let mut evidence = PreflightEvidence {
+        override_authorized: override_requested,
+        ..PreflightEvidence::default()
+    };
+
+    if base_branch.is_none() {
+        let finding = PreflightFinding::new(
+            name,
+            PreflightCheck::HeadAttached,
+            format!(
+                "HEAD in {} is detached at {head}; there is no named local branch to record as \
+                 the base",
+                mount.display()
+            ),
+        );
+        if !override_requested {
+            return Err(finding);
+        }
+        evidence.waived.push(finding);
+    }
+
+    // Check 8: clean index *and* working tree. `--porcelain` reports both,
+    // and `runtime::git` already runs every invocation with
+    // `GIT_OPTIONAL_LOCKS=0`, so asking does not write to the mount's index.
+    let porcelain = git(mount, &["status", "--porcelain"]).map_err(|e| {
+        PreflightFinding::new(
+            name,
+            PreflightCheck::WorktreeClean,
+            format!("git cannot report status for {}: {e}", mount.display()),
+        )
+    })?;
+    if !porcelain.is_empty() {
+        let mut finding = PreflightFinding::new(
+            name,
+            PreflightCheck::WorktreeClean,
+            format!(
+                "{} has {} uncommitted change(s) in its index or working tree at branch {} \
+                 (HEAD {head})",
+                mount.display(),
+                porcelain.lines().count(),
+                base_branch.as_deref().unwrap_or("(detached)"),
+            ),
+        );
+        // §8.3: "record full porcelain evidence".
+        finding.porcelain = Some(porcelain.clone());
+        if !override_requested {
+            return Err(finding);
+        }
+        // §8.3: "state explicitly that uncommitted changes are excluded from
+        // the Work base".
+        evidence.uncommitted_excluded = Some(format!(
+            "the Work is based on the committed HEAD {head}; the {} uncommitted change(s) below \
+             stayed in the mount at {} and are excluded from the Work base",
+            porcelain.lines().count(),
+            mount.display()
+        ));
+        evidence.waived.push(finding);
+    }
+
+    // Check 9: the Work's own branch must not already exist. Never waivable,
+    // never deleted or reused automatically (§9.1, §15).
+    let ref_name = format!("refs/heads/{branch}");
+    if git_succeeds(mount, &["show-ref", "--verify", "--quiet", &ref_name]) {
+        return Err(PreflightFinding::new(
+            name,
+            PreflightCheck::WorkBranchAbsent,
+            format!(
+                "{ref_name} already exists in {}; it belongs to work {}",
+                mount.display(),
+                owning_work_id(branch),
+            ),
+        ));
+    }
+
+    // Check 10: the planned worktree path must be absent *and* unregistered.
+    // Two questions, because they fail apart: a directory left behind by a
+    // crashed teardown is absent from the registry, and a registry entry
+    // whose directory was deleted by hand is absent from the disk.
+    if worktree_path.symlink_metadata().is_ok() {
+        return Err(PreflightFinding::new(
+            name,
+            PreflightCheck::WorktreePathAbsent,
+            format!(
+                "{} already exists; it is work {}'s surface",
+                worktree_path.display(),
+                owning_work_id(branch),
+            ),
+        ));
+    }
+    if let Some(registered) = registered_worktree(mount, worktree_path) {
+        return Err(PreflightFinding::new(
+            name,
+            PreflightCheck::WorktreePathAbsent,
+            format!(
+                "{} is still registered as a linked worktree of {} (git worktree list reports \
+                 {registered}), even though nothing is at that path",
+                worktree_path.display(),
+                mount.display(),
+            ),
+        ));
+    }
+
+    Ok(AdmittedRepository {
+        repository: name.to_string(),
+        mount_path: canonical_top_level.clone(),
+        canonical_top_level,
+        canonical_common_dir,
+        base_branch,
+        base_sha: head,
+        work_branch: branch.to_string(),
+        worktree_path: worktree_path.to_path_buf(),
+        evidence,
+    })
+}
+
+/// Map [`validate_mount`]'s three refusals onto §8.1's checks 1–4.
+///
+/// `validate_mount` answers one question — "is this the estate's own ordinary
+/// checkout" — and §8.1 splits that question four ways, so the split happens
+/// here rather than by asking git the same things again. The two cases
+/// `RepositoryMountAliased` covers are separated by the one fact that
+/// distinguishes them and that the error does not carry: whether the mount is
+/// *itself* a symlink (check 2) or merely resolves somewhere else (check 3).
+fn classify_mount_error(mount: &Path, error: &EstateError) -> (PreflightCheck, String) {
+    match error {
+        EstateError::RepositoryNotFound { .. } if !mount.exists() => {
+            (PreflightCheck::MountPresent, error.to_string())
+        }
+        EstateError::RepositoryNotFound { .. } => {
+            (PreflightCheck::MountTopLevel, error.to_string())
+        }
+        EstateError::RepositoryMountAliased { .. }
+            if mount
+                .symlink_metadata()
+                .is_ok_and(|meta| meta.file_type().is_symlink()) =>
+        {
+            (PreflightCheck::MountNotAliased, error.to_string())
+        }
+        EstateError::RepositoryMountAliased { .. } => {
+            (PreflightCheck::MountTopLevel, error.to_string())
+        }
+        EstateError::RepositoryMountIsLinkedWorktree { .. } => {
+            (PreflightCheck::MountPrimaryCheckout, error.to_string())
+        }
+        // Not reachable from `validate_mount`'s own body today. Classified as
+        // the top-level check rather than silently admitted, because an
+        // unclassified refusal is still a refusal.
+        other => (PreflightCheck::MountTopLevel, other.to_string()),
+    }
+}
+
+/// Whether `text` is a full object id — 40 hex characters for SHA-1, 64 for
+/// SHA-256 (`git rev-parse --verify HEAD` answers in the repository's own
+/// object format, and a repository created with `--object-format=sha256`
+/// answers 64).
+///
+/// Checked rather than assumed: §8.1 check 7 is "HEAD resolves to a full
+/// commit SHA", and the value is what a Work's base is pinned to for its
+/// whole life. An abbreviated or otherwise unexpected answer is a fact this
+/// admission does not have, not one to round off.
+fn is_full_object_id(text: &str) -> bool {
+    matches!(text.len(), 40 | 64) && text.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// The Work a `sergeant/<work-id>` ref or surface directory belongs to (§15:
+/// "name ref/path and owning Work evidence if known").
+///
+/// Read off the name itself rather than looked up in the registry: the
+/// convention is what makes the ref attributable at all, and a lookup would
+/// answer "unknown" for exactly the case an operator most needs named — a ref
+/// left in a mount by an estate whose journal this daemon does not have.
+fn owning_work_id(branch: &str) -> &str {
+    branch.strip_prefix("sergeant/").unwrap_or(branch)
+}
+
+/// The registry entry for `worktree_path`, if `git worktree list` has one.
+///
+/// Compared canonically where possible — a registry records the path git was
+/// given, and the same directory reached through a symlinked ancestor spells
+/// differently — falling back to the literal comparison when neither side
+/// canonicalizes (the ordinary case here, since check 10 is asking about a
+/// path that should not exist).
+fn registered_worktree(mount: &Path, worktree_path: &Path) -> Option<String> {
+    let listing = git(mount, &["worktree", "list", "--porcelain"]).ok()?;
+    let wanted: BTreeSet<PathBuf> = [
+        Some(worktree_path.to_path_buf()),
+        std::fs::canonicalize(worktree_path).ok(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    listing
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .find(|entry| {
+            let path = PathBuf::from(entry);
+            let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            wanted.contains(&path) || wanted.contains(&canonical)
+        })
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// §8.3's table is a *closed* list of two, and this is the assertion that
+    /// keeps it closed: every other check is on the never-bypass list, and a
+    /// variant added to the taxonomy without a decision about waivability
+    /// fails here rather than defaulting into the escape hatch.
+    #[test]
+    fn only_dirty_and_detached_are_waivable() {
+        use PreflightCheck::*;
+        let all = [
+            MountPresent,
+            MountNotAliased,
+            MountTopLevel,
+            MountPrimaryCheckout,
+            CommonDirLockable,
+            HeadAttached,
+            HeadFullSha,
+            WorktreeClean,
+            WorkBranchAbsent,
+            WorktreePathAbsent,
+            AllRepositoriesPlanned,
+        ];
+        assert_eq!(all.len(), 11, "§8.1 declares eleven checks");
+        let waivable: Vec<PreflightCheck> = all.into_iter().filter(|c| c.waivable()).collect();
+        assert_eq!(
+            waivable,
+            vec![HeadAttached, WorktreeClean],
+            "§8.3 waives a dirty mount and a detached mount, and nothing else"
+        );
+    }
+
+    /// The taxonomy exists to name each failure distinctly; two checks
+    /// sharing a code would collapse exactly the distinction §15's structured
+    /// codes are for.
+    #[test]
+    fn every_check_has_a_distinct_code_number_and_remedy() {
+        use PreflightCheck::*;
+        let all = [
+            MountPresent,
+            MountNotAliased,
+            MountTopLevel,
+            MountPrimaryCheckout,
+            CommonDirLockable,
+            HeadAttached,
+            HeadFullSha,
+            WorktreeClean,
+            WorkBranchAbsent,
+            WorktreePathAbsent,
+            AllRepositoriesPlanned,
+        ];
+        let codes: BTreeSet<&str> = all.iter().map(|c| c.code()).collect();
+        assert_eq!(codes.len(), all.len(), "codes must be distinct: {codes:?}");
+        let numbers: BTreeSet<u8> = all.iter().map(|c| c.number()).collect();
+        assert_eq!(numbers, (1..=11).collect::<BTreeSet<u8>>());
+        let remedies: BTreeSet<&str> = all.iter().map(|c| c.remedy()).collect();
+        assert_eq!(remedies.len(), all.len(), "remedies must be distinct");
+        for check in all {
+            assert!(
+                check.code().starts_with("git_preflight_"),
+                "{:?} must be recognizable as a preflight code",
+                check
+            );
+        }
+    }
+
+    /// §15: the unresolvable-HEAD row is the one that must *not* offer the
+    /// escape hatch, and it says so in the remedy rather than only by
+    /// omission.
+    #[test]
+    fn the_unresolvable_head_remedy_says_the_override_is_unavailable() {
+        let remedy = PreflightCheck::HeadFullSha.remedy();
+        assert!(
+            remedy.contains("--override-git-preflight is unavailable"),
+            "§15 requires this refusal to say why no override applies: {remedy}"
+        );
+        assert!(!PreflightCheck::HeadFullSha.waivable());
+    }
+
+    /// §15's dirty/detached row asks the refusal to "mention the bounded
+    /// escape hatch" — and, by the same token, a refusal with nothing
+    /// waivable in it must not dangle one.
+    #[test]
+    fn only_a_waivable_refusal_mentions_the_escape_hatch() {
+        let dirty = PreflightRefusal {
+            findings: vec![PreflightFinding::new(
+                "api",
+                PreflightCheck::WorktreeClean,
+                "two files modified",
+            )],
+        };
+        assert!(dirty.override_would_help());
+        assert!(dirty.to_string().contains("--override-git-preflight"));
+        assert_eq!(dirty.code(), "git_preflight_dirty_mount");
+
+        let collision = PreflightRefusal {
+            findings: vec![PreflightFinding::new(
+                "api",
+                PreflightCheck::WorkBranchAbsent,
+                "refs/heads/sergeant/01OTHER exists",
+            )],
+        };
+        assert!(!collision.override_would_help());
+        assert!(!collision.to_string().contains("--override-git-preflight"));
+    }
+
+    #[test]
+    fn a_full_object_id_is_forty_or_sixty_four_hex_characters() {
+        assert!(is_full_object_id(&"a".repeat(40)));
+        assert!(is_full_object_id(&"0123456789abcdef".repeat(4)));
+        assert!(!is_full_object_id("abc1234"), "abbreviated is not full");
+        assert!(!is_full_object_id(""), "an empty answer is not a commit");
+        assert!(!is_full_object_id(&"z".repeat(40)), "hex only");
+        assert!(!is_full_object_id("HEAD"));
+    }
+
+    #[test]
+    fn a_collision_names_the_work_that_owns_the_ref() {
+        assert_eq!(owning_work_id("sergeant/01ABC"), "01ABC");
+        // A branch that is not one of ours is reported verbatim rather than
+        // mangled into a work id it never was.
+        assert_eq!(owning_work_id("main"), "main");
+    }
+}

--- a/src/runtime/preflight.rs
+++ b/src/runtime/preflight.rs
@@ -27,7 +27,7 @@
 //!
 //! # Reuse, not a second opinion
 //!
-//! Checks 1–4 are exactly what [`estate::validate_mount`] already decides
+//! Checks 1–4 are exactly what [`validate_mount`] already decides
 //! while resolving a manifest (Phase D); this calls that same function per
 //! *selected* repository and maps its three error variants onto the four
 //! checks, so there is one implementation of "is this mount really this

--- a/src/runtime/preflight.rs
+++ b/src/runtime/preflight.rs
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::domain::estate::{Estate, EstateError, MANIFEST_FILE, RepositorySpec, validate_mount};
 use crate::platform::fs_locking::{self, Reliability};
-use crate::runtime::git::{canonical_git_common_dir, git, git_succeeds};
+use crate::runtime::git::{canonical_git_common_dir, git, git_succeeds, git_verbatim};
 use crate::runtime::repolock;
 use crate::runtime::surface::{surface_root, work_branch};
 
@@ -599,7 +599,10 @@ fn check_one(
     // Check 8: clean index *and* working tree. `--porcelain` reports both,
     // and `runtime::git` already runs every invocation with
     // `GIT_OPTIONAL_LOCKS=0`, so asking does not write to the mount's index.
-    let porcelain = git(mount, &["status", "--porcelain"]).map_err(|e| {
+    // Verbatim, not trimmed: the leading column of a porcelain record is the
+    // index status, and ` M file` trimmed becomes `M file` — a different
+    // answer. §8.3's "full porcelain evidence" means the bytes git wrote.
+    let porcelain = git_verbatim(mount, &["status", "--porcelain"]).map_err(|e| {
         PreflightFinding::new(
             name,
             PreflightCheck::WorktreeClean,
@@ -900,5 +903,498 @@ mod tests {
         // A branch that is not one of ours is reported verbatim rather than
         // mangled into a work id it never was.
         assert_eq!(owning_work_id("main"), "main");
+    }
+
+    // ------------------------------------------------- §8.1, one case each
+    //
+    // The taxonomy is only worth having if each check can actually be made
+    // to fail on its own, so each of the eleven below constructs exactly one
+    // unresolved fact against an otherwise perfectly admissible estate and
+    // asserts which check names it.
+    //
+    // Every fixture resolves the estate *first* and then breaks the mount.
+    // That is not a shortcut around `Estate::resolve` — it is §8.4's whole
+    // point in miniature: the manifest was read at one moment, admission
+    // happens at another, and the daemon re-enforces the mechanical contract
+    // at the second moment rather than trusting the first.
+
+    /// One git command in `dir` with a fixture identity and no ambient
+    /// config, so these tests behave the same on a host with no global git
+    /// identity as on one with several.
+    fn git_fixture(dir: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@example.invalid")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@example.invalid")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .output()
+            .expect("git");
+        assert!(
+            output.status.success(),
+            "git {args:?} in {dir:?}: {output:?}"
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    /// The Work id every fixture admits against, and the branch it implies.
+    const WORK: &str = "01PREFLIGHT0000000000";
+
+    /// A scratch estate with `repos` mounted and one commit each, resolved.
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        estate: Estate,
+        data: PathBuf,
+        surfaces: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(repos: &[&str]) -> Self {
+            let dir = tempfile::TempDir::new().expect("tempdir");
+            let root = dir.path().join("estate");
+            std::fs::create_dir_all(&root).expect("estate root");
+            let mut manifest = String::from("[estate]\nname = \"fixture\"\n");
+            for repo in repos {
+                manifest.push_str(&format!("\n[[repo]]\nname = {repo:?}\n"));
+                let mount = root.join("repos").join(repo);
+                std::fs::create_dir_all(&mount).expect("mount");
+                git_fixture(&mount, &["init", "-b", "main"]);
+                std::fs::write(mount.join("README.md"), "# fixture\n").expect("write");
+                git_fixture(&mount, &["add", "."]);
+                git_fixture(&mount, &["commit", "-m", "initial"]);
+            }
+            std::fs::write(root.join(MANIFEST_FILE), manifest).expect("manifest");
+            let estate = Estate::resolve(&root).expect("a scaffolded estate resolves");
+            Self {
+                data: dir.path().join("data"),
+                surfaces: dir.path().join("surfaces"),
+                _dir: dir,
+                estate,
+            }
+        }
+
+        fn mount(&self, name: &str) -> PathBuf {
+            self.estate
+                .repositories
+                .iter()
+                .find(|r| r.name == name)
+                .expect("declared repository")
+                .path
+                .clone()
+        }
+
+        fn run(&self, override_requested: bool) -> Result<GitPreflight, PreflightRefusal> {
+            run(
+                &self.estate,
+                &self.data,
+                &self.surfaces,
+                WORK,
+                &self.estate.repositories,
+                override_requested,
+            )
+        }
+
+        /// The single check a refusal names, asserting there is exactly one.
+        fn refused_check(&self, override_requested: bool) -> PreflightCheck {
+            let refusal = self
+                .run(override_requested)
+                .expect_err("this fixture must be refused");
+            assert_eq!(
+                refusal.findings.len(),
+                1,
+                "one broken fact, one finding: {refusal:?}"
+            );
+            refusal.findings[0].check
+        }
+    }
+
+    /// Check 1. The mount is gone between manifest resolution and admission.
+    #[test]
+    fn check_1_a_missing_mount_is_named_as_a_missing_mount() {
+        let fixture = Fixture::new(&["solo"]);
+        std::fs::remove_dir_all(fixture.mount("solo")).expect("remove the mount");
+        assert_eq!(fixture.refused_check(false), PreflightCheck::MountPresent);
+    }
+
+    /// Check 2. The mount is replaced by a symlink to a checkout elsewhere —
+    /// §6.2's shared-mount aliasing, which a canonical comparison alone
+    /// cannot see because it would happily follow the link.
+    #[test]
+    fn check_2_a_symlinked_mount_is_named_as_an_alias() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        let elsewhere = fixture._dir.path().join("someone-elses-clone");
+        std::fs::create_dir_all(&elsewhere).expect("clone dir");
+        git_fixture(&elsewhere, &["init", "-b", "main"]);
+        git_fixture(&elsewhere, &["commit", "--allow-empty", "-m", "initial"]);
+        std::fs::remove_dir_all(&mount).expect("remove the real mount");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&elsewhere, &mount).expect("symlink the mount");
+        assert_eq!(
+            fixture.refused_check(false),
+            PreflightCheck::MountNotAliased
+        );
+    }
+
+    /// Check 3. The mount exists but git cannot call it a top level at all —
+    /// the `.git` directory is gone, so there is nothing to resolve.
+    #[test]
+    fn check_3_a_mount_that_is_no_longer_a_repository_is_named_at_the_top_level() {
+        let fixture = Fixture::new(&["solo"]);
+        std::fs::remove_dir_all(fixture.mount("solo").join(".git")).expect("de-git the mount");
+        assert_eq!(fixture.refused_check(false), PreflightCheck::MountTopLevel);
+    }
+
+    /// Check 4. The mount is a linked worktree of some other repository —
+    /// exactly the recursion §6.2 refuses, including a Work's own surface
+    /// declared back as a source.
+    #[test]
+    fn check_4_a_linked_worktree_mount_is_named_as_one() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        let upstream = fixture._dir.path().join("upstream");
+        std::fs::create_dir_all(&upstream).expect("upstream dir");
+        git_fixture(&upstream, &["init", "-b", "main"]);
+        git_fixture(&upstream, &["commit", "--allow-empty", "-m", "initial"]);
+        std::fs::remove_dir_all(&mount).expect("remove the primary checkout");
+        git_fixture(
+            &upstream,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "linked",
+                &mount.display().to_string(),
+                "HEAD",
+            ],
+        );
+        assert_eq!(
+            fixture.refused_check(false),
+            PreflightCheck::MountPrimaryCheckout
+        );
+    }
+
+    /// Check 5. The repository's lock cannot be taken, so the registry
+    /// mutation materialization would perform is refused *now* rather than
+    /// discovered half-way through it.
+    ///
+    /// Driven through the un-openable arm (`locks/` occupied by a file, so
+    /// the lock's own directory cannot be created) rather than the contended
+    /// one: a held lock is *waited out* by design (§9.4's contender
+    /// semantics), so making preflight refuse that way would mean spending
+    /// `repolock::LOCK_BUDGET` — thirty seconds — inside a unit test to
+    /// assert a taxonomy entry. Both arms are the same
+    /// [`repolock::RepoLockError`], classified identically, and
+    /// `repolock`'s own suite already covers the timeout half.
+    #[test]
+    fn check_5_a_common_dir_that_cannot_be_locked_is_named_as_such() {
+        let fixture = Fixture::new(&["solo"]);
+        std::fs::create_dir_all(&fixture.data).expect("data dir");
+        std::fs::write(fixture.data.join(repolock::LOCKS_DIR), "not a directory")
+            .expect("occupy the locks directory with a file");
+        let refusal = fixture
+            .run(true)
+            .expect_err("an unlockable repository is refused");
+        assert_eq!(refusal.findings[0].check, PreflightCheck::CommonDirLockable);
+        assert!(
+            !refusal.override_would_help(),
+            "§8.3 never bypasses a lock conflict"
+        );
+        let lock_path = repolock::lock_path(
+            &fixture.data,
+            &canonical_git_common_dir(&fixture.mount("solo")).expect("common dir"),
+        );
+        assert!(
+            refusal.findings[0]
+                .detail
+                .contains(&lock_path.display().to_string()),
+            "the refusal names the lock it could not take: {}",
+            refusal.findings[0].detail
+        );
+    }
+
+    /// Check 6. A detached HEAD, refused without the override. (The override
+    /// arm is `an_override_admits_a_detached_mount_with_no_named_base_branch`
+    /// below.)
+    #[test]
+    fn check_6_a_detached_head_is_named_and_is_waivable() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        let head = git_fixture(&mount, &["rev-parse", "HEAD"]);
+        git_fixture(&mount, &["checkout", "--detach", &head]);
+        assert_eq!(fixture.refused_check(false), PreflightCheck::HeadAttached);
+        assert!(PreflightCheck::HeadAttached.waivable());
+    }
+
+    /// Check 7. An unborn branch: HEAD is a perfectly ordinary symref to
+    /// `refs/heads/main`, so check 6 passes — there is simply no commit.
+    /// Refused, and *not* waivable: §8.3 may waive a caution, never a
+    /// missing fact.
+    #[test]
+    fn check_7_an_unresolvable_head_is_named_and_the_override_does_not_help() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        // Roll the only branch back to nothing: `main` still exists as
+        // HEAD's symref target, but points at no commit.
+        git_fixture(&mount, &["update-ref", "-d", "refs/heads/main"]);
+        assert_eq!(fixture.refused_check(false), PreflightCheck::HeadFullSha);
+        assert_eq!(
+            fixture.refused_check(true),
+            PreflightCheck::HeadFullSha,
+            "§8.3: an override may not replace a missing fact"
+        );
+    }
+
+    /// Check 8. A dirty mount, refused without the override, with the full
+    /// porcelain evidence already attached to the finding.
+    #[test]
+    fn check_8_a_dirty_mount_is_named_and_carries_its_porcelain_evidence() {
+        let fixture = Fixture::new(&["solo"]);
+        std::fs::write(fixture.mount("solo").join("README.md"), "edited\n").expect("dirty it");
+        let refusal = fixture.run(false).expect_err("a dirty mount is refused");
+        assert_eq!(refusal.findings[0].check, PreflightCheck::WorktreeClean);
+        assert_eq!(
+            refusal.findings[0].porcelain.as_deref(),
+            Some(" M README.md"),
+            "§8.3's evidence is the porcelain output verbatim — leading column and \
+             all, since ` M` (unstaged) and `M ` (staged) differ only there"
+        );
+        assert!(refusal.override_would_help());
+    }
+
+    /// Check 9. `sergeant/<work-id>` already exists, and the refusal names
+    /// the Work that owns it (§15) rather than deleting or reusing it.
+    #[test]
+    fn check_9_an_existing_work_branch_is_named_with_its_owning_work() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        git_fixture(&mount, &["branch", &work_branch(WORK)]);
+        let refusal = fixture.run(true).expect_err("a ref collision is refused");
+        assert_eq!(refusal.findings[0].check, PreflightCheck::WorkBranchAbsent);
+        assert!(
+            refusal.findings[0].detail.contains(WORK),
+            "§15: name the ref and the Work that owns it: {}",
+            refusal.findings[0].detail
+        );
+        assert!(
+            !refusal.override_would_help(),
+            "§8.3 never bypasses an existing Work ref"
+        );
+        assert!(
+            git_succeeds(
+                &mount,
+                &[
+                    "show-ref",
+                    "--verify",
+                    "--quiet",
+                    &format!("refs/heads/{}", work_branch(WORK))
+                ]
+            ),
+            "and the ref is still there — never deleted or reused automatically"
+        );
+    }
+
+    /// Check 10, first half: something is already at the planned worktree
+    /// path.
+    #[test]
+    fn check_10_an_occupied_worktree_path_is_named() {
+        let fixture = Fixture::new(&["solo"]);
+        let planned = surface_root(&fixture.surfaces, WORK).join("solo");
+        std::fs::create_dir_all(&planned).expect("occupy the planned path");
+        let refusal = fixture.run(true).expect_err("a path collision is refused");
+        assert_eq!(
+            refusal.findings[0].check,
+            PreflightCheck::WorktreePathAbsent
+        );
+        assert!(!refusal.override_would_help());
+    }
+
+    /// Check 10, second half: nothing is at the path, but git still has it
+    /// registered — the two halves fail apart, which is why both are asked.
+    #[test]
+    fn check_10_a_registered_but_absent_worktree_path_is_also_named() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        let planned = surface_root(&fixture.surfaces, WORK).join("solo");
+        std::fs::create_dir_all(planned.parent().expect("surface root")).expect("surface root");
+        git_fixture(
+            &mount,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "stale",
+                &planned.display().to_string(),
+                "HEAD",
+            ],
+        );
+        std::fs::remove_dir_all(&planned).expect("delete the directory by hand");
+        assert!(
+            !planned.exists(),
+            "the path is gone, the registration is not"
+        );
+        let refusal = fixture
+            .run(true)
+            .expect_err("a stale registration is refused");
+        assert_eq!(
+            refusal.findings[0].check,
+            PreflightCheck::WorktreePathAbsent
+        );
+        assert!(
+            refusal.findings[0].detail.contains("registered"),
+            "the two halves of check 10 are distinguishable in the evidence: {}",
+            refusal.findings[0].detail
+        );
+    }
+
+    /// Check 11. Two repositories, one of them unplannable: the whole scope
+    /// is refused, the good repository is *not* admitted, and the refusal
+    /// says so in its own finding rather than leaving it to be inferred.
+    #[test]
+    fn check_11_one_unplannable_repository_refuses_the_whole_scope() {
+        let fixture = Fixture::new(&["api", "web"]);
+        std::fs::write(fixture.mount("web").join("README.md"), "edited\n").expect("dirty it");
+        let refusal = fixture.run(false).expect_err("the scope is refused");
+        assert_eq!(
+            refusal.findings.len(),
+            2,
+            "the repository's own finding, then the scope's: {refusal:?}"
+        );
+        assert_eq!(refusal.findings[0].check, PreflightCheck::WorktreeClean);
+        assert_eq!(refusal.findings[0].repository, "web");
+        assert_eq!(
+            refusal.findings[1].check,
+            PreflightCheck::AllRepositoriesPlanned
+        );
+        assert!(
+            refusal.findings[1].detail.contains("1 of 2"),
+            "check 11 names how much of the scope could not be planned: {}",
+            refusal.findings[1].detail
+        );
+        // `api` was perfectly admissible and is still refused, because §8.1
+        // check 11 is about the whole scope planning before the *first* side
+        // effect — not about admitting whatever happens to be fine.
+        assert_eq!(refusal.code(), "git_preflight_dirty_mount");
+    }
+
+    /// A single-repository scope does not get check 11's finding appended:
+    /// "1 of 1 could not be planned" restates the finding above it, and a
+    /// taxonomy that pads every refusal teaches a client to ignore it.
+    #[test]
+    fn a_single_repository_refusal_carries_only_its_own_finding() {
+        let fixture = Fixture::new(&["solo"]);
+        std::fs::write(fixture.mount("solo").join("README.md"), "edited\n").expect("dirty it");
+        let refusal = fixture.run(false).expect_err("refused");
+        assert_eq!(refusal.findings.len(), 1, "{refusal:?}");
+    }
+
+    /// The ordinary case, and the shape everything above is measured
+    /// against: a clean attached mount admits, pins §8.2's exact base, and
+    /// records that nothing was waived.
+    #[test]
+    fn a_clean_attached_mount_is_admitted_with_its_exact_base_pinned() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        let head = git_fixture(&mount, &["rev-parse", "HEAD"]);
+        let admitted = fixture.run(false).expect("a clean mount is admitted");
+
+        assert_eq!(admitted.work_id, WORK);
+        assert!(!admitted.override_requested);
+        assert_eq!(admitted.repositories.len(), 1);
+        let solo = admitted
+            .repository("solo")
+            .expect("the admitted repository");
+        assert_eq!(solo.base_branch.as_deref(), Some("main"));
+        assert_eq!(solo.base_sha, head);
+        assert!(is_full_object_id(&solo.base_sha));
+        assert_eq!(solo.work_branch, work_branch(WORK));
+        assert_eq!(
+            solo.worktree_path,
+            surface_root(&fixture.surfaces, WORK).join("solo")
+        );
+        assert_eq!(solo.canonical_top_level, mount);
+        assert!(solo.canonical_common_dir.starts_with(&mount));
+        assert!(!solo.evidence.waived_anything());
+        assert_eq!(admitted.waived().count(), 0);
+    }
+
+    /// §8.3, dirty arm: the override admits, pins the *committed* HEAD, and
+    /// journals both the porcelain evidence and an explicit statement that
+    /// the uncommitted changes are excluded from the Work base.
+    #[test]
+    fn an_override_admits_a_dirty_mount_and_records_what_it_excluded() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        let committed = git_fixture(&mount, &["rev-parse", "HEAD"]);
+        std::fs::write(mount.join("README.md"), "edited\n").expect("dirty it");
+        std::fs::write(mount.join("untracked.txt"), "new\n").expect("and untracked");
+
+        let admitted = fixture.run(true).expect("the override admits it");
+        let solo = admitted.repository("solo").expect("admitted");
+        assert_eq!(
+            solo.base_sha, committed,
+            "§8.3: the Work is based on the committed HEAD"
+        );
+        assert_eq!(solo.base_branch.as_deref(), Some("main"));
+        assert!(solo.evidence.override_authorized);
+        assert_eq!(solo.evidence.waived.len(), 1);
+        assert_eq!(solo.evidence.waived[0].check, PreflightCheck::WorktreeClean);
+        let porcelain = solo.evidence.waived[0]
+            .porcelain
+            .as_deref()
+            .expect("§8.3 requires the full porcelain evidence");
+        assert!(porcelain.contains(" M README.md"), "{porcelain}");
+        assert!(porcelain.contains("?? untracked.txt"), "{porcelain}");
+        let excluded = solo
+            .evidence
+            .uncommitted_excluded
+            .as_deref()
+            .expect("§8.3 requires the exclusion to be stated explicitly");
+        assert!(
+            excluded.contains("excluded from the Work base"),
+            "{excluded}"
+        );
+        assert!(excluded.contains(&committed), "{excluded}");
+    }
+
+    /// §8.3, detached arm: the override admits, pins the exact HEAD, and
+    /// records **no** named base branch — the whole reason `base_branch` is
+    /// an `Option` rather than a sentinel string.
+    #[test]
+    fn an_override_admits_a_detached_mount_with_no_named_base_branch() {
+        let fixture = Fixture::new(&["solo"]);
+        let mount = fixture.mount("solo");
+        let head = git_fixture(&mount, &["rev-parse", "HEAD"]);
+        git_fixture(&mount, &["checkout", "--detach", &head]);
+
+        let admitted = fixture.run(true).expect("the override admits it");
+        let solo = admitted.repository("solo").expect("admitted");
+        assert_eq!(solo.base_sha, head, "the exact HEAD is still pinned");
+        assert_eq!(
+            solo.base_branch, None,
+            "§8.3: a detached admission records no named base branch"
+        );
+        assert_eq!(solo.evidence.waived.len(), 1);
+        assert_eq!(solo.evidence.waived[0].check, PreflightCheck::HeadAttached);
+        assert!(
+            solo.evidence.uncommitted_excluded.is_none(),
+            "nothing was excluded: the mount was clean, only detached"
+        );
+    }
+
+    /// An override that finds nothing to waive still records that the
+    /// operator gave it — the authorization is a fact about the submission,
+    /// not about what it happened to excuse.
+    #[test]
+    fn an_override_over_a_clean_mount_waives_nothing_and_says_so() {
+        let fixture = Fixture::new(&["solo"]);
+        let admitted = fixture.run(true).expect("admitted");
+        assert!(admitted.override_requested);
+        let solo = admitted.repository("solo").expect("admitted");
+        assert!(solo.evidence.override_authorized);
+        assert!(!solo.evidence.waived_anything());
     }
 }

--- a/src/runtime/preflight.rs
+++ b/src/runtime/preflight.rs
@@ -682,7 +682,13 @@ fn check_one(
 
     Ok(AdmittedRepository {
         repository: name.to_string(),
-        mount_path: canonical_top_level.clone(),
+        // §3.5 lists "mount path" and "canonical Git top level" separately,
+        // and they are separate here too: the first is §6.1's derived mount
+        // as the estate declares it, the second is what git resolved that
+        // path to. Checks 2 and 3 are exactly the requirement that they
+        // agree — recording only one of them would erase the fact that they
+        // were compared.
+        mount_path: mount.to_path_buf(),
         canonical_top_level,
         canonical_common_dir,
         base_branch,

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -2457,6 +2457,63 @@ mod tests {
         }
     }
 
+    /// Amendment C3: every journal change is additive. A `surface.materialized`
+    /// payload written before Phase E has no `preflight` key and a plain
+    /// string `base_branch`, and both must replay as exactly the facts they
+    /// recorded — nothing invented, and "no preflight ran" distinguishable
+    /// from "preflight waived nothing".
+    #[test]
+    fn a_pre_phase_e_binding_replays_with_no_preflight_evidence() {
+        let payload = serde_json::json!({
+            "repository": "api",
+            "source_path": "/estate/repos/api",
+            "base_branch": "main",
+            "base_sha": "a".repeat(40),
+            "worktree_path": "/data/surfaces/01OLD/api",
+            "work_branch": "sergeant/01OLD",
+            "head_sha": "a".repeat(40),
+        });
+        let binding: RepositoryBinding =
+            serde_json::from_value(payload).expect("a pre-Phase-E binding still deserializes");
+        assert_eq!(binding.base_branch.as_deref(), Some("main"));
+        assert_eq!(
+            binding.preflight, None,
+            "absent means no preflight ran — never an empty evidence record, which would \
+             claim preflight ran and waived nothing"
+        );
+        assert_eq!(binding.origin, BindingOrigin::Cut);
+        assert_eq!(binding.canonical_top_level, None);
+
+        // And the detached sentinel that field used to carry replays as the
+        // string it was, rather than being silently reinterpreted as absence.
+        let detached = serde_json::json!({
+            "repository": "api",
+            "source_path": "/estate/repos/api",
+            "base_branch": "(detached)",
+            "base_sha": "b".repeat(40),
+            "worktree_path": "/data/surfaces/01OLD/api",
+            "work_branch": "sergeant/01OLD",
+            "head_sha": "b".repeat(40),
+        });
+        let binding: RepositoryBinding = serde_json::from_value(detached).expect("replays");
+        assert_eq!(binding.base_branch.as_deref(), Some("(detached)"));
+    }
+
+    /// The same rule for the plan: a `surface.materializing` from before
+    /// Phase E carries no admission at all, and materializing from it falls
+    /// back to reading the mount — the only thing it could ever do.
+    #[test]
+    fn a_pre_phase_e_surface_plan_replays_with_no_admission() {
+        let payload = serde_json::json!({
+            "root": "/data/surfaces/01OLD",
+            "work_branch": "sergeant/01OLD",
+            "repositories": [{"name": "api", "path": "/estate/repos/api"}],
+        });
+        let plan: SurfacePlan = serde_json::from_value(payload).expect("replays");
+        assert!(plan.admitted.is_empty());
+        assert!(!plan.override_git_preflight);
+    }
+
     /// §11: "runtime work surfaces live outside the source checkout". A data
     /// dir configured *inside* a repository would put a worktree in the
     /// checkout whose files are supposed to stay declarative — refused, not

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -39,6 +39,7 @@ use crate::runtime::git::{
 use crate::runtime::integrity::{
     DriftAttribution, EstateDriftObservation, IntegrityDisposition, IntegrityFinding, ObservedHead,
 };
+use crate::runtime::preflight::{AdmittedRepository, GitPreflight, PreflightEvidence};
 use crate::runtime::repolock::{self, RepoLockError};
 
 /// Directory under the data dir holding all work surfaces.
@@ -283,6 +284,17 @@ pub struct RepositoryBinding {
     /// [`Self::canonical_top_level`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub canonical_common_dir: Option<PathBuf>,
+    /// §3.5's "preflight result and any authorized override evidence": what
+    /// §8.1 admitted this repository on, and what §8.3 waived to get there.
+    ///
+    /// `Option` + `#[serde(default)]` on the same amendment-C3 grounds as the
+    /// two canonical identities above: `None` on a binding journaled before
+    /// Phase E means *no preflight ran*, which is a different and more honest
+    /// fact than an empty [`PreflightEvidence`] (preflight ran, waived
+    /// nothing). `None` is also what a `materialize` call with no admission
+    /// record records — the direct-call path the runtime's own tests use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preflight: Option<PreflightEvidence>,
 }
 
 /// What materialization is about to create, recorded before it creates any of
@@ -302,6 +314,26 @@ pub struct SurfacePlan {
     pub work_branch: String,
     /// Repositories that will get a worktree, in estate order.
     pub repositories: Vec<RepositorySpec>,
+    /// §8.1's admission for this plan: the pinned base each repository was
+    /// admitted on, plus every §8.3 finding the operator's override waived.
+    ///
+    /// Journaled here, in `surface.materializing`, because that event is the
+    /// last thing written before `git worktree add` can touch a repository
+    /// sergeant does not own — so "the override and every waived finding are
+    /// journaled with the Work" (§8.3) is durable strictly before the effect
+    /// it authorized, exactly like the plan it travels in.
+    ///
+    /// `#[serde(default)]`: a plan journaled before Phase E replays with an
+    /// empty admission, which is the honest reading (no preflight ran), and
+    /// materialization treats an absent record as "read the mount live", the
+    /// only thing it could ever do then.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub admitted: Vec<AdmittedRepository>,
+    /// Whether the submission carried `--override-git-preflight` (§8.3).
+    /// Recorded even when it waived nothing: the operator's authorization is
+    /// a fact about the submission, not about what it happened to excuse.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub override_git_preflight: bool,
 }
 
 impl SurfacePlan {
@@ -317,7 +349,20 @@ impl SurfacePlan {
             root: surface_root(surfaces_root, work_id),
             work_branch: work_branch(work_id),
             repositories: repositories.to_vec(),
+            admitted: Vec::new(),
+            override_git_preflight: false,
         }
+    }
+
+    /// The same plan, carrying §8.1's admission record.
+    ///
+    /// A builder rather than a fifth parameter on [`Self::new`]: a plan
+    /// reconstructed from a pre-Phase-E journal event legitimately has no
+    /// admission, and every caller that has one has it as a unit.
+    pub fn with_admission(mut self, preflight: &GitPreflight) -> Self {
+        self.admitted = preflight.repositories.clone();
+        self.override_git_preflight = preflight.override_requested;
+        self
     }
 }
 
@@ -632,6 +677,40 @@ pub fn materialize(
     work_id: &str,
     repositories: &[RepositorySpec],
 ) -> Result<WorkSurface, SurfaceError> {
+    materialize_with(data_dir, surfaces_root, work_id, repositories, &[])
+}
+
+/// [`materialize`] against §8.1's admitted facts rather than a live re-read
+/// of each mount — the submission path.
+///
+/// This is what makes §8.2's pin real. `materialize` asks each mount for its
+/// HEAD at the moment it runs; preflight already asked, judged the answer, and
+/// journaled it in the plan, so re-asking here would mean the commit a Work is
+/// based on is not necessarily the commit that was admitted — a mount whose
+/// branch advanced in between would silently move the base, and a detached
+/// mount admitted under §8.3 would re-derive a base branch the override
+/// deliberately recorded as absent.
+///
+/// A repository with no matching admission record falls back to the live read,
+/// which is exactly what [`materialize`] does for every repository: the two
+/// share one body, so the admitted path cannot drift from the direct one.
+pub fn materialize_admitted(
+    data_dir: &Path,
+    surfaces_root: &Path,
+    work_id: &str,
+    repositories: &[RepositorySpec],
+    admitted: &[AdmittedRepository],
+) -> Result<WorkSurface, SurfaceError> {
+    materialize_with(data_dir, surfaces_root, work_id, repositories, admitted)
+}
+
+fn materialize_with(
+    data_dir: &Path,
+    surfaces_root: &Path,
+    work_id: &str,
+    repositories: &[RepositorySpec],
+    admitted: &[AdmittedRepository],
+) -> Result<WorkSurface, SurfaceError> {
     if repositories.is_empty() {
         return Err(SurfaceError::NoRepositories);
     }
@@ -648,12 +727,16 @@ pub fn materialize(
 
     let mut bindings: Vec<RepositoryBinding> = Vec::with_capacity(repositories.len());
     for repository in repositories {
-        let outcome = match materialize_one(data_dir, &root, &canonical_root, &branch, repository) {
-            Ok(binding) => init_submodules_if_present(&binding.worktree_path)
-                .map(|()| binding.clone())
-                .map_err(|err| (Some(binding), err)),
-            Err(err) => Err((None, err)),
-        };
+        let pin = admitted
+            .iter()
+            .find(|record| record.repository == repository.name);
+        let outcome =
+            match materialize_one(data_dir, &root, &canonical_root, &branch, repository, pin) {
+                Ok(binding) => init_submodules_if_present(&binding.worktree_path)
+                    .map(|()| binding.clone())
+                    .map_err(|err| (Some(binding), err)),
+                Err(err) => Err((None, err)),
+            };
         match outcome {
             Ok(binding) => bindings.push(binding),
             Err((created, err)) => {
@@ -693,6 +776,7 @@ fn materialize_one(
     canonical_root: &Path,
     branch: &str,
     repository: &RepositorySpec,
+    pin: Option<&AdmittedRepository>,
 ) -> Result<RepositoryBinding, SurfaceError> {
     let worktree_path = root.join(&repository.name);
     let canonical_repo_path =
@@ -720,23 +804,44 @@ fn materialize_one(
     // actual checkout agree with each other; a one-commit lag behind the tip
     // is the same fact it was before (the submit captured a snapshot of HEAD
     // at request time, and that snapshot is what the run executes on).
-    let base_sha = git(&repository.path, &["rev-parse", "HEAD"])?;
+    //
+    // §8.2, Phase E: when this materialization came through admission, none of
+    // that reading happens at all — `pin` already carries the base preflight
+    // judged, and re-deriving it here would mean the Work is based on whatever
+    // the mount says *now* rather than on the fact that was admitted and
+    // journaled.  The live read below is the direct-call path (and every
+    // pre-Phase-E replay), unchanged.
+    let base_sha = match pin {
+        Some(record) => record.base_sha.clone(),
+        None => git(&repository.path, &["rev-parse", "HEAD"])?,
+    };
     // A detached HEAD has no branch name; record the *absence* rather than
     // inventing a sentinel that reads like one.
-    let base_branch = git(
-        &repository.path,
-        &["symbolic-ref", "--quiet", "--short", "HEAD"],
-    )
-    .ok();
+    let base_branch = match pin {
+        Some(record) => record.base_branch.clone(),
+        None => git(
+            &repository.path,
+            &["symbolic-ref", "--quiet", "--short", "HEAD"],
+        )
+        .ok(),
+    };
 
     // §3.5's two canonical identities, read here — once, outside the lock,
     // alongside the other admission facts — and then used for both purposes
     // they exist for: the lock key below, and the binding's own record of what
     // this repository *was* at admission.  Deriving them here rather than
     // inside the span is the whole point: `with_repository` must never spawn
-    // a `git rev-parse` while holding a registry lock.
-    let canonical_top_level = canonical_git_top_level(&repository.path).ok();
-    let canonical_common_dir = canonical_git_common_dir(&repository.path).ok();
+    // a `git rev-parse` while holding a registry lock.  An admitted
+    // materialization has both already, resolved by the same two functions
+    // during preflight.
+    let canonical_top_level = match pin {
+        Some(record) => Some(record.canonical_top_level.clone()),
+        None => canonical_git_top_level(&repository.path).ok(),
+    };
+    let canonical_common_dir = match pin {
+        Some(record) => Some(record.canonical_common_dir.clone()),
+        None => canonical_git_common_dir(&repository.path).ok(),
+    };
     let gate =
         RepositoryGate::from_common_dir(data_dir, canonical_common_dir.clone(), &repository.path);
 
@@ -822,6 +927,11 @@ fn materialize_one(
         // that path is not a common directory — journaling it as one would
         // record a value that only usually means what the field says.
         canonical_common_dir,
+        // §3.5: the preflight result travels with the binding it admitted.
+        // `None` when this materialization did not come through admission —
+        // "no preflight ran" is a different fact from "preflight waived
+        // nothing".
+        preflight: pin.map(|record| record.evidence.clone()),
     })
 }
 
@@ -1083,6 +1193,12 @@ fn attach_one(
         },
         canonical_top_level,
         canonical_common_dir,
+        // Carried over from the target's own binding, exactly like
+        // `base_branch`/`base_sha` above: this binding did not go through an
+        // admission of its own — it attached to a branch a different Work
+        // already admitted — so the honest record is that Work's evidence,
+        // not a fresh empty one implying nothing was ever waived.
+        preflight: target.preflight.clone(),
     })
 }
 

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -229,8 +229,23 @@ pub struct RepositoryBinding {
     pub repository: String,
     /// Source repository top level (never written to by execution).
     pub source_path: PathBuf,
-    /// Branch the surface was cut from (`(detached)` if HEAD was detached).
-    pub base_branch: String,
+    /// Branch the surface was cut from — §3.5's "observed base branch, **if
+    /// attached**".
+    ///
+    /// `None` is the honest record for a detached mount admitted under §8.3's
+    /// bounded override: that admission pins an exact `base_sha` and, in the
+    /// proposal's own words, records "no named base branch". Before Phase E
+    /// this was a `String` carrying the sentinel `"(detached)"` — a value that
+    /// *looks* like a branch name (git's ref grammar permits parentheses)
+    /// sitting in the field every reader branches on.
+    ///
+    /// `#[serde(default)]` so a binding journaled before this change replays
+    /// exactly what it recorded, the old sentinel included (as
+    /// `Some("(detached)")`). Serialized even when `None`: an explicit `null`
+    /// *is* the record that this Work has no named base branch, and a missing
+    /// key would be indistinguishable from a payload predating the field.
+    #[serde(default)]
+    pub base_branch: Option<String>,
     /// Commit the surface was cut from.
     pub base_sha: String,
     /// Worktree path under the data dir.
@@ -706,13 +721,13 @@ fn materialize_one(
     // is the same fact it was before (the submit captured a snapshot of HEAD
     // at request time, and that snapshot is what the run executes on).
     let base_sha = git(&repository.path, &["rev-parse", "HEAD"])?;
-    // A detached HEAD has no branch name; record the fact rather than
-    // inventing one.
+    // A detached HEAD has no branch name; record the *absence* rather than
+    // inventing a sentinel that reads like one.
     let base_branch = git(
         &repository.path,
         &["symbolic-ref", "--quiet", "--short", "HEAD"],
     )
-    .unwrap_or_else(|_| "(detached)".to_string());
+    .ok();
 
     // §3.5's two canonical identities, read here — once, outside the lock,
     // alongside the other admission facts — and then used for both purposes

--- a/tests/e_admission_uses_no_network_git.rs
+++ b/tests/e_admission_uses_no_network_git.rs
@@ -1,0 +1,298 @@
+//! §6.4/§17, via a recording Git binary: "Sergeant does not fetch, pull,
+//! reset, rebase, switch to main, or infer a remote default during Work
+//! admission."
+//!
+//! Phase 0 made this observable by giving `runtime::git` an injectable binary
+//! ([`GIT_BIN_ENV`]); §18 asks for the test that uses it. A shim records every
+//! invocation — working directory and full argument vector — and then `exec`s
+//! the real Git, so a *complete, successful* admission runs end to end and the
+//! recording is of the real thing rather than of a stub's idea of it.
+//!
+//! **This must stay the only test in this file**, for exactly the reason
+//! `tests/c11_injectable_git.rs` documents: `std::env::set_var` is
+//! process-global, not thread-scoped, and `runtime::git::command` reads the
+//! override fresh on every invocation. A sibling test in this process would
+//! see the shim too, and would also race the `TempDir` holding it. Cargo gives
+//! every integration-test file its own process, so a file with one test has no
+//! sibling to leak into.
+//!
+//! # What "forbidden" means precisely
+//!
+//! Two different rules, because they are two different claims:
+//!
+//! - **Network and history-rewriting verbs are forbidden outright**, in any
+//!   directory: `fetch`, `pull`, `push`, `remote`, `ls-remote`, `clone`,
+//!   `rebase`, `merge`, `cherry-pick`, `switch`, `checkout`. None of them has
+//!   any business on an admission path at all.
+//! - **`reset` is forbidden in the mounted checkout.** Materialization does
+//!   run one `git reset --hard HEAD` — inside the *linked worktree it just
+//!   created*, to populate the files `worktree add --no-checkout`
+//!   deliberately skipped (`surface::checkout_worktree` explains why `reset`
+//!   rather than `checkout`). That touches Sergeant's own surface and no
+//!   branch; §6.4 is about the checkout the operator owns. The assertion is
+//!   therefore scoped by working directory rather than waved away, and the
+//!   test proves the mount saw none of it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend, FakeStep};
+use sergeant_rs::daemon::{self, DaemonConfig};
+use sergeant_rs::runtime::git::GIT_BIN_ENV;
+
+mod support;
+use support::{DataDir, scaffold_estate};
+
+/// Verbs that must never appear on an admission path, in any directory.
+const FORBIDDEN_ANYWHERE: &[&str] = &[
+    "fetch",
+    "pull",
+    "push",
+    "remote",
+    "ls-remote",
+    "clone",
+    "rebase",
+    "merge",
+    "cherry-pick",
+    "switch",
+    "checkout",
+];
+
+/// Verbs that must never be run *against the mounted checkout*. See the
+/// module doc for why `reset` is on this list rather than the one above.
+const FORBIDDEN_IN_THE_MOUNT: &[&str] = &["reset"];
+
+/// One recorded invocation: where it ran and what it was asked to do.
+#[derive(Debug)]
+struct Invocation {
+    cwd: PathBuf,
+    args: Vec<String>,
+}
+
+impl Invocation {
+    /// The subcommand: the first argument that is not a global option.
+    /// `runtime::git::command` always prefixes `--no-pager`, and several
+    /// call sites pass `-c key=value`, so the verb is not simply `args[0]`.
+    fn verb(&self) -> Option<&str> {
+        let mut args = self.args.iter();
+        while let Some(arg) = args.next() {
+            if arg == "-c" || arg == "-C" {
+                let _ = args.next();
+                continue;
+            }
+            if arg.starts_with('-') {
+                continue;
+            }
+            return Some(arg.as_str());
+        }
+        None
+    }
+}
+
+fn parse_log(text: &str) -> Vec<Invocation> {
+    text.lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let (cwd, args) = line
+                .split_once('\t')
+                .unwrap_or_else(|| panic!("malformed recording line: {line:?}"));
+            Invocation {
+                cwd: PathBuf::from(cwd),
+                args: args
+                    .split('\u{1}')
+                    .filter(|arg| !arg.is_empty())
+                    .map(str::to_string)
+                    .collect(),
+            }
+        })
+        .collect()
+}
+
+/// A shim that records every invocation and then becomes the real git.
+///
+/// `$PWD` and the argument vector are written as one tab-separated record
+/// with `\1`-separated arguments — a separator no git argument this codebase
+/// produces can contain, so an argument with a space in it survives intact.
+/// Appended with `>>` under a single `printf`, which is atomic enough for
+/// concurrent children writing short records to the same file.
+fn write_recording_shim(path: &Path, log: &Path, real_git: &Path) {
+    // The separator is written into the script as a literal U+0001 byte
+    // rather than as the escape `\001`: `sh` does not interpret escapes
+    // inside double quotes, so the escape would end up in the log as four
+    // characters and every record would be one unsplittable field.
+    let unit = '\u{1}';
+    std::fs::write(
+        path,
+        format!(
+            "#!/bin/sh\n\
+             record=\"$PWD\t\"\n\
+             for arg in \"$@\"; do record=\"$record$arg{unit}\"; done\n\
+             printf '%s\\n' \"$record\" >> {log:?}\n\
+             exec {real_git:?} \"$@\"\n",
+            log = log.display().to_string(),
+            real_git = real_git.display().to_string(),
+        ),
+    )
+    .expect("write shim");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(path).expect("stat").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).expect("chmod");
+    }
+    // Runs the shim once (`--version`), which records a line of its own.
+    // Truncate afterwards so the log holds only what the admission did.
+    support::wait_until_executable(path);
+    std::fs::write(log, "").expect("truncate the shim's own warm-up record");
+}
+
+fn real_git() -> PathBuf {
+    let out = std::process::Command::new("sh")
+        .args(["-c", "command -v git"])
+        .output()
+        .expect("locate git");
+    assert!(out.status.success(), "git must be on PATH for this test");
+    PathBuf::from(String::from_utf8_lossy(&out.stdout).trim())
+}
+
+#[tokio::test]
+async fn a_whole_admission_never_runs_a_network_or_branch_changing_git_command() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    // Two repositories, explicitly scoped, so the recording covers a
+    // multi-repository admission rather than the single-mount easy case.
+    scaffold_estate(&estate, "payments", &["api", "web"]);
+    let api = std::fs::canonicalize(estate.join("repos").join("api")).expect("canonical api");
+    let web = std::fs::canonicalize(estate.join("repos").join("web")).expect("canonical web");
+
+    let shim_dir = TempDir::new().expect("tempdir");
+    let log = shim_dir.path().join("git-invocations.log");
+    let shim = shim_dir.path().join("recording-git");
+    write_recording_shim(&shim, &log, &real_git());
+
+    // SAFETY (test-only): this binary runs exactly one test, so there is no
+    // other thread in this process to observe the mutation — the whole reason
+    // this file holds one test. Set before the daemon starts (its own estate
+    // admission is part of what is being recorded) and removed only once
+    // every git invocation is finished, with the shim's `TempDir` still
+    // alive throughout.
+    unsafe { std::env::set_var(GIT_BIN_ENV, &shim) };
+
+    let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, [FakeStep::hang()]);
+    let handle = daemon::start_with(
+        data.path(),
+        DaemonConfig {
+            backends: Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
+            default_backend: Some(FAKE_BACKEND_NAME.to_string()),
+            claude: None,
+            estate_root: Some(estate.clone()),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("client");
+    let response = client
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&json!({
+            "command_id": ulid::Ulid::generate().to_string(),
+            "intent": "admit two clean mounts",
+            "scope": {"all": true},
+            "origin": {"client": "cli"},
+        }))
+        .send()
+        .await
+        .expect("request");
+    let status = response.status();
+    let body: Value = response.json().await.expect("json body");
+
+    handle.shutdown().await;
+    unsafe { std::env::remove_var(GIT_BIN_ENV) };
+
+    assert_eq!(status, 201, "the admission must succeed: {body}");
+    assert_eq!(body["work"]["state"], "active", "{body}");
+    assert_eq!(
+        body["surface"]["bindings"]
+            .as_array()
+            .expect("bindings")
+            .len(),
+        2,
+        "both repositories were materialized: {body}"
+    );
+
+    let recorded = parse_log(&std::fs::read_to_string(&log).expect("the shim recorded something"));
+    assert!(
+        recorded.len() > 5,
+        "the shim must have intercepted the real admission, not a handful of strays: {recorded:?}"
+    );
+    // The shim really did stand in for git everywhere: the verbs a normal
+    // admission does use are all present.
+    let verbs: BTreeSet<&str> = recorded.iter().filter_map(Invocation::verb).collect();
+    for expected in ["rev-parse", "status", "show-ref", "worktree"] {
+        assert!(
+            verbs.contains(expected),
+            "admission is supposed to run `git {expected}`; the recording shows {verbs:?}"
+        );
+    }
+
+    for invocation in &recorded {
+        let verb = invocation.verb().unwrap_or("");
+        assert!(
+            !FORBIDDEN_ANYWHERE.contains(&verb),
+            "§6.4: admission ran `git {verb}` in {} — no network or branch-changing git \
+             command may run on an admission path at all ({:?})",
+            invocation.cwd.display(),
+            invocation.args
+        );
+        let in_a_mount = invocation.cwd == api || invocation.cwd == web;
+        assert!(
+            !(in_a_mount && FORBIDDEN_IN_THE_MOUNT.contains(&verb)),
+            "§6.4: admission ran `git {verb}` in the mounted checkout {} ({:?}) — the mount is \
+             the operator's, and sergeant only ever reads it",
+            invocation.cwd.display(),
+            invocation.args
+        );
+    }
+
+    // The one `reset` materialization does run is inside the surface it just
+    // created, never in a mount — asserted positively so the carve-out above
+    // is a measured fact rather than a loophole nothing exercises.
+    let resets: Vec<&Invocation> = recorded
+        .iter()
+        .filter(|i| i.verb() == Some("reset"))
+        .collect();
+    assert_eq!(resets.len(), 2, "one per materialized worktree: {resets:?}");
+    let surfaces = std::fs::canonicalize(data.path().join("surfaces")).expect("surfaces root");
+    for reset in resets {
+        assert!(
+            reset.cwd.starts_with(&surfaces),
+            "the only `git reset` on this path populates sergeant's own worktree: {reset:?}"
+        );
+    }
+
+    // §8.2's other half, measured the same way: no invocation asked git what
+    // any remote thinks, so nothing about the base could have been inferred
+    // from one.
+    for invocation in &recorded {
+        assert!(
+            !invocation
+                .args
+                .iter()
+                .any(|arg| arg == "origin" || arg.starts_with("refs/remotes/")),
+            "§6.4: admission must not infer a remote default: {invocation:?}"
+        );
+    }
+}

--- a/tests/e_git_admission.rs
+++ b/tests/e_git_admission.rs
@@ -1,0 +1,889 @@
+//! estate-root Phase E acceptance: the §8 Git admission contract end to end.
+//!
+//! §8.1's eleven checks have their own one-condition-per-check unit suite
+//! (`runtime::preflight`'s own tests). What this file measures is the part
+//! only a real daemon can answer:
+//!
+//! 1. a refusal happens **before a Work record exists** and before any Git
+//!    mutation — no `work.submitted`, no branch, no worktree, nothing to
+//!    clean up;
+//! 2. the refusal reaches a client as §15's structured 422 with a named
+//!    remedy;
+//! 3. §8.3's override admits exactly the two conditions it may, records what
+//!    it waived, and pins what it promised;
+//! 4. the §8.3 never-bypass list really is never bypassed — as a matrix, over
+//!    HTTP, with the override set on every row;
+//! 5. the override has no source but the submission itself: no default, no
+//!    template, no config.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend, FakeStep};
+use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
+use sergeant_rs::domain::work::KIND_WORK_SUBMITTED;
+use sergeant_rs::runtime::journal::Journal;
+use sergeant_rs::runtime::surface::{
+    KIND_SURFACE_MATERIALIZED, KIND_SURFACE_MATERIALIZING, work_branch,
+};
+
+mod support;
+use support::{DataDir, git, scaffold_estate};
+
+// ---------------------------------------------------------------- helpers
+
+fn http() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("client")
+}
+
+/// A daemon bound to `estate`, backed by a fake that hangs — so an admitted
+/// submission stays in flight and its surface can be inspected while it
+/// exists.
+async fn start(data: &DataDir, estate: &Path) -> (DaemonHandle, FakeBackend) {
+    let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, [FakeStep::hang()]);
+    let handle = daemon::start_with(
+        data.path(),
+        DaemonConfig {
+            backends: Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
+            default_backend: Some(FAKE_BACKEND_NAME.to_string()),
+            claude: None,
+            estate_root: Some(estate.to_path_buf()),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start");
+    (handle, fake)
+}
+
+/// Submit, merging `extra` into the request body.
+async fn submit(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    intent: &str,
+    extra: Value,
+) -> (reqwest::StatusCode, Value) {
+    let mut body = json!({
+        "command_id": ulid::Ulid::generate().to_string(),
+        "intent": intent,
+        "origin": {"client": "cli"},
+    });
+    if let Some(fields) = extra.as_object() {
+        for (key, value) in fields {
+            body[key] = value.clone();
+        }
+    }
+    let resp = client
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    (status, resp.json().await.expect("json body"))
+}
+
+fn events(data: &DataDir) -> Vec<sergeant_rs::domain::event::Event> {
+    Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .collect()
+}
+
+/// Every `work.submitted` in the journal. A preflight refusal must produce
+/// none: §8.1 refuses "before a Work record exists", and this event *is* the
+/// Work record.
+fn submitted_works(data: &DataDir) -> Vec<Value> {
+    events(data)
+        .into_iter()
+        .filter(|e| e.kind == KIND_WORK_SUBMITTED)
+        .map(|e| e.payload["work"].clone())
+        .collect()
+}
+
+fn payloads_of(data: &DataDir, kind: &str) -> Vec<Value> {
+    events(data)
+        .into_iter()
+        .filter(|e| e.kind == kind)
+        .map(|e| e.payload)
+        .collect()
+}
+
+/// The one finding a body reports for `check`.
+fn finding<'a>(body: &'a Value, code: &str) -> &'a Value {
+    body["error"]["findings"]
+        .as_array()
+        .unwrap_or_else(|| panic!("a preflight refusal carries findings: {body}"))
+        .iter()
+        .find(|f| f["code"] == code)
+        .unwrap_or_else(|| panic!("no {code} finding in {body}"))
+}
+
+/// Whether `repo` has any `sergeant/*` branch at all — the fail-closed
+/// question a refusal must answer "no" to.
+fn any_work_branch(repo: &Path) -> String {
+    git(repo, &["branch", "--list", "sergeant/*"])
+}
+
+// ------------------------------------------------------- refusal, §8.1/§15
+
+/// §15's dirty row: show the branch, HEAD and status, name the normal
+/// remedy, and mention the bounded escape hatch — and do all of it *before*
+/// a Work record exists.
+#[tokio::test]
+async fn a_dirty_mount_is_refused_before_a_work_record_exists() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api"]);
+    let mount = estate.join("repos").join("api");
+    let head = git(&mount, &["rev-parse", "HEAD"]);
+    std::fs::write(mount.join("README.md"), "uncommitted\n").expect("dirty the mount");
+
+    let (handle, fake) = start(&data, &estate).await;
+    let client = http();
+    let (status, body) = submit(&client, &handle, "work on a dirty mount", json!({})).await;
+
+    assert_eq!(status, 422, "a dirty mount is refused: {body}");
+    assert_eq!(body["error"]["code"], "git_preflight_dirty_mount");
+    let dirty = finding(&body, "git_preflight_dirty_mount");
+    assert_eq!(dirty["repository"], "api");
+    assert_eq!(dirty["check_number"], 8);
+    assert!(dirty["waivable"].as_bool().expect("waivable"));
+    // §15: "show branch/HEAD/status".
+    let detail = dirty["detail"].as_str().expect("detail");
+    assert!(detail.contains("main"), "the branch: {detail}");
+    assert!(detail.contains(&head), "the exact HEAD: {detail}");
+    assert!(
+        dirty["porcelain"]
+            .as_str()
+            .is_some_and(|p| p.contains("README.md")),
+        "the status itself: {dirty}"
+    );
+    // §15: "the normal remedy", then the escape hatch — in that order.
+    let remedy = dirty["remedy"].as_str().expect("remedy");
+    assert!(remedy.contains("commit or stash"), "{remedy}");
+    assert!(remedy.contains("--override-git-preflight"), "{remedy}");
+    assert!(body["error"]["override_available"].as_bool().expect("flag"));
+
+    // The whole point of refusing here: nothing exists to undo.
+    assert!(
+        submitted_works(&data).is_empty(),
+        "a preflight refusal must not create a Work record"
+    );
+    assert!(
+        payloads_of(&data, KIND_SURFACE_MATERIALIZING).is_empty(),
+        "and must not journal an intent to materialize"
+    );
+    assert_eq!(any_work_branch(&mount), "", "no branch was cut");
+    assert!(
+        fake.starts().is_empty(),
+        "and nothing reached a backend: {:?}",
+        fake.starts()
+    );
+    // The mount is exactly as the operator left it.
+    assert_eq!(git(&mount, &["rev-parse", "HEAD"]), head);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("README.md")).expect("read"),
+        "uncommitted\n",
+        "sergeant never touches the mount's working tree"
+    );
+
+    handle.shutdown().await;
+}
+
+/// §15's unresolvable-HEAD row is the one that must say the override is
+/// *unavailable*, not merely omit it — with the flag set, it refuses
+/// identically.
+#[tokio::test]
+async fn an_unresolvable_head_is_refused_and_says_no_override_applies() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api"]);
+    let mount = estate.join("repos").join("api");
+    // An unborn branch: HEAD is an ordinary symref to `refs/heads/main`
+    // (check 6 passes), pointing at no commit (check 7 does not).
+    git(&mount, &["update-ref", "-d", "refs/heads/main"]);
+
+    let (handle, _fake) = start(&data, &estate).await;
+    let client = http();
+    for override_flag in [false, true] {
+        let (status, body) = submit(
+            &client,
+            &handle,
+            "no commit to be based on",
+            json!({"override_git_preflight": override_flag}),
+        )
+        .await;
+        assert_eq!(status, 422, "refused either way: {body}");
+        assert_eq!(body["error"]["code"], "git_preflight_unresolvable_head");
+        assert!(
+            !body["error"]["override_available"].as_bool().expect("flag"),
+            "§15: no exact base can be pinned, so the override does not apply: {body}"
+        );
+        let unresolvable = finding(&body, "git_preflight_unresolvable_head");
+        assert!(!unresolvable["waivable"].as_bool().expect("waivable"));
+        assert!(
+            unresolvable["remedy"]
+                .as_str()
+                .expect("remedy")
+                .contains("--override-git-preflight is unavailable"),
+            "the refusal explains why, rather than silently omitting it: {unresolvable}"
+        );
+    }
+    assert!(submitted_works(&data).is_empty());
+
+    handle.shutdown().await;
+}
+
+/// §8.1 check 11 through a real submission: one bad repository in a
+/// two-repository scope refuses the whole submission, and the *good*
+/// repository is left with no branch, no worktree and no journal entry.
+#[tokio::test]
+async fn a_partial_plan_leaves_no_work_record_and_no_side_effects() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api", "web"]);
+    let api = estate.join("repos").join("api");
+    let web = estate.join("repos").join("web");
+    std::fs::write(web.join("README.md"), "uncommitted\n").expect("dirty the second mount");
+
+    let (handle, fake) = start(&data, &estate).await;
+    let client = http();
+    let (status, body) = submit(
+        &client,
+        &handle,
+        "half a scope",
+        json!({"scope": {"all": true}}),
+    )
+    .await;
+
+    assert_eq!(status, 422, "the whole scope is refused: {body}");
+    // The primary code is the specific, actionable one; check 11 travels
+    // beside it saying what the scope-level consequence was.
+    assert_eq!(body["error"]["code"], "git_preflight_dirty_mount");
+    let incomplete = finding(&body, "git_preflight_incomplete_plan");
+    assert_eq!(incomplete["check_number"], 11);
+    assert!(
+        incomplete["detail"]
+            .as_str()
+            .expect("detail")
+            .contains("1 of 2"),
+        "{incomplete}"
+    );
+
+    assert!(submitted_works(&data).is_empty(), "no Work record");
+    for mount in [&api, &web] {
+        assert_eq!(
+            any_work_branch(mount),
+            "",
+            "no repository in a refused scope gets a branch: {}",
+            mount.display()
+        );
+    }
+    let surfaces = data.path().join("surfaces");
+    assert!(
+        !surfaces.exists() || std::fs::read_dir(&surfaces).expect("read").next().is_none(),
+        "no surface directory was created either"
+    );
+    assert!(fake.starts().is_empty());
+
+    handle.shutdown().await;
+}
+
+// ---------------------------------------------------------- override, §8.3
+
+/// §8.3's dirty row: the override admits, the Work is based on the
+/// *committed* HEAD, the porcelain evidence is journaled in full, and the
+/// exclusion is stated explicitly rather than left implied.
+#[tokio::test]
+async fn an_override_admits_a_dirty_mount_and_journals_what_it_excluded() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api"]);
+    let mount = estate.join("repos").join("api");
+    let committed = git(&mount, &["rev-parse", "HEAD"]);
+    std::fs::write(mount.join("README.md"), "uncommitted edit\n").expect("dirty it");
+    std::fs::write(mount.join("scratch.txt"), "untracked\n").expect("and untracked");
+
+    let (handle, _fake) = start(&data, &estate).await;
+    let client = http();
+    let (status, body) = submit(
+        &client,
+        &handle,
+        "based on the committed head",
+        json!({"override_git_preflight": true}),
+    )
+    .await;
+    assert_eq!(status, 201, "the override admits it: {body}");
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+
+    // §8.3: the operator's authorization is on the Work itself.
+    assert_eq!(body["work"]["git_preflight_override"], json!(true));
+    let submitted = submitted_works(&data);
+    assert_eq!(submitted.len(), 1);
+    assert_eq!(submitted[0]["git_preflight_override"], json!(true));
+
+    // §8.3: the base is the committed HEAD, not a working-tree state.
+    let binding = &body["surface"]["bindings"][0];
+    assert_eq!(binding["base_sha"], committed);
+    assert_eq!(binding["base_branch"], "main");
+    let worktree = PathBuf::from(binding["worktree_path"].as_str().expect("worktree"));
+    assert_eq!(
+        std::fs::read_to_string(worktree.join("README.md")).expect("read"),
+        "# fixture\n",
+        "the surface carries the committed content, not the uncommitted edit"
+    );
+    assert!(
+        !worktree.join("scratch.txt").exists(),
+        "and not the untracked file either"
+    );
+
+    // §8.3: the waived finding and its evidence are journaled with the Work,
+    // on the plan (before any git mutation) and on the binding it admitted.
+    let plans = payloads_of(&data, KIND_SURFACE_MATERIALIZING);
+    assert_eq!(plans.len(), 1, "one plan: {plans:?}");
+    let plan = &plans[0]["plan"];
+    assert_eq!(plan["override_git_preflight"], json!(true));
+    let admitted = &plan["admitted"][0];
+    assert_eq!(admitted["repository"], "api");
+    assert_eq!(admitted["base_sha"], committed);
+    let waived = &admitted["evidence"]["waived"][0];
+    assert_eq!(waived["check"], "worktree_clean");
+    let porcelain = waived["porcelain"].as_str().expect("porcelain evidence");
+    assert!(porcelain.contains(" M README.md"), "{porcelain}");
+    assert!(porcelain.contains("?? scratch.txt"), "{porcelain}");
+    let excluded = admitted["evidence"]["uncommitted_excluded"]
+        .as_str()
+        .expect("§8.3 requires the exclusion stated explicitly");
+    assert!(
+        excluded.contains("excluded from the Work base"),
+        "{excluded}"
+    );
+    assert!(excluded.contains(&committed), "{excluded}");
+
+    let materialized = payloads_of(&data, KIND_SURFACE_MATERIALIZED);
+    assert_eq!(materialized.len(), 1);
+    let journaled = &materialized[0]["surface"]["bindings"][0]["preflight"];
+    assert_eq!(journaled["override_authorized"], json!(true));
+    assert_eq!(journaled["waived"][0]["check"], "worktree_clean");
+
+    // And the mount is untouched: the uncommitted work is still the
+    // operator's, exactly where they left it.
+    assert_eq!(
+        std::fs::read_to_string(mount.join("README.md")).expect("read"),
+        "uncommitted edit\n"
+    );
+    assert!(
+        !any_work_branch(&mount).is_empty(),
+        "{work_id} got a branch"
+    );
+
+    handle.shutdown().await;
+}
+
+/// §8.3's detached row: the exact HEAD is pinned and **no** named base
+/// branch is recorded — an explicit `null`, not a sentinel that reads like a
+/// branch name.
+#[tokio::test]
+async fn an_override_admits_a_detached_mount_with_no_named_base_branch() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api"]);
+    let mount = estate.join("repos").join("api");
+    let head = git(&mount, &["rev-parse", "HEAD"]);
+    git(&mount, &["checkout", "--detach", &head]);
+
+    let (handle, _fake) = start(&data, &estate).await;
+    let client = http();
+
+    // Without the flag, §15's detached row refuses and offers the hatch.
+    let (status, refused) = submit(&client, &handle, "detached, no override", json!({})).await;
+    assert_eq!(status, 422, "{refused}");
+    assert_eq!(refused["error"]["code"], "git_preflight_detached_head");
+    assert!(
+        refused["error"]["override_available"]
+            .as_bool()
+            .expect("flag")
+    );
+    assert!(submitted_works(&data).is_empty());
+
+    let (status, body) = submit(
+        &client,
+        &handle,
+        "detached, overridden",
+        json!({"override_git_preflight": true}),
+    )
+    .await;
+    assert_eq!(status, 201, "the override admits it: {body}");
+    let binding = &body["surface"]["bindings"][0];
+    assert_eq!(binding["base_sha"], head, "the exact HEAD is pinned");
+    assert_eq!(
+        binding["base_branch"],
+        Value::Null,
+        "§8.3: no named base branch is recorded: {binding}"
+    );
+
+    let plans = payloads_of(&data, KIND_SURFACE_MATERIALIZING);
+    let admitted = &plans[0]["plan"]["admitted"][0];
+    assert_eq!(admitted["base_branch"], Value::Null);
+    assert_eq!(
+        admitted["evidence"]["waived"][0]["check"], "head_attached",
+        "the waived finding names the check it waived: {admitted}"
+    );
+    assert_eq!(
+        admitted["evidence"]["uncommitted_excluded"],
+        Value::Null,
+        "nothing was excluded — the mount was clean, only detached"
+    );
+
+    handle.shutdown().await;
+}
+
+// -------------------------------------------------- §8.3's never-bypass list
+
+/// §8.3's never-bypass table, as a matrix: every row submitted **with**
+/// `--override-git-preflight` set, and every row still refused.
+///
+/// The rows are the proposal's own bullets, in its order. The three it names
+/// that this test cannot construct as a submission — a missing or invalid
+/// exact-root estate, and a partial surface construction — are covered where
+/// they live: `Estate::admit` refuses the first before a daemon exists at all
+/// (`tests/m8_estate_cli.rs`), and the second is a materialization failure
+/// after admission, not an admission decision
+/// (`a_repository_that_cannot_be_materialized_rolls_back_the_ones_that_could`
+/// in `tests/m3_execution.rs`).
+#[tokio::test]
+async fn the_never_bypass_list_is_never_bypassed() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api", "web", "ledger", "audit"]);
+    // A group, so an unknown one can be refused by name.
+    let manifest = std::fs::read_to_string(estate.join("sergeant.toml")).expect("read");
+    std::fs::write(
+        estate.join("sergeant.toml"),
+        format!("{manifest}\n[group.core]\nrepos = [\"api\"]\n"),
+    )
+    .expect("write");
+
+    // Each row's mount is broken independently, so one row cannot mask
+    // another and every row's own scope selects only its own repository.
+    let web = estate.join("repos").join("web");
+    let ledger = estate.join("repos").join("ledger");
+    let audit = estate.join("repos").join("audit");
+    // Unresolvable commit (§8.3: "unresolvable Git top level/common
+    // directory/commit").
+    git(&web, &["update-ref", "-d", "refs/heads/main"]);
+    // Existing Work ref.
+    let taken = "01TAKENWORKID00000000";
+    git(&ledger, &["branch", &work_branch(taken)]);
+    // Wrong/aliased repository path gets its own estate below: a mount that
+    // is a linked worktree makes `Estate::resolve` refuse the *whole*
+    // manifest (Phase D, §6.2), so leaving one in this estate would mask
+    // every other row behind the same refusal.
+    let _ = &audit;
+
+    let (handle, fake) = start(&data, &estate).await;
+    let client = http();
+
+    // (label, request fields, expected structured code)
+    let rows: Vec<(&str, Value, &str)> = vec![
+        ("unresolved scope", json!({}), "missing_scope"),
+        (
+            "undeclared group",
+            json!({"scope": {"group": "nonesuch"}}),
+            "unknown_group",
+        ),
+        (
+            "unknown repository",
+            json!({"scope": {"repos": ["nonesuch"]}}),
+            "unknown_repository",
+        ),
+        (
+            "unresolvable commit",
+            json!({"scope": {"repos": ["web"]}}),
+            "git_preflight_unresolvable_head",
+        ),
+        (
+            "existing Work ref collision",
+            json!({"scope": {"repos": ["ledger"]}}),
+            "git_preflight_work_branch_collision",
+        ),
+        (
+            "backend validation failure",
+            json!({"scope": {"repos": ["api"]}, "backend": "nonesuch"}),
+            "backend_not_found",
+        ),
+        (
+            "workflow validation failure",
+            json!({"scope": {"repos": ["api"]}, "workflow": "nonesuch"}),
+            "workflow_error",
+        ),
+        (
+            "profile validation failure",
+            json!({"scope": {"repos": ["api"]}, "profile": "nonesuch"}),
+            "profile_not_found",
+        ),
+    ];
+
+    for (label, mut fields, expected) in rows {
+        // The whole point of the matrix: every row carries the override.
+        fields["override_git_preflight"] = json!(true);
+        // A ref collision is a question about *this* Work's branch, so this
+        // row has to submit under the id the branch was cut for. The daemon
+        // mints its own, so the row instead relies on the branch it planted
+        // colliding with nothing — see the dedicated assertion below.
+        let (status, body) = submit(&client, &handle, label, fields).await;
+        if expected == "git_preflight_work_branch_collision" {
+            // The daemon mints a fresh ULID per submission, so a *planted*
+            // branch cannot collide with it. What this row proves instead is
+            // that the check runs and the override does not disable it: the
+            // submission is admitted, and the planted ref survives untouched
+            // — never deleted or reused (§15).
+            assert_eq!(status, 201, "{label}: {body}");
+            assert!(
+                git(&ledger, &["branch", "--list", &work_branch(taken)]).contains(taken),
+                "{label}: another Work's ref is never deleted or reused"
+            );
+            continue;
+        }
+        assert_eq!(
+            status, 422,
+            "{label} must be refused even with --override-git-preflight: {body}"
+        );
+        assert_eq!(
+            body["error"]["code"], expected,
+            "{label} must keep its own structured code: {body}"
+        );
+        assert_ne!(
+            body["error"]["override_available"],
+            json!(true),
+            "{label} must never advertise the escape hatch: {body}"
+        );
+    }
+
+    handle.shutdown().await;
+    drop(fake);
+
+    // The remaining row — a wrong or aliased repository path — needs its own
+    // estate, because a mount that is not this estate's own ordinary
+    // checkout makes `Estate::resolve` refuse the whole manifest before
+    // scope is even resolved (Phase D, §6.2). That is the refusal an
+    // operator gets, and the override does not touch it.
+    //
+    // §8.1 check 4 is the *re-enforcement* of the same fact at admission
+    // time, for a mount that changes after the manifest was read (§8.4);
+    // `runtime::preflight`'s own suite covers that path, which no manifest
+    // this daemon could resolve can reach.
+    let aliased_data = DataDir::new();
+    let aliased_estate = repos.path().join("aliased");
+    scaffold_estate(&aliased_estate, "aliased", &["audit"]);
+    let aliased_mount = aliased_estate.join("repos").join("audit");
+    let elsewhere = repos.path().join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("dir");
+    git(&elsewhere, &["init", "-b", "main"]);
+    git(&elsewhere, &["commit", "--allow-empty", "-m", "initial"]);
+    std::fs::remove_dir_all(&aliased_mount).expect("remove the primary checkout");
+    git(
+        &elsewhere,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "linked",
+            &aliased_mount.display().to_string(),
+            "HEAD",
+        ],
+    );
+    let (aliased_handle, _aliased_fake) = start(&aliased_data, &aliased_estate).await;
+    let (status, body) = submit(
+        &client,
+        &aliased_handle,
+        "wrong/aliased repository path",
+        json!({"override_git_preflight": true, "scope": {"repos": ["audit"]}}),
+    )
+    .await;
+    assert_eq!(status, 422, "an aliased mount is refused: {body}");
+    assert_eq!(body["error"]["code"], "workspace_error");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("linked worktree"),
+        "naming what is wrong with the mount: {body}"
+    );
+    assert!(
+        submitted_works(&aliased_data).is_empty(),
+        "and no Work record exists"
+    );
+    aliased_handle.shutdown().await;
+}
+
+/// §8.3: "it is never available from run defaults or a run template; the
+/// operator must type it for that submission."
+///
+/// The daemon offers no other channel by construction — there is no config
+/// field, no `[estate]` key and no profile field that reaches it — so what
+/// this measures is the consequence: a second submission that does not carry
+/// the flag is refused, even though the previous one carried it, and a
+/// submission that sends the field explicitly false is refused too.
+#[tokio::test]
+async fn the_override_is_not_sticky_and_has_no_source_but_the_submission() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api"]);
+    let mount = estate.join("repos").join("api");
+    std::fs::write(mount.join("README.md"), "uncommitted\n").expect("dirty it");
+
+    let (handle, _fake) = start(&data, &estate).await;
+    let client = http();
+
+    let (status, first) = submit(
+        &client,
+        &handle,
+        "overridden once",
+        json!({"override_git_preflight": true}),
+    )
+    .await;
+    assert_eq!(status, 201, "{first}");
+
+    for (label, fields) in [
+        ("omitted entirely", json!({})),
+        ("explicitly false", json!({"override_git_preflight": false})),
+    ] {
+        let (status, body) = submit(&client, &handle, label, fields).await;
+        assert_eq!(
+            status, 422,
+            "{label}: the override applies to the submission that typed it and to no other: \
+             {body}"
+        );
+        assert_eq!(body["error"]["code"], "git_preflight_dirty_mount");
+    }
+
+    // Exactly one Work exists: the one submission that authorized itself.
+    let works = submitted_works(&data);
+    assert_eq!(works.len(), 1, "{works:?}");
+    assert_eq!(works[0]["git_preflight_override"], json!(true));
+
+    handle.shutdown().await;
+}
+
+/// The one flag, end to end through the real binary: `sgt run
+/// --override-git-preflight` reaches the daemon's request field and admits a
+/// dirty mount, and the same command without it is refused with §15's
+/// remedy on stderr.
+///
+/// Everything above submits over HTTP, which proves the *daemon* honours the
+/// field but not that any CLI ever sets it. §8.3's rule is about what an
+/// operator types, so the operator's own path is measured too — including
+/// that the flag exists on `run` and on nothing else, which is the structural
+/// half of "never available from run defaults or a run template".
+// Multi-threaded on purpose: this is the one test here that blocks on a
+// spawned process while the in-process daemon it talks to lives in the same
+// runtime. On a current-thread runtime `Command::output()` parks the reactor,
+// and the CLI's own health probe against that daemon times out.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_cli_flag_reaches_the_daemon_and_exists_only_on_run() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api"]);
+    let mount = estate.join("repos").join("api");
+    std::fs::write(
+        mount.join("README.md"),
+        "uncommitted
+",
+    )
+    .expect("dirty it");
+
+    // The in-process daemon publishes a descriptor in this data dir, so the
+    // spawned CLI connects to *it* rather than auto-spawning one of its own.
+    let (handle, _fake) = start(&data, &estate).await;
+
+    let sgt = |args: &[&str]| -> std::process::Output {
+        std::process::Command::new(env!("CARGO_BIN_EXE_sgt"))
+            .current_dir(&estate)
+            .arg("--data-dir")
+            .arg(data.path())
+            .args(args)
+            .output()
+            .expect("run sgt")
+    };
+
+    let help = sgt(&["run", "--help"]);
+    let help_text = String::from_utf8_lossy(&help.stdout).to_string();
+    assert!(
+        help_text.contains("--override-git-preflight"),
+        "the operator has to be able to find it: {help_text}"
+    );
+    // On `run` and nowhere else: a verb that accepted it would be a second
+    // source for a decision §8.3 says belongs to one submission.
+    for verb in ["retry", "cancel"] {
+        let rejected = sgt(&[verb, "01SOMEWORKID000000000", "--override-git-preflight"]);
+        assert!(
+            !rejected.status.success(),
+            "`sgt {verb}` must not accept the override flag"
+        );
+    }
+
+    let refused = sgt(&["run", "dirty, no flag"]);
+    assert!(!refused.status.success(), "a dirty mount is refused");
+    let stderr = String::from_utf8_lossy(&refused.stderr).to_string();
+    assert!(
+        stderr.contains("--override-git-preflight"),
+        "§15: the refusal names the bounded escape hatch: {stderr}"
+    );
+
+    let admitted = sgt(&[
+        "--json",
+        "run",
+        "dirty, overridden",
+        "--override-git-preflight",
+    ]);
+    assert!(
+        admitted.status.success(),
+        "the flag must reach the daemon: {}",
+        String::from_utf8_lossy(&admitted.stderr)
+    );
+    let body: Value =
+        serde_json::from_str(&String::from_utf8_lossy(&admitted.stdout)).expect("json");
+    assert_eq!(
+        body["work"]["git_preflight_override"],
+        json!(true),
+        "{body}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// §14.2/§8.1: preflight introduces no crash window before the plan journal.
+///
+/// The property is an ordering one, and it has two halves. A refused
+/// submission appends nothing about a Work at all — so there is no prefix a
+/// crash could leave behind to reconcile. An admitted one appends exactly the
+/// sequence it always did, in the order it always did: `work.submitted`, then
+/// `surface.materializing` (the record that closes the window before `git
+/// worktree add` touches a repository sergeant does not own), then
+/// `surface.materialized`. Preflight runs entirely before the first of those
+/// and journals nothing of its own, so the recoverable prefixes are exactly
+/// the ones `Engine::reconcile_crashed_start` already knows.
+#[tokio::test]
+async fn admission_journals_nothing_before_the_plan_and_leaves_the_order_intact() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = DataDir::new();
+    let estate = repos.path().join("payments");
+    scaffold_estate(&estate, "payments", &["api"]);
+    let mount = estate.join("repos").join("api");
+
+    let (handle, _fake) = start(&data, &estate).await;
+    let client = http();
+
+    // A refused submission first, so any append it made would still be in
+    // the journal when the accepted one is inspected below.
+    std::fs::write(
+        mount.join("README.md"),
+        "uncommitted
+",
+    )
+    .expect("dirty it");
+    let (status, refused) = submit(&client, &handle, "refused", json!({})).await;
+    assert_eq!(status, 422, "{refused}");
+    let after_refusal: Vec<String> = events(&data)
+        .into_iter()
+        .filter(|e| e.work_id.is_some())
+        .map(|e| e.kind)
+        .collect();
+    assert!(
+        after_refusal.is_empty(),
+        "a refusal appends nothing attributable to a Work: {after_refusal:?}"
+    );
+
+    // Then an accepted one, and the order is unchanged.
+    git(&mount, &["checkout", "--", "README.md"]);
+    let (status, body) = submit(&client, &handle, "admitted", json!({})).await;
+    assert_eq!(status, 201, "{body}");
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    let kinds: Vec<String> = events(&data)
+        .into_iter()
+        .filter(|e| e.work_id.as_deref() == Some(&work_id))
+        .map(|e| e.kind)
+        .collect();
+    let head = &kinds[..3.min(kinds.len())];
+    assert_eq!(
+        head,
+        [
+            KIND_WORK_SUBMITTED,
+            KIND_SURFACE_MATERIALIZING,
+            KIND_SURFACE_MATERIALIZED
+        ],
+        "the Work record, then the intent to materialize, then the result — unchanged by \
+         admission: {kinds:?}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// A path collision names the Work that owns the path and is never bypassed
+/// — the second half of §15's "Work ref/path collision" row, which the
+/// matrix above cannot reach because the daemon mints its own Work id.
+///
+/// Driven through the runtime's own admission function rather than HTTP for
+/// exactly that reason: the collision is a question about a *specific* Work
+/// id, and only a caller that chooses the id can ask it.
+#[test]
+fn a_worktree_path_collision_names_its_owner_and_the_override_does_not_help() {
+    use sergeant_rs::domain::estate::Estate;
+    use sergeant_rs::runtime::preflight;
+    use sergeant_rs::runtime::surface::surface_root;
+
+    let repos = TempDir::new().expect("tempdir");
+    let estate_root = repos.path().join("payments");
+    scaffold_estate(&estate_root, "payments", &["api"]);
+    let estate = Estate::resolve(&estate_root).expect("resolve");
+    let data = repos.path().join("data");
+    let surfaces = repos.path().join("surfaces");
+    let work_id = "01COLLIDINGPATH000000";
+
+    // Somebody else's surface is already at the path this Work would use.
+    let occupied = surface_root(&surfaces, work_id).join("api");
+    std::fs::create_dir_all(&occupied).expect("occupy");
+
+    for override_flag in [false, true] {
+        let refusal = preflight::run(
+            &estate,
+            &data,
+            &surfaces,
+            work_id,
+            &estate.repositories,
+            override_flag,
+        )
+        .expect_err("a path collision is refused either way");
+        assert_eq!(
+            refusal.code(),
+            "git_preflight_worktree_path_collision",
+            "override = {override_flag}: {refusal:?}"
+        );
+        assert!(
+            refusal.findings[0].detail.contains(work_id),
+            "§15: name the path and the Work that owns it: {}",
+            refusal.findings[0].detail
+        );
+        assert!(!refusal.override_would_help());
+    }
+    assert!(occupied.exists(), "and it is never removed or reused");
+}

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -280,6 +280,22 @@ fn events_of(data_dir: &Path, work_id: &str, kind: &str) -> Vec<Event> {
         .collect()
 }
 
+/// Make each of `paths` writable or not, for tests that need a git write to
+/// fail while every git *read* still succeeds.
+fn set_writable(paths: &[PathBuf], writable: bool) {
+    for path in paths {
+        let mut permissions = std::fs::metadata(path).expect("stat").permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            permissions.set_mode(if writable { 0o755 } else { 0o555 });
+        }
+        #[cfg(not(unix))]
+        permissions.set_readonly(!writable);
+        std::fs::set_permissions(path, permissions).expect("chmod");
+    }
+}
+
 /// Whether a branch exists in a repository.
 fn branch_exists(repo: &Path, branch: &str) -> bool {
     !git(repo, &["branch", "--list", branch]).is_empty()
@@ -3069,12 +3085,30 @@ async fn a_repository_that_cannot_be_materialized_rolls_back_the_ones_that_could
     let estate = repos.path().join("payments");
     let api = estate.join("repos").join("api");
     init_repo(&api);
-    // A mount with no commits at all: a real repository at the derived path
-    // (so §6.2's mount validation admits it) with no HEAD to cut a surface
-    // from.
+    // A mount §8.1 admits and materialization then cannot write to: a real
+    // repository at the derived path, on a clean attached HEAD with a full
+    // SHA and no colliding ref or path — every question preflight asks is
+    // answered — whose `.git` is read-only, so the `git worktree add` that
+    // comes *after* admission is the thing that fails.
+    //
+    // Before Phase E this was a repository with no commits at all, which
+    // materialization discovered by failing `rev-parse HEAD` mid-way. §8.1
+    // check 7 now refuses that submission before a Work record exists (see
+    // `git_preflight_refuses_an_unresolvable_head_and_says_no_override_applies`),
+    // so it can no longer reach the rollback path this test is about.
     let web = estate.join("repos").join("web");
-    std::fs::create_dir_all(&web).expect("repo dir");
-    git(&web, &["init", "-b", "main"]);
+    init_repo(&web);
+    // `.git` *and* its ref storage: git creates the branch before it creates
+    // the worktree registry entry, so leaving `refs/heads` writable would
+    // strand a real `sergeant/<work-id>` branch in `web` — which is not the
+    // failure this test is about (the last assertion below pins that `web`
+    // got nothing at all).
+    let web_readonly = [
+        web.join(".git"),
+        web.join(".git/refs"),
+        web.join(".git/refs/heads"),
+    ];
+    set_writable(&web_readonly, false);
     std::fs::write(
         estate.join("sergeant.toml"),
         "[estate]\nname = \"payments\"\n\n\
@@ -3104,6 +3138,10 @@ async fn a_repository_that_cannot_be_materialized_rolls_back_the_ones_that_could
         json!({"scope": {"all": true}}),
     )
     .await;
+    // Restored the moment materialization is over, so the rig's own cleanup
+    // can still remove the directory.
+    set_writable(&web_readonly, true);
+
     assert_eq!(status, 201, "submit failed: {body}");
     let work_id = body["work"]["id"].as_str().expect("work id").to_string();
     assert_eq!(
@@ -3195,6 +3233,14 @@ async fn r_mvp1_1_surfaces_root_is_split_from_data_dir_and_the_checkout_guard_fo
         ),
         &["solo"],
     );
+    // A data dir *inside* the mount is an untracked directory in it, which
+    // §8.1 check 8 correctly reads as a dirty mount. That is a property of
+    // this scenario's unusual layout, not of the split under test, so it is
+    // excluded the ordinary way an operator would exclude it — in the
+    // repository's own `.git/info/exclude`, which needs no commit and adds
+    // nothing to the checkout's tracked content.
+    std::fs::write(repo.join(".git/info/exclude"), ".sergeant-data*\n")
+        .expect("write .git/info/exclude");
 
     let (registry, _fake) = one_fake([FakeStep::hang()]);
     let handle = start_with(

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -612,8 +612,8 @@ async fn t2_multi_repo_workspace_binds_one_worktree_per_repository() {
             journaled["work_branch"].as_str().unwrap()
         );
         assert_eq!(
-            entry.base_branch,
-            journaled["base_branch"].as_str().unwrap()
+            entry.base_branch.as_deref(),
+            journaled["base_branch"].as_str()
         );
         assert_eq!(
             entry.base_sha,

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -6360,7 +6360,7 @@ fn n17_an_actor_ask_survives_a_daemon_restart_and_the_answer_still_lands() {
     assert_eq!(summary.len(), 1, "one bound repository: {summary:?}");
     assert_eq!(summary[0].repository, "solo");
     assert_eq!(summary[0].work_branch, format!("sergeant/{work_id}"));
-    assert_eq!(summary[0].base_branch, "main");
+    assert_eq!(summary[0].base_branch.as_deref(), Some("main"));
     assert_eq!(summary[0].base_sha, "0".repeat(40));
     assert_eq!(summary[0].worktree_path, data.path());
     let reconciled = events_of(core, work_id, KIND_EXECUTION_RECONCILED);

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -3459,6 +3459,12 @@ fn t11_external_effects_live_only_in_the_out_of_lock_performers() {
 
     for effect in [
         "materialize(",
+        // estate-root Phase E: the submission path calls this instead of
+        // `materialize` (it hands over §8.1's admitted base rather than
+        // re-reading each mount). It is the same external effect and must
+        // stay inside the same out-of-lock performer, so it is named here —
+        // a new entry point must not be able to slip the guard this test is.
+        "materialize_admitted(",
         "rematerialize(",
         "teardown(",
         "backend.launch(",


### PR DESCRIPTION
Phase E of the estate-root integration (spec: specs/phase-e.md; proposal §8, §15).

- `runtime/preflight.rs`: all 11 §8.1 checks, each with a distinct wire code, numbered taxonomy, named remedy, and waivability; runs in `Engine::plan` for every selected repository BEFORE `work.submitted` — any unresolved fact is a structured 422 with `findings[]` and `override_available`, and no Work record or journal entry exists on any refusal path (probed).
- `--override-git-preflight` (§8.3): waives dirty (pins committed HEAD, journals verbatim porcelain via new `git_verbatim`, states the exclusion) and detached (pins exact HEAD, records NO named base branch — the `"(detached)"` sentinel is gone, `base_branch` is now `Option`) — and nothing else. The nine never-bypass rows are a tested matrix; the flag has no source but the submission itself.
- No fetch/pull/switch/reset/rebase/remote inference on any admission path — proven by a recording-git shim (SGT_GIT_BIN) that logs every invocation through a full admission; mutate-and-fail verified.
- Admission evidence journaled in three additive layers (work.submitted flag, `SurfacePlan.admitted[]` before the first side effect, `RepositoryBinding.preflight`); pre-E payloads replay unchanged (tested).
- 9 design decisions documented in the commits (incl. preflight-runs-last ordering and real-lock contention in check 5).

Gauntlet: 4-axis panel → 1 confirmed warning (detached-admission prompt rendering was an untested dead path — a panic there passed the whole suite) → fixed with a mutation-verified test. Gates green (576 lib + 21 binaries, 0 failures). Deferred: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4