### PR TITLE
W2 — Actions/runners/canary: exact pins everywhere, loud weekly canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,82 @@
+name: canary
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # weekly, Monday 06:00 UTC — matches coverage.yml's
+                            # existing weekly-Monday pattern (coverage.yml:24)
+                            # for one predictable non-blocking-lane cadence
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]   # deliberately the FLOATING
+                                              # aliases, not the pinned
+                                              # ubuntu-24.04/macos-26 used
+                                              # everywhere else — this job's
+                                              # whole point is to notice the
+                                              # runner image moving too, not
+                                              # just Rust. Pinning it here
+                                              # would defeat it.
+    runs-on: ${{ matrix.os }}
+    # NO continue-on-error: this is a standalone scheduled workflow, not a
+    # required PR check, so a red run blocks nothing and GitHub's own
+    # default scheduled-workflow-failure notification already fires;
+    # continue-on-error would only muffle the redness this job exists to
+    # produce.
+    env:
+      RUSTUP_TOOLCHAIN: stable   # rank 2 in rustup's override precedence —
+                                  # bypasses rust-toolchain.toml (rank 4)
+                                  # deliberately, so this job canaries the
+                                  # upstream `stable` channel, not the
+                                  # repo's own pin.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: rustup update stable (install/refresh the floating toolchain the env var selects)
+        run: rustup update stable
+
+      - name: cargo check --locked --all-targets
+        run: cargo check --locked --all-targets
+
+      - name: cargo clippy --locked --all-targets
+        run: cargo clippy --locked --all-targets -- -D warnings
+
+      - name: cargo test --locked
+        run: cargo test --locked
+
+  on-drift:
+    needs: canary
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write   # the ONLY new permission this sprint introduces
+                        # anywhere in the four+one workflows — everything
+                        # else stays at existing contents: read. gh issue
+                        # create/edit/comment all require it; nothing else
+                        # in this job's path touches repo state.
+    steps:
+      - name: open-or-update the upstream-drift tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          title="Upstream drift: canary failed on ${{ github.run_id }}"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --repo "${{ github.repository }}" \
+            --label upstream-drift --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "${{ github.repository }}" \
+              --body "Canary failed again: $run_url"
+          else
+            gh issue create --repo "${{ github.repository }}" \
+              --title "upstream drift: canary red" \
+              --label upstream-drift \
+              --body "The weekly canary tripped: $run_url"
+          fi

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -67,7 +67,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
-          title="Upstream drift: canary failed on ${{ github.run_id }}"
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           existing=$(gh issue list --repo "${{ github.repository }}" \
             --label upstream-drift --state open --json number --jq '.[0].number // empty')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -53,7 +53,7 @@ jobs:
     # target mode, so it cannot enforce the scripts/ floor. The macos-check
     # job below only runs `cargo check` (type-check, no test execution), so
     # it does NOT exercise scripts/demo.sh; the real enforcement of the
-    # bash-3.2 floor is matrix.yml's full-suite `cargo test` on macos-latest
+    # bash-3.2 floor is matrix.yml's full-suite `cargo test` on macos-26
     # (via tests/m6_surfaces.rs t4's scripts/demo.sh subprocess), which runs
     # on PR-to-main, nightly, and release — not on every push. Gated at
     # --severity=error only: a 2026-08-14 sweep of all 25 scripts/**/*.sh
@@ -63,7 +63,7 @@ jobs:
     # on intentionally-external vars). Triaging those individually is out of
     # scope here; this still gives every future change a real,
     # currently-clean gate against actual shell bugs.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: shellcheck (errors only — see comment above for the warning backlog)
@@ -73,14 +73,14 @@ jobs:
     # ADR 0004 (D9) / ADR 0002 (D2): the macOS module is `#[cfg]`-selected and
     # not compiled at all on Linux, so breaking it is invisible locally — this
     # is the compensating lane, run per push. `cargo check` on an actual
-    # macos-latest runner rather than a literal Linux->macOS cross-compile:
+    # macos-26 runner rather than a literal Linux->macOS cross-compile:
     # the `duckdb` dependency's `bundled` feature compiles DuckDB's C++ from
     # source via its own build script, which needs a real Apple toolchain
     # (cross-compiling that from Linux needs an osxcross-style Apple SDK
     # extraction that hosted runners don't carry). Since this repo is public,
-    # a real macos-latest runner is free and unmetered (ADR 0004 D9), so it's
+    # a real macos-26 runner is free and unmetered (ADR 0004 D9), so it's
     # both cheaper and more faithful than fighting a cross C++ toolchain.
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -102,7 +102,7 @@ jobs:
     # Cargo.toml's rust-version were added. Check only, no clippy — lint
     # policy belongs to the pinned dev compiler (rust-toolchain.toml), not
     # to this deliberately-older floor.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # Single source of truth for this job's two 1.89.0 uses below. Keep in
       # sync with Cargo.toml's rust-version (see the comment there) — YAML
@@ -126,7 +126,7 @@ jobs:
     # unchanged Cargo.lock and turn an unrelated documentation PR red
     # overnight. Advisories are a release-time gate instead: release.yml's
     # Gate E runs the full `cargo deny check`, including advisories.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -146,7 +146,7 @@ jobs:
     # where there is no PR diff to review, so the job is scoped out there
     # rather than running meaninglessly or failing for lack of a base ref.
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,9 +39,9 @@ jobs:
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
       - name: rustup toolchain install (rust-toolchain.toml pins the version; -c adds llvm-tools for cargo-llvm-cov)
         run: rustup toolchain install -c llvm-tools
-      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+      - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov@0.9.0
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-directories: target/llvm-cov-target

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Cold instrumented DuckDB (~500 C++ TUs) is unmeasured on 2-core
     # runners; the 4-core dev-container estimate was 15-25 min. Wide
     # margin on purpose (review finding 4).

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-26]
     runs-on: ${{ matrix.os }}
     # Cold DuckDB C++ build (~500 TUs, ~10 min) plus the real suites; wide
     # margin on purpose, matching coverage.yml's posture for the same build.
@@ -68,7 +68,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # macOS's plain `bash` here resolves to the system-frozen 3.2.57 (ADR
-      # 0004, D7) — GitHub's macos-latest image does not preinstall a newer
+      # 0004, D7) — GitHub's macos-26 image does not preinstall a newer
       # Homebrew bash ahead of it on PATH. `cargo test` includes
       # tests/m6_surfaces.rs t4, which spawns `scripts/demo.sh` via
       # `Command::new("bash")`, so this job's test run is what ADR 0004 means

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,28 @@ jobs:
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
+      - name: record build environment
+        run: |
+          mkdir -p target/distrib
+          {
+            echo "commit: ${{ github.sha }}"
+            echo "target: ${{ matrix.target }}"
+            echo "runner-os: ${{ runner.os }}"
+            echo "runner-arch: ${{ runner.arch }}"
+            echo
+            echo "--- rustc -Vv ---"
+            rustc -Vv
+            echo
+            echo "--- cargo -V ---"
+            cargo -V
+            echo
+            echo "--- git --version ---"
+            git --version
+            echo
+            echo "--- bash --version ---"
+            bash --version
+          } > target/distrib/build-environment-${{ matrix.target }}.txt
+
       - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
@@ -532,7 +554,9 @@ jobs:
             sgt_bin_x86_64-unknown-linux-gnu.cdx.json \
             sgt_bin_aarch64-apple-darwin.cdx.json \
             sergeant-rs-installer.sh \
-            SHA256SUMS.txt; do
+            SHA256SUMS.txt \
+            build-environment-x86_64-unknown-linux-gnu.txt \
+            build-environment-aarch64-apple-darwin.txt; do
             if [ ! -f "$f" ]; then
               echo "::error::release manifest missing expected asset $f" >&2
               exit 1
@@ -571,7 +595,8 @@ jobs:
             release-assets/*.sha256 \
             release-assets/*.cdx.json \
             release-assets/sergeant-rs-installer.sh \
-            release-assets/SHA256SUMS.txt
+            release-assets/SHA256SUMS.txt \
+            release-assets/build-environment-*.txt
 
       # A tag is not a unique key for a draft — GitHub lets multiple drafts
       # share one tag_name, which is exactly what let a stale dry-run draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,9 +197,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+      - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
         with:
-          tool: cargo-deny
+          tool: cargo-deny@0.20.2
       - name: cargo deny check (full — advisories, bans, licenses, sources)
         run: cargo deny check --locked
 
@@ -425,9 +425,9 @@ jobs:
       - name: rustup toolchain install (rust-toolchain.toml pins the version; -t adds the cross target)
         run: rustup toolchain install -t ${{ matrix.target }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-      - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
+      - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
         with:
-          tool: cargo-cyclonedx
+          tool: cargo-cyclonedx@0.5.9
       - name: "cargo metadata --locked (guard: cargo-cyclonedx has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
       - name: generate target-scoped CycloneDX SBOM for the sgt binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
   # invariant before anything else runs. Failing here creates no tag and no
   # release — this job does nothing but check facts.
   gate-a-repo-state:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -192,7 +192,7 @@ jobs:
   # included, so a known RustSec advisory cannot silently enter a release.
   gate-e-cargo-deny:
     needs: gate-a-repo-state
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -217,7 +217,7 @@ jobs:
   # PR.
   gate-f-distro-validator:
     needs: gate-a-repo-state
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -233,15 +233,19 @@ jobs:
   # Only after A-F. Measured on real GitHub-hosted runners, both targets,
   # 2026-08-18 (docs/measure-dist-2026-08-18.md, proposal §10 condition 1):
   # `dist build` successfully builds sgt with bundled DuckDB and packages it
-  # on both ubuntu-latest (897s cold build) and macos-latest (1002s cold
+  # on both ubuntu-24.04 (897s cold build) and macos-26 (1002s cold
   # build), with no disk or cache pressure on either. Binary behavioral
   # equivalence and the generated installer's correctness (conditions 2-3)
-  # were additionally measured against a real archive on ubuntu-latest
+  # were additionally measured against a real archive on ubuntu-24.04
   # (docs/measure-dist-conditions-2026-08-18.md) and found identical to an
   # ordinary `cargo build --release` binary, including the embedded distro.
+  # (ubuntu-24.04/macos-26 are the exact images the prior floating-alias
+  # runner labels served on the 2026-08-18 measurement date — the runner
+  # below is now pinned to those images directly, so this measurement is
+  # not stale relative to the pin.)
   #
   # aarch64-apple-darwin per ADR 0001's measured-target set: the *build*
-  # succeeded on a real macos-latest runner (above), but binary equivalence
+  # succeeded on a real macos-26 runner (above), but binary equivalence
   # and installer correctness were not re-measured on macOS — see docs/adr/
   # 0018-measured-vocabulary-obligation-clean-build-not-full-validation.md,
   # which clarifies ADR 0001 D8's "measured" vocabulary. Per that ruling,
@@ -262,9 +266,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-26
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -333,7 +337,7 @@ jobs:
       - gate-d-coverage
       - gate-e-cargo-deny
       - gate-f-distro-validator
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -373,9 +377,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-26
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -414,9 +418,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-26
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -460,7 +464,7 @@ jobs:
       - smoke-test
       - sbom
       - package-installer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       id-token: write
@@ -639,7 +643,7 @@ jobs:
   publish:
     needs: draft-release
     if: ${{ inputs.mode == 'publish' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -663,7 +667,7 @@ jobs:
   verify-latest:
     needs: [draft-release, publish]
     if: ${{ inputs.mode == 'publish' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: rustup toolchain install (rust-toolchain.toml pins the version; closes this job's prior lack of a pinned toolchain)
         run: rustup toolchain install


### PR DESCRIPTION
Wave 2 of the CI/CD-hardening sprint.

- Stray checkout v4.4.0 (package-installer) → the v7.0.1 SHA used everywhere else
- taiki-e/install-action v2.86.2 → v2.86.4 (full-SHA); tool inputs exact-pinned: cargo-llvm-cov@0.9.0, cargo-deny@0.20.2, cargo-cyclonedx@0.5.9
- Runners pinned to what the aliases serve today: ubuntu-latest→ubuntu-24.04, macos-latest→macos-26 (behavior unchanged on day one — this PR's CI run is the qualification)
- New canary.yml: weekly + dispatch, floating stable Rust (RUSTUP_TOOLCHAIN=stable env deliberately outranks the pinned toolchain file) on floating *-latest runners, NO continue-on-error, if:failure() maintains a single upstream-drift tracking issue (label created)
- Build-environment evidence recorded into each package leg's release artifact
- Panel: 1 confirmed minor (dead shell var in canary) — fixed

Orchestrator gate: YAML parse ×5, fmt, 24 test suites ok, no-mutation — pass. Watch-item for this PR's CI: coverage now installs cargo-llvm-cov 0.9.0 (locally verified against 0.8.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4