### PR TITLE
CI/CD hardening & version policy (ships in 0.1.2)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,82 @@
+name: canary
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # weekly, Monday 06:00 UTC — matches coverage.yml's
+                            # existing weekly-Monday pattern (coverage.yml:24)
+                            # for one predictable non-blocking-lane cadence
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]   # deliberately the FLOATING
+                                              # aliases, not the pinned
+                                              # ubuntu-24.04/macos-26 used
+                                              # everywhere else — this job's
+                                              # whole point is to notice the
+                                              # runner image moving too, not
+                                              # just Rust. Pinning it here
+                                              # would defeat it.
+    runs-on: ${{ matrix.os }}
+    # NO continue-on-error: this is a standalone scheduled workflow, not a
+    # required PR check, so a red run blocks nothing and GitHub's own
+    # default scheduled-workflow-failure notification already fires;
+    # continue-on-error would only muffle the redness this job exists to
+    # produce.
+    env:
+      RUSTUP_TOOLCHAIN: stable   # rank 2 in rustup's override precedence —
+                                  # bypasses rust-toolchain.toml (rank 4)
+                                  # deliberately, so this job canaries the
+                                  # upstream `stable` channel, not the
+                                  # repo's own pin.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: rustup update stable (install/refresh the floating toolchain the env var selects)
+        run: rustup update stable
+
+      - name: cargo check --locked --all-targets
+        run: cargo check --locked --all-targets
+
+      - name: cargo clippy --locked --all-targets
+        run: cargo clippy --locked --all-targets -- -D warnings
+
+      - name: cargo test --locked
+        run: cargo test --locked
+
+  on-drift:
+    needs: canary
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write   # the ONLY new permission this sprint introduces
+                        # anywhere in the four+one workflows — everything
+                        # else stays at existing contents: read. gh issue
+                        # create/edit/comment all require it; nothing else
+                        # in this job's path touches repo state.
+    steps:
+      - name: open-or-update the upstream-drift tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          title="Upstream drift: canary failed on ${{ github.run_id }}"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --repo "${{ github.repository }}" \
+            --label upstream-drift --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "${{ github.repository }}" \
+              --body "Canary failed again: $run_url"
+          else
+            gh issue create --repo "${{ github.repository }}" \
+              --title "upstream drift: canary red" \
+              --label upstream-drift \
+              --body "The weekly canary tripped: $run_url"
+          fi

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -67,7 +67,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
-          title="Upstream drift: canary failed on ${{ github.run_id }}"
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           existing=$(gh issue list --repo "${{ github.repository }}" \
             --label upstream-drift --state open --json number --jq '.[0].number // empty')

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -41,6 +41,12 @@ jobs:
       - name: rustup update stable (install/refresh the floating toolchain the env var selects)
         run: rustup update stable
 
+      # RUSTUP_TOOLCHAIN=stable scopes this to the floating toolchain. The
+      # runner image usually preinstalls these with stable, but this job's
+      # clippy step must not depend on image packaging staying that way.
+      - name: rustup component add clippy rustfmt (against floating stable)
+        run: rustup component add clippy rustfmt
+
       - name: cargo check --locked --all-targets
         run: cargo check --locked --all-targets
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,28 @@ jobs:
       - name: cargo check
         run: cargo check --locked --all-targets
 
+  msrv:
+    # W1 §E: measured floor, not recon's static 1.88.0 prediction — the
+    # extra minor version comes from this crate's own use of
+    # std::fs::File::try_lock/TryLockError (stabilized 1.89.0), which a
+    # cargo-metadata pass over dependency rust-version fields cannot see.
+    # Verified empirically: cargo +1.89.0 check --locked --all-targets and
+    # cargo +1.89.0 test --locked both passed cleanly before this job and
+    # Cargo.toml's rust-version were added. Check only, no clippy — lint
+    # policy belongs to the pinned dev compiler (rust-toolchain.toml), not
+    # to this deliberately-older floor.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: rustup toolchain install (MSRV floor — deliberately older than rust-toolchain.toml's pin)
+        run: rustup toolchain install 1.89.0 --profile minimal
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: cargo check --locked --all-targets (MSRV floor — check only, no clippy on an old compiler)
+        run: cargo +1.89.0 check --locked --all-targets
+
   dependency-policy:
     # proposal §5.2: routine PRs check bans/licenses/sources only. Advisories
     # deliberately excluded here — a new RustSec advisory can land against an

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          components: clippy, rustfmt
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; -c adds clippy+rustfmt)
+        run: rustup toolchain install -c clippy,rustfmt
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -41,10 +40,13 @@ jobs:
         run: cargo fmt --check
 
       - name: cargo clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: cargo test
-        run: cargo test
+        run: cargo test --locked
+
+      - name: git diff --exit-code (no step above should have mutated a tracked file)
+        run: git diff --exit-code
 
   shellcheck:
     # ADR 0004 (D7): hygiene, not a version gate — shellcheck has no bash-3.2
@@ -82,12 +84,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - name: rustup toolchain install (rust-toolchain.toml pins the version)
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: cargo check
-        run: cargo check --all-targets
+        run: cargo check --locked --all-targets
 
   dependency-policy:
     # proposal §5.2: routine PRs check bans/licenses/sources only. Advisories
@@ -99,8 +102,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: "cargo metadata --locked (guard: belt-and-suspenders around the action's own --locked argument below)"
+        run: cargo metadata --locked --format-version 1 >/dev/null
+
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
+          arguments: --all-features --locked
           command: check bans licenses sources
 
   dependency-review:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,22 @@ jobs:
     # policy belongs to the pinned dev compiler (rust-toolchain.toml), not
     # to this deliberately-older floor.
     runs-on: ubuntu-latest
+    env:
+      # Single source of truth for this job's two 1.89.0 uses below. Keep in
+      # sync with Cargo.toml's rust-version (see the comment there) — YAML
+      # and TOML can't share a literal without added machinery, so this only
+      # collapses the duplication within this job, from two sites to one.
+      MSRV: 1.89.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: rustup toolchain install (MSRV floor — deliberately older than rust-toolchain.toml's pin)
-        run: rustup toolchain install 1.89.0 --profile minimal
+        run: rustup toolchain install ${{ env.MSRV }} --profile minimal
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: cargo check --locked --all-targets (MSRV floor — check only, no clippy on an old compiler)
-        run: cargo +1.89.0 check --locked --all-targets
+        run: cargo +${{ env.MSRV }} check --locked --all-targets
 
   dependency-policy:
     # proposal §5.2: routine PRs check bans/licenses/sources only. Advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -53,7 +53,7 @@ jobs:
     # target mode, so it cannot enforce the scripts/ floor. The macos-check
     # job below only runs `cargo check` (type-check, no test execution), so
     # it does NOT exercise scripts/demo.sh; the real enforcement of the
-    # bash-3.2 floor is matrix.yml's full-suite `cargo test` on macos-latest
+    # bash-3.2 floor is matrix.yml's full-suite `cargo test` on macos-26
     # (via tests/m6_surfaces.rs t4's scripts/demo.sh subprocess), which runs
     # on PR-to-main, nightly, and release — not on every push. Gated at
     # --severity=error only: a 2026-08-14 sweep of all 25 scripts/**/*.sh
@@ -63,7 +63,7 @@ jobs:
     # on intentionally-external vars). Triaging those individually is out of
     # scope here; this still gives every future change a real,
     # currently-clean gate against actual shell bugs.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: shellcheck (errors only — see comment above for the warning backlog)
@@ -73,14 +73,14 @@ jobs:
     # ADR 0004 (D9) / ADR 0002 (D2): the macOS module is `#[cfg]`-selected and
     # not compiled at all on Linux, so breaking it is invisible locally — this
     # is the compensating lane, run per push. `cargo check` on an actual
-    # macos-latest runner rather than a literal Linux->macOS cross-compile:
+    # macos-26 runner rather than a literal Linux->macOS cross-compile:
     # the `duckdb` dependency's `bundled` feature compiles DuckDB's C++ from
     # source via its own build script, which needs a real Apple toolchain
     # (cross-compiling that from Linux needs an osxcross-style Apple SDK
     # extraction that hosted runners don't carry). Since this repo is public,
-    # a real macos-latest runner is free and unmetered (ADR 0004 D9), so it's
+    # a real macos-26 runner is free and unmetered (ADR 0004 D9), so it's
     # both cheaper and more faithful than fighting a cross C++ toolchain.
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -102,7 +102,7 @@ jobs:
     # Cargo.toml's rust-version were added. Check only, no clippy — lint
     # policy belongs to the pinned dev compiler (rust-toolchain.toml), not
     # to this deliberately-older floor.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # Single source of truth for this job's two 1.89.0 uses below. Keep in
       # sync with Cargo.toml's rust-version (see the comment there) — YAML
@@ -126,7 +126,7 @@ jobs:
     # unchanged Cargo.lock and turn an unrelated documentation PR red
     # overnight. Advisories are a release-time gate instead: release.yml's
     # Gate E runs the full `cargo deny check`, including advisories.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -146,7 +146,7 @@ jobs:
     # where there is no PR diff to review, so the job is scoped out there
     # rather than running meaninglessly or failing for lack of a base ref.
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,17 @@ jobs:
       - name: cargo test
         run: cargo test --locked
 
+      - name: docs-consistency (README release literals match the current version)
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 --locked | jq -r '.packages[0].version')
+          stale=$(grep -noE 'releases/(download|tag)/v[0-9]+\.[0-9]+\.[0-9]+|release download v[0-9]+\.[0-9]+\.[0-9]+' README.md \
+            | grep -v "v${version}\b" || true)
+          if [ -n "$stale" ]; then
+            echo "::error::README.md references a release version other than the current v${version}:"
+            echo "$stale"
+            exit 1
+          fi
+
       - name: git diff --exit-code (no step above should have mutated a tracked file)
         run: git diff --exit-code
 
@@ -55,7 +66,8 @@ jobs:
     # it does NOT exercise scripts/demo.sh; the real enforcement of the
     # bash-3.2 floor is matrix.yml's full-suite `cargo test` on macos-26
     # (via tests/m6_surfaces.rs t4's scripts/demo.sh subprocess), which runs
-    # on PR-to-main, nightly, and release — not on every push. Gated at
+    # via workflow_call from release.yml's Gate C, or by manual
+    # workflow_dispatch — never on a routine push. Gated at
     # --severity=error only: a 2026-08-14 sweep of all 25 scripts/**/*.sh
     # found the tree clean at that threshold but carrying ~84 pre-existing
     # warning/note/style findings (mostly SC2154 false positives from the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: rustup toolchain install (rust-toolchain.toml pins the version; -c adds clippy+rustfmt)
-        run: rustup toolchain install -c clippy,rustfmt
+      # Two steps, deliberately: bare file-driven `rustup toolchain install`
+      # ignores `-c` flags on the runner's rustup (proven on this repo's
+      # first pinned CI run — it installed the minimal profile's 3
+      # components and cargo fmt then failed), while `rustup component add`
+      # always targets the active toolchain rust-toolchain.toml selects.
+      - name: rustup toolchain install (rust-toolchain.toml pins the version)
+        run: rustup toolchain install
+      - name: rustup component add clippy rustfmt (file-selected toolchain)
+        run: rustup component add clippy rustfmt
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,9 +37,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: reclaim runner disk (the stage scripts enforce a 10 GB floor)
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          components: llvm-tools
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; -c adds llvm-tools for cargo-llvm-cov)
+        run: rustup toolchain install -c llvm-tools
       - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,9 +39,9 @@ jobs:
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
       - name: rustup toolchain install (rust-toolchain.toml pins the version; -c adds llvm-tools for cargo-llvm-cov)
         run: rustup toolchain install -c llvm-tools
-      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+      - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov@0.9.0
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-directories: target/llvm-cov-target

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,8 +37,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: reclaim runner disk (the stage scripts enforce a 10 GB floor)
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-      - name: rustup toolchain install (rust-toolchain.toml pins the version; -c adds llvm-tools for cargo-llvm-cov)
-        run: rustup toolchain install -c llvm-tools
+      # Bare file-driven install ignores `-c` (see ci.yml's note); add the
+      # component explicitly against the file-selected toolchain.
+      - name: rustup toolchain install (rust-toolchain.toml pins the version)
+        run: rustup toolchain install
+      - name: rustup component add llvm-tools (for cargo-llvm-cov)
+        run: rustup component add llvm-tools
       - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
         with:
           tool: cargo-llvm-cov@0.9.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Cold instrumented DuckDB (~500 C++ TUs) is unmeasured on 2-core
     # runners; the 4-core dev-container estimate was 15-25 min. Wide
     # margin on purpose (review finding 4).

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-26]
     runs-on: ${{ matrix.os }}
     # Cold DuckDB C++ build (~500 TUs, ~10 min) plus the real suites; wide
     # margin on purpose, matching coverage.yml's posture for the same build.
@@ -68,7 +68,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # macOS's plain `bash` here resolves to the system-frozen 3.2.57 (ADR
-      # 0004, D7) — GitHub's macos-latest image does not preinstall a newer
+      # 0004, D7) — GitHub's macos-26 image does not preinstall a newer
       # Homebrew bash ahead of it on PATH. `cargo test` includes
       # tests/m6_surfaces.rs t4, which spawns `scripts/demo.sh` via
       # `Command::new("bash")`, so this job's test run is what ADR 0004 means

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -62,7 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - name: rustup toolchain install (rust-toolchain.toml pins the version)
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -75,7 +76,7 @@ jobs:
       # enforcement" of the scripts/ bash-3.2 floor from #86 — no separate
       # step needed.
       - name: cargo test (full suite)
-        run: cargo test -- --nocapture 2>&1 | tee test-output.log
+        run: cargo test --locked -- --nocapture 2>&1 | tee test-output.log
 
       - name: publish skip count (ADR 0001 D8 measured bar)
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,28 @@ jobs:
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
+      - name: record build environment
+        run: |
+          mkdir -p target/distrib
+          {
+            echo "commit: ${{ github.sha }}"
+            echo "target: ${{ matrix.target }}"
+            echo "runner-os: ${{ runner.os }}"
+            echo "runner-arch: ${{ runner.arch }}"
+            echo
+            echo "--- rustc -Vv ---"
+            rustc -Vv
+            echo
+            echo "--- cargo -V ---"
+            cargo -V
+            echo
+            echo "--- git --version ---"
+            git --version
+            echo
+            echo "--- bash --version ---"
+            bash --version
+          } > target/distrib/build-environment-${{ matrix.target }}.txt
+
       - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
@@ -532,7 +554,9 @@ jobs:
             sgt_bin_x86_64-unknown-linux-gnu.cdx.json \
             sgt_bin_aarch64-apple-darwin.cdx.json \
             sergeant-rs-installer.sh \
-            SHA256SUMS.txt; do
+            SHA256SUMS.txt \
+            build-environment-x86_64-unknown-linux-gnu.txt \
+            build-environment-aarch64-apple-darwin.txt; do
             if [ ! -f "$f" ]; then
               echo "::error::release manifest missing expected asset $f" >&2
               exit 1
@@ -571,7 +595,8 @@ jobs:
             release-assets/*.sha256 \
             release-assets/*.cdx.json \
             release-assets/sergeant-rs-installer.sh \
-            release-assets/SHA256SUMS.txt
+            release-assets/SHA256SUMS.txt \
+            release-assets/build-environment-*.txt
 
       # A tag is not a unique key for a draft — GitHub lets multiple drafts
       # share one tag_name, which is exactly what let a stale dry-run draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           tool: cargo-deny
       - name: cargo deny check (full — advisories, bans, licenses, sources)
-        run: cargo deny check
+        run: cargo deny check --locked
 
   # ── Gate F — distro structural validator ───────────────────────────────
   # Does not execute here — see the top-of-file comment for why (workspace
@@ -271,9 +271,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; -t adds the cross target)
+        run: rustup toolchain install -t ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -281,6 +280,9 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+
+      - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
+        run: cargo metadata --locked --format-version 1 >/dev/null
 
       - name: dist build (packages the binary + LICENSE/README + checksum)
         run: dist build --artifacts=local --target ${{ matrix.target }}
@@ -337,10 +339,16 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; closes this job's prior lack of a pinned toolchain)
+        run: rustup toolchain install
+
       - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+
+      - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
+        run: cargo metadata --locked --format-version 1 >/dev/null
 
       - name: dist build --artifacts=global (shell installer only)
         run: |
@@ -414,13 +422,14 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; -t adds the cross target)
+        run: rustup toolchain install -t ${{ matrix.target }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
         with:
           tool: cargo-cyclonedx
+      - name: "cargo metadata --locked (guard: cargo-cyclonedx has no native --locked/--frozen flag)"
+        run: cargo metadata --locked --format-version 1 >/dev/null
       - name: generate target-scoped CycloneDX SBOM for the sgt binary
         run: |
           cargo cyclonedx --format json --describe binaries \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,53 +310,22 @@ jobs:
       # aggregate `sha256.sum`, and has no build-provenance attestation at all
       # (`gh attestation verify cargo-dist-installer.sh --repo
       # axodotdev/cargo-dist` → HTTP 404). The per-target tarballs have both.
-      # The two checks below prove different things and neither subsumes the
-      # other: the committed sha256 pins the exact v0.32.0 bytes we qualified
-      # (an attestation alone would accept a *different* axodotdev-built
-      # tarball served from this URL), and `gh attestation verify` proves those
-      # bytes came out of axodotdev/cargo-dist's own release workflow rather
-      # than merely matching a hash someone uploaded. Bumping DIST_VERSION
-      # means re-recording both sha256 literals from that release's
-      # `sha256.sum` — deliberately, so a version bump is a qualification, not
-      # a one-character edit.
+      # The two checks prove different things and neither subsumes the other:
+      # the committed sha256 pins the exact v0.32.0 bytes we qualified (an
+      # attestation alone would accept a *different* axodotdev-built tarball
+      # served from this URL), and `gh attestation verify` proves those bytes
+      # came out of axodotdev/cargo-dist's own release workflow rather than
+      # merely matching a hash someone uploaded. Bumping the version means
+      # re-recording both sha256 literals from that release's `sha256.sum` —
+      # deliberately, so a version bump is a qualification, not a
+      # one-character edit. Lives in scripts/release/install-dist.sh, shared
+      # by both bootstrap sites (package, package-installer), so there is one
+      # copy of the pinned hashes to re-qualify, not two (same pattern as
+      # verify-installer-checksums.sh below).
       - name: install dist 0.32.0 (checksum-pinned + attestation-verified tarball)
         env:
           GH_TOKEN: ${{ github.token }}
-          DIST_VERSION: "0.32.0"
-        run: |
-          set -euo pipefail
-          case "${RUNNER_OS}-${RUNNER_ARCH}" in
-            Linux-X64)
-              dist_target="x86_64-unknown-linux-gnu"
-              dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
-              ;;
-            macOS-ARM64)
-              dist_target="aarch64-apple-darwin"
-              dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
-              ;;
-            *)
-              echo "::error::no qualified cargo-dist ${DIST_VERSION} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-              exit 1
-              ;;
-          esac
-          archive="cargo-dist-${dist_target}.tar.xz"
-          curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
-            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/${archive}"
-          echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum -c "${RUNNER_TEMP}/dist.sha256"
-          else
-            shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
-          fi
-          gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
-          mkdir -p "${RUNNER_TEMP}/dist-bin"
-          tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
-          got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
-          if [ "$got" != "cargo-dist ${DIST_VERSION}" ]; then
-            echo "::error::extracted dist reports '$got', expected 'cargo-dist ${DIST_VERSION}'" >&2
-            exit 1
-          fi
-          echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"
+        run: scripts/release/install-dist.sh 0.32.0
 
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
@@ -456,53 +425,22 @@ jobs:
       # aggregate `sha256.sum`, and has no build-provenance attestation at all
       # (`gh attestation verify cargo-dist-installer.sh --repo
       # axodotdev/cargo-dist` → HTTP 404). The per-target tarballs have both.
-      # The two checks below prove different things and neither subsumes the
-      # other: the committed sha256 pins the exact v0.32.0 bytes we qualified
-      # (an attestation alone would accept a *different* axodotdev-built
-      # tarball served from this URL), and `gh attestation verify` proves those
-      # bytes came out of axodotdev/cargo-dist's own release workflow rather
-      # than merely matching a hash someone uploaded. Bumping DIST_VERSION
-      # means re-recording both sha256 literals from that release's
-      # `sha256.sum` — deliberately, so a version bump is a qualification, not
-      # a one-character edit.
+      # The two checks prove different things and neither subsumes the other:
+      # the committed sha256 pins the exact v0.32.0 bytes we qualified (an
+      # attestation alone would accept a *different* axodotdev-built tarball
+      # served from this URL), and `gh attestation verify` proves those bytes
+      # came out of axodotdev/cargo-dist's own release workflow rather than
+      # merely matching a hash someone uploaded. Bumping the version means
+      # re-recording both sha256 literals from that release's `sha256.sum` —
+      # deliberately, so a version bump is a qualification, not a
+      # one-character edit. Lives in scripts/release/install-dist.sh, shared
+      # by both bootstrap sites (package, package-installer), so there is one
+      # copy of the pinned hashes to re-qualify, not two (same pattern as
+      # verify-installer-checksums.sh below).
       - name: install dist 0.32.0 (checksum-pinned + attestation-verified tarball)
         env:
           GH_TOKEN: ${{ github.token }}
-          DIST_VERSION: "0.32.0"
-        run: |
-          set -euo pipefail
-          case "${RUNNER_OS}-${RUNNER_ARCH}" in
-            Linux-X64)
-              dist_target="x86_64-unknown-linux-gnu"
-              dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
-              ;;
-            macOS-ARM64)
-              dist_target="aarch64-apple-darwin"
-              dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
-              ;;
-            *)
-              echo "::error::no qualified cargo-dist ${DIST_VERSION} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-              exit 1
-              ;;
-          esac
-          archive="cargo-dist-${dist_target}.tar.xz"
-          curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
-            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/${archive}"
-          echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum -c "${RUNNER_TEMP}/dist.sha256"
-          else
-            shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
-          fi
-          gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
-          mkdir -p "${RUNNER_TEMP}/dist-bin"
-          tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
-          got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
-          if [ "$got" != "cargo-dist ${DIST_VERSION}" ]; then
-            echo "::error::extracted dist reports '$got', expected 'cargo-dist ${DIST_VERSION}'" >&2
-            exit 1
-          fi
-          echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"
+        run: scripts/release/install-dist.sh 0.32.0
 
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,8 +276,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: rustup toolchain install (rust-toolchain.toml pins the version; -t adds the cross target)
-        run: rustup toolchain install -t ${{ matrix.target }}
+      # Bare file-driven install ignores side flags like `-t` (see ci.yml's
+      # note on `-c`); add the target explicitly. Today both matrix legs are
+      # host-native so this is belt-and-braces, but it stops being a no-op
+      # the day a non-native target joins the matrix.
+      - name: rustup toolchain install (rust-toolchain.toml pins the version)
+        run: rustup toolchain install
+      - name: rustup target add ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -556,8 +562,14 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: rustup toolchain install (rust-toolchain.toml pins the version; -t adds the cross target)
-        run: rustup toolchain install -t ${{ matrix.target }}
+      # Bare file-driven install ignores side flags like `-t` (see ci.yml's
+      # note on `-c`); add the target explicitly. Today both matrix legs are
+      # host-native so this is belt-and-braces, but it stops being a no-op
+      # the day a non-native target joins the matrix.
+      - name: rustup toolchain install (rust-toolchain.toml pins the version)
+        run: rustup toolchain install
+      - name: rustup target add ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,25 +402,35 @@ jobs:
   # topology — it does not create or depend on the release tag existing in
   # the repository, only on being told what tag string to embed.
   #
-  # This job produces the installer script and, separately, the per-archive
-  # `.sha256` files (via `dist build --artifacts=local` in `package`,
-  # above). Nothing wires the two together: the generated
-  # `sergeant-rs-installer.sh` declares the local variables it would use to
-  # verify a downloaded archive's checksum but never assigns them, so its
-  # verification branch is unreachable and every install via this script
-  # prints "no checksums to verify" and installs unverified — confirmed by
-  # running the installer against a published release
-  # (`docs/measure-dist-conditions-2026-08-18.md`'s own "no checksums to
-  # verify" observation, condition 3, generalizes past the ad hoc local-server
-  # setup that first surfaced it — see that file's 2026-08-19 amendment).
-  # The documented, deliberate verification path is manual: README.md's
-  # "Installing a released binary instead of building from source" section
-  # walks `sha256sum -c` against the `.sha256` this job's sibling produces,
-  # plus `gh attestation verify` against the build-provenance attestation
-  # `draft-release` (below) creates. This job does not attempt to fix that
-  # gap — patching or post-processing `dist`'s generated installer to wire
-  # in checksum verification is a larger change with its own supply-chain
-  # risk surface, and is the owner's call, not a packaging-job comment's.
+  # This job produces the installer script; `package` (above) produces the
+  # per-archive `.sha256` files and, since 0.1.2, a per-target
+  # `<target>-dist-manifest.json`. Those manifests are what wire the two
+  # together: `dist build --artifacts=global` reads each archive's sha256 out
+  # of them and renders it into the installer's per-artifact case arms, so the
+  # generated `sergeant-rs-installer.sh` now verifies what it downloads before
+  # extracting it. This is cargo-dist's own mechanism — its generated CI
+  # downloads the local jobs' artifacts into target/distrib/ before the global
+  # build for exactly this reason — not a patch on its output; nothing here
+  # post-processes the generated script.
+  #
+  # Before 0.1.2 the manifests were never passed forward, so the installer's
+  # verification branch was unreachable and every install printed "no checksums
+  # to verify" (docs/measure-dist-conditions-2026-08-18.md, condition 3, and its
+  # 2026-08-19 amendment — an accurate record of the behavior on that date, not
+  # of the behavior now). The two steps after the global build below are what
+  # keep that from silently regressing: one asserts every released target's arm
+  # carries a real sha256, the other installs from a local origin and then
+  # proves a substituted archive is actually rejected.
+  #
+  # `needs: package` exists for the manifests only — a global artifact is still
+  # built once per app rather than once per target, and this job still never
+  # needs any target's binary. It costs nothing downstream: `draft-release`
+  # already waits on `smoke-test` and `sbom`, which already wait on `package`.
+  #
+  # Checksums are not the whole story and the README says so: they prove the
+  # archive matches what the release published, not that the release came from
+  # this repository. Provenance is `gh attestation verify` against the
+  # build-provenance attestation `draft-release` (below) creates.
   package-installer:
     needs:
       - gate-b-ci
@@ -428,6 +438,7 @@ jobs:
       - gate-d-coverage
       - gate-e-cargo-deny
       - gate-f-distro-validator
+      - package
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -496,12 +507,51 @@ jobs:
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
 
+      # Get the per-target build manifests `package` produced (and, harmlessly,
+      # the archives beside them) so `dist build --artifacts=global` can read
+      # each archive's sha256 out of them and render it into the installer's
+      # per-artifact case arms. This is cargo-dist's own mechanism, not a patch
+      # on its output: its generated CI performs the same download into
+      # target/distrib/ before the global build, under the comment "Get all the
+      # local artifacts for the global tasks to use (for e.g. checksums)".
+      # This job still does not need any target's *binary* — only the manifest
+      # JSON — so the reason this is a separate job from `package` (a global
+      # artifact is built once per app, not once per target) is unchanged.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: "dist-*"
+          path: target/distrib
+          merge-multiple: true
+
       - name: dist build --artifacts=global (shell installer only)
         run: |
           dist build --artifacts=global \
             --target x86_64-unknown-linux-gnu \
             --target aarch64-apple-darwin \
             --tag "$RELEASE_TAG"
+
+      - name: assert the generated installer carries a checksum for every released target
+        run: |
+          set -euo pipefail
+          installer=target/distrib/sergeant-rs-installer.sh
+          populated=$(grep -c '^[[:space:]]*_checksum_value="[0-9a-f]\{64\}"$' "$installer" || true)
+          if [ "$populated" -ne 2 ]; then
+            echo "::error::generated installer has $populated populated checksum value(s), expected 2 (one per released target) — dist did not see a per-target build manifest for every target" >&2
+            grep -n '_checksum_style\|_checksum_value\|\.tar\.xz")' "$installer" >&2 || true
+            exit 1
+          fi
+          echo "::notice::generated installer carries $populated per-artifact sha256 values"
+
+      # Proves the property, rather than asserting it: a good archive installs,
+      # a substituted one is rejected with a non-zero exit and nothing installed.
+      # Lives in scripts/ so ci.yml's shellcheck job lints it and so it can be
+      # re-run by hand against any published release's assets.
+      - name: installer smoke test — accepts a good archive, rejects a substituted one
+        run: |
+          scripts/release/verify-installer-checksums.sh \
+            target/distrib/sergeant-rs-installer.sh \
+            target/distrib \
+            "$RELEASE_TAG"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,9 +197,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+      - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
         with:
-          tool: cargo-deny
+          tool: cargo-deny@0.20.2
       - name: cargo deny check (full — advisories, bans, licenses, sources)
         run: cargo deny check --locked
 
@@ -425,9 +425,9 @@ jobs:
       - name: rustup toolchain install (rust-toolchain.toml pins the version; -t adds the cross target)
         run: rustup toolchain install -t ${{ matrix.target }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+      - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
         with:
-          tool: cargo-cyclonedx
+          tool: cargo-cyclonedx@0.5.9
       - name: "cargo metadata --locked (guard: cargo-cyclonedx has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
       - name: generate target-scoped CycloneDX SBOM for the sgt binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -701,13 +701,13 @@ jobs:
       # for that platform, and a direct contradiction of the SBOM job's own
       # point (target-scoped documents, not one generator for everything).
       - name: GitHub artifact attestations — SBOM (x86_64-unknown-linux-gnu)
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: "release-assets/sergeant-rs-x86_64-unknown-linux-gnu.tar.xz"
           sbom-path: "release-assets/sgt_bin_x86_64-unknown-linux-gnu.cdx.json"
 
       - name: GitHub artifact attestations — SBOM (aarch64-apple-darwin)
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: "release-assets/sergeant-rs-aarch64-apple-darwin.tar.xz"
           sbom-path: "release-assets/sgt_bin_aarch64-apple-darwin.cdx.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
   # invariant before anything else runs. Failing here creates no tag and no
   # release — this job does nothing but check facts.
   gate-a-repo-state:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -192,7 +192,7 @@ jobs:
   # included, so a known RustSec advisory cannot silently enter a release.
   gate-e-cargo-deny:
     needs: gate-a-repo-state
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -217,7 +217,7 @@ jobs:
   # PR.
   gate-f-distro-validator:
     needs: gate-a-repo-state
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -233,15 +233,19 @@ jobs:
   # Only after A-F. Measured on real GitHub-hosted runners, both targets,
   # 2026-08-18 (docs/measure-dist-2026-08-18.md, proposal §10 condition 1):
   # `dist build` successfully builds sgt with bundled DuckDB and packages it
-  # on both ubuntu-latest (897s cold build) and macos-latest (1002s cold
+  # on both ubuntu-24.04 (897s cold build) and macos-26 (1002s cold
   # build), with no disk or cache pressure on either. Binary behavioral
   # equivalence and the generated installer's correctness (conditions 2-3)
-  # were additionally measured against a real archive on ubuntu-latest
+  # were additionally measured against a real archive on ubuntu-24.04
   # (docs/measure-dist-conditions-2026-08-18.md) and found identical to an
   # ordinary `cargo build --release` binary, including the embedded distro.
+  # (ubuntu-24.04/macos-26 are the exact images the prior floating-alias
+  # runner labels served on the 2026-08-18 measurement date — the runner
+  # below is now pinned to those images directly, so this measurement is
+  # not stale relative to the pin.)
   #
   # aarch64-apple-darwin per ADR 0001's measured-target set: the *build*
-  # succeeded on a real macos-latest runner (above), but binary equivalence
+  # succeeded on a real macos-26 runner (above), but binary equivalence
   # and installer correctness were not re-measured on macOS — see docs/adr/
   # 0018-measured-vocabulary-obligation-clean-build-not-full-validation.md,
   # which clarifies ADR 0001 D8's "measured" vocabulary. Per that ruling,
@@ -262,9 +266,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-26
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -333,7 +337,7 @@ jobs:
       - gate-d-coverage
       - gate-e-cargo-deny
       - gate-f-distro-validator
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -373,9 +377,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-26
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -414,9 +418,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-26
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -460,7 +464,7 @@ jobs:
       - smoke-test
       - sbom
       - package-installer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       id-token: write
@@ -639,7 +643,7 @@ jobs:
   publish:
     needs: draft-release
     if: ${{ inputs.mode == 'publish' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -663,7 +667,7 @@ jobs:
   verify-latest:
     needs: [draft-release, publish]
     if: ${{ inputs.mode == 'publish' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,8 +361,26 @@ jobs:
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
 
+      # `--output-format=json` makes dist write this target's build manifest,
+      # which carries the archive's sha256. `package-installer` downloads it and
+      # `dist build --artifacts=global` reads the checksum straight out of it, so
+      # the generated installer ships real checksum values instead of the empty
+      # ones every release before 0.1.2 shipped (w3-recon.md §2a). The manifest
+      # is written OUTSIDE target/distrib and copied in afterwards, because
+      # `dist build` owns that directory while it runs — this is the exact order
+      # cargo-dist's own generated CI uses (templates/ci/github/release.yml.j2 @
+      # v0.32.0: `dist build … --output-format=json > dist-manifest.json` then
+      # `cp dist-manifest.json "$BUILD_MANIFEST_NAME"`, where BUILD_MANIFEST_NAME
+      # is target/distrib/<target>-dist-manifest.json). The <target>- filename
+      # prefix is that same convention and is what keeps the two matrix legs'
+      # manifests from colliding in the merged download.
       - name: dist build (packages the binary + LICENSE/README + checksum)
-        run: dist build --artifacts=local --target ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          dist build --artifacts=local --target ${{ matrix.target }} \
+            --output-format=json > "${RUNNER_TEMP}/local-dist-manifest.json"
+          cp "${RUNNER_TEMP}/local-dist-manifest.json" \
+            "target/distrib/${{ matrix.target }}-dist-manifest.json"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,6 +272,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -302,10 +303,60 @@ jobs:
             bash --version
           } > target/distrib/build-environment-${{ matrix.target }}.txt
 
-      - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
+      # dist is bootstrapped from its attested, checksum-pinned prebuilt
+      # tarball — NOT `curl … cargo-dist-installer.sh | sh`. Measured against
+      # axodotdev's own v0.32.0 release assets (w3-recon.md §1, 2026-08-21):
+      # cargo-dist-installer.sh has no `.sha256` sidecar, is absent from the
+      # aggregate `sha256.sum`, and has no build-provenance attestation at all
+      # (`gh attestation verify cargo-dist-installer.sh --repo
+      # axodotdev/cargo-dist` → HTTP 404). The per-target tarballs have both.
+      # The two checks below prove different things and neither subsumes the
+      # other: the committed sha256 pins the exact v0.32.0 bytes we qualified
+      # (an attestation alone would accept a *different* axodotdev-built
+      # tarball served from this URL), and `gh attestation verify` proves those
+      # bytes came out of axodotdev/cargo-dist's own release workflow rather
+      # than merely matching a hash someone uploaded. Bumping DIST_VERSION
+      # means re-recording both sha256 literals from that release's
+      # `sha256.sum` — deliberately, so a version bump is a qualification, not
+      # a one-character edit.
+      - name: install dist 0.32.0 (checksum-pinned + attestation-verified tarball)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIST_VERSION: "0.32.0"
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+          set -euo pipefail
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64)
+              dist_target="x86_64-unknown-linux-gnu"
+              dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
+              ;;
+            macOS-ARM64)
+              dist_target="aarch64-apple-darwin"
+              dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
+              ;;
+            *)
+              echo "::error::no qualified cargo-dist ${DIST_VERSION} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+              exit 1
+              ;;
+          esac
+          archive="cargo-dist-${dist_target}.tar.xz"
+          curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/${archive}"
+          echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c "${RUNNER_TEMP}/dist.sha256"
+          else
+            shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
+          fi
+          gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
+          mkdir -p "${RUNNER_TEMP}/dist-bin"
+          tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
+          got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
+          if [ "$got" != "cargo-dist ${DIST_VERSION}" ]; then
+            echo "::error::extracted dist reports '$got', expected 'cargo-dist ${DIST_VERSION}'" >&2
+            exit 1
+          fi
+          echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"
 
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
@@ -362,16 +413,67 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: rustup toolchain install (rust-toolchain.toml pins the version; closes this job's prior lack of a pinned toolchain)
         run: rustup toolchain install
 
-      - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
+      # dist is bootstrapped from its attested, checksum-pinned prebuilt
+      # tarball — NOT `curl … cargo-dist-installer.sh | sh`. Measured against
+      # axodotdev's own v0.32.0 release assets (w3-recon.md §1, 2026-08-21):
+      # cargo-dist-installer.sh has no `.sha256` sidecar, is absent from the
+      # aggregate `sha256.sum`, and has no build-provenance attestation at all
+      # (`gh attestation verify cargo-dist-installer.sh --repo
+      # axodotdev/cargo-dist` → HTTP 404). The per-target tarballs have both.
+      # The two checks below prove different things and neither subsumes the
+      # other: the committed sha256 pins the exact v0.32.0 bytes we qualified
+      # (an attestation alone would accept a *different* axodotdev-built
+      # tarball served from this URL), and `gh attestation verify` proves those
+      # bytes came out of axodotdev/cargo-dist's own release workflow rather
+      # than merely matching a hash someone uploaded. Bumping DIST_VERSION
+      # means re-recording both sha256 literals from that release's
+      # `sha256.sum` — deliberately, so a version bump is a qualification, not
+      # a one-character edit.
+      - name: install dist 0.32.0 (checksum-pinned + attestation-verified tarball)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIST_VERSION: "0.32.0"
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+          set -euo pipefail
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64)
+              dist_target="x86_64-unknown-linux-gnu"
+              dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
+              ;;
+            macOS-ARM64)
+              dist_target="aarch64-apple-darwin"
+              dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
+              ;;
+            *)
+              echo "::error::no qualified cargo-dist ${DIST_VERSION} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+              exit 1
+              ;;
+          esac
+          archive="cargo-dist-${dist_target}.tar.xz"
+          curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/${archive}"
+          echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c "${RUNNER_TEMP}/dist.sha256"
+          else
+            shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
+          fi
+          gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
+          mkdir -p "${RUNNER_TEMP}/dist-bin"
+          tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
+          got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
+          if [ "$got" != "cargo-dist ${DIST_VERSION}" ]; then
+            echo "::error::extracted dist reports '$got', expected 'cargo-dist ${DIST_VERSION}'" >&2
+            exit 1
+          fi
+          echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"
 
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: rustup toolchain install (rust-toolchain.toml pins the version; closes this job's prior lack of a pinned toolchain)
         run: rustup toolchain install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,47 @@ released before a release can proceed.
 ## [0.1.2] - 2026-08-20
 
 Maintenance release: one day of backlog close-out rationalizing the base
-feature set the estate-root contract (0.1.1) implied. Nothing here is a new
-direction — these are the verbs, declarations, and honest reports that
-should have always been there, plus the accumulated perf and hygiene debts
-paid down.
+feature set the estate-root contract (0.1.1) implied, followed by a CI/CD
+hardening pass adopting one rule — float to discover, pin to build. Nothing
+here is a new direction — these are the verbs, declarations, and honest
+reports that should have always been there, plus the accumulated perf,
+hygiene, and reproducibility debts paid down.
+
+### CI/CD and supply chain
+
+- The compiler is pinned: `rust-toolchain.toml` names 1.98.0 exactly (dev
+  boxes and CI resolve the same toolchain from the same file; the
+  dtolnay/rust-toolchain wrapper is gone), and MSRV is declared and
+  CI-checked at the measured floor 1.89.0 — set by this crate's own
+  `File::try_lock` usage, verified empirically, not inferred from metadata.
+- Every cargo invocation in CI runs `--locked`, with `cargo metadata
+  --locked` guards ahead of third-party subcommands and a
+  `git diff --exit-code` no-mutation gate; runners are numbered
+  (`ubuntu-24.04`, `macos-26`), helper tools exact-pinned
+  (`cargo-llvm-cov@0.9.0`, `cargo-deny@0.20.2`, `cargo-cyclonedx@0.5.9`),
+  and the one stray checkout v4.4.0 joined the repo-wide v7.0.1 SHA pin.
+- A weekly `canary.yml` builds against floating `stable` Rust on floating
+  `*-latest` runners — deliberately loud: no `continue-on-error`, and a red
+  run maintains an `upstream-drift` tracking issue. Required CI stays
+  deterministic; the canary is how the next upgrade PR gets discovered.
+- The release path verifies what it executes and ships: `dist` is
+  bootstrapped from its checksum-pinned, attestation-verified tarball
+  (`scripts/release/install-dist.sh`) instead of `curl | sh`, and the
+  generated shell installer now verifies archive SHA-256s before extraction
+  — dist's per-target build manifests are wired into the global build so
+  its own (previously starved) `verify_checksum()` path runs, gated in CI
+  by positive and corrupted-archive smoke tests
+  (`scripts/release/verify-installer-checksums.sh`). SBOM attestations
+  moved from the deprecated `actions/attest-sbom` to unified
+  `actions/attest` v4.2.2, keeping 1:1 target↔SBOM pairing. Each package
+  leg records a build-environment evidence file into the release assets.
+- The doctor probe image is minor-pinned (`alpine:3.24`), the direct
+  reqwest dependency moved 0.12→0.13.4 collapsing a duplicate HTTP/TLS
+  stack out of the binary, README install commands use the `/latest`
+  release alias guarded by a new docs-consistency CI step, internal
+  schema identifiers gained golden contract tests, and
+  `docs/version-policy.md` records the pinning policy — including what is
+  deliberately not pinned, and why.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,10 +599,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -639,6 +681,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -873,6 +925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1065,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1272,7 +1336,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1510,6 +1573,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,7 +1650,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1882,6 +1994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,7 +2009,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1904,7 +2022,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -1919,8 +2037,8 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
- "thiserror 2.0.19",
+ "reqwest",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1947,7 +2065,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -2204,7 +2322,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2216,6 +2334,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -2226,7 +2345,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2369,7 +2488,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -2491,44 +2610,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2542,13 +2623,22 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2619,6 +2709,7 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2626,6 +2717,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2639,11 +2742,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2662,10 +2793,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2762,11 +2934,11 @@ dependencies = [
  "opentelemetry_sdk",
  "ratatui",
  "ratatui-textarea",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "toml",
@@ -2838,6 +3010,22 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3004,7 +3192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3097,11 +3285,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3117,9 +3305,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3555,6 +3743,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,6 +3956,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "sergeant-rs"
 version = "0.1.2"
 edition = "2024"
+# Keep in sync with the `msrv` job's `env.MSRV` in .github/workflows/ci.yml
+# (W1 spec §E) — cargo has no way to read this field back into that job's
+# `run:` steps without added machinery, so the two are hand-synced.
 rust-version = "1.89.0"
 license = "MIT"
 repository = "https://github.com/miztertea/sergeant-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ opentelemetry_sdk = { version = "0.32", default-features = false, features = ["t
 # a fact nobody re-decided.
 ratatui = "0.30.2"
 ratatui-textarea = "0.9.2"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 thiserror = "2.0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sergeant-rs"
 version = "0.1.2"
 edition = "2024"
+rust-version = "1.89.0"
 license = "MIT"
 repository = "https://github.com/miztertea/sergeant-rs"
 description = "Local execution surface for coding agents: durable work, isolated git worktrees, and a complete evidence trail behind one daemon"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ catalog](#workflows) below for what a workflow actually is.
 `dist` (cargo-dist) publishes a prebuilt `sgt` for each [release](https://github.com/miztertea/sergeant-rs/releases), plus a `curl | sh` convenience installer:
 
 ```sh
-curl -fsSL https://github.com/miztertea/sergeant-rs/releases/download/v0.1.0/sergeant-rs-installer.sh | sh
+curl -fsSL https://github.com/miztertea/sergeant-rs/releases/latest/download/sergeant-rs-installer.sh | sh
 ```
 
 **As of v0.1.2 this one-liner verifies the archive it downloads.** The
@@ -87,7 +87,7 @@ extra commands, run once per release:
 ```sh
 # 1. Download the archive for your platform, its checksum file, and the installer.
 mkdir -p /tmp/sgt-install && cd /tmp/sgt-install
-gh release download v0.1.0 --repo miztertea/sergeant-rs \
+gh release download --repo miztertea/sergeant-rs \
   -p 'sergeant-rs-x86_64-unknown-linux-gnu.tar.xz' \
   -p 'sergeant-rs-x86_64-unknown-linux-gnu.tar.xz.sha256'
 

--- a/README.md
+++ b/README.md
@@ -63,19 +63,26 @@ catalog](#workflows) below for what a workflow actually is.
 curl -fsSL https://github.com/miztertea/sergeant-rs/releases/download/v0.1.0/sergeant-rs-installer.sh | sh
 ```
 
-**This one-liner does not verify anything.** It downloads the archive for
-your platform and installs it — it does not check a checksum, a signature,
-or an attestation. If you watch its output you'll see it say so plainly:
-`no checksums to verify`. That line isn't a warning about a missing file;
-`dist`'s generated installer declares the local variables it would use to
-verify a checksum but nothing in the script ever assigns them, so the
-verification branch is structurally unreachable — the installer always
-takes the "nothing to verify" path, for every release. Convenient, but it
-gives you no evidence the artifact you're running is the one this project
-published.
+**As of v0.1.2 this one-liner verifies the archive it downloads.** The
+generated installer carries the SHA-256 of every published archive and checks
+the download against it before extracting anything; a substituted or corrupted
+archive aborts the install with `checksum mismatch` and installs nothing. Every
+release run proves this on itself — the release workflow installs from a local
+origin and then re-runs the install against a deliberately substituted archive,
+and fails the release if that one is not rejected.
 
-If you want that evidence, verify by hand — it's a few extra commands, run
-once per release:
+Releases before v0.1.2 did **not** verify: `dist` fills those values in only
+when its global build can see the per-target build manifests, and this
+project's release workflow did not pass them forward until 0.1.2. Installing
+v0.1.1 or older with this one-liner prints `no checksums to verify` and installs
+unverified — for those, the manual steps below are the only evidence you get.
+
+Two things the one-liner still does not give you, at any version: it does not
+check **provenance** — that the archive came from *this* repository's release
+workflow rather than from anyone able to produce a matching hash — and its
+checksum arrives inside the very script that consumes it, from the same origin
+as the archive. To verify independently of the script, do it by hand — a few
+extra commands, run once per release:
 
 ```sh
 # 1. Download the archive for your platform, its checksum file, and the installer.
@@ -97,12 +104,13 @@ install -m 755 sergeant-rs-x86_64-unknown-linux-gnu/sgt ~/.local/bin/sgt
 sgt --version
 ```
 
-Step 2 confirms the bytes weren't corrupted or swapped in transit; step 3
-confirms they came from a GitHub Actions run of *this* repository's
-`release.yml`, via Sigstore/GitHub's build-provenance attestation — the
-thing the convenience one-liner skips entirely. Swap the target triple
-(`aarch64-apple-darwin`) and `~/.local/bin` for your platform and preferred
-install location as needed.
+Step 2 confirms the bytes weren't corrupted or swapped in transit — the same
+property the installer now checks for itself, but against a checksum you fetched
+as its own release asset rather than one embedded in the script; step 3 confirms
+they came from a GitHub Actions run of *this* repository's `release.yml`, via
+Sigstore/GitHub's build-provenance attestation — which the convenience one-liner
+still does not check. Swap the target triple (`aarch64-apple-darwin`) and
+`~/.local/bin` for your platform and preferred install location as needed.
 
 Want to see the whole loop first, with no tokens spent and no estate to
 set up? `scripts/demo.sh` builds the debug binary itself and drives it end

--- a/docs/proposals/cicd-hardening-2026-08-20.md
+++ b/docs/proposals/cicd-hardening-2026-08-20.md
@@ -1,0 +1,256 @@
+# Sprint plan — CI/CD hardening & version policy (2026-08-20)
+
+Owner-commissioned same-day follow-on to the backlog close-out sprint. Source
+material: the owner-supplied repo audit (`~/inbox/repo-analysis.md`, an external
+LLM deep-research report) **as re-ranked and verified in conversation** — the
+report is a lead sheet, not a spec. Every upstream version number it claims is
+re-verified against live registries by the `cicd-audit-recon` workflow before
+any spec cites it (results table below).
+
+**Protocol** (same as backlog close-out): integration branch
+`integration/cicd-hardening`, draft head PR carrying this plan, wave branches
+`cicd/w<N>-<slug>` in `/var/tmp/cicd-impl/` worktrees, per wave:
+recon → spec → implement → 4-axis blind panel (spec-fidelity / invariants /
+simplicity / test-honesty) + per-axis refuters defaulting to refuted → fixer on
+confirmed findings only → wave PR → merge to integration. Sonnet subagents by
+default, opus where earned, Fable never in subagents. Only the owner merges
+main. No GitHub issues filed for this sprint — this plan + the head PR
+checklist are the tracker (the backlog was just cleaned; filing 15 issues to
+close them same-day is churn).
+
+**Base**: PR #202 merged to main 2026-08-20 21:47 (merge commit 74fc2deb) —
+the owner merged before this sprint started. `integration/cicd-hardening`
+sits on main's tip; the head PR targets main with no stacking. v0.1.2 is
+merged but not yet tagged/released — **owner ruled 2026-08-20: this sprint
+ships as part of 0.1.2.** No version bump; the release waits for this head
+PR, then the owner tags v0.1.2 once (its first run also proves #200's
+repaired Latest pipeline — now with this sprint's hardened release path).
+
+**Version**: **0.1.2** (owner-ruled) — the bump already landed with #202;
+this sprint adds no version change, only extends the 0.1.2 CHANGELOG section.
+
+**Standing constraints** (owner rulings carried forward):
+- Designed for Linux/macOS/WSL — never tuned to Cerberus. Concretely: alpine
+  gets a minor-line pin, **not** a manifest digest; runner pinning stops at OS
+  generation, not self-hosted images.
+- `Cargo.toml` keeps compatible semver ranges; `Cargo.lock` is the exact pin;
+  never mass-`=x.y.z`.
+- Internal `/vN` identifiers (`sergeant.watch/v1`, `sergeant.event/v1`,
+  `sergeant.runtime/v1`, `execution/v1`) are compatibility contracts, never
+  update targets.
+- MSRV is **low priority** (binary ships prebuilt; `rust-version` serves only
+  from-source builders) — in scope as a cheap W1 tail item, dropped without
+  ceremony if measurement drags.
+
+## The one-rule target state
+
+> Discover the newest acceptable version on an upgrade branch, qualify it
+> completely, commit the exact working state, and use non-blocking canaries to
+> discover the next change.
+
+Pin at the correct layer: compatible ranges in Cargo.toml, exact graph in
+Cargo.lock (+ `--locked` everywhere), exact compiler in rust-toolchain.toml,
+full-SHA action pins, exact helper-tool releases, explicit runner generations,
+checksummed/attested artifacts.
+
+## Verified upstream versions (recon results)
+
+All numbers below verified live 2026-08-20 by the `cicd-audit-recon` workflow
+(5 sonnet agents, evidence URLs in `recon-results.json` alongside this plan).
+
+| Item | Audit claimed | Recon verified (live) | Delta |
+|---|---|---|---|
+| Rust stable | 1.98.0 | **1.98.0** — released *today* 2026-08-20; no 1.98.1 | confirmed |
+| `result_large_err` | "new in 1.98" | exists since 1.66; **1.98 fixed its async-fn false negative** (clippy #17130) — why it newly fired on `with_analytics` | audit framing corrected |
+| taiki-e/install-action | v2.86.3 | **v2.86.4** @ `a2a5f6e99e1a31540baa0468acfa302cff0f359f` (also released today; ~daily cadence) | audit stale |
+| actions/attest | v4.2.2 | **v4.2.2** @ `1e69f48acb82d1966a394da916b4c1698aa569d6`; inputs `subject-path` + `sbom-path`, README-quoted | confirmed |
+| attest-sbom deprecation | claimed | **confirmed verbatim** ("being deprecated in favor of actions/attest… inputs are compatible") | confirmed |
+| actions/checkout | v7.0.1 | v7.0.1 still latest — repo's 12 pins current; only release.yml:338 (v4.4.0) stale | confirmed |
+| upload/download-artifact, dependency-review, rust-cache, cargo-deny-action | current | all current at repo's exact pinned SHAs | confirmed, no action |
+| cargo-llvm-cov | 0.9.0 | **0.9.0** (crates.io max_stable) | confirmed |
+| cargo-deny | 0.20.2 | **0.20.2** | confirmed |
+| cargo-cyclonedx | 0.5.9 | **0.5.9** | confirmed |
+| cargo-dist | 0.32.0 current | **0.32.0** current — repo pin not stale; crates.io name still `cargo-dist` (the `dist` crate is an unrelated squat) | confirmed |
+| dist installer verifies checksums? | audit assumed patchable | **NO — upstream gap**: generated installer.sh ships `verify_checksum()` but no code path populates `_checksum_style`/`_checksum_value` for shell artifacts; always prints "no checksums to verify". cargo-dist book: "still a work in progress" | audit's fix premise wrong |
+| install-action supports cargo-dist? | (unasked) | **No** — no manifest, zero TOOLS.md hits. Bootstrap hardening needs download→verify→execute or `cargo install --locked` | new finding |
+| reqwest | 0.13.4 | **0.13.4**; migration TRIVIAL for our surface — one Cargo.toml feature rename (`rustls-tls`→`rustls`), zero src changes; async-only usage inventoried at every call site. Watch: ring→aws-lc-rs default provider; MSRV 1.85 | confirmed + derisked |
+| thiserror | 2.0.20 | **2.0.20** | confirmed |
+| ubuntu-latest | 24.04 | **Ubuntu 24.04 x64** (26.04 exists but preview) → pin `ubuntu-24.04` | confirmed |
+| macos-latest | unresolved | **macOS 26 arm64** → pin `macos-26` (same image the alias serves today; numbering jumped 15→26) | resolved |
+| alpine 3.x | unspecified | latest cycle **3.24** (patch 3.24.1) → pin `alpine:3.24` (minor line, per Cerberus rule) | resolved |
+
+## Waves
+
+### W1 — Toolchain determinism
+The local/CI compiler skew that reddened #202's CI is the motivating incident:
+local clippy 1.97.1 passed while CI's floating `stable` (1.98) failed.
+- Pin `rust-toolchain.toml` `channel` to the exact current stable
+  (recon-verified; expect 1.98.x). rustup then gives the dev box and CI the
+  same compiler.
+- Thread the pin through CI — with the precedence stated CORRECTLY (panel
+  fix): rust-toolchain.toml (rustup precedence rank 4) already outranks the
+  `rustup default` that `dtolnay/rust-toolchain@stable` sets (rank 5), so
+  the pinned file alone controls which compiler bare `cargo` calls use. The
+  six action sites (ci.yml:34,85; coverage.yml:40; matrix.yml:65;
+  release.yml:274,417) are therefore not overrides but pre-installers of the
+  WRONG (floating) toolchain — every CI job would pay an unplanned on-demand
+  fetch of the pinned one at first `cargo` call. Spec's task: make the
+  pre-install match the file under a hard constraint of **one source of
+  truth** (e.g. read the channel out of rust-toolchain.toml, or replace the
+  action with a `rustup show`-style warm-up honoring the file), preserving
+  coverage.yml's `llvm-tools` component however it lands.
+- `--locked` on every cargo invocation across all four workflows (current
+  count: zero), plus a cheap first guard
+  (`cargo metadata --locked --format-version 1 >/dev/null`) and a
+  `git diff --exit-code` post-qualification step in ci.yml.
+- Tail item (droppable): measure MSRV empirically from 1.85 upward
+  (`cargo check/test --locked`), declare `rust-version`, add a check-only MSRV
+  CI job (no clippy on old compilers — lint policy belongs to the pinned dev
+  compiler).
+
+### W2 — Actions, runners, canary
+- Stray `actions/checkout` v4.4.0 at release.yml:338 (package-installer job) →
+  the v7.0.1 SHA already used at 12 other sites.
+- `taiki-e/install-action` v2.86.2 → v2.86.4 @
+  `a2a5f6e99e1a31540baa0468acfa302cff0f359f` (full-SHA pin; project ships
+  ~daily patches — the pin records today's qualified one, the canary finds
+  the next).
+- Exact-pin the three mutable `tool:` inputs: `cargo-llvm-cov@0.9.0`
+  (coverage.yml:45), `cargo-deny@0.20.2` (release.yml:202),
+  `cargo-cyclonedx@0.5.9` (release.yml:423) — all three ARE in
+  install-action's manifest set (verified).
+- `runs-on: ubuntu-latest` → `ubuntu-24.04` and `macos-latest` → `macos-26`
+  (arm64 — exactly what the alias serves today) in every required job across
+  ci/coverage/matrix/release. Pinning to the alias's current target means
+  behavior is unchanged on day one — that IS the qualification; the wave PR's
+  own CI run on the pinned runners is the proof.
+- New canary workflow (`canary.yml`): weekly schedule + `workflow_dispatch`,
+  floating `stable` Rust on `ubuntu-latest`/`macos-latest`, runs
+  check/clippy/test `--locked`. Panel fix — the canary must be LOUD when it
+  trips, or it's not a canary: NO `continue-on-error` (it's a standalone
+  scheduled workflow, not a required PR check, so a red run blocks nothing
+  and GitHub's default scheduled-failure notification fires), plus an
+  `if: failure()` step that opens-or-updates a single "upstream drift"
+  tracking issue with the failing job link. Required CI stays deterministic;
+  a red canary is the trigger for a deliberate upgrade PR.
+- `Record build environment` evidence step in release.yml (commit, runner
+  os/arch, rustc -Vv, cargo, git, bash versions → build-environment.txt
+  uploaded with release evidence).
+
+### W3 — Release supply chain
+- Replace both `curl …cargo-dist-installer.sh | sh` bootstrap sites
+  (release.yml:282, :342). install-action does NOT carry cargo-dist
+  (recon-verified: no manifest, zero TOOLS.md hits), so the mechanism is
+  download-to-disk → verify → execute. Wave recon determines what axodotdev's
+  v0.32.0 release actually publishes to verify against (checksum sidecar
+  and/or `gh attestation verify --repo axodotdev/cargo-dist`); fallback if
+  neither exists: `cargo install cargo-dist --locked --version 0.32.0`
+  (slower, but source-built against our own lockfile discipline).
+- Sergeant's own installer verifying SHA-256 before extraction: release.yml's
+  own comment (~:315-326) records this as a known gap deferred as "the
+  owner's call" — the owner has now made that call via this sprint. But recon
+  falsified the audit's premise: dist 0.32's generated installer ships a full
+  `verify_checksum()` implementation that is NEVER fed — no code path
+  populates `_checksum_style`/`_checksum_value` for shell artifacts (verified
+  against our own v0.1.1 release asset), and the cargo-dist book calls shell
+  installer checksum wiring "still a work in progress". No config flag or
+  version bump fixes this. The spec chooses between exactly two honest
+  options and the choice is a **ratify-at-review** item:
+  (a) post-process the generated installer in `package-installer` to inject
+      the per-artifact sha256 values dist itself computed (the `.sha256`
+      sidecars), gated by BOTH a positive smoke test and a corrupted-archive
+      negative test — the injection targets the exact hook `verify_checksum()`
+      already exposes, so the patch is data, not logic; or
+  (b) don't touch the generated artifact: keep the README's documented manual
+      `sha256sum -c` + `gh attestation verify` path as the verification
+      story, record the upstream gap in docs/version-policy.md, and revisit
+      when cargo-dist lands its own wiring.
+  My recommendation going in: (a), because the verification hook is
+  upstream's own and the negative test makes the patch honest — but the spec
+  must prove the injection survives dist regenerating the installer
+  byte-for-byte differently across targets before committing to it.
+- Migrate the two `actions/attest-sbom` v4.1.0 steps (release.yml:499,:505)
+  to `actions/attest` v4.2.2 @ `1e69f48acb82d1966a394da916b4c1698aa569d6`.
+  Deprecation confirmed from attest-sbom's own README; inputs are
+  declared compatible (`subject-path` + `sbom-path`, quoted from the live
+  actions/attest README) — a low-risk swap.
+  **Preserve** the 1:1 target↔SBOM pairing the current design defends in its
+  comments, and the existing least-privilege permissions layout.
+  (`attest-build-provenance` is already current at v4.2.2 — untouched.)
+- `alpine:3` probe image (src/backend/docker.rs:138 PROD_PROBE_IMAGE, plus
+  test fixtures :1350,:1475,:1521,:1523) → `alpine:3.24` (current cycle,
+  patch 3.24.1). Minor pin only, per the Cerberus rule.
+
+### W4 — Dependencies, docs, contracts
+- reqwest direct dep 0.12 → 0.13.4: our direct line is the only holder of
+  0.12.28 in the lockfile while opentelemetry-otlp already brings 0.13.4 —
+  migration deletes a duplicate HTTP/TLS stack. Recon already inventoried
+  every `reqwest::` call site against 0.13.0's breaking-change list: our
+  surface (async `Client::builder().timeout().build()`, `.send()`,
+  `.json()` both directions, `reqwest::Error`/`Response` types) is untouched;
+  the ONE required change is the Cargo.toml feature rename
+  `rustls-tls` → `rustls`. Two verifications the wave must still run:
+  grep for `CryptoProvider`/`rustls::crypto::ring` conflicts (0.13 defaults
+  the provider to aws-lc-rs) and confirm both platform builds in CI. Gate:
+  full test suite + `cargo tree -i reqwest@0.12.28` returns nothing.
+- thiserror 2.0.19 → 2.0.20 (precise bump).
+- README release literals: two `v0.1.0` sites (README.md:63,:83) are now two
+  releases stale. Spec decides per-site between `/latest` URLs (the badge
+  #200 fixed now makes Latest trustworthy) and current-literal + a CI
+  docs-consistency check (version extracted from `cargo metadata`, grep for
+  stale literals — new cheap step in ci.yml). Recurrence prevention is the
+  requirement; the mechanism is the spec's call.
+- `docs/version-policy.md`: the policy table (pin-at-the-correct-layer rules
+  above, including what is deliberately NOT pinned and why — alpine digest,
+  crate `=` pins — so future audits don't re-litigate).
+- Contract tests for the internal schema identifiers — precise inventory
+  first (panel correction: the runtime descriptor schema is already
+  `sergeant.runtime/v2` at daemon.rs:58, not v1; current set is watch/v1,
+  event/v1, execution/v1, runtime/v2). Verify what coverage already exists
+  (event.rs and daemon.rs already assert schema strings), add golden
+  fixtures only where missing. Small; no protocol changes.
+- Stale-comment truth pass (audit Low item, panel-verified live instance):
+  ci.yml:56 claims matrix runs "PR-to-main, nightly, and release" but
+  matrix.yml is `workflow_call`/`workflow_dispatch` only (ADR-0014-D9
+  topology). Fix that comment and sweep workflows for similar
+  topology-drift comments.
+- Audit Low-item dispositions, stated so nothing drops silently:
+  duplicate-transitive-version documentation → a short subsection of
+  docs/version-policy.md (the one named duplicate, reqwest 0.12/0.13, is
+  eliminated by this very wave); machine-readable non-Cargo tool inventory →
+  **deliberately declined** (Cerberus rule — version-policy.md's prose table
+  is the inventory; a schema for two shell scripts and four tools is
+  process for its own sake).
+
+### Finalize (head PR release-ready)
+Extend the existing 0.1.2 CHANGELOG section with this sprint's entries (no
+version bump — owner-ruled), Cargo.lock sync (reqwest/thiserror), README
+consistency re-check against 0.1.2, full local gate (fmt/clippy/test with
+the pinned toolchain, `--locked`), head PR with wave checklist +
+ratify-at-review items.
+
+## Wave ordering & conflict control
+Strictly serial W1→W2→W3→W4. W1↔W2↔W3 is conflict-forced (W1's pin +
+`--locked` change every workflow file W2/W3 also touch; W2 and W3 both edit
+release.yml). W3→W4 is NOT conflict-forced (panel note: W4 touches only
+Cargo.{toml,lock}, README, docs, fixtures) — serial there is a deliberate
+simplicity choice: one integration head to reason about, one wave in flight,
+same rebase discipline throughout. Each wave rebases on integration head
+before its PR.
+
+## Ratify-at-review items (owner, at head PR)
+1. ~~Version~~ — ruled in-session: ships in 0.1.2, no bump.
+2. Installer verification: option (a) checksum injection vs (b) documented
+   manual verification + upstream wait — spec's choice flagged in the PR body
+   with the dist-gap evidence.
+3. macOS pin `macos-26` (arm64 — what `macos-latest` already serves; flagged
+   in case the owner prefers `macos-15` for an extra generation of headroom).
+
+## Risks
+- reqwest 0.13 migration is the only change touching runtime code paths
+  (webhooks/OTLP HTTP); mitigated by wave recon + full suite + panel.
+- Pinned-runner day-one equivalence depends on recon reading the alias
+  mapping correctly; mitigated by CI itself (wave PR runs on the pinned
+  runners).
+- (resolved) The plan originally stacked on unmerged #202; the owner had in
+  fact already merged it — branch was reset onto main @ 74fc2deb.

--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -1,0 +1,145 @@
+# Version policy
+
+How sergeant-rs pins its dependencies, tools, and runners — and, just as
+importantly, what it deliberately does *not* pin and why. Written so a
+future audit does not re-litigate a decision already made here. Source:
+the CI/CD hardening sprint plan (`sprint-plan-2026-08-20.md`), "The
+one-rule target state":
+
+> Discover the newest acceptable version on an upgrade branch, qualify it
+> completely, commit the exact working state, and use non-blocking
+> canaries to discover the next change.
+
+## Pin at the correct layer
+
+| Layer | Mechanism | Example |
+|---|---|---|
+| Crate compatible range | `Cargo.toml` semver range, never `=x.y.z` | `reqwest = "0.13"`, `duckdb = "1"`, `axum = "0.8"` |
+| Crate exact graph | `Cargo.lock`, enforced everywhere with `--locked` | every `cargo` invocation in `ci.yml`, `matrix.yml`, `coverage.yml`, `release.yml` |
+| Compiler | `rust-toolchain.toml` exact channel | `channel = "1.98.0"` |
+| GitHub Actions | full 40-char SHA + a `# vX.Y.Z` comment | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`, `Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2` |
+| `install-action` helper tools | exact version per `tool:` input | `cargo-llvm-cov@0.9.0` (`coverage.yml`), `cargo-deny@0.20.2` and `cargo-cyclonedx@0.5.9` (`release.yml`) |
+| `cargo-dist` | exact version, `[workspace.metadata.dist]` | `cargo-dist-version = "0.32.0"` (`Cargo.toml`) |
+| CI/release runners | explicit OS generation, never the floating alias | `ubuntu-24.04`, `macos-26` — required in every job in `ci.yml`/`matrix.yml`/`coverage.yml`/`release.yml` |
+| Release artifacts | checksummed + attested | per-target `.sha256` sidecars, `actions/attest` provenance + SBOM, `gh attestation verify` (README's manual-verification section) |
+
+The floating `stable`/`ubuntu-latest`/`macos-latest` aliases appear in
+exactly one place on purpose: `canary.yml` (weekly schedule +
+`workflow_dispatch`). That is canary's whole job — notice the alias moving
+before required CI does. Required CI (`ci.yml`, `matrix.yml`) stays on the
+pinned toolchain and pinned runner generations regardless of canary state;
+a red canary triggers a deliberate upgrade PR, never a silent auto-bump. No
+`continue-on-error` on the canary job — a green run means nothing changed
+upstream; a red one is the signal, and GitHub's default scheduled-failure
+notification plus the workflow's own `if: failure()` "upstream drift"
+tracking-issue step both depend on the run actually going red when
+something moved.
+
+## Deliberate non-pins
+
+These are gaps only if you don't already know why. They're not gaps.
+
+**Alpine minor-line, not a manifest digest.** `PROD_PROBE_IMAGE` in
+`src/backend/docker.rs` and the matching test fixtures pin `alpine:3.24` —
+the current minor cycle (patch 3.24.1) — not a `sha256:` digest. This repo
+is designed for Linux/macOS/WSL and is never tuned to a specific self-hosted
+image generation ("Cerberus"); runner and base-image pinning stops at the
+OS/distro generation, not at a byte-exact manifest. A digest pin would swap
+"drifts with the next Alpine 3.24 patch" for "never gets a security patch
+without a manual bump" — the wrong trade for a probe image, not a supply
+chain artifact.
+
+**Crate versions stay ranges, never mass-`=x.y.z`.** `Cargo.lock` is already
+the exact pin every build actually uses (with `--locked` enforced
+everywhere). A blanket `=` policy in `Cargo.toml` would duplicate what the
+lockfile already guarantees while turning every transitive bump into a
+manual `Cargo.toml` edit for no added safety.
+
+**No machine-readable tool inventory.** The two shell installers
+(`scripts/*.sh`) and the four `install-action`/`cargo-dist` tool versions
+are not captured in a schema or manifest file of their own — this
+document's tables *are* the inventory. A structured format for four tools
+and two scripts is process for its own sake; this table is read by people,
+not parsed by tooling, and that's the right size for what it covers.
+
+## Duplicate transitives
+
+The pattern: two versions of the same crate resolve simultaneously because
+one dependency pins a different line than sergeant's own direct dependency.
+Worth naming explicitly so a future "why are there two X in the lockfile"
+question has an answer here instead of becoming a fresh investigation.
+
+- **Eliminated this wave**: `reqwest` 0.12.28 (sergeant's own direct
+  dependency) and 0.13.4 (transitively via `opentelemetry-otlp`) both
+  resolved simultaneously before the reqwest 0.13 migration. Collapsed to a
+  single `reqwest 0.13.4` by that migration (see the sprint's W4 wave) —
+  `cargo tree -i reqwest@0.12.28` now returns "did not match any packages".
+- **Surfaced by the same migration, understood, not a conflict**: `ring
+  0.17.14` (via `ureq 3.4.0`, a **build-dependency** of `libduckdb-sys`'s
+  `bundled` feature — compiled and run only inside that crate's `build.rs`,
+  never linked into the `sgt` binary) coexists with `aws-lc-rs 1.16.2` (via
+  reqwest 0.13.4's `rustls` feature, sergeant's actual runtime TLS
+  provider — reqwest 0.13's `rustls` feature is defined as
+  `__rustls-aws-lc-rs + rustls-platform-verifier + __rustls`, i.e. enabling
+  it is what first pulls `aws-lc-rs` into this tree at all). These are two
+  different processes with two different `rustls::crypto::CryptoProvider`
+  installs; a `CryptoProvider` conflict only matters within one process, and
+  grep of `src/` for `CryptoProvider`/`rustls::crypto`/`install_default`
+  returns zero hits — nothing in sergeant's own runtime code races to
+  install a provider either. Not a false alarm to re-discover; recorded here
+  once.
+
+## MSRV
+
+`Cargo.toml`'s `rust-version = "1.89.0"` is a **from-source-builder-only**
+floor — the `sgt` binary itself always ships prebuilt via `cargo-dist`, so
+this field serves nobody who installs a release. It exists for anyone
+building from a clone. The number is measured empirically, not predicted:
+`ci.yml`'s `msrv` job comment records that a static `cargo-metadata` scan of
+dependency `rust-version` fields under-predicted the floor by one minor
+version, because this crate's own use of
+`std::fs::File::try_lock`/`TryLockError` (stabilized 1.89.0) isn't visible
+to that kind of scan. `cargo +1.89.0 check --locked --all-targets` and
+`cargo +1.89.0 test --locked` were run directly to confirm the real floor
+before this field and the `msrv` CI job were added. That job runs
+`cargo check` only — no `clippy` — because lint policy belongs to the pinned
+dev compiler (`rust-toolchain.toml`), not to a deliberately-older
+from-source floor. Keep `Cargo.toml:8`'s `rust-version` and `ci.yml`'s
+`env.MSRV` hand-synced (no shared source of truth exists between TOML and
+YAML without added machinery); both carry a comment pointing at the other.
+
+## Canary
+
+`canary.yml`: weekly schedule + `workflow_dispatch`, deliberately floating
+`stable` Rust on `ubuntu-latest`/`macos-latest` (the one place in this repo
+those aliases are intentional — see "Pin at the correct layer" above), runs
+`check`/`clippy`/`test --locked`. No `continue-on-error`: it is a standalone
+scheduled workflow, not a required PR check, so a red run blocks nothing
+and GitHub's own scheduled-failure notification fires on it. An `if:
+failure()` step opens-or-updates a single tracking issue with the failing
+job link, so drift doesn't need someone to notice a red badge by chance. A
+red canary is the trigger for a deliberate, reviewed upgrade PR — never a
+silent auto-bump, and required CI stays on the pinned toolchain/runners
+throughout, unaffected by canary state.
+
+## Internal `/vN` identifiers are contracts, not update targets
+
+Four schema identifiers, each a compatibility contract:
+
+| Schema | Constant | Location | Current value |
+|---|---|---|---|
+| Watch | `WATCH_SCHEMA` | `src/watch.rs:34` | `sergeant.watch/v1` |
+| Event | `EVENT_SCHEMA` | `src/domain/event.rs:15` | `sergeant.event/v1` |
+| Execution | `SCHEMA_VERSION` | `src/backend/docker.rs:130` | `execution/v1` |
+| Runtime descriptor | `DESCRIPTOR_SCHEMA` | `src/daemon.rs:58` | `sergeant.runtime/v2` |
+
+Bumping any of these is a breaking-change event requiring an explicit
+compatibility decision — never a routine "current version" edit the way a
+`Cargo.toml` range or a README release literal is. The one identifier that
+*has* been bumped, the runtime descriptor (v1 → v2), models the expected
+shape of that decision: no compatibility shim, an old descriptor fails
+closed with a diagnostic naming both schema versions and the concrete
+remedy (`sgt daemon stop` then restart) — see `src/daemon.rs`'s
+`read_descriptor` and its `a_v1_descriptor_fails_closed_with_a_restart_remedy`
+test. A future bump to any of the other three should read as a deliberate
+repeat of that pattern, not a fresh design.

--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -77,7 +77,7 @@ question has an answer here instead of becoming a fresh investigation.
 - **Surfaced by the same migration, understood, not a conflict**: `ring
   0.17.14` (via `ureq 3.4.0`, a **build-dependency** of `libduckdb-sys`'s
   `bundled` feature — compiled and run only inside that crate's `build.rs`,
-  never linked into the `sgt` binary) coexists with `aws-lc-rs 1.16.2` (via
+  never linked into the `sgt` binary) coexists with `aws-lc-rs 1.18.0` (via
   reqwest 0.13.4's `rustls` feature, sergeant's actual runtime TLS
   provider — reqwest 0.13's `rustls` feature is defined as
   `__rustls-aws-lc-rs + rustls-platform-verifier + __rustls`, i.e. enabling

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.98.0"

--- a/scripts/coverage/c1-lib.sh
+++ b/scripts/coverage/c1-lib.sh
@@ -21,7 +21,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cov_stage_begin c1
 
-cov_run cargo llvm-cov --no-report --lib || cov_fail "the unit tests failed under instrumentation"
+cov_run cargo llvm-cov --no-report --lib --locked || cov_fail "the unit tests failed under instrumentation"
 
 # One test binary ran, so one profraw is the floor. Zero means the binary
 # never flushed — a crash, an abort, or a profile pattern pointing somewhere

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -18,19 +18,19 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/common.sh"
 
 cov_stage_begin c2-m1_event_core
-cov_run cargo llvm-cov --no-report --test m1_event_core || cov_fail "m1_event_core failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m1_event_core --locked || cov_fail "m1_event_core failed under instrumentation"
 cov_stage_end 1 "the m1 test binary must write its own profile"
 
 cov_stage_begin c2-m4_backends
-cov_run cargo llvm-cov --no-report --test m4_backends || cov_fail "m4_backends failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m4_backends --locked || cov_fail "m4_backends failed under instrumentation"
 cov_stage_end 1 "the m4 test binary must write its own profile"
 
 cov_stage_begin c2-m3_execution
-cov_run cargo llvm-cov --no-report --test m3_execution || cov_fail "m3_execution failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m3_execution --locked || cov_fail "m3_execution failed under instrumentation"
 cov_stage_end 1 "the m3 test binary must write its own profile"
 
 cov_stage_begin c2-m5_projections
-cov_run cargo llvm-cov --no-report --test m5_projections || cov_fail "m5_projections failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m5_projections --locked || cov_fail "m5_projections failed under instrumentation"
 cov_stage_end 1 "the m5 test binary must write its own profile"
 
 # Added 2026-08-19. These four suites existed in tests/ but were invoked by no
@@ -43,21 +43,21 @@ cov_stage_end 1 "the m5 test binary must write its own profile"
 # than spawning, so all four sit here rather than in C3, whose floor rule is
 # written for suites dominated by real `sgt` subprocesses.
 cov_stage_begin c2-m8_estate_cli
-cov_run cargo llvm-cov --no-report --test m8_estate_cli || cov_fail "m8_estate_cli failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m8_estate_cli --locked || cov_fail "m8_estate_cli failed under instrumentation"
 cov_stage_end 1 "the m8 test binary must write its own profile"
 
 cov_stage_begin c2-m9_watch
-cov_run cargo llvm-cov --no-report --test m9_watch || cov_fail "m9_watch failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m9_watch --locked || cov_fail "m9_watch failed under instrumentation"
 cov_stage_end 1 "the m9 test binary must write its own profile"
 
 cov_stage_begin c2-m10_harness
-cov_run cargo llvm-cov --no-report --test m10_harness || cov_fail "m10_harness failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m10_harness --locked || cov_fail "m10_harness failed under instrumentation"
 cov_stage_end 1 "the m10 test binary must write its own profile"
 
 cov_stage_begin c2-estate_routes
-cov_run cargo llvm-cov --no-report --test estate_routes || cov_fail "estate_routes failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test estate_routes --locked || cov_fail "estate_routes failed under instrumentation"
 cov_stage_end 1 "the estate_routes test binary must write its own profile"
 
 cov_stage_begin c2-t2_workflow_catalog
-cov_run cargo llvm-cov --no-report --test t2_workflow_catalog || cov_fail "t2_workflow_catalog failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test t2_workflow_catalog --locked || cov_fail "t2_workflow_catalog failed under instrumentation"
 cov_stage_end 1 "the t2_workflow_catalog test binary must write its own profile"

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -22,12 +22,12 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/common.sh"
 
 cov_stage_begin c3-m2_daemon_api
-cov_run cargo llvm-cov --no-report --test m2_daemon_api || cov_fail "m2_daemon_api failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m2_daemon_api --locked || cov_fail "m2_daemon_api failed under instrumentation"
 cov_stage_end 2 "m2 spawns clients and daemons; more than the test binary's own profile must arrive, \
 or no subprocess flushed and the suite's real coverage is missing"
 
 cov_stage_begin c3-m6_surfaces
-cov_run cargo llvm-cov --no-report --test m6_surfaces || cov_fail "m6_surfaces failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m6_surfaces --locked || cov_fail "m6_surfaces failed under instrumentation"
 cov_stage_end 2 "m6 spawns daemons (TUI, doctor) and runs scripts/demo.sh; more than the test \
 binary's own profile must arrive, or no subprocess flushed"
 
@@ -43,6 +43,6 @@ binary's own profile must arrive, or no subprocess flushed"
 # The trade is stated rather than hidden: on a Docker-capable host this stage
 # will not catch a subprocess that silently failed to flush.
 cov_stage_begin c3-m7_docker_executor
-cov_run cargo llvm-cov --no-report --test m7_docker_executor || cov_fail "m7_docker_executor failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m7_docker_executor --locked || cov_fail "m7_docker_executor failed under instrumentation"
 cov_stage_end 1 "the m7 test binary must write its own profile; container subprocesses are not \
 required because the suite self-skips where Docker is unreachable"

--- a/scripts/release/install-dist.sh
+++ b/scripts/release/install-dist.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Bootstrap `dist` (cargo-dist) from its attested, checksum-pinned prebuilt
+# tarball — NOT `curl … cargo-dist-installer.sh | sh`. Measured against
+# axodotdev's own release assets (w3-recon.md §1, 2026-08-21):
+# cargo-dist-installer.sh has no `.sha256` sidecar, is absent from the
+# aggregate `sha256.sum`, and has no build-provenance attestation at all
+# (`gh attestation verify cargo-dist-installer.sh --repo axodotdev/cargo-dist`
+# → HTTP 404). The per-target tarballs have both.
+#
+# Two checks, deliberately, because they prove different things: the
+# committed sha256 pins the exact bytes we qualified for this version (an
+# attestation alone would accept a *different* axodotdev-built tarball served
+# from the same URL), and `gh attestation verify` proves those bytes came out
+# of axodotdev/cargo-dist's own release workflow rather than merely matching a
+# hash someone uploaded. Neither check subsumes the other.
+#
+# Bumping the version means re-recording both sha256 literals below from that
+# release's `sha256.sum` — deliberately, so a version bump is a qualification,
+# not a one-character edit. Shared by both bootstrap call sites in
+# .github/workflows/release.yml (package, package-installer) so there is one
+# copy of the pinned hashes to re-qualify, not two.
+#
+# Requires GH_TOKEN in the environment (for `gh attestation verify`) and the
+# GitHub Actions runner environment: RUNNER_OS, RUNNER_ARCH, RUNNER_TEMP,
+# GITHUB_PATH.
+#
+# Usage: install-dist.sh <dist-version>
+#   e.g. install-dist.sh 0.32.0
+set -euo pipefail
+
+dist_version=${1:?usage: install-dist.sh <dist-version>}
+
+case "${RUNNER_OS}-${RUNNER_ARCH}" in
+  Linux-X64)
+    dist_target="x86_64-unknown-linux-gnu"
+    dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
+    ;;
+  macOS-ARM64)
+    dist_target="aarch64-apple-darwin"
+    dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
+    ;;
+  *)
+    echo "::error::no qualified cargo-dist ${dist_version} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+    exit 1
+    ;;
+esac
+
+archive="cargo-dist-${dist_target}.tar.xz"
+curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
+  "https://github.com/axodotdev/cargo-dist/releases/download/v${dist_version}/${archive}"
+echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c "${RUNNER_TEMP}/dist.sha256"
+else
+  shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
+fi
+gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
+mkdir -p "${RUNNER_TEMP}/dist-bin"
+tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
+got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
+if [ "$got" != "cargo-dist ${dist_version}" ]; then
+  echo "::error::extracted dist reports '$got', expected 'cargo-dist ${dist_version}'" >&2
+  exit 1
+fi
+echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"

--- a/scripts/release/verify-installer-checksums.sh
+++ b/scripts/release/verify-installer-checksums.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Prove the generated sergeant-rs installer actually verifies what it downloads.
+#
+# Two tests, run against a local origin so nothing here touches the network or a
+# published release:
+#   positive — the real archive installs, and the installer does NOT take its
+#              "no checksums to verify" path;
+#   negative — a structurally valid but WRONG archive served under the right
+#              filename (the supply-chain substitution a checksum defends
+#              against) is rejected with a non-zero exit and nothing installed.
+#
+# A single-byte corruption is deliberately NOT used: xz's frame CRC rejects it
+# before the installer's checksum ever runs, which would prove the wrong thing.
+#
+# Usage: verify-installer-checksums.sh <installer.sh> <artifacts-dir> <tag>
+#   e.g. verify-installer-checksums.sh target/distrib/sergeant-rs-installer.sh \
+#          target/distrib v0.1.2
+set -euo pipefail
+
+installer=${1:?usage: verify-installer-checksums.sh <installer.sh> <artifacts-dir> <tag>}
+artifacts_dir=${2:?usage: verify-installer-checksums.sh <installer.sh> <artifacts-dir> <tag>}
+tag=${3:?usage: verify-installer-checksums.sh <installer.sh> <artifacts-dir> <tag>}
+
+# This script runs on a linux x86_64 runner, so the installer will select the
+# x86_64 archive; the darwin archive is the substitute for the negative test.
+host_archive="sergeant-rs-x86_64-unknown-linux-gnu.tar.xz"
+other_archive="sergeant-rs-aarch64-apple-darwin.tar.xz"
+port="${INSTALLER_SMOKE_PORT:-8917}"
+
+for f in "$installer" "$artifacts_dir/$host_archive" "$artifacts_dir/$other_archive"; do
+  if [ ! -f "$f" ]; then
+    echo "::error::installer smoke test needs $f, which is not present" >&2
+    exit 1
+  fi
+done
+
+work=$(mktemp -d)
+server_pid=""
+cleanup() {
+  if [ -n "$server_pid" ]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+# Mirror GitHub's release-download URL layout; the installer appends
+# /miztertea/sergeant-rs/releases/download/<tag> to the base URL it is given.
+download_dir="$work/srv/miztertea/sergeant-rs/releases/download/$tag"
+mkdir -p "$download_dir"
+cp "$artifacts_dir/$host_archive" "$artifacts_dir/$other_archive" "$download_dir/"
+
+python3 -m http.server "$port" --bind 127.0.0.1 --directory "$work/srv" \
+  >"$work/http.log" 2>&1 &
+server_pid=$!
+
+ready=0
+for _ in $(seq 1 50); do
+  if curl -fsS -I -o /dev/null \
+    "http://127.0.0.1:$port/miztertea/sergeant-rs/releases/download/$tag/$host_archive"; then
+    ready=1
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" -ne 1 ]; then
+  echo "::error::local origin did not come up on 127.0.0.1:$port" >&2
+  cat "$work/http.log" >&2
+  exit 1
+fi
+
+# SERGEANT_RS_INSTALL_DIR / SERGEANT_RS_NO_MODIFY_PATH / ..._GITHUB_BASE_URL are
+# the generated installer's own env vars — nothing here edits the script.
+run_installer() {
+  local dest=$1 log=$2 rc=0
+  mkdir -p "$dest"
+  SERGEANT_RS_INSTALLER_GITHUB_BASE_URL="http://127.0.0.1:$port" \
+  SERGEANT_RS_INSTALL_DIR="$dest" \
+  SERGEANT_RS_NO_MODIFY_PATH=1 \
+    sh "$installer" >"$log" 2>&1 || rc=$?
+  return "$rc"
+}
+
+# ── positive ────────────────────────────────────────────────────────────────
+if ! run_installer "$work/good" "$work/good.log"; then
+  echo "::error::installer failed against a VALID archive" >&2
+  cat "$work/good.log" >&2
+  exit 1
+fi
+if grep -q 'no checksums to verify' "$work/good.log"; then
+  echo "::error::installer took its unverified path ('no checksums to verify') — the generated installer carries no checksum values" >&2
+  cat "$work/good.log" >&2
+  exit 1
+fi
+if [ ! -x "$work/good/bin/sgt" ]; then
+  echo "::error::installer reported success but did not install $work/good/bin/sgt" >&2
+  cat "$work/good.log" >&2
+  exit 1
+fi
+"$work/good/bin/sgt" --version
+
+# ── negative ────────────────────────────────────────────────────────────────
+# Serve a different, structurally valid archive under the host archive's name.
+cp "$download_dir/$other_archive" "$download_dir/$host_archive"
+if run_installer "$work/bad" "$work/bad.log"; then
+  echo "::error::installer ACCEPTED a substituted archive — checksum verification is not effective" >&2
+  cat "$work/bad.log" >&2
+  exit 1
+fi
+if ! grep -q 'checksum mismatch' "$work/bad.log"; then
+  echo "::error::installer rejected the substituted archive, but not for a checksum mismatch — the negative test is not proving what it claims" >&2
+  cat "$work/bad.log" >&2
+  exit 1
+fi
+if [ -e "$work/bad/bin/sgt" ]; then
+  echo "::error::installer aborted on checksum mismatch but still left a binary behind" >&2
+  exit 1
+fi
+
+echo "installer smoke test: valid archive installed and verified; substituted archive rejected on checksum mismatch"

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -135,7 +135,7 @@ const WORKSPACE_MOUNT: &str = "/estate";
 /// The small, always-pullable image [`DockerBackend::lifecycle_probe`] uses
 /// in production (`sgt doctor`) — see its own doc for why a test may need a
 /// different one (the environments matrix, §22.7's probe-gating rule).
-pub const PROD_PROBE_IMAGE: &str = "alpine:3";
+pub const PROD_PROBE_IMAGE: &str = "alpine:3.24";
 
 /// The `--user uid:gid` value to run a container as, so its writes into a
 /// `read_write` mount come out owned by whoever already owns the mounted
@@ -695,7 +695,7 @@ impl DockerBackend {
     /// the module docs). Mounts a scratch directory, verifies a write is
     /// visible on the host, and cleans up its own labeled container.
     /// `probe_image` should be a small image sergeant can rely on
-    /// (`alpine:3` in production; a test may point this at a locally-built
+    /// (`alpine:3.24` in production; a test may point this at a locally-built
     /// probe image instead, per the environments matrix — §22.7's
     /// probe-gating rule).
     pub fn lifecycle_probe(&self, probe_image: &str) -> DockerLifecycleProbe {
@@ -1347,7 +1347,7 @@ mod tests {
             model: None,
             profile: None,
             execute: Some(ExecuteSpec {
-                image: "alpine:3".into(),
+                image: "alpine:3.24".into(),
                 command: vec!["true".into()],
                 workdir: "/estate".into(),
                 workspace_access: WorkspaceAccess::ReadOnly,
@@ -1472,7 +1472,7 @@ mod tests {
                 bindings: Vec::new(),
             };
             let spec = ExecuteSpec {
-                image: "alpine:3".into(),
+                image: "alpine:3.24".into(),
                 command: vec!["true".into()],
                 workdir: "/estate".into(),
                 workspace_access: WorkspaceAccess::ReadOnly,
@@ -1518,7 +1518,7 @@ mod tests {
         let backend = DockerBackend::new(config).expect("backend");
         assert!(backend.read_pin("w1", "s1").is_none());
         let image = ResolvedImage {
-            image_requested: "alpine:3".into(),
+            image_requested: "alpine:3.24".into(),
             image_id: "sha256:deadbeef".into(),
             repo_digests: vec!["alpine@sha256:deadbeef".into()],
             platform: "linux/amd64".into(),

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -1319,6 +1319,14 @@ mod tests {
     }
 
     #[test]
+    fn execution_schema_label_is_the_pinned_contract_string() {
+        assert_eq!(
+            format!("{LABEL_SCHEMA}={SCHEMA_VERSION}"),
+            "io.sergeant.schema=execution/v1"
+        );
+    }
+
+    #[test]
     fn container_name_is_deterministic_from_execution_id() {
         let (_dir, config) = config();
         let backend = DockerBackend::new(config).expect("backend");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1220,6 +1220,46 @@ mod tests {
         );
     }
 
+    /// Complements `a_v1_descriptor_fails_closed_with_a_restart_remedy` above:
+    /// the positive case for the *current* schema, going through the same
+    /// on-disk file-write → `read_descriptor` path (not the in-memory
+    /// `descriptor_bound_to()` helper, which never touches disk).
+    #[test]
+    fn a_v2_descriptor_round_trips_through_read_descriptor() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(
+            dir.path().join(DESCRIPTOR_FILE),
+            serde_json::json!({
+                "schema": DESCRIPTOR_SCHEMA,
+                "endpoint": "http://127.0.0.1:1",
+                "pid": 1,
+                "api_revision": API_REVISION,
+                "token": "t",
+                "estate_root": "/estates/payments",
+                "manifest_path": "/estates/payments/sergeant.toml",
+            })
+            .to_string(),
+        )
+        .expect("write v2 descriptor");
+
+        let descriptor = read_descriptor(dir.path())
+            .expect("read must succeed")
+            .expect("descriptor must be present");
+        assert_eq!(descriptor.schema, DESCRIPTOR_SCHEMA);
+        assert_eq!(descriptor.endpoint, "http://127.0.0.1:1");
+        assert_eq!(descriptor.pid, 1);
+        assert_eq!(descriptor.api_revision, API_REVISION);
+        assert_eq!(descriptor.token, "t");
+        assert_eq!(
+            descriptor.estate_root.as_deref(),
+            Some(Path::new("/estates/payments"))
+        );
+        assert_eq!(
+            descriptor.manifest_path.as_deref(),
+            Some(Path::new("/estates/payments/sergeant.toml"))
+        );
+    }
+
     /// A minimal, directly-constructed [`Core`] over a fresh journal — no
     /// HTTP surface, no engine, just what the committer and the export loop
     /// actually touch.

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -1838,7 +1838,7 @@ mod tests {
                 "\n",
                 "[stage.\"00-validate\"]\n",
                 "kind = \"execute\"\n",
-                "image = \"alpine:3\"\n",
+                "image = \"alpine:3.24\"\n",
                 "command = [\"true\"]\n",
                 "workdir = \"/estate\"\n",
                 "workspace_access = \"read_only\"\n",
@@ -1877,7 +1877,7 @@ mod tests {
             (
                 "no-command",
                 concat!(
-                    "image = \"alpine:3\"\n",
+                    "image = \"alpine:3.24\"\n",
                     "workdir = \"/estate\"\n",
                     "workspace_access = \"read_only\"\n",
                     "network = \"none\"\n"
@@ -1886,7 +1886,7 @@ mod tests {
             (
                 "no-workdir",
                 concat!(
-                    "image = \"alpine:3\"\n",
+                    "image = \"alpine:3.24\"\n",
                     "command = [\"true\"]\n",
                     "workspace_access = \"read_only\"\n",
                     "network = \"none\"\n"
@@ -1895,7 +1895,7 @@ mod tests {
             (
                 "no-access",
                 concat!(
-                    "image = \"alpine:3\"\n",
+                    "image = \"alpine:3.24\"\n",
                     "command = [\"true\"]\n",
                     "workdir = \"/estate\"\n",
                     "network = \"none\"\n"
@@ -1904,7 +1904,7 @@ mod tests {
             (
                 "no-network",
                 concat!(
-                    "image = \"alpine:3\"\n",
+                    "image = \"alpine:3.24\"\n",
                     "command = [\"true\"]\n",
                     "workdir = \"/estate\"\n",
                     "workspace_access = \"read_only\"\n"
@@ -1946,7 +1946,7 @@ mod tests {
             wf.join(WORKFLOW_FILE),
             concat!(
                 "[workflow]\nname = \"bad-access\"\nversion = \"1\"\nstages = [\"00-only\"]\n\n",
-                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3\"\n",
+                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3.24\"\n",
                 "command = [\"true\"]\nworkdir = \"/estate\"\n",
                 "workspace_access = \"read_and_write_and_more\"\nnetwork = \"none\"\n",
             ),
@@ -1964,7 +1964,7 @@ mod tests {
             wf.join(WORKFLOW_FILE),
             concat!(
                 "[workflow]\nname = \"bad-network\"\nversion = \"1\"\nstages = [\"00-only\"]\n\n",
-                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3\"\n",
+                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3.24\"\n",
                 "command = [\"true\"]\nworkdir = \"/estate\"\n",
                 "workspace_access = \"read_only\"\nnetwork = \"bridge\"\n",
             ),
@@ -1991,7 +1991,7 @@ mod tests {
             concat!(
                 "[workflow]\nname = \"misplaced-actor-field\"\nversion = \"1\"\n",
                 "stages = [\"00-only\"]\n\n",
-                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3\"\n",
+                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3.24\"\n",
                 "command = [\"true\"]\nworkdir = \"/estate\"\n",
                 "workspace_access = \"read_only\"\nnetwork = \"none\"\nharness = \"claude\"\n",
             ),
@@ -2270,7 +2270,7 @@ mod tests {
                 "\n",
                 "[stage.\"20-x\"]\n",
                 "kind = \"execute\"\n",
-                "image = \"alpine:3\"\n",
+                "image = \"alpine:3.24\"\n",
                 "command = [\"true\"]\n",
                 "workdir = \"/estate\"\n",
                 "workspace_access = \"read_only\"\n",

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -701,6 +701,25 @@ mod tests {
     // ---- §9.1/§9.2: JSON shape -------------------------------------------
 
     #[test]
+    fn a_literal_watch_notice_blob_deserializes_with_the_pinned_schema() {
+        // Unlike `notice_json_shape_matches_the_contract...` above (which
+        // serializes a Rust-constructed WatchNotice), this parses a
+        // hand-written JSON blob as real input data — mirroring event.rs's
+        // `explicit_null_known_field_reads_as_unset_and_unknown_nulls_survive`
+        // pattern for its own schema string.
+        let blob = concat!(
+            r#"{"schema":"sergeant.watch/v1","reason":"state_transition","#,
+            r#""trigger":{"seq":1,"id":"01EVT","timestamp":"2026-08-13T18:42:31.417Z","kind":"work.completed"},"#,
+            r#""snapshot":{"work":{"state":"completed"}}}"#
+        );
+        let value: Value = serde_json::from_str(blob).expect("parse literal watch notice");
+        assert_eq!(value["schema"], WATCH_SCHEMA);
+        assert_eq!(value["reason"], "state_transition");
+        assert_eq!(value["trigger"]["kind"], "work.completed");
+        assert_eq!(value["snapshot"]["work"]["state"], "completed");
+    }
+
+    #[test]
     fn notice_json_shape_matches_the_contract_and_excludes_the_raw_payload() {
         let notice = WatchNotice {
             schema: WATCH_SCHEMA,

--- a/tests/m7_docker_executor.rs
+++ b/tests/m7_docker_executor.rs
@@ -44,7 +44,7 @@ use sergeant_rs::domain::workflow::{ExecuteSpec, NetworkPolicy, WorkspaceAccess}
 /// already has (`docs/environments/cerberus.md`'s Docker probes use
 /// `alpine`). Kept as one named constant so a future environment that needs
 /// a different probe image changes one line.
-const PROBE_IMAGE: &str = "alpine:3";
+const PROBE_IMAGE: &str = "alpine:3.24";
 
 /// Whether the local Docker Engine answers at all. Every test in this file
 /// calls this first and returns early (with a loud, named skip) when it does
@@ -1162,7 +1162,7 @@ async fn a_kind_execute_stage_is_refused_at_submit_when_docker_is_unavailable() 
             "\n",
             "[stage.\"10-execute\"]\n",
             "kind = \"execute\"\n",
-            "image = \"alpine:3\"\n",
+            "image = \"alpine:3.24\"\n",
             "command = [\"true\"]\n",
             "workdir = \"/estate\"\n",
             "workspace_access = \"read_only\"\n",
@@ -1398,7 +1398,7 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
             "\n",
             "[stage.\"10-validate\"]\n",
             "kind = \"execute\"\n",
-            "image = \"alpine:3\"\n",
+            "image = \"alpine:3.24\"\n",
             "command = [\"sh\", \"-c\", \"echo container-produced-evidence > /estate/validated.txt\"]\n",
             "workdir = \"/estate\"\n",
             "workspace_access = \"read_write\"\n",


### PR DESCRIPTION
# CI/CD hardening & version policy — sprint head PR (ships in 0.1.2)

Owner-commissioned follow-on to #202, sourced from an external repo audit whose every version claim was **re-verified live** before planning (5-agent recon; evidence + panel-validated plan in `docs/proposals/cicd-hardening-2026-08-20.md`). Owner ruling: ships inside **0.1.2** — no version bump here. After merge, your entire release surface is one Actions dispatch (`version: 0.1.2`, `mode: publish`, dry-run first if you like); the tag is created automatically on successful publish, and `verify-latest` asserts the Latest badge moved (#200's fix, first proving run).

**The rule adopted:** float to discover, pin to build — compatible ranges in Cargo.toml, exact graph in Cargo.lock (`--locked` everywhere), exact compiler in rust-toolchain.toml, full-SHA actions, exact tool versions, numbered runners, loud canary for drift. `docs/version-policy.md` is the durable record, including deliberate non-pins.

## Waves (all merged to this branch, each recon→spec→implement→panel+refuters→fix)
- [x] **W1 — Toolchain determinism** (#210): Rust pinned 1.98.0 (file is the single source; dtolnay wrapper removed), `--locked` everywhere + metadata guards + no-mutation gate, **MSRV measured 1.89.0** (our own `File::try_lock`; empirical, one above the metadata prediction) declared + CI-checked
- [x] **W2 — Actions/runners/canary** (#211): stray checkout v4.4.0→v7.0.1, install-action v2.86.4, tools exact-pinned (llvm-cov 0.9.0 / deny 0.20.2 / cyclonedx 0.5.9), `ubuntu-24.04` + `macos-26`, weekly **loud** canary (floating stable via RUSTUP_TOOLCHAIN on floating runners; red run + `upstream-drift` issue, label created), build-env evidence per package leg
- [x] **W3 — Release supply chain** (#212): dist bootstrapped via checksum+attestation-verified tarball (shared `scripts/release/install-dist.sh`, both `curl|sh` sites gone); **installer now self-verifies** — root cause was dist's global build never seeing per-target manifests, so its own `verify_checksum()` was starved; manifests wired through + CI smoke tests both directions (good archive installs, corrupted archive rejected — proven locally against real artifacts); attest-sbom→`actions/attest` v4.2.2 (1:1 pairing kept); `alpine:3.24`
- [x] **W4 — Deps/docs/contracts** (#213): reqwest 0.12→0.13.4 (duplicate HTTP/TLS stack deleted; `cargo tree` proves one reqwest), thiserror 2.0.20, README → `/latest` URLs + docs-consistency CI gate (negative-plant proven), stale topology comment fixed, schema golden tests (watch/v1, execution/v1, runtime/v2), `docs/version-policy.md`
- [x] **Finalize**: 0.1.2 CHANGELOG extended (no bump), lock verified, full local gate green

## Ratify at review
1. **Installer verification mechanism** (was flagged as a choice): resolved better than either planned option — no generated-code patching; dist's own machinery fed the data it was missing. Evidence in #212.
2. **macOS pin = `macos-26`** (arm64; exactly what `macos-latest` served at pin time; `macos-15` remains available if you want one generation of headroom).

## Notes for review
- **Incident (resolved):** mid-W4, a scratch cargo build in the tmpfs scratchpad blew the per-user /tmp quota and killed the Bash tool harness-wide; recovery agent shipped the wave via an alternate shell path, quota root-caused/cleaned, wave re-paneled against the real tree (caught 1 doc-vs-lockfile drift, fixed). Memory rule written: builds never go to the scratchpad.
- Residual items only a real release run can prove (listed in #212): `gh attestation verify` under Actions' token, darwin installer arm population in CI, macOS shasum branch. **Recommend one `mode: dry-run` dispatch after merge** — it exercises all three and deletes its draft.
- Audit Low items deliberately declined (Cerberus rule): machine-readable tool inventory. Recorded with rationale in version-policy.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4
