### PR TITLE
Wave 2 — perf + journal: #12 shared replay, #10 events index, #4 bounded Work cache, #169 torn-tail contract, #8 rep knob

### DIFF
--- a/scripts/perf/s3-deep.sh
+++ b/scripts/perf/s3-deep.sh
@@ -9,7 +9,18 @@
 #   scripts/perf/s3-deep.sh <outdir>
 #
 # Knobs: PERF_S3_TARGET_EVENTS (1000), PERF_S3_MAX_CYCLES (500),
-#        PERF_S3_SEQ_READS (100), PERF_S3_CONC (20), PERF_S3_ROUNDS (5).
+#        PERF_S3_SEQ_READS (100), PERF_S3_CONC (20), PERF_S3_ROUNDS (5),
+#        PERF_S3_REPS (1) — repeat the read-burst block (sequential + concurrent
+#        graph reads, work show) this many times before the daemon stops, so a
+#        held-open daemon's read paths can be loaded well past a single pass
+#        without a second invocation of this script. At the default REPS=1
+#        every output is byte-identical to before this knob existed; above 1,
+#        the per-request CSVs and the latency/count `perf_kv` keys they feed
+#        become cumulative across reps (more samples, same percentile math),
+#        and a new s3-reps.csv (rep, rss_kb) tracks RSS at each rep boundary
+#        — repeated reads that grow RSS are exactly what this knob exists to
+#        surface. The orchestrator runs the 12-rep measurement pass; this
+#        worktree only adds the knob.
 #
 # The fake backend's script is a single queue shared by the whole daemon: one
 # step is consumed per execution START and one per input SEND. With exactly one
@@ -30,6 +41,7 @@ MAXC="${PERF_S3_MAX_CYCLES:-500}"
 SEQ_READS="${PERF_S3_SEQ_READS:-100}"
 CONC="${PERF_S3_CONC:-20}"
 ROUNDS="${PERF_S3_ROUNDS:-5}"
+REPS="${PERF_S3_REPS:-1}"
 
 DD="$PERF_SCRATCH/s3/data"
 REPO="$PERF_SCRATCH/s3/repo"
@@ -89,54 +101,74 @@ FDS_BEFORE="$(perf_proc_fds "$PERF_DAEMON_PID")"
 SAMPLE="$PERF_OUT/s3-sample.csv"
 perf_sampler_start "$PERF_DAEMON_PID" "$SAMPLE" 0.2 reads
 
-perf_step "$SEQ_READS sequential graph reads"
+# #8: the read-burst block below (sequential + concurrent graph reads, work
+# show) repeats REPS times. Every CSV it writes is initialized once here, kept
+# open across reps (each rep appends), so `perf_latency_kv`/the `_http` counts
+# it feeds are cumulative over every rep by the time the loop ends — more
+# samples behind the same percentile math, not a second, separate summary. At
+# the default REPS=1 the loop body runs exactly once and every artifact below
+# is byte-identical to before this knob existed.
 SEQ_CSV="$PERF_OUT/s3-graph-seq.csv"
 echo 't_start_ns,wall_ns,curl_total_s,http_code,bytes' > "$SEQ_CSV"
-for ((i = 1; i <= SEQ_READS; i++)); do
-  perf_mark g0
-  line="$(curl -sS -m 300 -o "$PERF_SCRATCH/s3/graph.json" \
-    -w '%{http_code} %{size_download} %{time_total}' \
-    -H "Authorization: Bearer $PERF_TOKEN" "$PERF_ENDPOINT/v1/graph/work/$WORK" 2>/dev/null)"
-  perf_mark g1
-  read -r code bytes total <<< "$line"
-  printf '%s,%s,%s,%s,%s\n' "$g0" "$((g1 - g0))" "$total" "$code" "$bytes" >> "$SEQ_CSV"
-done
-perf_latency_kv graph_seq "$SEQ_CSV" 2
-perf_kv graph_seq_http "$(tail -n +2 "$SEQ_CSV" | awk -F, '$4 == 200' | wc -l | tr -d ' ')/$SEQ_READS"
-perf_kv graph_bytes "$(tail -n +2 "$SEQ_CSV" | cut -d, -f5 | sort -n | tail -1)"
-perf_kv graph_nodes "$(jq '.nodes | length' "$PERF_SCRATCH/s3/graph.json" 2>/dev/null || echo 0)"
-perf_kv graph_edges "$(jq '.edges | length' "$PERF_SCRATCH/s3/graph.json" 2>/dev/null || echo 0)"
-
-perf_step "$ROUNDS rounds of $CONC concurrent graph reads"
 CONC_DIR="$PERF_SCRATCH/s3/conc"
-rm -rf "$CONC_DIR"; mkdir -p "$CONC_DIR"
 CONC_CSV="$PERF_OUT/s3-graph-conc.csv"
 echo 't_start_ns,wall_ns,curl_total_s,http_code,bytes' > "$CONC_CSV"
-round_walls=()
-for ((r = 1; r <= ROUNDS; r++)); do
-  rdir="$CONC_DIR/r$r"; mkdir -p "$rdir"
-  perf_mark r0
-  seq 1 "$CONC" | xargs -P "$CONC" -I@ \
-    "$PERF_DIR/_get-one.sh" "$PERF_ENDPOINT" "$PERF_TOKEN" "/v1/graph/work/$WORK" "$rdir/@.csv"
-  perf_mark r1
-  round_walls+=("$((r1 - r0))")
-  cat "$rdir"/*.csv >> "$CONC_CSV"
-  perf_say "round $r: $(perf_s $((r1 - r0)))s wall for $CONC concurrent"
-done
-perf_latency_kv graph_conc "$CONC_CSV" 2
-perf_kv graph_conc_http "$(tail -n +2 "$CONC_CSV" | awk -F, '$4 == 200' | wc -l | tr -d ' ')/$((CONC * ROUNDS))"
-perf_kv graph_conc_round_walls_s "$(for w in "${round_walls[@]}"; do printf '%s ' "$(perf_s "$w")"; done)"
-
-perf_step "work show and the events tail at depth"
 SHOW_CSV="$PERF_OUT/s3-show.csv"
 echo 't_start_ns,wall_ns,curl_total_s,http_code,bytes' > "$SHOW_CSV"
-for ((i = 1; i <= 20; i++)); do
-  read -r w code bytes total <<< "$(perf_timed_get "/v1/work/$WORK" "$PERF_SCRATCH/s3/show.json")"
-  printf '%s,%s,%s,%s,%s\n' "$(perf_now_ns)" "$w" "$total" "$code" "$bytes" >> "$SHOW_CSV"
-done
-perf_latency_kv work_show "$SHOW_CSV" 2
-perf_kv work_show_bytes "$(stat -c %s "$PERF_SCRATCH/s3/show.json" 2>/dev/null || echo 0)"
+REPS_CSV="$PERF_OUT/s3-reps.csv"
+echo 'rep,rss_kb' > "$REPS_CSV"
 
+for ((rep = 1; rep <= REPS; rep++)); do
+  [ "$REPS" -gt 1 ] && perf_step "read-burst rep $rep/$REPS"
+
+  perf_step "$SEQ_READS sequential graph reads"
+  for ((i = 1; i <= SEQ_READS; i++)); do
+    perf_mark g0
+    line="$(curl -sS -m 300 -o "$PERF_SCRATCH/s3/graph.json" \
+      -w '%{http_code} %{size_download} %{time_total}' \
+      -H "Authorization: Bearer $PERF_TOKEN" "$PERF_ENDPOINT/v1/graph/work/$WORK" 2>/dev/null)"
+    perf_mark g1
+    read -r code bytes total <<< "$line"
+    printf '%s,%s,%s,%s,%s\n' "$g0" "$((g1 - g0))" "$total" "$code" "$bytes" >> "$SEQ_CSV"
+  done
+  perf_latency_kv graph_seq "$SEQ_CSV" 2
+  perf_kv graph_seq_http "$(tail -n +2 "$SEQ_CSV" | awk -F, '$4 == 200' | wc -l | tr -d ' ')/$((SEQ_READS * rep))"
+  perf_kv graph_bytes "$(tail -n +2 "$SEQ_CSV" | cut -d, -f5 | sort -n | tail -1)"
+  perf_kv graph_nodes "$(jq '.nodes | length' "$PERF_SCRATCH/s3/graph.json" 2>/dev/null || echo 0)"
+  perf_kv graph_edges "$(jq '.edges | length' "$PERF_SCRATCH/s3/graph.json" 2>/dev/null || echo 0)"
+
+  perf_step "$ROUNDS rounds of $CONC concurrent graph reads"
+  rm -rf "$CONC_DIR"; mkdir -p "$CONC_DIR"
+  round_walls=()
+  for ((r = 1; r <= ROUNDS; r++)); do
+    rdir="$CONC_DIR/r$r"; mkdir -p "$rdir"
+    perf_mark r0
+    seq 1 "$CONC" | xargs -P "$CONC" -I@ \
+      "$PERF_DIR/_get-one.sh" "$PERF_ENDPOINT" "$PERF_TOKEN" "/v1/graph/work/$WORK" "$rdir/@.csv"
+    perf_mark r1
+    round_walls+=("$((r1 - r0))")
+    cat "$rdir"/*.csv >> "$CONC_CSV"
+    perf_say "round $r: $(perf_s $((r1 - r0)))s wall for $CONC concurrent"
+  done
+  perf_latency_kv graph_conc "$CONC_CSV" 2
+  perf_kv graph_conc_http "$(tail -n +2 "$CONC_CSV" | awk -F, '$4 == 200' | wc -l | tr -d ' ')/$((CONC * ROUNDS * rep))"
+  perf_kv graph_conc_round_walls_s "$(for w in "${round_walls[@]}"; do printf '%s ' "$(perf_s "$w")"; done)"
+
+  perf_step "work show at depth"
+  for ((i = 1; i <= 20; i++)); do
+    read -r w code bytes total <<< "$(perf_timed_get "/v1/work/$WORK" "$PERF_SCRATCH/s3/show.json")"
+    printf '%s,%s,%s,%s,%s\n' "$(perf_now_ns)" "$w" "$total" "$code" "$bytes" >> "$SHOW_CSV"
+  done
+  perf_latency_kv work_show "$SHOW_CSV" 2
+  perf_kv work_show_bytes "$(stat -c %s "$PERF_SCRATCH/s3/show.json" 2>/dev/null || echo 0)"
+
+  printf '%s,%s\n' "$rep" "$(perf_proc_rss "$PERF_DAEMON_PID")" >> "$REPS_CSV"
+done
+
+perf_kv rss_first_rep_kb "$(sed -n '2p' "$REPS_CSV" | cut -d, -f2)"
+perf_kv rss_last_rep_kb "$(tail -n 1 "$REPS_CSV" | cut -d, -f2)"
+
+perf_step "the events tail at depth"
 TAIL_CSV="$PERF_OUT/s3-events-tail.csv"
 echo 't_start_ns,wall_ns,curl_total_s,http_code,bytes,variant' > "$TAIL_CSV"
 for variant in "limit=50" "limit=200" "all"; do

--- a/src/api.rs
+++ b/src/api.rs
@@ -1691,18 +1691,14 @@ fn stranded_completion(work: &Work, run: &WorkRun) -> bool {
     let Some(surface) = run.surface.as_ref() else {
         return false;
     };
-    teardown.bindings.iter().any(|binding| {
-        let never_advanced = surface
-            .bindings
-            .iter()
-            .find(|b| b.repository == binding.repository)
-            .is_some_and(|b| binding.final_sha.as_deref() == Some(b.base_sha.as_str()));
-        never_advanced
-            && matches!(
-                binding.disposition,
-                BindingDisposition::RetainedDirty { .. }
-            )
-    })
+    // The structural predicate itself lives on `TeardownReport` (surface.rs,
+    // beside `integrity()`) so the projection reducer can compute the same
+    // thing at `surface.torn_down` time, with no live `Work` at hand, for
+    // `WorkIndexRow`'s effective disposition (#4's slim-row eviction gap).
+    // Only the `work.state == Completed` gate stays here — that is the one
+    // fact the reducer already knows a different way (it runs after
+    // `work.completed` has already updated `work.state`/`row.state`).
+    teardown.stranded_completion(surface)
 }
 
 /// The `state` `work list`/`work show` report: verbatim for every ordinary
@@ -1931,12 +1927,13 @@ fn fleet_body(core: &Core, engine: &Engine) -> Value {
 /// narrowing explicitly rather than leaving a client to infer it from
 /// absent keys.
 ///
-/// One known gap versus the full row's `reported_state`: [`stranded_completion`]
-/// reads the teardown's finalize commit against the surface's base SHA,
-/// neither of which the slim row retains, so an evicted stranded completion
-/// whose retained `integrity` disposition was never marked `Dirty` reads
-/// plain `completed` here instead of `completed_dirty`. Disclosed, not
-/// silently narrowed — same spirit as the rest of this row.
+/// No gap versus the full row's `reported_state` for the `completed_dirty`
+/// question, despite the slim row never retaining `run.teardown`/
+/// `run.surface`: `WorkIndexRow::integrity` (projection.rs) is the *effective*
+/// disposition — explicit `Dirty` OR [`stranded_completion`]'s structural
+/// check — already folded in at `surface.torn_down` time, while both were
+/// still in hand. So the plain `== Some(Dirty)` check below is enough; it
+/// does not need to re-derive stranded-ness from fields this row never kept.
 fn evicted_fleet_row(row: &WorkIndexRow) -> Value {
     let state = if row.state == WorkState::Completed
         && row.integrity == Some(IntegrityDisposition::Dirty)
@@ -5534,6 +5531,278 @@ mod tests {
                 .work_index
                 .contains_key("01NOSUCHWORKATALL"),
             "an id nothing ever journaled must not be found"
+        );
+    }
+
+    /// Panel finding (the explicit-Dirty half): `evicted_fleet_row` reads
+    /// `WorkIndexRow::integrity` directly, and an explicit `Dirty`
+    /// disposition was always mirrored into it verbatim — so this half
+    /// already passed before the fix. It is kept here as a regression guard
+    /// alongside its stranded-completion sibling just below, which the fix
+    /// was actually for.
+    ///
+    /// Same churn shape as
+    /// `a_work_view_survives_terminal_work_cache_eviction_and_unknown_ids_still_404`
+    /// just above: submit the target first (so it is oldest and ages out
+    /// first), then churn ordinary completions past
+    /// `TERMINAL_WORK_CACHE_CAPACITY` (1024) so `evicted_fleet_row` is the
+    /// branch `fleet_body` actually takes for it, not the full-row branch.
+    #[test]
+    fn evicted_fleet_row_reports_completed_dirty_for_an_explicit_dirty_disposition() {
+        use crate::runtime::testing;
+
+        fn surface(work_id: &str) -> Value {
+            json!({"surface": {
+                "work_id": work_id,
+                "root": "/data/surfaces/x",
+                "bindings": [{
+                    "repository": "solo",
+                    "source_path": "/repos/solo",
+                    "base_branch": "main",
+                    "base_sha": "0".repeat(40),
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "head_sha": "0".repeat(40),
+                }],
+            }})
+        }
+
+        fn ordinary_teardown(work_id: &str) -> Value {
+            json!({"report": {
+                "work_id": work_id,
+                "clean": true,
+                "bindings": [{
+                    "repository": "solo",
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "disposition": "removed",
+                }],
+            }})
+        }
+
+        fn explicit_dirty_teardown(work_id: &str) -> Value {
+            // A clean removal in every way `TeardownReport::integrity()`
+            // itself would score, but retired with an explicit `Dirty`
+            // disposition anyway — the two ways to `completed_dirty` §11.5's
+            // own doc calls out as a union rather than a competition.
+            let mut payload = ordinary_teardown(work_id);
+            payload["integrity"] = json!("dirty");
+            payload
+        }
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+
+        let target_id = "01EXPLICITDIRTY0000001";
+        testing::submit(&mut core, target_id, "retired dirty on purpose");
+        testing::commit(
+            &mut core,
+            target_id,
+            KIND_SURFACE_MATERIALIZED,
+            surface(target_id),
+        );
+        testing::commit(&mut core, target_id, KIND_WORK_COMPLETED, json!({}));
+        testing::commit(
+            &mut core,
+            target_id,
+            KIND_SURFACE_TORN_DOWN,
+            explicit_dirty_teardown(target_id),
+        );
+
+        let backends = BackendRegistry::new().with(Arc::new(
+            crate::backend::fake::FakeBackend::new(crate::backend::fake::FAKE_BACKEND_NAME),
+        ));
+        let engine = Engine::new(
+            Arc::new(backends),
+            Some(crate::backend::fake::FAKE_BACKEND_NAME.to_string()),
+            dir.path(),
+        );
+
+        // Churn ordinary completions past `TERMINAL_WORK_CACHE_CAPACITY`
+        // (1024, private to `projection.rs`) so `target_id` — submitted
+        // first, so it is the oldest — actually ages out of `terminal_works`
+        // and `evicted_fleet_row` is the branch `fleet_body` actually takes.
+        for i in 0..1224 {
+            let id = format!("01EXPLICITDIRTYCHURN{i:06}");
+            testing::submit(&mut core, &id, "cache churn");
+            testing::commit(&mut core, &id, KIND_SURFACE_MATERIALIZED, surface(&id));
+            testing::commit(&mut core, &id, KIND_WORK_COMPLETED, json!({}));
+            testing::commit(
+                &mut core,
+                &id,
+                KIND_SURFACE_TORN_DOWN,
+                ordinary_teardown(&id),
+            );
+        }
+        assert!(
+            !core.registry.state().terminal_works.contains_key(target_id),
+            "the target must actually have aged out of the bounded cache for \
+             this test to prove anything"
+        );
+
+        let fleet = fleet_body(&core, &engine);
+        let row = fleet["works"]
+            .as_array()
+            .expect("works")
+            .iter()
+            .find(|w| w["id"] == target_id)
+            .expect("the evicted-past-cache work is still listed, narrowed");
+        assert_eq!(row["evicted"], true, "{row}");
+        assert_eq!(
+            row["state"], "completed_dirty",
+            "an explicit Dirty disposition must still read completed_dirty \
+             once the Work has aged past TERMINAL_WORK_CACHE_CAPACITY: {row}"
+        );
+    }
+
+    /// Panel finding (the core fix, stranded-completion half): before this
+    /// fix, `WorkIndexRow::integrity` only ever mirrored the *explicit*
+    /// disposition a `surface.torn_down` carried — never ADR 0007(b)'s
+    /// structural inference (`stranded_completion`: a closing stage's
+    /// finalize commit that never moved past the surface's base SHA, with a
+    /// `RetainedDirty` binding). A stranded completion with no explicit
+    /// `Dirty` disposition therefore read `completed_dirty` in `sgt work
+    /// show`/`sgt work list` right up until its Work aged past
+    /// `TERMINAL_WORK_CACHE_CAPACITY` — at which point `evicted_fleet_row`,
+    /// reading `WorkIndexRow` alone, would find `row.integrity` still `None`
+    /// and silently revert it to plain `completed`. The fix folds the
+    /// structural check into `WorkIndexRow::integrity` itself, at
+    /// `surface.torn_down` time in the reducer (`projection.rs`), while
+    /// `run.surface`/`run.teardown` are still in hand.
+    ///
+    /// **Why this fails without the fix.** This fixture's teardown payload
+    /// carries no `integrity` key at all (mirroring
+    /// `a_stranded_completion_survives_terminal_run_cache_eviction`'s
+    /// `stranded_teardown` shape exactly: `clean: false`, a `retained_dirty`
+    /// binding whose `final_sha` equals the surface binding's own
+    /// `base_sha`, i.e. never advanced) — so on the pre-fix reducer,
+    /// `row.integrity` is set from `run.integrity`, which
+    /// `serde_json::from_value` on an absent key resolves to `None`.
+    /// `evicted_fleet_row` only special-cases `row.integrity ==
+    /// Some(Dirty)`; with `row.integrity == None` it falls straight to
+    /// `row.state.as_str()`, i.e. `"completed"`. Only after the Work ages
+    /// past `TERMINAL_WORK_CACHE_CAPACITY` does that gap become visible —
+    /// while cached, `fleet_body`/`work_view` both still resolve the full
+    /// run and re-run `stranded_completion` directly, which is exactly why
+    /// this test churns past the cache rather than asserting immediately.
+    #[test]
+    fn evicted_fleet_row_reports_completed_dirty_for_a_stranded_completion() {
+        use crate::runtime::testing;
+
+        fn surface(work_id: &str) -> Value {
+            json!({"surface": {
+                "work_id": work_id,
+                "root": "/data/surfaces/x",
+                "bindings": [{
+                    "repository": "solo",
+                    "source_path": "/repos/solo",
+                    "base_branch": "main",
+                    "base_sha": "0".repeat(40),
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "head_sha": "0".repeat(40),
+                }],
+            }})
+        }
+
+        fn stranded_teardown(work_id: &str) -> Value {
+            json!({"report": {
+                "work_id": work_id,
+                "clean": false,
+                "bindings": [{
+                    "repository": "solo",
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "disposition": "retained_dirty",
+                    "changes": " M half-done.rs",
+                    // Never advanced past the base SHA `surface` recorded —
+                    // no explicit `integrity` key anywhere in this payload.
+                    "final_sha": "0".repeat(40),
+                }],
+            }})
+        }
+
+        fn ordinary_teardown(work_id: &str) -> Value {
+            json!({"report": {
+                "work_id": work_id,
+                "clean": true,
+                "bindings": [{
+                    "repository": "solo",
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "disposition": "removed",
+                }],
+            }})
+        }
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+
+        let stranded_id = "01STRANDEDEVICTED0001";
+        testing::submit(&mut core, stranded_id, "declares a commit, never makes one");
+        testing::commit(
+            &mut core,
+            stranded_id,
+            KIND_SURFACE_MATERIALIZED,
+            surface(stranded_id),
+        );
+        testing::commit(&mut core, stranded_id, KIND_WORK_COMPLETED, json!({}));
+        testing::commit(
+            &mut core,
+            stranded_id,
+            KIND_SURFACE_TORN_DOWN,
+            stranded_teardown(stranded_id),
+        );
+
+        let backends = BackendRegistry::new().with(Arc::new(
+            crate::backend::fake::FakeBackend::new(crate::backend::fake::FAKE_BACKEND_NAME),
+        ));
+        let engine = Engine::new(
+            Arc::new(backends),
+            Some(crate::backend::fake::FAKE_BACKEND_NAME.to_string()),
+            dir.path(),
+        );
+
+        // Churn ordinary completions past `TERMINAL_WORK_CACHE_CAPACITY`
+        // (1024) so `stranded_id` — submitted first, so it is the oldest —
+        // actually ages out of `terminal_works` and `evicted_fleet_row` is
+        // the branch `fleet_body` actually takes for it.
+        for i in 0..1224 {
+            let id = format!("01STRANDEDEVICTEDCHURN{i:06}");
+            testing::submit(&mut core, &id, "cache churn");
+            testing::commit(&mut core, &id, KIND_SURFACE_MATERIALIZED, surface(&id));
+            testing::commit(&mut core, &id, KIND_WORK_COMPLETED, json!({}));
+            testing::commit(
+                &mut core,
+                &id,
+                KIND_SURFACE_TORN_DOWN,
+                ordinary_teardown(&id),
+            );
+        }
+        assert!(
+            !core
+                .registry
+                .state()
+                .terminal_works
+                .contains_key(stranded_id),
+            "the stranded work must actually have aged out of the bounded \
+             cache for this test to prove anything"
+        );
+
+        let fleet = fleet_body(&core, &engine);
+        let row = fleet["works"]
+            .as_array()
+            .expect("works")
+            .iter()
+            .find(|w| w["id"] == stranded_id)
+            .expect("the evicted-past-cache work is still listed, narrowed");
+        assert_eq!(row["evicted"], true, "{row}");
+        assert_eq!(
+            row["state"], "completed_dirty",
+            "an evicted stranded completion (ADR 0007(b)'s structural \
+             inference, no explicit Dirty disposition) must not silently \
+             revert to plain completed just because its Work aged past \
+             TERMINAL_WORK_CACHE_CAPACITY: {row}"
         );
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -64,7 +64,8 @@ use crate::runtime::graph::{
 use crate::runtime::integrity::IntegrityDisposition;
 use crate::runtime::journal::{Journal, JournalError};
 use crate::runtime::projection::{
-    Projection, ProjectionError, WorkRegistry, WorkRun, is_absorbing, rederive_run,
+    Projection, ProjectionError, WorkIndexRow, WorkRegistry, WorkRun, is_absorbing, rederive_run,
+    rederive_work,
 };
 use crate::runtime::surface::{
     BindingDisposition, KIND_SURFACE_MATERIALIZED, KIND_SURFACE_MATERIALIZING,
@@ -1495,6 +1496,43 @@ async fn submit_work(
     )
 }
 
+/// #4's Work cache read side, the full-[`Work`] analog of [`resolve_run`]
+/// just below: `works` (active) -> `terminal_works` (cache) -> journal
+/// re-derivation, in that order. Every site that used to read
+/// `registry.works.get`/`.contains_key` directly for a Work it needed the
+/// full struct from — `work_view`, `cancel`/`extend`/`reap`-shaped
+/// handlers — routes through this instead, so a Work aged out of the
+/// bounded cache is still found, exactly the way `resolve_run` already
+/// keeps working for its run.
+///
+/// `None` only for a work id `WorkRegistry::work_index` has no row for —
+/// genuinely unknown, never journaled. The index is checked before ever
+/// paying for a replay: every Work this daemon has journaled has a row
+/// there for as long as the journal exists, evicted from the full-struct
+/// cache or not, so a miss there is conclusive without reading a single
+/// event.
+fn resolve_work(core: &Core, work_id: &str) -> Option<Work> {
+    let registry = core.registry.state();
+    if let Some(work) = registry.works.get(work_id) {
+        return Some(work.clone());
+    }
+    if let Some(work) = registry.terminal_works.get(work_id) {
+        return Some(work.clone());
+    }
+    registry.work_index.get(work_id)?;
+    match blocking_sync(|| rederive_work(&core.journal, work_id)) {
+        Ok(work) => work,
+        Err(e) => {
+            tracing::error!(
+                work_id = %work_id,
+                error = %e,
+                "could not re-derive an evicted work from the journal"
+            );
+            None
+        }
+    }
+}
+
 /// The [`WorkRun`] to render for a work: the live or R-MVP1-9-evicted-but-
 /// cached registry entry (`cached`, which callers pass as `WorkRegistry::
 /// run_view`'s answer — checking both `runs` and `terminal_runs`), or —
@@ -1705,14 +1743,17 @@ fn reported_state(work: &Work, run: Option<&WorkRun>) -> &'static str {
 /// into one record is how "in review" becomes a state-machine value.
 fn work_view(core: &Core, engine: &Engine, work_id: &str) -> Value {
     let registry = core.registry.state();
-    let work = registry.works.get(work_id);
+    // #4: `works` may have already evicted this id into `terminal_works` or
+    // beyond — `resolve_work` is the same works -> cache -> journal chain
+    // `resolve_run` below already uses for the run.
+    let work = resolve_work(core, work_id);
     let cached_run = registry.run_view(work_id);
-    let run = work.and_then(|w| resolve_run(core, w, cached_run));
+    let run = work.as_ref().and_then(|w| resolve_run(core, w, cached_run));
     // ADR 0007(b): the persisted `Work` serializes with its true `state`
     // (`Completed`) intact; only this view's own `state` key is overridden,
     // so a work still in flight and every non-stranded completion look
     // exactly as before.
-    let work_json = work.map(|w| {
+    let work_json = work.as_ref().map(|w| {
         let mut value = serde_json::to_value(w).unwrap_or(Value::Null);
         if let Some(object) = value.as_object_mut() {
             object.insert("state".to_string(), json!(reported_state(w, run.as_ref())));
@@ -1743,7 +1784,7 @@ fn work_view(core: &Core, engine: &Engine, work_id: &str) -> Value {
         "integrity": run.as_ref().and_then(integrity_view),
         // R-MVP1-2's sibling: named per repository once there is something to
         // point at.
-        "output": work.and_then(|w| run.as_ref().and_then(|r| output_pointer(w, r))),
+        "output": work.as_ref().and_then(|w| run.as_ref().and_then(|r| output_pointer(w, r))),
         // MVP-3's envelope-visibility item: how much of R-MVP1-7's turn
         // budget this Work has spent and how much it has, without decoding
         // the journal for `execution.started`/`stage.resumed` counts or the
@@ -1754,7 +1795,7 @@ fn work_view(core: &Core, engine: &Engine, work_id: &str) -> Value {
         // run yet — e.g. a `pending` Work with no repository context) still
         // reports a real, honest cap/ceiling: zero turns spent against
         // whatever this Work would be checked against once it starts.
-        "envelope": work.map(|w| {
+        "envelope": work.as_ref().map(|w| {
             let default_run = WorkRun::default();
             let run_ref = run.as_ref().unwrap_or(&default_run);
             json!({
@@ -1793,22 +1834,37 @@ fn run_stage_view(run: &WorkRun) -> Option<Value> {
 /// them is exactly how "in review" becomes a state-machine value — but a fleet
 /// view that cannot say which stage a running work is on is not a fleet view,
 /// so `stage` is a sibling key of `work` here as it is in `work_view`.
+///
+/// #4: iterates `registry.work_index` — the always-retained key set — not
+/// `registry.works`, which only holds active Works now. For each id this
+/// renders the same full row as before when the Work is still active or
+/// still in the bounded `terminal_works` cache; a Work aged out of that
+/// cache renders a narrowed row built from its [`WorkIndexRow`] alone,
+/// with `"evicted": true` naming the shape — see
+/// [`evicted_fleet_row`]'s own doc for exactly what that narrows.
 fn fleet_body(core: &Core, engine: &Engine) -> Value {
     let registry = core.registry.state();
     let works: Vec<Value> = registry
-        .works
-        .values()
-        .map(|work| {
-                // `registry.run_view` alone only reaches the bounded
-                // in-memory cache (`TERMINAL_RUN_CACHE_CAPACITY`); once a
-                // terminal run ages out of it, `resolve_run`'s journal-
-                // replay fallback is what `work_view` already relies on to
-                // keep `sgt work show` correct for the identical work. This
-                // row must use the same fallback, or an evicted work's
-                // `state` here would silently fall back to plain
-                // `completed` (ADR 0007(b)) while `work show` still says
-                // `completed_dirty` for it.
-            let run = resolve_run(core, work, registry.run_view(&work.id));
+        .work_index
+        .keys()
+        .map(|id| {
+            let Some(work) = registry
+                .works
+                .get(id)
+                .or_else(|| registry.terminal_works.get(id))
+            else {
+                return evicted_fleet_row(&registry.work_index[id]);
+            };
+            // `registry.run_view` alone only reaches the bounded
+            // in-memory cache (`TERMINAL_RUN_CACHE_CAPACITY`); once a
+            // terminal run ages out of it, `resolve_run`'s journal-
+            // replay fallback is what `work_view` already relies on to
+            // keep `sgt work show` correct for the identical work. This
+            // row must use the same fallback, or an evicted work's
+            // `state` here would silently fall back to plain
+            // `completed` (ADR 0007(b)) while `work show` still says
+            // `completed_dirty` for it.
+            let run = resolve_run(core, work, registry.run_view(id));
             let mut row = serde_json::to_value(work).unwrap_or(Value::Null);
             if let Some(object) = row.as_object_mut() {
                 // ADR 0007(b): `sgt work list` is where an operator looks
@@ -1859,6 +1915,45 @@ fn fleet_body(core: &Core, engine: &Engine) -> Value {
         })
         .collect();
     json!({"works": works})
+}
+
+/// The `sgt work list` row for a Work that has aged out of `terminal_works`
+/// entirely — #4's bounded-cost tradeoff made visible. Built from
+/// [`WorkIndexRow`] alone, so it carries only what that row keeps: `id`,
+/// `intent`, `state` (with the same `completed_dirty` compaction
+/// `reported_state` applies, when the retained disposition alone is enough
+/// to tell), `integrity` (disposition only — the findings and drift
+/// `integrity_view` composes from a live [`TeardownReport`] are not part of
+/// the slim row), and the two timestamps. No `stage`/`resolved_backend`/
+/// `envelope`/`output` — those need the run, which a Work this old no
+/// longer has cached, and re-deriving it here would be the very per-row
+/// journal replay this cache exists to avoid. `"evicted": true` names the
+/// narrowing explicitly rather than leaving a client to infer it from
+/// absent keys.
+///
+/// One known gap versus the full row's `reported_state`: [`stranded_completion`]
+/// reads the teardown's finalize commit against the surface's base SHA,
+/// neither of which the slim row retains, so an evicted stranded completion
+/// whose retained `integrity` disposition was never marked `Dirty` reads
+/// plain `completed` here instead of `completed_dirty`. Disclosed, not
+/// silently narrowed — same spirit as the rest of this row.
+fn evicted_fleet_row(row: &WorkIndexRow) -> Value {
+    let state = if row.state == WorkState::Completed
+        && row.integrity == Some(IntegrityDisposition::Dirty)
+    {
+        "completed_dirty"
+    } else {
+        row.state.as_str()
+    };
+    json!({
+        "id": row.id,
+        "intent": row.intent,
+        "state": state,
+        "integrity": row.integrity.map(|d| json!({"disposition": d})),
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+        "evicted": true,
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -2043,13 +2138,17 @@ async fn list_workflows(
 /// execution state (the M3 contract's `work show` surface).
 async fn show_work(State(state): State<ApiState>, Path(id): Path<String>) -> Response {
     let core = CoreGuard::acquire(&state.core).await;
-    match core.registry.state().works.get(&id) {
-        Some(_) => Json(work_view(&core, &state.engine, &id)).into_response(),
-        None => error_response(
+    // #4: existence is answered from the always-retained slim index, not
+    // the (now bounded) `works` map — an evicted-beyond-cache Work still
+    // has a row there, and `work_view`'s own `resolve_work` re-derives it.
+    if core.registry.state().work_index.contains_key(&id) {
+        Json(work_view(&core, &state.engine, &id)).into_response()
+    } else {
+        error_response(
             StatusCode::NOT_FOUND,
             "work_not_found",
             format!("no work with id {id}"),
-        ),
+        )
     }
 }
 
@@ -2090,7 +2189,7 @@ async fn show_work(State(state): State<ApiState>, Path(id): Path<String>) -> Res
 /// `resolve_run` already defers, not this build's.
 async fn work_transcript(State(state): State<ApiState>, Path(id): Path<String>) -> Response {
     let core = CoreGuard::acquire(&state.core).await;
-    if !core.registry.state().works.contains_key(&id) {
+    if !core.registry.state().work_index.contains_key(&id) {
         return error_response(
             StatusCode::NOT_FOUND,
             "work_not_found",
@@ -2287,7 +2386,12 @@ async fn cancel_work(
     if let Some(resp) = replay_command(&core, &req.command_id) {
         return resp;
     }
-    let Some(work) = core.registry.state().works.get(&id).cloned() else {
+    // #4: a duplicate cancel (fresh `command_id`, same target) against a
+    // Work canceled earlier — possibly already evicted, since `Canceled` is
+    // absorbing — must still find it to answer the idempotent-success arm
+    // below, not 404. `resolve_work` is the same works -> cache -> journal
+    // chain `work_view` uses.
+    let Some(work) = resolve_work(&core, &id) else {
         let result = error_body("work_not_found", format!("no work with id {id}"));
         return record_and_respond(
             &mut core,
@@ -2394,7 +2498,7 @@ async fn work_input(
     if let Some(resp) = replay_command(&core, &req.command_id) {
         return resp;
     }
-    if !core.registry.state().works.contains_key(&id) {
+    if !core.registry.state().work_index.contains_key(&id) {
         let result = error_body("work_not_found", format!("no work with id {id}"));
         return record_and_respond(
             &mut core,
@@ -2465,7 +2569,7 @@ async fn work_retry(
     if let Some(resp) = replay_command(&core, &req.command_id) {
         return resp;
     }
-    if !core.registry.state().works.contains_key(&id) {
+    if !core.registry.state().work_index.contains_key(&id) {
         let result = error_body("work_not_found", format!("no work with id {id}"));
         return record_and_respond(
             &mut core,
@@ -2541,7 +2645,7 @@ async fn work_extend(
     if let Some(resp) = replay_command(&core, &req.command_id) {
         return resp;
     }
-    if !core.registry.state().works.contains_key(&id) {
+    if !core.registry.state().work_index.contains_key(&id) {
         let result = error_body("work_not_found", format!("no work with id {id}"));
         return record_and_respond(
             &mut core,
@@ -2649,7 +2753,9 @@ async fn reap_work(
             result,
         );
     }
-    let Some(work) = core.registry.state().works.get(&id).cloned() else {
+    // #4: reap targets a terminal Work's teardown, so this id is exactly
+    // the shape likely to have aged out of the live map already.
+    let Some(work) = resolve_work(&core, &id) else {
         let result = error_body("work_not_found", format!("no work with id {id}"));
         return record_and_respond(
             &mut core,
@@ -2713,14 +2819,27 @@ async fn reap_work(
 /// tradeoff `work_transcript` discloses: a terminal work not already in the
 /// bounded cache costs a full journal replay under the guard. Inspecting
 /// retained state is an occasional, operator-driven action, not a hot path.
+///
+/// #4 doubles that accepted tradeoff rather than closing it: this walks
+/// every id in `registry.work_index` (every Work ever journaled, active or
+/// not — `registry.works` alone would silently stop finding any *terminal*
+/// Work the instant it aged out of the live map, and terminal is exactly
+/// what a teardown requires) and now resolves the Work itself through
+/// `resolve_work`'s cache-then-journal chain, on top of `resolve_run`'s own.
+/// Worst case — an estate with many more historical Works than either
+/// bounded cache holds — pays up to two replays per id instead of one.
+/// Still bounded by the same "occasional, operator-driven, not a hot path"
+/// argument above, not a new category of cost; called out here rather than
+/// left implicit for whoever tunes the cache capacities next.
 async fn list_retained(State(state): State<ApiState>) -> Response {
     let core = CoreGuard::acquire(&state.core).await;
     let registry = core.registry.state();
     let entries: Vec<Value> = registry
-        .works
-        .values()
-        .filter_map(|work| {
-            let run = resolve_run(&core, work, registry.run_view(&work.id))?;
+        .work_index
+        .keys()
+        .filter_map(|id| {
+            let work = resolve_work(&core, id)?;
+            let run = resolve_run(&core, &work, registry.run_view(id))?;
             let teardown = run.teardown?;
             Some((work.id.clone(), retained_bindings(&teardown)))
         })
@@ -3146,7 +3265,7 @@ fn projection_unavailable(e: impl std::fmt::Display) -> Response {
 async fn work_graph(State(state): State<ApiState>, Path(id): Path<String>) -> Response {
     {
         let core = CoreGuard::acquire(&state.core).await;
-        if !core.registry.state().works.contains_key(&id) {
+        if !core.registry.state().work_index.contains_key(&id) {
             return error_response(
                 StatusCode::NOT_FOUND,
                 "work_not_found",
@@ -5275,6 +5394,140 @@ mod tests {
             "an evicted stranded completion must not silently revert to plain \
              completed in `sgt work list` just because its run cache entry \
              aged out: {row}"
+        );
+    }
+
+    /// #4's own version of the test above, one layer further out: not just
+    /// the *run* cache but the *Work* cache too. Once `target_id` ages past
+    /// `TERMINAL_WORK_CACHE_CAPACITY`, `work_view` must route through
+    /// `resolve_work`'s journal fallback and answer byte-identically to
+    /// what it answered while the Work was still cached — R-MVP1-9's own
+    /// pin ("an evicted view is byte-identical to a non-evicted one"),
+    /// restated for #4. `fleet_body`'s row for the same id must also still
+    /// be there (narrowed, `"evicted": true`), and an id that was never
+    /// journaled at all must still 404 through the slim-index existence
+    /// check, exactly as it did before any of this churn.
+    #[test]
+    fn a_work_view_survives_terminal_work_cache_eviction_and_unknown_ids_still_404() {
+        use crate::runtime::testing;
+
+        fn surface(work_id: &str) -> Value {
+            json!({"surface": {
+                "work_id": work_id,
+                "root": "/data/surfaces/x",
+                "bindings": [{
+                    "repository": "solo",
+                    "source_path": "/repos/solo",
+                    "base_branch": "main",
+                    "base_sha": "0".repeat(40),
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "head_sha": "0".repeat(40),
+                }],
+            }})
+        }
+
+        fn ordinary_teardown(work_id: &str) -> Value {
+            json!({"report": {
+                "work_id": work_id,
+                "clean": true,
+                "bindings": [{
+                    "repository": "solo",
+                    "worktree_path": "/data/surfaces/x/solo",
+                    "work_branch": format!("sergeant/{work_id}"),
+                    "disposition": "removed",
+                }],
+            }})
+        }
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+
+        let target_id = "01TARGETWORK00000001";
+        testing::submit(&mut core, target_id, "declares a commit, never makes one");
+        testing::commit(
+            &mut core,
+            target_id,
+            KIND_SURFACE_MATERIALIZED,
+            surface(target_id),
+        );
+        testing::commit(&mut core, target_id, KIND_WORK_COMPLETED, json!({}));
+        testing::commit(
+            &mut core,
+            target_id,
+            KIND_SURFACE_TORN_DOWN,
+            ordinary_teardown(target_id),
+        );
+
+        let backends = BackendRegistry::new().with(Arc::new(
+            crate::backend::fake::FakeBackend::new(crate::backend::fake::FAKE_BACKEND_NAME),
+        ));
+        let engine = Engine::new(
+            Arc::new(backends),
+            Some(crate::backend::fake::FAKE_BACKEND_NAME.to_string()),
+            dir.path(),
+        );
+
+        assert!(
+            core.registry.state().terminal_works.contains_key(target_id),
+            "precondition: still cached, or the before/after comparison below \
+             proves nothing about eviction specifically"
+        );
+        let before = work_view(&core, &engine, target_id);
+
+        // Churn ordinary completions past `projection.rs`'s own
+        // `TERMINAL_WORK_CACHE_CAPACITY` (1024, private to that module) so
+        // `target_id` — submitted first, so it is the oldest — actually
+        // ages out of it.
+        for i in 0..1224 {
+            let id = format!("01WORKCACHECHURN{i:06}");
+            testing::submit(&mut core, &id, "cache churn");
+            testing::commit(&mut core, &id, KIND_SURFACE_MATERIALIZED, surface(&id));
+            testing::commit(&mut core, &id, KIND_WORK_COMPLETED, json!({}));
+            testing::commit(
+                &mut core,
+                &id,
+                KIND_SURFACE_TORN_DOWN,
+                ordinary_teardown(&id),
+            );
+        }
+        assert!(
+            !core.registry.state().terminal_works.contains_key(target_id),
+            "the target must actually have aged out of the bounded cache for \
+             this test to prove anything"
+        );
+        assert!(
+            core.registry.state().work_index.contains_key(target_id),
+            "the slim index must still know this id exists"
+        );
+
+        let after = work_view(&core, &engine, target_id);
+        assert_eq!(
+            before, after,
+            "an evicted Work's view must be byte-identical to what it answered \
+             while still cached: before={before}, after={after}"
+        );
+
+        let fleet = fleet_body(&core, &engine);
+        let row = fleet["works"]
+            .as_array()
+            .expect("works")
+            .iter()
+            .find(|w| w["id"] == target_id)
+            .expect("the evicted-past-cache work is still listed, narrowed");
+        assert_eq!(row["evicted"], true, "{row}");
+        assert_eq!(row["state"], after["work"]["state"], "{row}");
+        assert_eq!(row["intent"], after["work"]["intent"], "{row}");
+
+        // Existence checks must still 404 correctly for a truly unknown id
+        // — unaffected by any of the churn above.
+        assert!(
+            !core
+                .registry
+                .state()
+                .work_index
+                .contains_key("01NOSUCHWORKATALL"),
+            "an id nothing ever journaled must not be found"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2001,6 +2001,7 @@ pub(crate) mod doctor {
     use crate::backend::docker::{self, DockerBackend, DockerConfig};
     use crate::daemon;
     use crate::domain::estate::MANIFEST_FILE;
+    use crate::domain::event::Event;
     use crate::runtime::analytics::Analytics;
     use crate::runtime::journal::Journal;
 
@@ -2199,9 +2200,9 @@ pub(crate) mod doctor {
         // checked before anything derived from it; a projection rebuild over
         // an unreadable journal would report the journal's fault under the
         // projection's name.
-        let (journal_check, journal_ok) = journal_check(data_dir);
+        let (journal_check, journal_ok, journal_events) = journal_check(data_dir);
         checks.push(journal_check);
-        checks.push(projection_check(data_dir, journal_ok));
+        checks.push(projection_check(journal_ok, journal_events.as_deref()));
         checks.push(daemon_check(data_dir).await);
         // §4.2: `sgt doctor` is usable outside an estate and never searches
         // upward. The estate-root row is the one that says out loud whether
@@ -2218,7 +2219,11 @@ pub(crate) mod doctor {
         // §12.2: cheap, bounded — journal plus retained-artifact filesystem
         // metadata, never a per-branch git walk. Same estate-root threading
         // as the two rows above.
-        checks.push(git_surfaces_check(data_dir, admitted.as_deref()));
+        checks.push(git_surfaces_check(
+            data_dir,
+            admitted.as_deref(),
+            journal_events.as_deref(),
+        ));
         // N4/#23 (retention Rule B): disk pressure inside the data dir. Runs
         // after everything above regardless of their outcome — knowing "is
         // this installation about to run out of disk" does not depend on the
@@ -2625,7 +2630,11 @@ pub(crate) mod doctor {
     /// path is the captured patch file or the whole worktree directory
     /// fallback. "terminal dirty Works" counts work ids whose most recent
     /// teardown recorded [`crate::runtime::integrity::IntegrityDisposition::Dirty`].
-    fn git_surfaces_check(data_dir: &Path, estate_root: Option<&Path>) -> Check {
+    fn git_surfaces_check(
+        data_dir: &Path,
+        estate_root: Option<&Path>,
+        events: Option<&[Event]>,
+    ) -> Check {
         use crate::runtime::integrity::IntegrityDisposition;
         use crate::runtime::surface::{
             KIND_SURFACE_MATERIALIZED, KIND_SURFACE_TORN_DOWN, TeardownReport, WorkSurface,
@@ -2641,15 +2650,15 @@ pub(crate) mod doctor {
                 "no journal yet — nothing has run in this data dir",
             );
         }
-        let replay = match Journal::replay_data_dir(data_dir) {
-            Ok(replay) => replay,
-            Err(e) => {
-                return Check::warn(
-                    "git_surfaces",
-                    format!("cannot open the journal: {e}"),
-                    "see the journal check above",
-                );
-            }
+        // The journal dir exists, so `journal_check` above attempted a
+        // replay; `None` here means that replay failed — its Check already
+        // names the fault, this one just declines by pointing at it.
+        let Some(events) = events else {
+            return Check::warn(
+                "git_surfaces",
+                "not attempted: the journal did not replay",
+                "see the journal check above",
+            );
         };
 
         // work id -> binding count of its most recent `surface.materialized`.
@@ -2662,17 +2671,7 @@ pub(crate) mod doctor {
         let mut integrity: std::collections::BTreeMap<String, IntegrityDisposition> =
             std::collections::BTreeMap::new();
 
-        for event in replay {
-            let event = match event {
-                Ok(event) => event,
-                Err(e) => {
-                    return Check::warn(
-                        "git_surfaces",
-                        format!("journal replay failed: {e}"),
-                        "see the journal check above",
-                    );
-                }
-            };
+        for event in events {
             let Some(work_id) = event.work_id.clone() else {
                 continue;
             };
@@ -3199,9 +3198,16 @@ pub(crate) mod doctor {
     /// "the daemon will start". It never takes the journal's writer lock, so
     /// running this against a live daemon is safe.
     ///
-    /// Returns the check and whether the replay succeeded, so the projection
-    /// check below can say "not attempted" instead of blaming itself.
-    fn journal_check(data_dir: &Path) -> (Check, bool) {
+    /// Returns the check, whether the replay succeeded, and — on success —
+    /// the events it replayed, so every check derived from the journal
+    /// (`projection_check`, `git_surfaces_check`) can fold that same
+    /// `Vec<Event>` instead of each re-opening and re-replaying the journal
+    /// for itself (#12: one replay shared across doctor's checks). `None`
+    /// on both the no-journal and the replay-failure paths — callers that
+    /// need to tell those two apart still have the bool for that; this
+    /// function keeps sole ownership of the structured `Malformed` detail
+    /// either way.
+    fn journal_check(data_dir: &Path) -> (Check, bool, Option<Vec<Event>>) {
         let remedy = "the journal is the durable record — do not delete it. Inspect the \
                       reported segment by hand; a torn tail from a crash is quarantined \
                       automatically the next time the daemon opens it";
@@ -3216,6 +3222,7 @@ pub(crate) mod doctor {
                     "no journal yet — nothing has run in this data dir",
                 ),
                 true,
+                None,
             );
         }
         let replay = match Journal::replay_data_dir(data_dir) {
@@ -3224,25 +3231,27 @@ pub(crate) mod doctor {
                 return (
                     Check::fail("journal", format!("cannot open the journal: {e}"), remedy),
                     false,
+                    None,
                 );
             }
         };
-        let mut count = 0u64;
+        let mut events = Vec::new();
         let mut last_seq = 0u64;
         for event in replay {
             match event {
                 Ok(event) => {
-                    count += 1;
                     last_seq = event.seq;
+                    events.push(event);
                 }
                 Err(e) => {
                     return (
                         Check::fail(
                             "journal",
-                            format!("replay failed after {count} events: {e}"),
+                            format!("replay failed after {} events: {e}", events.len()),
                             remedy,
                         ),
                         false,
+                        None,
                     );
                 }
             }
@@ -3250,9 +3259,13 @@ pub(crate) mod doctor {
         (
             Check::ok(
                 "journal",
-                format!("{count} events replay cleanly (head seq {last_seq})"),
+                format!(
+                    "{} events replay cleanly (head seq {last_seq})",
+                    events.len()
+                ),
             ),
             true,
+            Some(events),
         )
     }
 
@@ -3263,7 +3276,7 @@ pub(crate) mod doctor {
     /// not own. What this proves is the property that matters — the fold from
     /// journal to projection completes — which is exactly what the daemon
     /// does on every start (§40: projections are disposable).
-    fn projection_check(data_dir: &Path, journal_ok: bool) -> Check {
+    fn projection_check(journal_ok: bool, events: Option<&[Event]>) -> Check {
         if !journal_ok {
             return Check::warn(
                 "projection",
@@ -3272,22 +3285,14 @@ pub(crate) mod doctor {
             );
         }
         let scratch = std::env::temp_dir().join(format!("sgt-doctor-{}", ulid::Ulid::generate()));
-        let outcome = if journal_dir(data_dir).exists() {
-            Journal::replay_data_dir(data_dir)
-                .map_err(|e| e.to_string())
-                .and_then(|replay| {
-                    Analytics::rebuild(&scratch, replay)
-                        .map(|analytics| analytics.last_seq())
-                        .map_err(|e| e.to_string())
-                })
-        } else {
-            // No journal yet: the fold has nothing to read, but the store
-            // itself must still open — which is the half of this check that
-            // a fresh install can actually be wrong about.
-            Analytics::rebuild(&scratch, std::iter::empty())
-                .map(|analytics| analytics.last_seq())
-                .map_err(|e| e.to_string())
-        };
+        // `events` is `None` on a fresh install with no journal at all, same
+        // as `Some(&[])` for a journal that exists but has nothing in it —
+        // either way the fold has nothing to read, but the store itself
+        // must still open, which is the half of this check that a fresh
+        // install can actually be wrong about.
+        let outcome = Analytics::rebuild(&scratch, events.unwrap_or(&[]).iter().cloned().map(Ok))
+            .map(|analytics| analytics.last_seq())
+            .map_err(|e| e.to_string());
         let _ = std::fs::remove_dir_all(&scratch);
         match outcome {
             Ok(last_seq) => Check::ok(
@@ -3431,7 +3436,7 @@ pub(crate) mod doctor {
         /// attempt to open a journal that was never asked for.
         #[test]
         fn git_surfaces_is_silent_outside_an_estate() {
-            let check = git_surfaces_check(Path::new("/nonexistent/data/dir"), None);
+            let check = git_surfaces_check(Path::new("/nonexistent/data/dir"), None, None);
             assert_eq!(check.status, Status::Ok);
             assert_eq!(check.detail, "not an estate root — nothing to check");
         }
@@ -3444,7 +3449,12 @@ pub(crate) mod doctor {
             let data_dir = std::env::temp_dir()
                 .join(format!("sgt-git-surfaces-test-{}", ulid::Ulid::generate()));
             Journal::open(&data_dir).expect("journal opens");
-            let check = git_surfaces_check(&data_dir, Some(Path::new("/some/estate")));
+            let events: Vec<Event> = Journal::replay_data_dir(&data_dir)
+                .expect("journal replays")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("events parse");
+            let check =
+                git_surfaces_check(&data_dir, Some(Path::new("/some/estate")), Some(&events));
             let _ = std::fs::remove_dir_all(&data_dir);
             assert_eq!(check.status, Status::Ok);
             assert!(check.remedy.is_none());
@@ -3642,7 +3652,12 @@ pub(crate) mod doctor {
                 .expect("append work-d torn down");
             drop(journal);
 
-            let check = git_surfaces_check(&data_dir, Some(Path::new("/some/estate")));
+            let events: Vec<Event> = Journal::replay_data_dir(&data_dir)
+                .expect("journal replays")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("events parse");
+            let check =
+                git_surfaces_check(&data_dir, Some(Path::new("/some/estate")), Some(&events));
             let _ = std::fs::remove_dir_all(&data_dir);
 
             assert_eq!(

--- a/src/runtime/analytics.rs
+++ b/src/runtime/analytics.rs
@@ -123,6 +123,7 @@ CREATE TABLE events (
     kind           VARCHAR NOT NULL,
     payload        VARCHAR NOT NULL
 );
+CREATE INDEX idx_events_kind_work ON events(kind, work_id);
 CREATE TABLE work (
     work_id       VARCHAR PRIMARY KEY,
     intent        VARCHAR,

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -247,16 +247,15 @@ pub fn branch_takeover_precondition(
     // just below refuses anything else), which is exactly the case #4
     // evicts the full `Work` struct for — `works` alone would 404 a
     // perfectly good takeover target the instant its run settled. Only
-    // `.state` is needed here, and the slim index carries it, never
-    // evicted, so this never has to fall back to a journal replay.
-    let state = registry
-        .works
-        .get(target_work_id)
-        .map(|w| w.state)
-        .or_else(|| registry.work_index.get(target_work_id).map(|row| row.state))
-        .ok_or_else(|| BranchTakeoverError::TargetNotFound {
-            work_id: target_work_id.to_string(),
-        })?;
+    // `.state` is needed here, and `state_view` answers it from the slim
+    // index, never evicted, so this never has to fall back to a journal
+    // replay.
+    let state =
+        registry
+            .state_view(target_work_id)
+            .ok_or_else(|| BranchTakeoverError::TargetNotFound {
+                work_id: target_work_id.to_string(),
+            })?;
     if !is_absorbing(state) {
         return Err(BranchTakeoverError::TargetNotTerminal {
             work_id: target_work_id.to_string(),
@@ -4360,18 +4359,16 @@ impl Engine {
     }
 
     fn work_state(&self, core: &Core, work_id: &str) -> Result<WorkState, EngineError> {
-        let registry = core.registry.state();
         // #4: `works` only holds active Works now. Most callers here only
         // ever ask about one (scheduling loops touch non-absorbing works by
         // construction), but this is a shared lookup, not scoped to those
-        // callers — the slim index carries `state` for exactly this case
-        // and is never evicted, so it answers correctly for an already-
-        // terminal (possibly evicted) `work_id` too, with no journal replay.
-        registry
-            .works
-            .get(work_id)
-            .map(|w| w.state)
-            .or_else(|| registry.work_index.get(work_id).map(|row| row.state))
+        // callers — `state_view` answers from the slim index for exactly
+        // this case, and it is never evicted, so it answers correctly for
+        // an already-terminal (possibly evicted) `work_id` too, with no
+        // journal replay.
+        core.registry
+            .state()
+            .state_view(work_id)
             .ok_or_else(|| EngineError::NoRun {
                 work_id: work_id.to_string(),
             })

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -243,17 +243,24 @@ pub fn branch_takeover_precondition(
     registry: &WorkRegistry,
     target_work_id: &str,
 ) -> Result<Vec<RepositoryBinding>, BranchTakeoverError> {
-    let work =
-        registry
-            .works
-            .get(target_work_id)
-            .ok_or_else(|| BranchTakeoverError::TargetNotFound {
-                work_id: target_work_id.to_string(),
-            })?;
-    if !is_absorbing(work.state) {
+    // #4: the target of a takeover is by definition terminal (the check
+    // just below refuses anything else), which is exactly the case #4
+    // evicts the full `Work` struct for — `works` alone would 404 a
+    // perfectly good takeover target the instant its run settled. Only
+    // `.state` is needed here, and the slim index carries it, never
+    // evicted, so this never has to fall back to a journal replay.
+    let state = registry
+        .works
+        .get(target_work_id)
+        .map(|w| w.state)
+        .or_else(|| registry.work_index.get(target_work_id).map(|row| row.state))
+        .ok_or_else(|| BranchTakeoverError::TargetNotFound {
+            work_id: target_work_id.to_string(),
+        })?;
+    if !is_absorbing(state) {
         return Err(BranchTakeoverError::TargetNotTerminal {
             work_id: target_work_id.to_string(),
-            state: work.state,
+            state,
         });
     }
     let run = registry
@@ -4353,11 +4360,18 @@ impl Engine {
     }
 
     fn work_state(&self, core: &Core, work_id: &str) -> Result<WorkState, EngineError> {
-        core.registry
-            .state()
+        let registry = core.registry.state();
+        // #4: `works` only holds active Works now. Most callers here only
+        // ever ask about one (scheduling loops touch non-absorbing works by
+        // construction), but this is a shared lookup, not scoped to those
+        // callers — the slim index carries `state` for exactly this case
+        // and is never evicted, so it answers correctly for an already-
+        // terminal (possibly evicted) `work_id` too, with no journal replay.
+        registry
             .works
             .get(work_id)
             .map(|w| w.state)
+            .or_else(|| registry.work_index.get(work_id).map(|row| row.state))
             .ok_or_else(|| EngineError::NoRun {
                 work_id: work_id.to_string(),
             })
@@ -5505,6 +5519,7 @@ mod tests {
 
     mod branch_takeover {
         use super::*;
+        use crate::runtime::projection::WorkIndexRow;
         use crate::runtime::surface::{BindingDisposition, BindingOrigin, BindingTeardown};
 
         fn work(id: &str, state: WorkState) -> Work {
@@ -5758,6 +5773,44 @@ mod tests {
             let bindings = branch_takeover_precondition(&registry, "01EVICTED")
                 .expect("an evicted-but-cached terminal run must still be readable");
             assert_eq!(bindings, vec![binding("01EVICTED")]);
+        }
+
+        /// #4's own version of the test above: the *Work* itself, not only
+        /// its run, can be evicted from the live map now — aged out of
+        /// `terminal_works` entirely, answerable only from `work_index`.
+        /// `branch_takeover_precondition` must consult that slim index for
+        /// `.state` rather than reading `registry.works` bare, or a
+        /// perfectly good ADR 0017 takeover target would refuse as
+        /// `TargetNotFound` the instant its Work aged out of the cache.
+        #[test]
+        fn permits_a_target_whose_work_was_evicted_from_the_live_map_too() {
+            let mut registry = WorkRegistry::default();
+            // Not in `works`, not even in `terminal_works` — only the slim
+            // index remembers this id exists and what state it is in.
+            registry.work_index.insert(
+                "01WORKEVICTED".to_string(),
+                WorkIndexRow {
+                    id: "01WORKEVICTED".to_string(),
+                    intent: "review this".to_string(),
+                    state: WorkState::Completed,
+                    integrity: None,
+                    created_at: "2026-01-01T00:00:00Z".to_string(),
+                    updated_at: "2026-01-01T00:00:00Z".to_string(),
+                },
+            );
+            registry.terminal_runs.insert(
+                "01WORKEVICTED".to_string(),
+                WorkRun {
+                    surface: Some(surface("01WORKEVICTED")),
+                    teardown: Some(teardown_report("01WORKEVICTED", true)),
+                    ..Default::default()
+                },
+            );
+            let bindings = branch_takeover_precondition(&registry, "01WORKEVICTED").expect(
+                "a Work evicted past `terminal_works`, with only a slim index row left, \
+                 must still be readable for its state",
+            );
+            assert_eq!(bindings, vec![binding("01WORKEVICTED")]);
         }
     }
 }

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -92,6 +92,12 @@ pub enum JournalError {
         line: u64,
         /// Parse failure.
         source: serde_json::Error,
+        /// Whether this could be a live writer's torn in-progress append
+        /// rather than corruption — see [`JournalError::is_possible_torn_tail`].
+        /// Always `false` from [`first_seq`], which only ever reads a
+        /// segment's first line and has no "is this the end of everything"
+        /// context to classify with.
+        possible_torn_tail: bool,
     },
     /// Replay found a seq that is not exactly `expected` — a gap (found >
     /// expected) or a duplicate/regression (found <= previous). Fail closed.
@@ -137,6 +143,35 @@ pub enum JournalError {
         /// The largest index the file-name scheme can represent.
         max: u64,
     },
+}
+
+impl JournalError {
+    /// True iff this could be a live writer's torn in-progress append rather
+    /// than corruption (issue #169's L6 question, answered): the failing
+    /// line is the last line of the last segment, with nothing readable
+    /// after it — exactly the shape `append_event`'s single unbuffered
+    /// `write_all` can leave for a reader racing it, and the *only* shape
+    /// it can leave, since rotation always starts a fresh segment before
+    /// the writer appends to it. A concurrent reader of a live journal
+    /// (`Journal::replay_data_dir` included) may observe exactly this case
+    /// and must tolerate/retry it; every other `Malformed` — a torn or
+    /// invalid line with something well-formed after it, or one anywhere
+    /// but the last segment — is corruption, not a race, and must not be
+    /// retried away.
+    ///
+    /// `false` for every other error variant, and for a `Malformed` from
+    /// [`Journal::replay`]'s own tail-recovering `open` path (which never
+    /// leaves a torn line to see in the first place) or from `first_seq`
+    /// (which has no "is this the very end" context to classify with).
+    pub fn is_possible_torn_tail(&self) -> bool {
+        matches!(
+            self,
+            JournalError::Malformed {
+                possible_torn_tail: true,
+                ..
+            }
+        )
+    }
 }
 
 /// Single-writer handle to the segmented journal.
@@ -422,6 +457,19 @@ impl Journal {
 
     /// Replay a journal directory without opening a writer handle (and
     /// without tail recovery). Useful for read-only inspection and tests.
+    ///
+    /// Without a writer handle there is no exclusive lock stopping this from
+    /// running against a *live* journal a daemon is actively appending to
+    /// (`sgt doctor`'s own journal check is exactly that caller). A reader
+    /// racing `append_event`'s single unbuffered `write_all` can therefore
+    /// observe a torn partial line — always the last line of the last
+    /// segment, since rotation never leaves a torn write behind a later
+    /// segment. [`JournalError::is_possible_torn_tail`] names that one
+    /// case; a caller reading a journal it does not know to be quiescent
+    /// must tolerate or retry it rather than treating it as corruption.
+    /// Every other `Malformed` — anywhere else, or with something readable
+    /// after it — is corruption, not a race, and must fail closed exactly
+    /// as it does today.
     pub fn replay_data_dir(data_dir: impl AsRef<Path>) -> Result<Replay, JournalError> {
         Ok(Replay::new(list_segments(
             &data_dir.as_ref().join("journal"),
@@ -536,6 +584,7 @@ fn first_seq(path: &Path) -> Result<Option<u64>, JournalError> {
             .unwrap_or_default(),
         line: 1,
         source,
+        possible_torn_tail: false,
     })?;
     Ok(Some(event.seq))
 }
@@ -587,10 +636,24 @@ impl Iterator for Replay {
                         Ok(ev) => ev,
                         Err(source) => {
                             self.failed = true;
+                            // A live writer's `append_event` is a single
+                            // unbuffered `write_all` (issue #169): a reader
+                            // racing it can observe a torn partial line, but
+                            // only ever as the very last line of the very
+                            // last segment — rotation always creates a *new*
+                            // segment before the writer appends to it, so a
+                            // torn write can never leave a well-formed line
+                            // after it. Peeking one more line (safe: this
+                            // iterator is dead the instant `failed` is set)
+                            // tells that apart from real corruption, which
+                            // always has something readable following it.
+                            let nothing_after = lines.next().is_none();
+                            let is_last_segment = self.segments.len() == 0;
                             return Some(Err(JournalError::Malformed {
                                 segment: segment.clone(),
                                 line: self.line_no,
                                 source,
+                                possible_torn_tail: nothing_after && is_last_segment,
                             }));
                         }
                     };
@@ -1156,5 +1219,93 @@ pub(crate) mod tests {
         let segments = list_segments(dir.path()).expect("list");
         assert_eq!(segments.len(), 1);
         assert_eq!(segments[0].0, MAX_SEGMENT_INDEX);
+    }
+
+    /// #169's L6 question, answered: a torn line — no trailing newline,
+    /// exactly the shape `append_event`'s single unbuffered `write_all` can
+    /// leave for a reader racing it — as the last content of the last
+    /// segment classifies as a possible torn tail. `replay_data_dir` is the
+    /// caller this matters for: unlike `Journal::open`, it deliberately
+    /// skips tail recovery, so it is the one path that can actually observe
+    /// the race rather than have it silently fixed up first.
+    #[test]
+    fn a_torn_final_line_is_a_possible_torn_tail() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        {
+            let mut journal = Journal::open(dir.path()).expect("open");
+            journal.append(draft(1)).expect("append 1");
+        }
+        let seg = dir.path().join("journal").join(segment_file_name(1));
+        let mut f = OpenOptions::new()
+            .append(true)
+            .open(&seg)
+            .expect("open segment");
+        // No trailing newline — a write_all caught mid-flight, never
+        // anything an append path or tail recovery would leave behind.
+        write!(f, r#"{{"schema":"sergeant.event/v1","seq":2"#).expect("write torn line");
+        drop(f);
+
+        let results: Vec<_> = Journal::replay_data_dir(dir.path())
+            .expect("replay")
+            .collect();
+        assert_eq!(
+            results.len(),
+            2,
+            "the torn line is still yielded, as an error"
+        );
+        assert!(results[0].is_ok());
+        match &results[1] {
+            Err(e @ JournalError::Malformed { line: 2, .. }) => {
+                assert!(
+                    e.is_possible_torn_tail(),
+                    "a torn final line must classify as a possible torn tail: {e:?}"
+                );
+            }
+            other => panic!("expected a Malformed error at line 2, got {other:?}"),
+        }
+    }
+
+    /// The other half: a malformed line with something well-formed *after*
+    /// it is corruption, not a race. `append_event` can never leave a torn
+    /// write with more content behind it — rotation always starts a fresh
+    /// segment before the writer appends to it — so this shape can only
+    /// mean real corruption, and it must never be tolerated or retried.
+    /// Reuses the exact fixture `m1_event_core`'s
+    /// `seq_gap_or_duplicate_fails_closed` test already builds for
+    /// "malformed line mid-journal", classified from the other side.
+    #[test]
+    fn a_torn_middle_line_is_not_a_possible_torn_tail() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        {
+            let mut journal = Journal::open(dir.path()).expect("open");
+            journal.append(draft(1)).expect("append 1");
+        }
+        let seg = dir.path().join("journal").join(segment_file_name(1));
+        let valid_line = serde_json::to_string(&draft(2).into_event(2)).expect("serialize");
+        let mut f = OpenOptions::new()
+            .append(true)
+            .open(&seg)
+            .expect("open segment");
+        // Newline-terminated garbage — not crash-truncated — with a
+        // well-formed line after it.
+        writeln!(f, "{{this is not an event}}").expect("write garbage line");
+        writeln!(f, "{valid_line}").expect("write valid line after garbage");
+        drop(f);
+
+        let results: Vec<_> = Journal::replay_data_dir(dir.path())
+            .expect("replay")
+            .collect();
+        assert_eq!(results.len(), 2, "replay stops at the malformed line");
+        assert!(results[0].is_ok());
+        match &results[1] {
+            Err(e @ JournalError::Malformed { line: 2, .. }) => {
+                assert!(
+                    !e.is_possible_torn_tail(),
+                    "a malformed line with something readable after it must never \
+                     read as a torn tail: {e:?}"
+                );
+            }
+            other => panic!("expected a Malformed error at line 2, got {other:?}"),
+        }
     }
 }

--- a/src/runtime/projection.rs
+++ b/src/runtime/projection.rs
@@ -321,6 +321,29 @@ pub struct WorkRegistry {
     /// [`TERMINAL_RUN_CACHE_CAPACITY`].
     #[serde(default)]
     pub terminal_run_order: std::collections::VecDeque<String>,
+    /// #4's Work cache (Rule A pattern, mirroring `terminal_runs`/
+    /// `terminal_run_order` exactly): the full [`Work`] struct for the most
+    /// recent [`TERMINAL_WORK_CACHE_CAPACITY`] Works `maybe_evict` has
+    /// reclaimed from `works`, keyed by work id. Same eviction trigger as
+    /// the run cache — a Work moves here the instant `run_is_settled` says
+    /// its run is safe to reclaim — and the same reason: `work_view`/
+    /// `fleet_body` read here before ever paying for a journal replay.
+    #[serde(default)]
+    pub terminal_works: std::collections::BTreeMap<String, Work>,
+    /// Insertion order for `terminal_works`, oldest first — mirrors
+    /// `terminal_run_order`.
+    #[serde(default)]
+    pub terminal_work_order: std::collections::VecDeque<String>,
+    /// The always-retained slim index: one [`WorkIndexRow`] per Work ever
+    /// journaled, created at `work.submitted` and updated in place — never
+    /// evicted. This is what makes eviction from `works`/`terminal_works`
+    /// bounded-*cost* rather than bounded-*history*: a Work that has aged
+    /// out of `terminal_works` still has a row here, so `sgt work list`
+    /// keeps listing it (narrowed) and existence checks still answer
+    /// correctly for it, at tens of bytes per work instead of the tens of
+    /// kB a full [`Work`] can reach.
+    #[serde(default)]
+    pub work_index: std::collections::BTreeMap<String, WorkIndexRow>,
     /// MVP-3's admission drain flag (`sgt daemon stop`, scoped exactly to
     /// that use): whether `POST /v1/work` currently refuses new
     /// submissions. Folded from `admission.paused`/`admission.resumed`
@@ -342,6 +365,18 @@ pub struct WorkRegistry {
 /// to here.
 const TERMINAL_RUN_CACHE_CAPACITY: usize = 512;
 
+/// Bound on how many terminal Works [`WorkRegistry::terminal_works`] holds
+/// at once — the Rule A pattern applied to `works` itself (#4), not only to
+/// `runs`.
+///
+/// **Proposal, for owner ratification at the PR:** 2x
+/// [`TERMINAL_RUN_CACHE_CAPACITY`]. A [`Work`] struct is smaller than a
+/// compacted [`WorkRun`] (no stage history, no surface/teardown/reservation
+/// detail), so twice as many entries costs a comparable order of memory to
+/// the run cache alone — worst case low tens of MB, argued for a modest 8GB
+/// host in general, not sized to whatever machine this was written on.
+const TERMINAL_WORK_CACHE_CAPACITY: usize = 1024;
+
 impl WorkRegistry {
     /// The run for `work_id`, live or evicted-but-cached — the one lookup
     /// every API view should use instead of reading `runs` directly, so a
@@ -352,6 +387,34 @@ impl WorkRegistry {
             .get(work_id)
             .or_else(|| self.terminal_runs.get(work_id))
     }
+}
+
+/// #4's bounded-cost replacement for an unbounded `works` map: exactly what
+/// a `sgt work list` row renders for a Work whose full [`Work`] struct has
+/// aged out of [`WorkRegistry::terminal_works`] — never evicted itself, so
+/// every Work this daemon has ever journaled has one, from creation to now.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkIndexRow {
+    /// Same value as the Work's own `id` — carried here too so a row is
+    /// self-describing without a caller threading the key back in.
+    pub id: String,
+    /// The human intent, as journaled at submission. Immutable thereafter,
+    /// like [`Work::intent`].
+    pub intent: String,
+    /// Current state, updated in place on every state transition — the
+    /// same mapping [`apply_registry_event`] applies to the live `Work`.
+    pub state: WorkState,
+    /// §11.5's integrity axis, updated in place from the same
+    /// `surface.torn_down` that sets [`WorkRun::integrity`]. `None` is not
+    /// assessed, same reading as the run's own field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<IntegrityDisposition>,
+    /// RFC3339 UTC creation time, copied from the Work at submission.
+    pub created_at: String,
+    /// RFC3339 UTC timestamp of the last event that changed `state` or
+    /// `integrity` — the journal event's own `timestamp`, not a wall clock
+    /// read at fold time, so replay reproduces it identically.
+    pub updated_at: String,
 }
 
 /// Everything the journal says about one work's run: the workflow it pinned,
@@ -591,11 +654,27 @@ fn run_is_settled(work: &Work, run: &WorkRun) -> bool {
         && run.unsettled_reservation().is_none()
 }
 
-/// Evict `work_id`'s run if [`run_is_settled`] says it is safe to. A no-op
-/// for a work with no run recorded at all, or one not yet settled — called
-/// unconditionally after every event, so it fires the instant the *last*
-/// settling event lands, whichever of teardown/reservation-closure/state
-/// transition that turns out to be for a given run.
+/// Evict `work_id`'s run if [`run_is_settled`] says it is safe to, then (#4)
+/// its full [`Work`] struct on the same trigger. A no-op for a work with no
+/// run recorded at all, or one not yet settled — called unconditionally
+/// after every event, so it fires the instant the *last* settling event
+/// lands, whichever of teardown/reservation-closure/state transition that
+/// turns out to be for a given run.
+///
+/// The Work eviction is gated on the identical condition as the run's,
+/// deliberately: a Work has no surface/teardown/reservation of its own for
+/// recovery to read mid-settling, so nothing about *it* needs the wait —
+/// but tying it to the same trigger, rather than firing independently the
+/// instant `is_absorbing(work.state)` goes true, keeps one settling moment
+/// for the pair rather than two. The one gap this leaves: a Work canceled
+/// before it ever gets a `runs` entry (no workflow bound, no surface, no
+/// reservation — e.g. `pending` -> `canceled`) never reaches this function
+/// at all, since the early return above requires one; it stays in `works`
+/// indefinitely. Rare in practice (most submissions bind a workflow and
+/// materialize before they can reach an absorbing state) and not a
+/// correctness problem — `works` unbounded for that narrow slice is exactly
+/// today's behavior, not a regression — so it is accepted rather than
+/// chased with a second, independent trigger.
 fn maybe_evict(state: &mut WorkRegistry, work_id: Option<&str>) {
     let Some(work_id) = work_id else { return };
     let Some(work) = state.works.get(work_id) else {
@@ -624,6 +703,19 @@ fn maybe_evict(state: &mut WorkRegistry, work_id: Option<&str>) {
     while state.terminal_run_order.len() > TERMINAL_RUN_CACHE_CAPACITY {
         if let Some(oldest) = state.terminal_run_order.pop_front() {
             state.terminal_runs.remove(&oldest);
+        }
+    }
+    // #4: the same settling moment moves the full `Work` out of the
+    // unbounded `works` map and into the bounded `terminal_works` cache.
+    // `work_index`'s row for `work_id` already exists and is untouched —
+    // it is what an entry overflowing `terminal_works` below drops back to.
+    if let Some(work) = state.works.remove(work_id) {
+        state.terminal_works.insert(work_id.to_string(), work);
+        state.terminal_work_order.push_back(work_id.to_string());
+        while state.terminal_work_order.len() > TERMINAL_WORK_CACHE_CAPACITY {
+            if let Some(oldest) = state.terminal_work_order.pop_front() {
+                state.terminal_works.remove(&oldest);
+            }
         }
     }
 }
@@ -656,12 +748,19 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
     // (`WorkState::for_event_kind`), so a kind cannot mean one state when
     // appended and another when replayed.
     if let Some(new_state) = WorkState::for_event_kind(&event.kind) {
-        if let Some(work) = event
-            .work_id
-            .as_ref()
-            .and_then(|id| state.works.get_mut(id))
-        {
-            work.state = new_state;
+        if let Some(work_id) = event.work_id.as_ref() {
+            if let Some(work) = state.works.get_mut(work_id) {
+                work.state = new_state;
+            }
+            // The slim index mirrors `state` for exactly this reason: it
+            // must answer `sgt work list`/existence checks correctly for a
+            // Work whose full struct has already been evicted, which a
+            // terminal transition's own `maybe_evict` call below is about
+            // to do for an absorbing `new_state`.
+            if let Some(row) = state.work_index.get_mut(work_id) {
+                row.state = new_state;
+                row.updated_at = event.timestamp.clone();
+            }
         }
         if evict {
             maybe_evict(state, event.work_id.as_deref());
@@ -676,6 +775,17 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
                         .command_works
                         .insert(command_id.clone(), work.id.clone());
                 }
+                state.work_index.insert(
+                    work.id.clone(),
+                    WorkIndexRow {
+                        id: work.id.clone(),
+                        intent: work.intent.clone(),
+                        state: work.state,
+                        integrity: None,
+                        created_at: work.created_at.clone(),
+                        updated_at: work.created_at.clone(),
+                    },
+                );
                 state.works.insert(work.id.clone(), work);
             }
         }
@@ -726,6 +836,14 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
                 // carrying the previous retirement's verdict forward would
                 // report a fact about a teardown this run has replaced.
                 run.integrity = None;
+                // Mirrored onto the slim index for the same reason: a
+                // rematerialization must not leave a stale verdict behind
+                // for a Work whose full run has already aged out of
+                // `terminal_works`.
+                if let Some(row) = state.work_index.get_mut(work_id) {
+                    row.integrity = None;
+                    row.updated_at = event.timestamp.clone();
+                }
             }
         }
         KIND_SURFACE_TORN_DOWN => {
@@ -741,6 +859,10 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
                 // and `from_value(Null)` is an error, so both read back as
                 // "not assessed" rather than being defaulted to clean.
                 run.integrity = serde_json::from_value(event.payload["integrity"].clone()).ok();
+                if let Some(row) = state.work_index.get_mut(work_id) {
+                    row.integrity = run.integrity;
+                    row.updated_at = event.timestamp.clone();
+                }
             }
         }
         KIND_STAGE_ENTERED => {
@@ -952,6 +1074,18 @@ pub fn work_registry_projection() -> Projection<WorkRegistry> {
 /// (never started, or genuinely unknown) — the same answer a live,
 /// non-evicted registry would give for that work.
 pub fn rederive_run(journal: &Journal, work_id: &str) -> Result<Option<WorkRun>, JournalError> {
+    Ok(rederive_registry_for(journal, work_id)?
+        .runs
+        .remove(work_id))
+}
+
+/// The fold shared by [`rederive_run`] and [`rederive_work`]: filters the
+/// journal down to `work_id`'s own events and folds them through
+/// [`apply_registry_event`] with `evict: false`, exactly as `rederive_run`'s
+/// own doc explains. One fold, read out two ways, so the two rederivations
+/// can never drift into different ideas of what `work_id`'s events replay
+/// to.
+fn rederive_registry_for(journal: &Journal, work_id: &str) -> Result<WorkRegistry, JournalError> {
     let mut scratch = WorkRegistry::default();
     for event in journal.replay()? {
         let event = event?;
@@ -959,7 +1093,23 @@ pub fn rederive_run(journal: &Journal, work_id: &str) -> Result<Option<WorkRun>,
             apply_registry_event(&mut scratch, &event, false);
         }
     }
-    Ok(scratch.runs.remove(work_id))
+    Ok(scratch)
+}
+
+/// #4's read side for the Work cache, mirroring [`rederive_run`] exactly
+/// (down to sharing its fold, [`rederive_registry_for`]): rebuild one
+/// Work's full struct straight from the journal, for a caller that finds
+/// `WorkRegistry::works` and `WorkRegistry::terminal_works` no longer have
+/// it — aged out of the bounded cache, or evicted in an earlier process
+/// lifetime a fresh rebuild-on-start re-folded from scratch.
+///
+/// Returns `Ok(None)` only for a work id the journal never mentions at all;
+/// every id `WorkRegistry::work_index` has ever held a row for rederives
+/// something.
+pub fn rederive_work(journal: &Journal, work_id: &str) -> Result<Option<Work>, JournalError> {
+    Ok(rederive_registry_for(journal, work_id)?
+        .works
+        .remove(work_id))
 }
 
 #[cfg(test)]
@@ -1334,15 +1484,28 @@ mod rule_a_eviction_tests {
         }
         assert_eq!(
             core.registry.state().works.len(),
-            N,
-            "the light Work record is never evicted — the fleet listing still \
-             sees every work"
+            0,
+            "every one of the {N} Works settled with nothing outstanding and \
+             must have been evicted from the live map too (#4) — a non-flat \
+             count here is the same leak back, just moved from `runs` to `works`"
         );
         assert_eq!(
             core.registry.state().runs.len(),
             0,
             "every one of the {N} runs settled with nothing outstanding and \
              must have been evicted — a non-flat count here is #4's leak back"
+        );
+        assert_eq!(
+            core.registry.state().terminal_works.len(),
+            N,
+            "well within TERMINAL_WORK_CACHE_CAPACITY: every evicted Work \
+             must still be answerable from the bounded cache, not lost"
+        );
+        assert_eq!(
+            core.registry.state().work_index.len(),
+            N,
+            "the slim index is never evicted — the fleet listing still sees \
+             every work, narrowed or not"
         );
     }
 
@@ -1397,6 +1560,132 @@ mod rule_a_eviction_tests {
         assert!(state.terminal_runs.contains_key(&still_cached));
     }
 
+    /// #4's own version of the test above: `terminal_works` must stay
+    /// bounded under sustained churn beyond *its* capacity too — the exact
+    /// leak this whole cache exists to close, just for the full `Work`
+    /// struct instead of the compacted run. `work_index` is the control:
+    /// unlike `terminal_works`, it must keep growing 1:1 with every work
+    /// submitted, never dropping an entry.
+    #[test]
+    fn the_terminal_work_cache_itself_stays_bounded_under_churn_beyond_its_capacity() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+        let total = TERMINAL_WORK_CACHE_CAPACITY + 200;
+        for i in 0..total {
+            let work_id = format!("01WORKCHURN{i:06}");
+            testing::submit(&mut core, &work_id, "cache churn");
+            testing::commit(
+                &mut core,
+                &work_id,
+                KIND_SURFACE_MATERIALIZED,
+                a_surface(&work_id),
+            );
+            testing::commit(&mut core, &work_id, KIND_WORK_COMPLETED, json!({}));
+            testing::commit(
+                &mut core,
+                &work_id,
+                KIND_SURFACE_TORN_DOWN,
+                a_teardown(&work_id),
+            );
+        }
+        let state = core.registry.state();
+        assert_eq!(
+            state.works.len(),
+            0,
+            "still fully evicted from the live map"
+        );
+        assert_eq!(
+            state.terminal_works.len(),
+            TERMINAL_WORK_CACHE_CAPACITY,
+            "the terminal-work cache must never exceed its own capacity, \
+             however many works settle — a growing count here is #4's leak, \
+             just moved to a new field"
+        );
+        assert_eq!(
+            state.terminal_work_order.len(),
+            TERMINAL_WORK_CACHE_CAPACITY,
+            "the order queue and the cache map must shrink together"
+        );
+        assert_eq!(
+            state.work_index.len(),
+            total,
+            "the slim index is the one structure here that must never shrink \
+             — it is the bounded-*cost*, not bounded-*history*, half of #4"
+        );
+        let aged_out = "01WORKCHURN000000";
+        let still_cached = format!("01WORKCHURN{:06}", total - 1);
+        assert!(!state.terminal_works.contains_key(aged_out));
+        assert!(state.terminal_works.contains_key(&still_cached));
+        assert!(
+            state.work_index.contains_key(aged_out),
+            "aged out of the full-struct cache, but the slim row must remain"
+        );
+    }
+
+    /// The pin, stated directly for #4 the way
+    /// `rederive_run_is_byte_identical_to_a_run_that_was_never_evicted`
+    /// states it for R-MVP1-9: `rederive_work` reconstructs a Work that is
+    /// byte-identical to the one a non-evicting fold of the identical
+    /// events would produce. Same events, same reducer logic
+    /// (`apply_registry_event` with `evict: false` either way), same order —
+    /// the only variable this test isolates is *whether eviction ran in
+    /// between*.
+    #[test]
+    fn rederive_work_is_byte_identical_to_a_work_that_was_never_evicted() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let journal_dir = dir.path().join("journal");
+        let work_id = "01REDERIVEWORK";
+
+        // Build the journal once, through the *evicting* live registry —
+        // exactly the daemon's own path.
+        let mut core = testing::core(&journal_dir);
+        testing::submit(&mut core, work_id, "rederive me too");
+        testing::commit(
+            &mut core,
+            work_id,
+            KIND_SURFACE_MATERIALIZED,
+            a_surface(work_id),
+        );
+        testing::commit(&mut core, work_id, KIND_WORK_COMPLETED, json!({}));
+        testing::commit(
+            &mut core,
+            work_id,
+            KIND_SURFACE_TORN_DOWN,
+            a_teardown(work_id),
+        );
+        assert!(
+            !core.registry.state().works.contains_key(work_id),
+            "precondition: this Work must actually have been evicted, or the \
+             comparison below proves nothing"
+        );
+
+        // The independent answer: fold the *same* journal from scratch with
+        // eviction switched off.
+        fn non_evicting(state: &mut WorkRegistry, event: &Event) {
+            apply_registry_event(state, event, false);
+        }
+        let mut never_evicted = Projection::new(WorkRegistry::default(), non_evicting);
+        never_evicted
+            .catch_up(core.journal.replay().expect("replay"))
+            .expect("catch up");
+        let expected = never_evicted
+            .state()
+            .works
+            .get(work_id)
+            .cloned()
+            .expect("the never-evicted fold must have a Work for this id");
+
+        let rederived = rederive_work(&core.journal, work_id)
+            .expect("replay")
+            .expect("a Work to rederive");
+        assert_eq!(
+            rederived, expected,
+            "the evicted Work's re-derived struct must be byte-identical to \
+             the Work a non-evicting fold of the same events would have \
+             produced"
+        );
+    }
+
     /// Restart indifference: rebuild-on-start is a full replay through the
     /// same evicting reducer, so a work that was evicted before a restart is
     /// evicted again afterwards — never resurrected into memory just because
@@ -1435,7 +1724,17 @@ mod rule_a_eviction_tests {
             !rebuilt.state().runs.contains_key(work_id),
             "rebuild-on-start must not resurrect an evicted run into memory"
         );
-        assert_eq!(rebuilt.state().works[work_id].state, WorkState::Completed);
+        assert!(
+            !rebuilt.state().works.contains_key(work_id),
+            "rebuild-on-start must not resurrect an evicted Work into the \
+             live map either (#4) — same indifference, both maps"
+        );
+        assert_eq!(
+            rebuilt.state().terminal_works[work_id].state,
+            WorkState::Completed,
+            "the evicted Work must still be answerable from the bounded cache \
+             after a rebuild, same as before it"
+        );
     }
 }
 

--- a/src/runtime/projection.rs
+++ b/src/runtime/projection.rs
@@ -387,6 +387,19 @@ impl WorkRegistry {
             .get(work_id)
             .or_else(|| self.terminal_runs.get(work_id))
     }
+
+    /// The current [`WorkState`] for `work_id`, live or evicted — #4's other
+    /// lookup every caller that only needs the state (not the full [`Work`])
+    /// should use instead of reading `works` directly. `works` only holds
+    /// active Works now; the always-retained `work_index` slim row carries
+    /// `state` too and is never evicted, so this answers correctly for an
+    /// already-terminal (possibly evicted) `work_id` with no journal replay.
+    pub fn state_view(&self, work_id: &str) -> Option<WorkState> {
+        self.works
+            .get(work_id)
+            .map(|w| w.state)
+            .or_else(|| self.work_index.get(work_id).map(|row| row.state))
+    }
 }
 
 /// #4's bounded-cost replacement for an unbounded `works` map: exactly what
@@ -405,7 +418,17 @@ pub struct WorkIndexRow {
     /// same mapping [`apply_registry_event`] applies to the live `Work`.
     pub state: WorkState,
     /// §11.5's integrity axis, updated in place from the same
-    /// `surface.torn_down` that sets [`WorkRun::integrity`]. `None` is not
+    /// `surface.torn_down` that sets [`WorkRun::integrity`] — but not a
+    /// verbatim mirror of it. This is the *effective* disposition: the
+    /// explicit `Dirty` retirement, OR ADR 0007(b)'s structural
+    /// stranded-completion check (`TeardownReport::stranded_completion`),
+    /// computed at `torn_down` time while `run.surface`/`run.teardown` are
+    /// both still in hand. The slim row never retains either of those, so
+    /// this is the only place it *can* be computed once a Work ages out of
+    /// `terminal_works` — without it, an evicted stranded completion would
+    /// silently read back as plain `completed` (#4's eviction gap) instead of
+    /// `completed_dirty`. Rederive paths replay through the same reducer, so
+    /// journal-truth consistency holds automatically. `None` is not
     /// assessed, same reading as the run's own field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub integrity: Option<IntegrityDisposition>,
@@ -860,7 +883,37 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
                 // "not assessed" rather than being defaulted to clean.
                 run.integrity = serde_json::from_value(event.payload["integrity"].clone()).ok();
                 if let Some(row) = state.work_index.get_mut(work_id) {
-                    row.integrity = run.integrity;
+                    // #4's slim-row eviction gap: `row.integrity` used to
+                    // mirror only the explicit disposition above, which is
+                    // all a stranded completion (ADR 0007(b)) has once its
+                    // Work ages out of `terminal_works` — the structural
+                    // `stranded_completion` check `reported_state` runs for
+                    // the live row needs `run.teardown`/`run.surface`, which
+                    // this slim row never keeps. Folding that structural
+                    // check in here, while both are still in hand, lets the
+                    // slim row carry the *effective* disposition instead: an
+                    // eviction can no longer make a stranded completion read
+                    // back as plain `completed`. `work.completed` is always
+                    // journaled before its trailing `surface.torn_down`
+                    // (engine.rs's R2 rung note), so `state.works[work_id]`
+                    // already reflects the terminal state this checks.
+                    let explicit_dirty = run.integrity == Some(IntegrityDisposition::Dirty);
+                    let completed = state
+                        .works
+                        .get(work_id)
+                        .is_some_and(|w| w.state == WorkState::Completed);
+                    let structural_stranded = completed
+                        && match (run.surface.as_ref(), run.teardown.as_ref()) {
+                            (Some(surface), Some(teardown)) => {
+                                teardown.stranded_completion(surface)
+                            }
+                            _ => false,
+                        };
+                    row.integrity = if explicit_dirty || structural_stranded {
+                        Some(IntegrityDisposition::Dirty)
+                    } else {
+                        run.integrity
+                    };
                     row.updated_at = event.timestamp.clone();
                 }
             }

--- a/src/runtime/recovery.rs
+++ b/src/runtime/recovery.rs
@@ -642,8 +642,11 @@ mod tests {
             Some(IntegrityDisposition::Dirty),
             "and the projection folds it the same way the live path's does"
         );
+        // #4: the recovered teardown just settled this run, so the same
+        // commit evicted the Work into `terminal_works` — it is no longer
+        // in `works` at all.
         assert_eq!(
-            core.registry.state().works[work_id].state,
+            core.registry.state().terminal_works[work_id].state,
             WorkState::Completed,
             "integrity never moves Work state (§11.5)"
         );

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -572,6 +572,41 @@ impl TeardownReport {
     pub fn findings(&self) -> impl Iterator<Item = &IntegrityFinding> {
         self.bindings.iter().flat_map(|b| b.findings.iter())
     }
+
+    /// ADR 0007(b): whether this teardown, against the surface it tore down,
+    /// shows a closing stage that declared a commit as its durable outcome
+    /// but never actually advanced the branch and left the worktree dirty —
+    /// the safety net for when an actor guesses wrong about its own runtime
+    /// model (`docs/adr/0007-actor-runtime-contract.md`).
+    ///
+    /// The engine still learns nothing about what a commit *is* (NORTH-STAR:
+    /// "the engine learns no output vocabulary; only the pointer is core"):
+    /// this reads two facts the pointer already computes — a binding's
+    /// teardown disposition, and whether its finalize commit ever moved past
+    /// the surface's own base SHA — rather than asking any workflow what it
+    /// meant to do.
+    ///
+    /// Structural, not state-aware: this alone does not know whether the
+    /// Work this teardown belongs to actually reached `Completed` — callers
+    /// that need `reported_state`'s full `stranded_completion` semantics
+    /// (api.rs) gate this on `work.state` themselves. It exists standalone
+    /// here specifically so a caller with no live `Work` at hand — the
+    /// projection reducer, computing the slim index's effective disposition
+    /// at `surface.torn_down` time — can still ask it.
+    pub fn stranded_completion(&self, surface: &WorkSurface) -> bool {
+        self.bindings.iter().any(|binding| {
+            let never_advanced = surface
+                .bindings
+                .iter()
+                .find(|b| b.repository == binding.repository)
+                .is_some_and(|b| binding.final_sha.as_deref() == Some(b.base_sha.as_str()));
+            never_advanced
+                && matches!(
+                    binding.disposition,
+                    BindingDisposition::RetainedDirty { .. }
+                )
+        })
+    }
 }
 
 /// Failure materializing a surface.

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -92,7 +92,8 @@ use sergeant_rs::domain::execution::{
 use sergeant_rs::domain::profile::Profile;
 use sergeant_rs::domain::work::{
     KIND_WORK_BLOCKED, KIND_WORK_CANCELED, KIND_WORK_COMPLETED, KIND_WORK_FAILED,
-    KIND_WORK_NEEDS_INPUT, KIND_WORK_RESUMED, KIND_WORK_STARTED, KIND_WORK_SUBMITTED, WorkState,
+    KIND_WORK_NEEDS_INPUT, KIND_WORK_RESUMED, KIND_WORK_STARTED, KIND_WORK_SUBMITTED, Work,
+    WorkState,
 };
 use sergeant_rs::domain::workflow::{
     KIND_STAGE_BLOCKED, KIND_STAGE_CANCELED, KIND_STAGE_ENTERED, KIND_STAGE_INPUT_RECEIVED,
@@ -324,6 +325,22 @@ fn core(data_dir: &Path) -> Core {
         .expect("catch up");
     let (events_tx, _rx) = tokio::sync::broadcast::channel(16);
     Core::new(journal, registry, events_tx)
+}
+
+/// #4: a Work whose run has settled may already have moved out of `works`
+/// into the bounded `terminal_works` cache by the time a test reads it back
+/// — mirrors the first two tiers of `api.rs`'s `resolve_work` (`works` then
+/// `terminal_works`). None of this file's fixtures churn anywhere near
+/// `terminal_works`'s own capacity, so the third tier (journal
+/// re-derivation) is never needed here.
+fn work_of(core: &Core, work_id: &str) -> Work {
+    let registry = core.registry.state();
+    registry
+        .works
+        .get(work_id)
+        .or_else(|| registry.terminal_works.get(work_id))
+        .unwrap_or_else(|| panic!("no Work found for {work_id}, live or cached"))
+        .clone()
 }
 
 fn commit(core: &mut Core, work_id: &str, kind: &str, payload: Value) {
@@ -3511,10 +3528,7 @@ fn a4_restart_reattaches_a_surviving_session_and_blocks_with_resumable_evidence(
         vec![work_id.to_string()],
         "definite evidence"
     );
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let blocked = events_of(&core, work_id, KIND_WORK_BLOCKED);
     assert_eq!(blocked.len(), 1);
     assert!(
@@ -3626,7 +3640,7 @@ fn a4_reconcile_reattaches_a_resumable_execution_before_it_classifies() {
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.resumed, vec![work_id.to_string()]);
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Completed,
         "an unambiguously resumable execution is resumed, not parked"
     );
@@ -3674,10 +3688,7 @@ fn a4_reconcile_that_cannot_reattach_stays_fail_closed() {
 
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let reconciled = events_of(&core, work_id, KIND_EXECUTION_RECONCILED);
     assert_eq!(reconciled[0]["disposition"], "ambiguous");
     assert_eq!(reconciled[0]["reattached"], false);
@@ -3741,10 +3752,7 @@ fn a4_reconcile_does_not_ask_a_backend_that_cannot_resume() {
     );
     let reconciled = events_of(&core, work_id, KIND_EXECUTION_RECONCILED);
     assert_eq!(reconciled[0]["reattached"], false);
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Completed
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Completed);
 }
 
 /// Acceptance 4b: a session that no longer exists → the execution is
@@ -3768,10 +3776,7 @@ fn a4_restart_with_vanished_session_retires_the_execution_and_blocks() {
 
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
 
     let reconciled = events_of(&core, work_id, KIND_EXECUTION_RECONCILED);
     assert_eq!(reconciled.len(), 1);
@@ -3856,10 +3861,7 @@ fn a4_a_crash_inside_the_reconcile_append_window_rederives_on_restart() {
 
     let report = recovery::reconcile(&engine, &mut core).expect("re-run reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let stopped = events_of(&core, work_id, KIND_EXECUTION_STOPPED);
     assert_eq!(
         stopped.len(),
@@ -3963,7 +3965,7 @@ fn a4_a_crash_between_completion_and_teardown_is_swept_on_restart() {
             "{work_id}: the record must not pretend it landed with the completion"
         );
         assert_eq!(
-            core.registry.state().works[work_id].state,
+            work_of(&core, work_id).state,
             WorkState::Completed,
             "{work_id}: sweeping scaffolding never rewrites the outcome"
         );
@@ -4128,7 +4130,7 @@ fn a4_a_swept_surface_that_cannot_be_removed_is_retained_named_and_not_re_swept(
         surface.root.display()
     );
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Canceled,
         "sweeping scaffolding never rewrites the outcome"
     );
@@ -4419,10 +4421,7 @@ fn a4_a_crash_between_spawn_and_execution_started_blocks_the_work() {
 
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let reconciled = events_of(&core, work_id, KIND_EXECUTION_RECONCILED);
     assert_eq!(reconciled[0]["disposition"], "ambiguous");
     assert!(
@@ -4585,10 +4584,7 @@ fn r1_worker_reports_done_but_native_session_stays_alive() {
     );
 
     engine.resume(&mut core, work_id).expect("drive");
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Completed
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Completed);
     assert!(
         fake.is_live("exec-01M4CATALOG1"),
         "the native session outlived completion — and that must not matter"
@@ -4646,10 +4642,7 @@ fn r2_daemon_dies_during_delivery_fails_closed_with_the_input_preserved() {
 
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let inputs = events_of(&core, work_id, KIND_STAGE_INPUT_RECEIVED);
     assert_eq!(inputs.len(), 1, "the delivered answer is journal-preserved");
     assert_eq!(inputs[0]["input"], "blue");
@@ -4693,7 +4686,7 @@ fn r3_native_dies_after_work_preserved_is_not_a_failure() {
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.resumed, vec![work_id.to_string()]);
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Completed,
         "dead process + completed signal = completed work, never failed"
     );
@@ -4900,10 +4893,7 @@ fn r7_work_waiting_for_input_is_never_timed_out_or_reclassified() {
         let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
         assert!(report.resumed.is_empty() && report.blocked.is_empty());
     }
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::NeedsInput
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::NeedsInput);
     assert!(
         events_of(&core, work_id, KIND_WORK_BLOCKED).is_empty(),
         "no timeout reclassified the wait"
@@ -4952,7 +4942,7 @@ fn n19_materializing_a_surface_is_an_effect_the_caller_performs() {
     let mut core = core(data.path());
     let work_id = "01N3SURFACE1";
     submit_work(&mut core, work_id, "materialize me");
-    let work = core.registry.state().works[work_id].clone();
+    let work = work_of(&core, work_id);
     let plan = plan_for(&engine);
 
     let step = engine
@@ -4976,7 +4966,7 @@ fn n19_materializing_a_surface_is_an_effect_the_caller_performs() {
         "no worktree may exist while the guard is still held"
     );
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Pending,
         "the work does not become active until the surface really exists"
     );
@@ -5018,7 +5008,7 @@ fn n20_tearing_a_surface_down_is_an_effect_the_caller_performs() {
     let mut core = core(data.path());
     let work_id = "01N3SURFACE2";
     submit_work(&mut core, work_id, "cancel me");
-    let work = core.registry.state().works[work_id].clone();
+    let work = work_of(&core, work_id);
     let plan = plan_for(&engine);
     engine.start(&mut core, &work, &plan).expect("start");
     let worktree = core.registry.state().runs[work_id]
@@ -5075,7 +5065,7 @@ fn n21_a_cancel_during_materialization_records_the_surface_and_tears_it_down() {
     let mut core = core(data.path());
     let work_id = "01N3SURFACE3";
     submit_work(&mut core, work_id, "cancel me mid-git");
-    let work = core.registry.state().works[work_id].clone();
+    let work = work_of(&core, work_id);
     let plan = plan_for(&engine);
 
     let step = engine
@@ -5096,7 +5086,7 @@ fn n21_a_cancel_during_materialization_records_the_surface_and_tears_it_down() {
     drain(&engine, &mut core, step);
 
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Canceled,
         "a late surface must not revive a work that moved on"
     );
@@ -5825,10 +5815,7 @@ fn n2_a_failed_launch_abandons_its_reservation_and_blocks_the_work() {
         events_of(&core, work_id, KIND_EXECUTION_STARTED).is_empty(),
         "nothing started"
     );
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     assert!(
         core.registry.state().runs[work_id]
             .unsettled_reservation()
@@ -5882,7 +5869,7 @@ fn n3_a_late_launch_cannot_revive_work_that_moved_on() {
     step.deferred.wait();
 
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Canceled,
         "a late launch must not revive terminal work"
     );
@@ -5971,10 +5958,7 @@ fn n4_a_reservation_whose_launch_never_reported_fails_closed_at_restart() {
 
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let blocked = events_of(&core, work_id, KIND_WORK_BLOCKED);
     let evidence = blocked
         .last()
@@ -6102,7 +6086,7 @@ fn n6_an_actor_authored_ask_parks_the_stage_and_respond_resumes_the_same_executi
 
     engine.retry(&mut core, work_id).expect("retry");
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::NeedsInput,
         "the actor's question parks the work"
     );
@@ -6138,10 +6122,7 @@ fn n6_an_actor_authored_ask_parks_the_stage_and_respond_resumes_the_same_executi
         1,
         "answering an ask continues the conversation; it does not start a second one"
     );
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Completed
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Completed);
 }
 
 /// The same park, authored by the *adapter* rather than the actor, is
@@ -6185,7 +6166,7 @@ fn n8_a_live_execution_can_raise_a_question_between_engine_calls() {
 
     engine.retry(&mut core, work_id).expect("retry");
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Active,
         "the execution is still working"
     );
@@ -6200,10 +6181,7 @@ fn n8_a_live_execution_can_raise_a_question_between_engine_calls() {
     assert!(fake.actor_asks(&execution_id, "which environment?"));
     engine.resume(&mut core, work_id).expect("resume");
 
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::NeedsInput
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::NeedsInput);
     let parked = events_of(&core, work_id, KIND_STAGE_NEEDS_INPUT);
     assert_eq!(parked[0]["detail"], "which environment?");
     assert_eq!(parked[0]["asked_by"], "actor");
@@ -6294,7 +6272,7 @@ fn n17_an_actor_ask_survives_a_daemon_restart_and_the_answer_still_lands() {
 
     engine.retry(&mut core, work_id).expect("retry");
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::NeedsInput,
         "the actor's question parks the work"
     );
@@ -6317,10 +6295,7 @@ fn n17_an_actor_ask_survives_a_daemon_restart_and_the_answer_still_lands() {
         report.resumed.is_empty() && report.blocked.is_empty(),
         "a parked work is a decision; recovery must not re-decide it: {report:?}"
     );
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::NeedsInput
-    );
+    assert_eq!(work_of(core, work_id).state, WorkState::NeedsInput);
 
     // The human answers the restarted daemon.
     engine
@@ -6333,7 +6308,7 @@ fn n17_an_actor_ask_survives_a_daemon_restart_and_the_answer_still_lands() {
         "the answer reached the execution that asked it"
     );
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(core, work_id).state,
         WorkState::Completed,
         "and the run continued from it"
     );
@@ -6404,7 +6379,7 @@ fn n18_a_refused_reattach_still_fails_the_answer_closed() {
         .expect("respond is accepted, then fails closed");
 
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(core, work_id).state,
         WorkState::Blocked,
         "an unprovable context blocks rather than guessing"
     );
@@ -6872,10 +6847,7 @@ fn n10_window1_before_the_reservation_append() {
 
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Blocked
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     assert_eq!(
         events_of(&core, work_id, KIND_WORK_BLOCKED)[0]["reason"],
         "no execution to reconcile"
@@ -7023,10 +6995,7 @@ fn n12_windows3_and_4_identity_created_and_process_started_are_one_window() {
             "{label}: the adapter's answer about the reserved identity is recorded"
         );
         let blocked = events_of(&core, work_id, KIND_WORK_BLOCKED);
-        outcomes.push((
-            core.registry.state().works[work_id].state,
-            abandoned["reason"].clone(),
-        ));
+        outcomes.push((work_of(&core, work_id).state, abandoned["reason"].clone()));
         evidence.push(blocked.last().expect("a block").clone());
     }
     assert_eq!(
@@ -7239,7 +7208,7 @@ fn n15_window7_terminal_before_the_cleanup_request() {
     let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
     assert_eq!(report.surfaces_retired, vec![work_id.to_string()]);
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Completed,
         "terminal work is never revived or reclassified"
     );
@@ -7287,10 +7256,7 @@ fn n16_window8_cleanup_done_before_the_cleanup_append() {
         torn[0]["report"]["bindings"][0]["disposition"], "missing",
         "evidence from the disk, not an assumption about which side of the window the crash fell on"
     );
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Completed
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Completed);
 }
 
 /// §22.5's **cancel-during-launch** window, which had no treatment at all.
@@ -7372,7 +7338,7 @@ fn n22_window7b_a_cancel_that_landed_during_a_launch_closes_its_reservation() {
 
     // §22.5's convergence rules, unchanged by the closure.
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Canceled,
         "no terminal work revived"
     );
@@ -7573,7 +7539,7 @@ fn park_with_a_live_turn(
         .expect("settle launch");
     step.deferred.wait();
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(core, work_id).state,
         WorkState::Active,
         "the run must be active with a turn in flight, or these tests are \
          asserting nothing"
@@ -7800,7 +7766,7 @@ fn n30_two_observations_of_one_finished_turn_complete_the_stage_once() {
         .expect("first settle");
     drain(&engine, &mut core, step);
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Completed,
         "the first observation is the one that lands"
     );
@@ -7870,7 +7836,7 @@ fn r_mvp1_8_a_k2_settle_reports_running_twice_then_completes_via_the_completion_
         .expect("settle launch");
     step.deferred.wait();
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Active,
         "settle tick 1 of 2: launch-settle's own observation must still \
          report Running, or this test is measuring the pre-R-MVP1-8 fake"
@@ -7896,7 +7862,7 @@ fn r_mvp1_8_a_k2_settle_reports_running_twice_then_completes_via_the_completion_
         .expect("settle observe");
     step.deferred.wait();
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Active,
         "settle tick 2 of 2 must still report Running"
     );
@@ -7957,10 +7923,7 @@ fn r_mvp1_8_k0_is_the_unchanged_default_scripted_signal_visible_at_launch_settle
         "k=0 must complete on launch-settle's own observation, unchanged: {:?}",
         kinds_of(&core, work_id)
     );
-    assert_eq!(
-        core.registry.state().works[work_id].state,
-        WorkState::Completed
-    );
+    assert_eq!(work_of(&core, work_id).state, WorkState::Completed);
 }
 
 /// The completion driver asks only about runs that could still be answered.
@@ -8554,7 +8517,7 @@ fn r_mvp1_7_a_scripted_run_exceeding_the_cap_blocks_at_exactly_n_spawned_turns()
 
     let work_id = "01MVP17CAP";
     submit_work(&mut core, work_id, "spend more turns than the cap allows");
-    let work = core.registry.state().works[work_id].clone();
+    let work = work_of(&core, work_id);
     let step = engine
         .begin_start(&mut core, &work, &plan)
         .expect("begin start");
@@ -8572,7 +8535,7 @@ fn r_mvp1_7_a_scripted_run_exceeding_the_cap_blocks_at_exactly_n_spawned_turns()
         "the durable counter must agree with the journal count above"
     );
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::Blocked,
         "the (N+1)th turn is refused, not silently skipped"
     );
@@ -8621,7 +8584,7 @@ fn r_mvp1_7_a_send_that_internally_retries_through_resume_counts_one_turn() {
 
     engine.retry(&mut core, work_id).expect("retry");
     assert_eq!(
-        core.registry.state().works[work_id].state,
+        work_of(&core, work_id).state,
         WorkState::NeedsInput,
         "the actor's question parks the work"
     );
@@ -9053,7 +9016,7 @@ fn r_mvp1_7_a_consumed_crossing_whose_turn_ended_is_journaled_stale_not_delivere
         work_id,
         "hang, then go stale in the delivery window",
     );
-    let work = core.registry.state().works[work_id].clone();
+    let work = work_of(&core, work_id);
     let step = engine
         .begin_start(&mut core, &work, &plan)
         .expect("begin start");

--- a/tests/m5_projections.rs
+++ b/tests/m5_projections.rs
@@ -188,11 +188,30 @@ async fn submit(handle: &DaemonHandle, cwd: &Path, intent: &str, extra: Value) -
     value
 }
 
+/// Every event currently committed to `data_dir`'s journal.
+///
+/// A short bounded retry absorbs #169's one legitimate transient —
+/// `replay_data_dir` racing a live `append_event` mid-write and observing a
+/// torn tail, which `JournalError::is_possible_torn_tail` names precisely.
+/// `wait_for_kinds` and `wait_for_a_quiet_journal` both poll this against a
+/// running daemon, so this is the one spot in the harness that can actually
+/// hit the race; every other `Malformed` still panics immediately on first
+/// sight, exactly as before — real corruption is never something a retry
+/// fixes, and pretending otherwise would only hide it.
 fn journal_events(data_dir: &Path) -> Vec<Event> {
-    Journal::replay_data_dir(data_dir)
-        .expect("replay")
-        .map(|e| e.expect("event"))
-        .collect()
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        match Journal::replay_data_dir(data_dir)
+            .expect("replay")
+            .collect::<Result<Vec<Event>, _>>()
+        {
+            Ok(events) => return events,
+            Err(e) if e.is_possible_torn_tail() && Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(e) => panic!("journal replay failed: {e}"),
+        }
+    }
 }
 
 /// Every canned query plus the table counts, as one comparable blob. This is


### PR DESCRIPTION
Wave 2 of the backlog close-out sprint (head PR #202). Spec: workspace backlog-series/w2-spec.md. 4-axis panel + refuters: 3 confirmed findings (stranded completed_dirty masked after Work-cache eviction — fixed by carrying the effective disposition on the slim index, revert-verified; missing eviction tests — added; duplicated state lookup — extracted state_view). Gates green post-fix: fmt, clippy -D warnings, full suite.

**For owner ratification (also listed on #202):** TERMINAL_WORK_CACHE_CAPACITY = 1024 (2× the run cache; Work structs are smaller, worst case low tens of MB on a modest 8GB host — platform-argued, not host-tuned), and the narrowed JSON shape for evicted fleet rows (id/intent/state/integrity-disposition/timestamps + "evicted": true).

Refs #12 #10 #4 #169 #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4