### PR TITLE
W1 — Toolchain determinism: pin Rust 1.98.0, --locked everywhere, MSRV 1.89.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,28 @@ jobs:
       - name: cargo check
         run: cargo check --locked --all-targets
 
+  msrv:
+    # W1 §E: measured floor, not recon's static 1.88.0 prediction — the
+    # extra minor version comes from this crate's own use of
+    # std::fs::File::try_lock/TryLockError (stabilized 1.89.0), which a
+    # cargo-metadata pass over dependency rust-version fields cannot see.
+    # Verified empirically: cargo +1.89.0 check --locked --all-targets and
+    # cargo +1.89.0 test --locked both passed cleanly before this job and
+    # Cargo.toml's rust-version were added. Check only, no clippy — lint
+    # policy belongs to the pinned dev compiler (rust-toolchain.toml), not
+    # to this deliberately-older floor.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: rustup toolchain install (MSRV floor — deliberately older than rust-toolchain.toml's pin)
+        run: rustup toolchain install 1.89.0 --profile minimal
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: cargo check --locked --all-targets (MSRV floor — check only, no clippy on an old compiler)
+        run: cargo +1.89.0 check --locked --all-targets
+
   dependency-policy:
     # proposal §5.2: routine PRs check bans/licenses/sources only. Advisories
     # deliberately excluded here — a new RustSec advisory can land against an

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          components: clippy, rustfmt
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; -c adds clippy+rustfmt)
+        run: rustup toolchain install -c clippy,rustfmt
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -41,10 +40,13 @@ jobs:
         run: cargo fmt --check
 
       - name: cargo clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: cargo test
-        run: cargo test
+        run: cargo test --locked
+
+      - name: git diff --exit-code (no step above should have mutated a tracked file)
+        run: git diff --exit-code
 
   shellcheck:
     # ADR 0004 (D7): hygiene, not a version gate — shellcheck has no bash-3.2
@@ -82,12 +84,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - name: rustup toolchain install (rust-toolchain.toml pins the version)
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: cargo check
-        run: cargo check --all-targets
+        run: cargo check --locked --all-targets
 
   dependency-policy:
     # proposal §5.2: routine PRs check bans/licenses/sources only. Advisories
@@ -99,8 +102,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: "cargo metadata --locked (guard: belt-and-suspenders around the action's own --locked argument below)"
+        run: cargo metadata --locked --format-version 1 >/dev/null
+
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
+          arguments: --all-features --locked
           command: check bans licenses sources
 
   dependency-review:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,22 @@ jobs:
     # policy belongs to the pinned dev compiler (rust-toolchain.toml), not
     # to this deliberately-older floor.
     runs-on: ubuntu-latest
+    env:
+      # Single source of truth for this job's two 1.89.0 uses below. Keep in
+      # sync with Cargo.toml's rust-version (see the comment there) — YAML
+      # and TOML can't share a literal without added machinery, so this only
+      # collapses the duplication within this job, from two sites to one.
+      MSRV: 1.89.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: rustup toolchain install (MSRV floor — deliberately older than rust-toolchain.toml's pin)
-        run: rustup toolchain install 1.89.0 --profile minimal
+        run: rustup toolchain install ${{ env.MSRV }} --profile minimal
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: cargo check --locked --all-targets (MSRV floor — check only, no clippy on an old compiler)
-        run: cargo +1.89.0 check --locked --all-targets
+        run: cargo +${{ env.MSRV }} check --locked --all-targets
 
   dependency-policy:
     # proposal §5.2: routine PRs check bans/licenses/sources only. Advisories

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,9 +37,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: reclaim runner disk (the stage scripts enforce a 10 GB floor)
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          components: llvm-tools
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; -c adds llvm-tools for cargo-llvm-cov)
+        run: rustup toolchain install -c llvm-tools
       - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -62,7 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - name: rustup toolchain install (rust-toolchain.toml pins the version)
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -75,7 +76,7 @@ jobs:
       # enforcement" of the scripts/ bash-3.2 floor from #86 — no separate
       # step needed.
       - name: cargo test (full suite)
-        run: cargo test -- --nocapture 2>&1 | tee test-output.log
+        run: cargo test --locked -- --nocapture 2>&1 | tee test-output.log
 
       - name: publish skip count (ADR 0001 D8 measured bar)
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           tool: cargo-deny
       - name: cargo deny check (full — advisories, bans, licenses, sources)
-        run: cargo deny check
+        run: cargo deny check --locked
 
   # ── Gate F — distro structural validator ───────────────────────────────
   # Does not execute here — see the top-of-file comment for why (workspace
@@ -271,9 +271,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; -t adds the cross target)
+        run: rustup toolchain install -t ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -281,6 +280,9 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+
+      - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
+        run: cargo metadata --locked --format-version 1 >/dev/null
 
       - name: dist build (packages the binary + LICENSE/README + checksum)
         run: dist build --artifacts=local --target ${{ matrix.target }}
@@ -337,10 +339,16 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; closes this job's prior lack of a pinned toolchain)
+        run: rustup toolchain install
+
       - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+
+      - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
+        run: cargo metadata --locked --format-version 1 >/dev/null
 
       - name: dist build --artifacts=global (shell installer only)
         run: |
@@ -414,13 +422,14 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: rustup toolchain install (rust-toolchain.toml pins the version; -t adds the cross target)
+        run: rustup toolchain install -t ${{ matrix.target }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
         with:
           tool: cargo-cyclonedx
+      - name: "cargo metadata --locked (guard: cargo-cyclonedx has no native --locked/--frozen flag)"
+        run: cargo metadata --locked --format-version 1 >/dev/null
       - name: generate target-scoped CycloneDX SBOM for the sgt binary
         run: |
           cargo cyclonedx --format json --describe binaries \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "sergeant-rs"
 version = "0.1.2"
 edition = "2024"
+# Keep in sync with the `msrv` job's `env.MSRV` in .github/workflows/ci.yml
+# (W1 spec §E) — cargo has no way to read this field back into that job's
+# `run:` steps without added machinery, so the two are hand-synced.
 rust-version = "1.89.0"
 license = "MIT"
 repository = "https://github.com/miztertea/sergeant-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sergeant-rs"
 version = "0.1.2"
 edition = "2024"
+rust-version = "1.89.0"
 license = "MIT"
 repository = "https://github.com/miztertea/sergeant-rs"
 description = "Local execution surface for coding agents: durable work, isolated git worktrees, and a complete evidence trail behind one daemon"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.98.0"

--- a/scripts/coverage/c1-lib.sh
+++ b/scripts/coverage/c1-lib.sh
@@ -21,7 +21,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cov_stage_begin c1
 
-cov_run cargo llvm-cov --no-report --lib || cov_fail "the unit tests failed under instrumentation"
+cov_run cargo llvm-cov --no-report --lib --locked || cov_fail "the unit tests failed under instrumentation"
 
 # One test binary ran, so one profraw is the floor. Zero means the binary
 # never flushed — a crash, an abort, or a profile pattern pointing somewhere

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -18,19 +18,19 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/common.sh"
 
 cov_stage_begin c2-m1_event_core
-cov_run cargo llvm-cov --no-report --test m1_event_core || cov_fail "m1_event_core failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m1_event_core --locked || cov_fail "m1_event_core failed under instrumentation"
 cov_stage_end 1 "the m1 test binary must write its own profile"
 
 cov_stage_begin c2-m4_backends
-cov_run cargo llvm-cov --no-report --test m4_backends || cov_fail "m4_backends failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m4_backends --locked || cov_fail "m4_backends failed under instrumentation"
 cov_stage_end 1 "the m4 test binary must write its own profile"
 
 cov_stage_begin c2-m3_execution
-cov_run cargo llvm-cov --no-report --test m3_execution || cov_fail "m3_execution failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m3_execution --locked || cov_fail "m3_execution failed under instrumentation"
 cov_stage_end 1 "the m3 test binary must write its own profile"
 
 cov_stage_begin c2-m5_projections
-cov_run cargo llvm-cov --no-report --test m5_projections || cov_fail "m5_projections failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m5_projections --locked || cov_fail "m5_projections failed under instrumentation"
 cov_stage_end 1 "the m5 test binary must write its own profile"
 
 # Added 2026-08-19. These four suites existed in tests/ but were invoked by no
@@ -43,21 +43,21 @@ cov_stage_end 1 "the m5 test binary must write its own profile"
 # than spawning, so all four sit here rather than in C3, whose floor rule is
 # written for suites dominated by real `sgt` subprocesses.
 cov_stage_begin c2-m8_estate_cli
-cov_run cargo llvm-cov --no-report --test m8_estate_cli || cov_fail "m8_estate_cli failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m8_estate_cli --locked || cov_fail "m8_estate_cli failed under instrumentation"
 cov_stage_end 1 "the m8 test binary must write its own profile"
 
 cov_stage_begin c2-m9_watch
-cov_run cargo llvm-cov --no-report --test m9_watch || cov_fail "m9_watch failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m9_watch --locked || cov_fail "m9_watch failed under instrumentation"
 cov_stage_end 1 "the m9 test binary must write its own profile"
 
 cov_stage_begin c2-m10_harness
-cov_run cargo llvm-cov --no-report --test m10_harness || cov_fail "m10_harness failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m10_harness --locked || cov_fail "m10_harness failed under instrumentation"
 cov_stage_end 1 "the m10 test binary must write its own profile"
 
 cov_stage_begin c2-estate_routes
-cov_run cargo llvm-cov --no-report --test estate_routes || cov_fail "estate_routes failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test estate_routes --locked || cov_fail "estate_routes failed under instrumentation"
 cov_stage_end 1 "the estate_routes test binary must write its own profile"
 
 cov_stage_begin c2-t2_workflow_catalog
-cov_run cargo llvm-cov --no-report --test t2_workflow_catalog || cov_fail "t2_workflow_catalog failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test t2_workflow_catalog --locked || cov_fail "t2_workflow_catalog failed under instrumentation"
 cov_stage_end 1 "the t2_workflow_catalog test binary must write its own profile"

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -22,12 +22,12 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/common.sh"
 
 cov_stage_begin c3-m2_daemon_api
-cov_run cargo llvm-cov --no-report --test m2_daemon_api || cov_fail "m2_daemon_api failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m2_daemon_api --locked || cov_fail "m2_daemon_api failed under instrumentation"
 cov_stage_end 2 "m2 spawns clients and daemons; more than the test binary's own profile must arrive, \
 or no subprocess flushed and the suite's real coverage is missing"
 
 cov_stage_begin c3-m6_surfaces
-cov_run cargo llvm-cov --no-report --test m6_surfaces || cov_fail "m6_surfaces failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m6_surfaces --locked || cov_fail "m6_surfaces failed under instrumentation"
 cov_stage_end 2 "m6 spawns daemons (TUI, doctor) and runs scripts/demo.sh; more than the test \
 binary's own profile must arrive, or no subprocess flushed"
 
@@ -43,6 +43,6 @@ binary's own profile must arrive, or no subprocess flushed"
 # The trade is stated rather than hidden: on a Docker-capable host this stage
 # will not catch a subprocess that silently failed to flush.
 cov_stage_begin c3-m7_docker_executor
-cov_run cargo llvm-cov --no-report --test m7_docker_executor || cov_fail "m7_docker_executor failed under instrumentation"
+cov_run cargo llvm-cov --no-report --test m7_docker_executor --locked || cov_fail "m7_docker_executor failed under instrumentation"
 cov_stage_end 1 "the m7 test binary must write its own profile; container subprocesses are not \
 required because the suite self-skips where Docker is unreachable"


### PR DESCRIPTION
Wave 1 of the CI/CD-hardening sprint (plan: docs/proposals/cicd-hardening-2026-08-20.md).

- rust-toolchain.toml pinned to 1.98.0 (today's stable — the version CI already runs)
- dtolnay/rust-toolchain replaced by bare `rustup toolchain install`, which reads rust-toolchain.toml: one source of truth, dependency on the action gone
- `--locked` on every cargo invocation across all four workflows + the 13 coverage-stage llvm-cov calls; `cargo metadata --locked` guards in front of third-party subcommands (deny, cyclonedx, dist) that lack native --locked
- `git diff --exit-code` no-mutation guard after ci's test steps
- MSRV measured empirically: **1.89.0** — floor set by our own `File::try_lock` usage (stabilized 1.89), one minor above the dependency-metadata prediction; declared in Cargo.toml + check-only msrv CI job
- Panel: 1 confirmed minor (MSRV literal duplication) — fixed (job-level env + cross-reference comments)

Gates re-run by orchestrator: fmt, clippy(-D warnings, 1.98.0), full suite (597+ tests, 0 fail), no-mutation — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4