### PR TITLE
Prep the 0.1.1 release: CHANGELOG section and Cargo.lock sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ released before a release can proceed.
 
 ## [Unreleased]
 
+(nothing yet)
+
+## [0.1.1] - 2026-08-20
+
 ### Added
 
 - **Terminal Works now report an integrity disposition (#173).** At

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "sergeant-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "blake3",


### PR DESCRIPTION
The 0.1.1 dispatch failed Gate A ("CHANGELOG.md does not mention 0.1.1") because PR #198 bumped only Cargo.toml via the web editor. This PR:

- Converts the Unreleased section (the entire estate-root integration, PR #190) into `## [0.1.1] - 2026-08-20`, leaving a fresh empty Unreleased.
- Syncs `Cargo.lock` to 0.1.1 — the web edit couldn't, and release.yml's `--locked` build would have been the next failure after Gate A.

After merge, re-dispatch the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4