### PR TITLE
W3 — Release supply chain: verified dist bootstrap, self-verifying installer, unified attest, alpine 3.24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,53 +310,22 @@ jobs:
       # aggregate `sha256.sum`, and has no build-provenance attestation at all
       # (`gh attestation verify cargo-dist-installer.sh --repo
       # axodotdev/cargo-dist` → HTTP 404). The per-target tarballs have both.
-      # The two checks below prove different things and neither subsumes the
-      # other: the committed sha256 pins the exact v0.32.0 bytes we qualified
-      # (an attestation alone would accept a *different* axodotdev-built
-      # tarball served from this URL), and `gh attestation verify` proves those
-      # bytes came out of axodotdev/cargo-dist's own release workflow rather
-      # than merely matching a hash someone uploaded. Bumping DIST_VERSION
-      # means re-recording both sha256 literals from that release's
-      # `sha256.sum` — deliberately, so a version bump is a qualification, not
-      # a one-character edit.
+      # The two checks prove different things and neither subsumes the other:
+      # the committed sha256 pins the exact v0.32.0 bytes we qualified (an
+      # attestation alone would accept a *different* axodotdev-built tarball
+      # served from this URL), and `gh attestation verify` proves those bytes
+      # came out of axodotdev/cargo-dist's own release workflow rather than
+      # merely matching a hash someone uploaded. Bumping the version means
+      # re-recording both sha256 literals from that release's `sha256.sum` —
+      # deliberately, so a version bump is a qualification, not a
+      # one-character edit. Lives in scripts/release/install-dist.sh, shared
+      # by both bootstrap sites (package, package-installer), so there is one
+      # copy of the pinned hashes to re-qualify, not two (same pattern as
+      # verify-installer-checksums.sh below).
       - name: install dist 0.32.0 (checksum-pinned + attestation-verified tarball)
         env:
           GH_TOKEN: ${{ github.token }}
-          DIST_VERSION: "0.32.0"
-        run: |
-          set -euo pipefail
-          case "${RUNNER_OS}-${RUNNER_ARCH}" in
-            Linux-X64)
-              dist_target="x86_64-unknown-linux-gnu"
-              dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
-              ;;
-            macOS-ARM64)
-              dist_target="aarch64-apple-darwin"
-              dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
-              ;;
-            *)
-              echo "::error::no qualified cargo-dist ${DIST_VERSION} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-              exit 1
-              ;;
-          esac
-          archive="cargo-dist-${dist_target}.tar.xz"
-          curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
-            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/${archive}"
-          echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum -c "${RUNNER_TEMP}/dist.sha256"
-          else
-            shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
-          fi
-          gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
-          mkdir -p "${RUNNER_TEMP}/dist-bin"
-          tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
-          got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
-          if [ "$got" != "cargo-dist ${DIST_VERSION}" ]; then
-            echo "::error::extracted dist reports '$got', expected 'cargo-dist ${DIST_VERSION}'" >&2
-            exit 1
-          fi
-          echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"
+        run: scripts/release/install-dist.sh 0.32.0
 
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
@@ -456,53 +425,22 @@ jobs:
       # aggregate `sha256.sum`, and has no build-provenance attestation at all
       # (`gh attestation verify cargo-dist-installer.sh --repo
       # axodotdev/cargo-dist` → HTTP 404). The per-target tarballs have both.
-      # The two checks below prove different things and neither subsumes the
-      # other: the committed sha256 pins the exact v0.32.0 bytes we qualified
-      # (an attestation alone would accept a *different* axodotdev-built
-      # tarball served from this URL), and `gh attestation verify` proves those
-      # bytes came out of axodotdev/cargo-dist's own release workflow rather
-      # than merely matching a hash someone uploaded. Bumping DIST_VERSION
-      # means re-recording both sha256 literals from that release's
-      # `sha256.sum` — deliberately, so a version bump is a qualification, not
-      # a one-character edit.
+      # The two checks prove different things and neither subsumes the other:
+      # the committed sha256 pins the exact v0.32.0 bytes we qualified (an
+      # attestation alone would accept a *different* axodotdev-built tarball
+      # served from this URL), and `gh attestation verify` proves those bytes
+      # came out of axodotdev/cargo-dist's own release workflow rather than
+      # merely matching a hash someone uploaded. Bumping the version means
+      # re-recording both sha256 literals from that release's `sha256.sum` —
+      # deliberately, so a version bump is a qualification, not a
+      # one-character edit. Lives in scripts/release/install-dist.sh, shared
+      # by both bootstrap sites (package, package-installer), so there is one
+      # copy of the pinned hashes to re-qualify, not two (same pattern as
+      # verify-installer-checksums.sh below).
       - name: install dist 0.32.0 (checksum-pinned + attestation-verified tarball)
         env:
           GH_TOKEN: ${{ github.token }}
-          DIST_VERSION: "0.32.0"
-        run: |
-          set -euo pipefail
-          case "${RUNNER_OS}-${RUNNER_ARCH}" in
-            Linux-X64)
-              dist_target="x86_64-unknown-linux-gnu"
-              dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
-              ;;
-            macOS-ARM64)
-              dist_target="aarch64-apple-darwin"
-              dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
-              ;;
-            *)
-              echo "::error::no qualified cargo-dist ${DIST_VERSION} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-              exit 1
-              ;;
-          esac
-          archive="cargo-dist-${dist_target}.tar.xz"
-          curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
-            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/${archive}"
-          echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum -c "${RUNNER_TEMP}/dist.sha256"
-          else
-            shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
-          fi
-          gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
-          mkdir -p "${RUNNER_TEMP}/dist-bin"
-          tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
-          got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
-          if [ "$got" != "cargo-dist ${DIST_VERSION}" ]; then
-            echo "::error::extracted dist reports '$got', expected 'cargo-dist ${DIST_VERSION}'" >&2
-            exit 1
-          fi
-          echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"
+        run: scripts/release/install-dist.sh 0.32.0
 
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,25 +402,35 @@ jobs:
   # topology — it does not create or depend on the release tag existing in
   # the repository, only on being told what tag string to embed.
   #
-  # This job produces the installer script and, separately, the per-archive
-  # `.sha256` files (via `dist build --artifacts=local` in `package`,
-  # above). Nothing wires the two together: the generated
-  # `sergeant-rs-installer.sh` declares the local variables it would use to
-  # verify a downloaded archive's checksum but never assigns them, so its
-  # verification branch is unreachable and every install via this script
-  # prints "no checksums to verify" and installs unverified — confirmed by
-  # running the installer against a published release
-  # (`docs/measure-dist-conditions-2026-08-18.md`'s own "no checksums to
-  # verify" observation, condition 3, generalizes past the ad hoc local-server
-  # setup that first surfaced it — see that file's 2026-08-19 amendment).
-  # The documented, deliberate verification path is manual: README.md's
-  # "Installing a released binary instead of building from source" section
-  # walks `sha256sum -c` against the `.sha256` this job's sibling produces,
-  # plus `gh attestation verify` against the build-provenance attestation
-  # `draft-release` (below) creates. This job does not attempt to fix that
-  # gap — patching or post-processing `dist`'s generated installer to wire
-  # in checksum verification is a larger change with its own supply-chain
-  # risk surface, and is the owner's call, not a packaging-job comment's.
+  # This job produces the installer script; `package` (above) produces the
+  # per-archive `.sha256` files and, since 0.1.2, a per-target
+  # `<target>-dist-manifest.json`. Those manifests are what wire the two
+  # together: `dist build --artifacts=global` reads each archive's sha256 out
+  # of them and renders it into the installer's per-artifact case arms, so the
+  # generated `sergeant-rs-installer.sh` now verifies what it downloads before
+  # extracting it. This is cargo-dist's own mechanism — its generated CI
+  # downloads the local jobs' artifacts into target/distrib/ before the global
+  # build for exactly this reason — not a patch on its output; nothing here
+  # post-processes the generated script.
+  #
+  # Before 0.1.2 the manifests were never passed forward, so the installer's
+  # verification branch was unreachable and every install printed "no checksums
+  # to verify" (docs/measure-dist-conditions-2026-08-18.md, condition 3, and its
+  # 2026-08-19 amendment — an accurate record of the behavior on that date, not
+  # of the behavior now). The two steps after the global build below are what
+  # keep that from silently regressing: one asserts every released target's arm
+  # carries a real sha256, the other installs from a local origin and then
+  # proves a substituted archive is actually rejected.
+  #
+  # `needs: package` exists for the manifests only — a global artifact is still
+  # built once per app rather than once per target, and this job still never
+  # needs any target's binary. It costs nothing downstream: `draft-release`
+  # already waits on `smoke-test` and `sbom`, which already wait on `package`.
+  #
+  # Checksums are not the whole story and the README says so: they prove the
+  # archive matches what the release published, not that the release came from
+  # this repository. Provenance is `gh attestation verify` against the
+  # build-provenance attestation `draft-release` (below) creates.
   package-installer:
     needs:
       - gate-b-ci
@@ -428,6 +438,7 @@ jobs:
       - gate-d-coverage
       - gate-e-cargo-deny
       - gate-f-distro-validator
+      - package
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -496,12 +507,51 @@ jobs:
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
 
+      # Get the per-target build manifests `package` produced (and, harmlessly,
+      # the archives beside them) so `dist build --artifacts=global` can read
+      # each archive's sha256 out of them and render it into the installer's
+      # per-artifact case arms. This is cargo-dist's own mechanism, not a patch
+      # on its output: its generated CI performs the same download into
+      # target/distrib/ before the global build, under the comment "Get all the
+      # local artifacts for the global tasks to use (for e.g. checksums)".
+      # This job still does not need any target's *binary* — only the manifest
+      # JSON — so the reason this is a separate job from `package` (a global
+      # artifact is built once per app, not once per target) is unchanged.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: "dist-*"
+          path: target/distrib
+          merge-multiple: true
+
       - name: dist build --artifacts=global (shell installer only)
         run: |
           dist build --artifacts=global \
             --target x86_64-unknown-linux-gnu \
             --target aarch64-apple-darwin \
             --tag "$RELEASE_TAG"
+
+      - name: assert the generated installer carries a checksum for every released target
+        run: |
+          set -euo pipefail
+          installer=target/distrib/sergeant-rs-installer.sh
+          populated=$(grep -c '^[[:space:]]*_checksum_value="[0-9a-f]\{64\}"$' "$installer" || true)
+          if [ "$populated" -ne 2 ]; then
+            echo "::error::generated installer has $populated populated checksum value(s), expected 2 (one per released target) — dist did not see a per-target build manifest for every target" >&2
+            grep -n '_checksum_style\|_checksum_value\|\.tar\.xz")' "$installer" >&2 || true
+            exit 1
+          fi
+          echo "::notice::generated installer carries $populated per-artifact sha256 values"
+
+      # Proves the property, rather than asserting it: a good archive installs,
+      # a substituted one is rejected with a non-zero exit and nothing installed.
+      # Lives in scripts/ so ci.yml's shellcheck job lints it and so it can be
+      # re-run by hand against any published release's assets.
+      - name: installer smoke test — accepts a good archive, rejects a substituted one
+        run: |
+          scripts/release/verify-installer-checksums.sh \
+            target/distrib/sergeant-rs-installer.sh \
+            target/distrib \
+            "$RELEASE_TAG"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -701,13 +701,13 @@ jobs:
       # for that platform, and a direct contradiction of the SBOM job's own
       # point (target-scoped documents, not one generator for everything).
       - name: GitHub artifact attestations — SBOM (x86_64-unknown-linux-gnu)
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: "release-assets/sergeant-rs-x86_64-unknown-linux-gnu.tar.xz"
           sbom-path: "release-assets/sgt_bin_x86_64-unknown-linux-gnu.cdx.json"
 
       - name: GitHub artifact attestations — SBOM (aarch64-apple-darwin)
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: "release-assets/sergeant-rs-aarch64-apple-darwin.tar.xz"
           sbom-path: "release-assets/sgt_bin_aarch64-apple-darwin.cdx.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,8 +361,26 @@ jobs:
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
 
+      # `--output-format=json` makes dist write this target's build manifest,
+      # which carries the archive's sha256. `package-installer` downloads it and
+      # `dist build --artifacts=global` reads the checksum straight out of it, so
+      # the generated installer ships real checksum values instead of the empty
+      # ones every release before 0.1.2 shipped (w3-recon.md §2a). The manifest
+      # is written OUTSIDE target/distrib and copied in afterwards, because
+      # `dist build` owns that directory while it runs — this is the exact order
+      # cargo-dist's own generated CI uses (templates/ci/github/release.yml.j2 @
+      # v0.32.0: `dist build … --output-format=json > dist-manifest.json` then
+      # `cp dist-manifest.json "$BUILD_MANIFEST_NAME"`, where BUILD_MANIFEST_NAME
+      # is target/distrib/<target>-dist-manifest.json). The <target>- filename
+      # prefix is that same convention and is what keeps the two matrix legs'
+      # manifests from colliding in the merged download.
       - name: dist build (packages the binary + LICENSE/README + checksum)
-        run: dist build --artifacts=local --target ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          dist build --artifacts=local --target ${{ matrix.target }} \
+            --output-format=json > "${RUNNER_TEMP}/local-dist-manifest.json"
+          cp "${RUNNER_TEMP}/local-dist-manifest.json" \
+            "target/distrib/${{ matrix.target }}-dist-manifest.json"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,6 +272,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -302,10 +303,60 @@ jobs:
             bash --version
           } > target/distrib/build-environment-${{ matrix.target }}.txt
 
-      - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
+      # dist is bootstrapped from its attested, checksum-pinned prebuilt
+      # tarball — NOT `curl … cargo-dist-installer.sh | sh`. Measured against
+      # axodotdev's own v0.32.0 release assets (w3-recon.md §1, 2026-08-21):
+      # cargo-dist-installer.sh has no `.sha256` sidecar, is absent from the
+      # aggregate `sha256.sum`, and has no build-provenance attestation at all
+      # (`gh attestation verify cargo-dist-installer.sh --repo
+      # axodotdev/cargo-dist` → HTTP 404). The per-target tarballs have both.
+      # The two checks below prove different things and neither subsumes the
+      # other: the committed sha256 pins the exact v0.32.0 bytes we qualified
+      # (an attestation alone would accept a *different* axodotdev-built
+      # tarball served from this URL), and `gh attestation verify` proves those
+      # bytes came out of axodotdev/cargo-dist's own release workflow rather
+      # than merely matching a hash someone uploaded. Bumping DIST_VERSION
+      # means re-recording both sha256 literals from that release's
+      # `sha256.sum` — deliberately, so a version bump is a qualification, not
+      # a one-character edit.
+      - name: install dist 0.32.0 (checksum-pinned + attestation-verified tarball)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIST_VERSION: "0.32.0"
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+          set -euo pipefail
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64)
+              dist_target="x86_64-unknown-linux-gnu"
+              dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
+              ;;
+            macOS-ARM64)
+              dist_target="aarch64-apple-darwin"
+              dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
+              ;;
+            *)
+              echo "::error::no qualified cargo-dist ${DIST_VERSION} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+              exit 1
+              ;;
+          esac
+          archive="cargo-dist-${dist_target}.tar.xz"
+          curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/${archive}"
+          echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c "${RUNNER_TEMP}/dist.sha256"
+          else
+            shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
+          fi
+          gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
+          mkdir -p "${RUNNER_TEMP}/dist-bin"
+          tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
+          got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
+          if [ "$got" != "cargo-dist ${DIST_VERSION}" ]; then
+            echo "::error::extracted dist reports '$got', expected 'cargo-dist ${DIST_VERSION}'" >&2
+            exit 1
+          fi
+          echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"
 
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null
@@ -362,16 +413,67 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: rustup toolchain install (rust-toolchain.toml pins the version; closes this job's prior lack of a pinned toolchain)
         run: rustup toolchain install
 
-      - name: install dist (pinned to workspace.metadata.dist's cargo-dist-version)
+      # dist is bootstrapped from its attested, checksum-pinned prebuilt
+      # tarball — NOT `curl … cargo-dist-installer.sh | sh`. Measured against
+      # axodotdev's own v0.32.0 release assets (w3-recon.md §1, 2026-08-21):
+      # cargo-dist-installer.sh has no `.sha256` sidecar, is absent from the
+      # aggregate `sha256.sum`, and has no build-provenance attestation at all
+      # (`gh attestation verify cargo-dist-installer.sh --repo
+      # axodotdev/cargo-dist` → HTTP 404). The per-target tarballs have both.
+      # The two checks below prove different things and neither subsumes the
+      # other: the committed sha256 pins the exact v0.32.0 bytes we qualified
+      # (an attestation alone would accept a *different* axodotdev-built
+      # tarball served from this URL), and `gh attestation verify` proves those
+      # bytes came out of axodotdev/cargo-dist's own release workflow rather
+      # than merely matching a hash someone uploaded. Bumping DIST_VERSION
+      # means re-recording both sha256 literals from that release's
+      # `sha256.sum` — deliberately, so a version bump is a qualification, not
+      # a one-character edit.
+      - name: install dist 0.32.0 (checksum-pinned + attestation-verified tarball)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIST_VERSION: "0.32.0"
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
+          set -euo pipefail
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64)
+              dist_target="x86_64-unknown-linux-gnu"
+              dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
+              ;;
+            macOS-ARM64)
+              dist_target="aarch64-apple-darwin"
+              dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
+              ;;
+            *)
+              echo "::error::no qualified cargo-dist ${DIST_VERSION} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+              exit 1
+              ;;
+          esac
+          archive="cargo-dist-${dist_target}.tar.xz"
+          curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/${archive}"
+          echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c "${RUNNER_TEMP}/dist.sha256"
+          else
+            shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
+          fi
+          gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
+          mkdir -p "${RUNNER_TEMP}/dist-bin"
+          tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
+          got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
+          if [ "$got" != "cargo-dist ${DIST_VERSION}" ]; then
+            echo "::error::extracted dist reports '$got', expected 'cargo-dist ${DIST_VERSION}'" >&2
+            exit 1
+          fi
+          echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"
 
       - name: "cargo metadata --locked (guard: dist build has no native --locked/--frozen flag)"
         run: cargo metadata --locked --format-version 1 >/dev/null

--- a/README.md
+++ b/README.md
@@ -63,19 +63,26 @@ catalog](#workflows) below for what a workflow actually is.
 curl -fsSL https://github.com/miztertea/sergeant-rs/releases/download/v0.1.0/sergeant-rs-installer.sh | sh
 ```
 
-**This one-liner does not verify anything.** It downloads the archive for
-your platform and installs it — it does not check a checksum, a signature,
-or an attestation. If you watch its output you'll see it say so plainly:
-`no checksums to verify`. That line isn't a warning about a missing file;
-`dist`'s generated installer declares the local variables it would use to
-verify a checksum but nothing in the script ever assigns them, so the
-verification branch is structurally unreachable — the installer always
-takes the "nothing to verify" path, for every release. Convenient, but it
-gives you no evidence the artifact you're running is the one this project
-published.
+**As of v0.1.2 this one-liner verifies the archive it downloads.** The
+generated installer carries the SHA-256 of every published archive and checks
+the download against it before extracting anything; a substituted or corrupted
+archive aborts the install with `checksum mismatch` and installs nothing. Every
+release run proves this on itself — the release workflow installs from a local
+origin and then re-runs the install against a deliberately substituted archive,
+and fails the release if that one is not rejected.
 
-If you want that evidence, verify by hand — it's a few extra commands, run
-once per release:
+Releases before v0.1.2 did **not** verify: `dist` fills those values in only
+when its global build can see the per-target build manifests, and this
+project's release workflow did not pass them forward until 0.1.2. Installing
+v0.1.1 or older with this one-liner prints `no checksums to verify` and installs
+unverified — for those, the manual steps below are the only evidence you get.
+
+Two things the one-liner still does not give you, at any version: it does not
+check **provenance** — that the archive came from *this* repository's release
+workflow rather than from anyone able to produce a matching hash — and its
+checksum arrives inside the very script that consumes it, from the same origin
+as the archive. To verify independently of the script, do it by hand — a few
+extra commands, run once per release:
 
 ```sh
 # 1. Download the archive for your platform, its checksum file, and the installer.
@@ -97,12 +104,13 @@ install -m 755 sergeant-rs-x86_64-unknown-linux-gnu/sgt ~/.local/bin/sgt
 sgt --version
 ```
 
-Step 2 confirms the bytes weren't corrupted or swapped in transit; step 3
-confirms they came from a GitHub Actions run of *this* repository's
-`release.yml`, via Sigstore/GitHub's build-provenance attestation — the
-thing the convenience one-liner skips entirely. Swap the target triple
-(`aarch64-apple-darwin`) and `~/.local/bin` for your platform and preferred
-install location as needed.
+Step 2 confirms the bytes weren't corrupted or swapped in transit — the same
+property the installer now checks for itself, but against a checksum you fetched
+as its own release asset rather than one embedded in the script; step 3 confirms
+they came from a GitHub Actions run of *this* repository's `release.yml`, via
+Sigstore/GitHub's build-provenance attestation — which the convenience one-liner
+still does not check. Swap the target triple (`aarch64-apple-darwin`) and
+`~/.local/bin` for your platform and preferred install location as needed.
 
 Want to see the whole loop first, with no tokens spent and no estate to
 set up? `scripts/demo.sh` builds the debug binary itself and drives it end

--- a/scripts/release/install-dist.sh
+++ b/scripts/release/install-dist.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Bootstrap `dist` (cargo-dist) from its attested, checksum-pinned prebuilt
+# tarball — NOT `curl … cargo-dist-installer.sh | sh`. Measured against
+# axodotdev's own release assets (w3-recon.md §1, 2026-08-21):
+# cargo-dist-installer.sh has no `.sha256` sidecar, is absent from the
+# aggregate `sha256.sum`, and has no build-provenance attestation at all
+# (`gh attestation verify cargo-dist-installer.sh --repo axodotdev/cargo-dist`
+# → HTTP 404). The per-target tarballs have both.
+#
+# Two checks, deliberately, because they prove different things: the
+# committed sha256 pins the exact bytes we qualified for this version (an
+# attestation alone would accept a *different* axodotdev-built tarball served
+# from the same URL), and `gh attestation verify` proves those bytes came out
+# of axodotdev/cargo-dist's own release workflow rather than merely matching a
+# hash someone uploaded. Neither check subsumes the other.
+#
+# Bumping the version means re-recording both sha256 literals below from that
+# release's `sha256.sum` — deliberately, so a version bump is a qualification,
+# not a one-character edit. Shared by both bootstrap call sites in
+# .github/workflows/release.yml (package, package-installer) so there is one
+# copy of the pinned hashes to re-qualify, not two.
+#
+# Requires GH_TOKEN in the environment (for `gh attestation verify`) and the
+# GitHub Actions runner environment: RUNNER_OS, RUNNER_ARCH, RUNNER_TEMP,
+# GITHUB_PATH.
+#
+# Usage: install-dist.sh <dist-version>
+#   e.g. install-dist.sh 0.32.0
+set -euo pipefail
+
+dist_version=${1:?usage: install-dist.sh <dist-version>}
+
+case "${RUNNER_OS}-${RUNNER_ARCH}" in
+  Linux-X64)
+    dist_target="x86_64-unknown-linux-gnu"
+    dist_sha256="eb52f9fae0d0506774e9f1801c1168f87fa2c87a45e2d64d3ae7c89401929946"
+    ;;
+  macOS-ARM64)
+    dist_target="aarch64-apple-darwin"
+    dist_sha256="aa343b2ff78ec2981f17a65140250c5ad6062c74072163f68c5c2686d94763a7"
+    ;;
+  *)
+    echo "::error::no qualified cargo-dist ${dist_version} tarball is pinned for runner ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+    exit 1
+    ;;
+esac
+
+archive="cargo-dist-${dist_target}.tar.xz"
+curl --proto '=https' --tlsv1.2 -LsSf --retry 3 -o "${RUNNER_TEMP}/${archive}" \
+  "https://github.com/axodotdev/cargo-dist/releases/download/v${dist_version}/${archive}"
+echo "${dist_sha256}  ${RUNNER_TEMP}/${archive}" > "${RUNNER_TEMP}/dist.sha256"
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c "${RUNNER_TEMP}/dist.sha256"
+else
+  shasum -a 256 -c "${RUNNER_TEMP}/dist.sha256"
+fi
+gh attestation verify "${RUNNER_TEMP}/${archive}" --repo axodotdev/cargo-dist
+mkdir -p "${RUNNER_TEMP}/dist-bin"
+tar xf "${RUNNER_TEMP}/${archive}" --strip-components 1 -C "${RUNNER_TEMP}/dist-bin"
+got=$("${RUNNER_TEMP}/dist-bin/dist" --version)
+if [ "$got" != "cargo-dist ${dist_version}" ]; then
+  echo "::error::extracted dist reports '$got', expected 'cargo-dist ${dist_version}'" >&2
+  exit 1
+fi
+echo "${RUNNER_TEMP}/dist-bin" >> "$GITHUB_PATH"

--- a/scripts/release/verify-installer-checksums.sh
+++ b/scripts/release/verify-installer-checksums.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Prove the generated sergeant-rs installer actually verifies what it downloads.
+#
+# Two tests, run against a local origin so nothing here touches the network or a
+# published release:
+#   positive — the real archive installs, and the installer does NOT take its
+#              "no checksums to verify" path;
+#   negative — a structurally valid but WRONG archive served under the right
+#              filename (the supply-chain substitution a checksum defends
+#              against) is rejected with a non-zero exit and nothing installed.
+#
+# A single-byte corruption is deliberately NOT used: xz's frame CRC rejects it
+# before the installer's checksum ever runs, which would prove the wrong thing.
+#
+# Usage: verify-installer-checksums.sh <installer.sh> <artifacts-dir> <tag>
+#   e.g. verify-installer-checksums.sh target/distrib/sergeant-rs-installer.sh \
+#          target/distrib v0.1.2
+set -euo pipefail
+
+installer=${1:?usage: verify-installer-checksums.sh <installer.sh> <artifacts-dir> <tag>}
+artifacts_dir=${2:?usage: verify-installer-checksums.sh <installer.sh> <artifacts-dir> <tag>}
+tag=${3:?usage: verify-installer-checksums.sh <installer.sh> <artifacts-dir> <tag>}
+
+# This script runs on a linux x86_64 runner, so the installer will select the
+# x86_64 archive; the darwin archive is the substitute for the negative test.
+host_archive="sergeant-rs-x86_64-unknown-linux-gnu.tar.xz"
+other_archive="sergeant-rs-aarch64-apple-darwin.tar.xz"
+port="${INSTALLER_SMOKE_PORT:-8917}"
+
+for f in "$installer" "$artifacts_dir/$host_archive" "$artifacts_dir/$other_archive"; do
+  if [ ! -f "$f" ]; then
+    echo "::error::installer smoke test needs $f, which is not present" >&2
+    exit 1
+  fi
+done
+
+work=$(mktemp -d)
+server_pid=""
+cleanup() {
+  if [ -n "$server_pid" ]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+# Mirror GitHub's release-download URL layout; the installer appends
+# /miztertea/sergeant-rs/releases/download/<tag> to the base URL it is given.
+download_dir="$work/srv/miztertea/sergeant-rs/releases/download/$tag"
+mkdir -p "$download_dir"
+cp "$artifacts_dir/$host_archive" "$artifacts_dir/$other_archive" "$download_dir/"
+
+python3 -m http.server "$port" --bind 127.0.0.1 --directory "$work/srv" \
+  >"$work/http.log" 2>&1 &
+server_pid=$!
+
+ready=0
+for _ in $(seq 1 50); do
+  if curl -fsS -I -o /dev/null \
+    "http://127.0.0.1:$port/miztertea/sergeant-rs/releases/download/$tag/$host_archive"; then
+    ready=1
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" -ne 1 ]; then
+  echo "::error::local origin did not come up on 127.0.0.1:$port" >&2
+  cat "$work/http.log" >&2
+  exit 1
+fi
+
+# SERGEANT_RS_INSTALL_DIR / SERGEANT_RS_NO_MODIFY_PATH / ..._GITHUB_BASE_URL are
+# the generated installer's own env vars — nothing here edits the script.
+run_installer() {
+  local dest=$1 log=$2 rc=0
+  mkdir -p "$dest"
+  SERGEANT_RS_INSTALLER_GITHUB_BASE_URL="http://127.0.0.1:$port" \
+  SERGEANT_RS_INSTALL_DIR="$dest" \
+  SERGEANT_RS_NO_MODIFY_PATH=1 \
+    sh "$installer" >"$log" 2>&1 || rc=$?
+  return "$rc"
+}
+
+# ── positive ────────────────────────────────────────────────────────────────
+if ! run_installer "$work/good" "$work/good.log"; then
+  echo "::error::installer failed against a VALID archive" >&2
+  cat "$work/good.log" >&2
+  exit 1
+fi
+if grep -q 'no checksums to verify' "$work/good.log"; then
+  echo "::error::installer took its unverified path ('no checksums to verify') — the generated installer carries no checksum values" >&2
+  cat "$work/good.log" >&2
+  exit 1
+fi
+if [ ! -x "$work/good/bin/sgt" ]; then
+  echo "::error::installer reported success but did not install $work/good/bin/sgt" >&2
+  cat "$work/good.log" >&2
+  exit 1
+fi
+"$work/good/bin/sgt" --version
+
+# ── negative ────────────────────────────────────────────────────────────────
+# Serve a different, structurally valid archive under the host archive's name.
+cp "$download_dir/$other_archive" "$download_dir/$host_archive"
+if run_installer "$work/bad" "$work/bad.log"; then
+  echo "::error::installer ACCEPTED a substituted archive — checksum verification is not effective" >&2
+  cat "$work/bad.log" >&2
+  exit 1
+fi
+if ! grep -q 'checksum mismatch' "$work/bad.log"; then
+  echo "::error::installer rejected the substituted archive, but not for a checksum mismatch — the negative test is not proving what it claims" >&2
+  cat "$work/bad.log" >&2
+  exit 1
+fi
+if [ -e "$work/bad/bin/sgt" ]; then
+  echo "::error::installer aborted on checksum mismatch but still left a binary behind" >&2
+  exit 1
+fi
+
+echo "installer smoke test: valid archive installed and verified; substituted archive rejected on checksum mismatch"

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -135,7 +135,7 @@ const WORKSPACE_MOUNT: &str = "/estate";
 /// The small, always-pullable image [`DockerBackend::lifecycle_probe`] uses
 /// in production (`sgt doctor`) — see its own doc for why a test may need a
 /// different one (the environments matrix, §22.7's probe-gating rule).
-pub const PROD_PROBE_IMAGE: &str = "alpine:3";
+pub const PROD_PROBE_IMAGE: &str = "alpine:3.24";
 
 /// The `--user uid:gid` value to run a container as, so its writes into a
 /// `read_write` mount come out owned by whoever already owns the mounted
@@ -695,7 +695,7 @@ impl DockerBackend {
     /// the module docs). Mounts a scratch directory, verifies a write is
     /// visible on the host, and cleans up its own labeled container.
     /// `probe_image` should be a small image sergeant can rely on
-    /// (`alpine:3` in production; a test may point this at a locally-built
+    /// (`alpine:3.24` in production; a test may point this at a locally-built
     /// probe image instead, per the environments matrix — §22.7's
     /// probe-gating rule).
     pub fn lifecycle_probe(&self, probe_image: &str) -> DockerLifecycleProbe {
@@ -1347,7 +1347,7 @@ mod tests {
             model: None,
             profile: None,
             execute: Some(ExecuteSpec {
-                image: "alpine:3".into(),
+                image: "alpine:3.24".into(),
                 command: vec!["true".into()],
                 workdir: "/estate".into(),
                 workspace_access: WorkspaceAccess::ReadOnly,
@@ -1472,7 +1472,7 @@ mod tests {
                 bindings: Vec::new(),
             };
             let spec = ExecuteSpec {
-                image: "alpine:3".into(),
+                image: "alpine:3.24".into(),
                 command: vec!["true".into()],
                 workdir: "/estate".into(),
                 workspace_access: WorkspaceAccess::ReadOnly,
@@ -1518,7 +1518,7 @@ mod tests {
         let backend = DockerBackend::new(config).expect("backend");
         assert!(backend.read_pin("w1", "s1").is_none());
         let image = ResolvedImage {
-            image_requested: "alpine:3".into(),
+            image_requested: "alpine:3.24".into(),
             image_id: "sha256:deadbeef".into(),
             repo_digests: vec!["alpine@sha256:deadbeef".into()],
             platform: "linux/amd64".into(),

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -1838,7 +1838,7 @@ mod tests {
                 "\n",
                 "[stage.\"00-validate\"]\n",
                 "kind = \"execute\"\n",
-                "image = \"alpine:3\"\n",
+                "image = \"alpine:3.24\"\n",
                 "command = [\"true\"]\n",
                 "workdir = \"/estate\"\n",
                 "workspace_access = \"read_only\"\n",
@@ -1877,7 +1877,7 @@ mod tests {
             (
                 "no-command",
                 concat!(
-                    "image = \"alpine:3\"\n",
+                    "image = \"alpine:3.24\"\n",
                     "workdir = \"/estate\"\n",
                     "workspace_access = \"read_only\"\n",
                     "network = \"none\"\n"
@@ -1886,7 +1886,7 @@ mod tests {
             (
                 "no-workdir",
                 concat!(
-                    "image = \"alpine:3\"\n",
+                    "image = \"alpine:3.24\"\n",
                     "command = [\"true\"]\n",
                     "workspace_access = \"read_only\"\n",
                     "network = \"none\"\n"
@@ -1895,7 +1895,7 @@ mod tests {
             (
                 "no-access",
                 concat!(
-                    "image = \"alpine:3\"\n",
+                    "image = \"alpine:3.24\"\n",
                     "command = [\"true\"]\n",
                     "workdir = \"/estate\"\n",
                     "network = \"none\"\n"
@@ -1904,7 +1904,7 @@ mod tests {
             (
                 "no-network",
                 concat!(
-                    "image = \"alpine:3\"\n",
+                    "image = \"alpine:3.24\"\n",
                     "command = [\"true\"]\n",
                     "workdir = \"/estate\"\n",
                     "workspace_access = \"read_only\"\n"
@@ -1946,7 +1946,7 @@ mod tests {
             wf.join(WORKFLOW_FILE),
             concat!(
                 "[workflow]\nname = \"bad-access\"\nversion = \"1\"\nstages = [\"00-only\"]\n\n",
-                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3\"\n",
+                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3.24\"\n",
                 "command = [\"true\"]\nworkdir = \"/estate\"\n",
                 "workspace_access = \"read_and_write_and_more\"\nnetwork = \"none\"\n",
             ),
@@ -1964,7 +1964,7 @@ mod tests {
             wf.join(WORKFLOW_FILE),
             concat!(
                 "[workflow]\nname = \"bad-network\"\nversion = \"1\"\nstages = [\"00-only\"]\n\n",
-                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3\"\n",
+                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3.24\"\n",
                 "command = [\"true\"]\nworkdir = \"/estate\"\n",
                 "workspace_access = \"read_only\"\nnetwork = \"bridge\"\n",
             ),
@@ -1991,7 +1991,7 @@ mod tests {
             concat!(
                 "[workflow]\nname = \"misplaced-actor-field\"\nversion = \"1\"\n",
                 "stages = [\"00-only\"]\n\n",
-                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3\"\n",
+                "[stage.\"00-only\"]\nkind = \"execute\"\nimage = \"alpine:3.24\"\n",
                 "command = [\"true\"]\nworkdir = \"/estate\"\n",
                 "workspace_access = \"read_only\"\nnetwork = \"none\"\nharness = \"claude\"\n",
             ),
@@ -2270,7 +2270,7 @@ mod tests {
                 "\n",
                 "[stage.\"20-x\"]\n",
                 "kind = \"execute\"\n",
-                "image = \"alpine:3\"\n",
+                "image = \"alpine:3.24\"\n",
                 "command = [\"true\"]\n",
                 "workdir = \"/estate\"\n",
                 "workspace_access = \"read_only\"\n",

--- a/tests/m7_docker_executor.rs
+++ b/tests/m7_docker_executor.rs
@@ -44,7 +44,7 @@ use sergeant_rs::domain::workflow::{ExecuteSpec, NetworkPolicy, WorkspaceAccess}
 /// already has (`docs/environments/cerberus.md`'s Docker probes use
 /// `alpine`). Kept as one named constant so a future environment that needs
 /// a different probe image changes one line.
-const PROBE_IMAGE: &str = "alpine:3";
+const PROBE_IMAGE: &str = "alpine:3.24";
 
 /// Whether the local Docker Engine answers at all. Every test in this file
 /// calls this first and returns early (with a loud, named skip) when it does
@@ -1162,7 +1162,7 @@ async fn a_kind_execute_stage_is_refused_at_submit_when_docker_is_unavailable() 
             "\n",
             "[stage.\"10-execute\"]\n",
             "kind = \"execute\"\n",
-            "image = \"alpine:3\"\n",
+            "image = \"alpine:3.24\"\n",
             "command = [\"true\"]\n",
             "workdir = \"/estate\"\n",
             "workspace_access = \"read_only\"\n",
@@ -1398,7 +1398,7 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
             "\n",
             "[stage.\"10-validate\"]\n",
             "kind = \"execute\"\n",
-            "image = \"alpine:3\"\n",
+            "image = \"alpine:3.24\"\n",
             "command = [\"sh\", \"-c\", \"echo container-produced-evidence > /estate/validated.txt\"]\n",
             "workdir = \"/estate\"\n",
             "workspace_access = \"read_write\"\n",


### PR DESCRIPTION
Wave 3 of the CI/CD-hardening sprint.

**Installer verification (ratify-at-review item — recommended resolution):** recon prototyping found the root cause of the upstream gap as it affects US: dist's global build DOES populate the installer's checksum variables when it can see the per-target build manifests — our CI built the installer in an isolated job, so dist had nothing to embed. Fix is data-plumbing, not patching: `package` legs emit their dist manifests as artifacts, `package-installer` (now `needs: package`) feeds them to the global build, and a committed `scripts/release/verify-installer-checksums.sh` gate proves BOTH paths in CI — good archive verifies + installs, corrupted archive is rejected. Proven locally end-to-end against real artifacts (x86_64 checksum byte-exact; negative test rejects with 'checksum mismatch'). No sed-patching of generated code anywhere.

- Both `curl … | sh` bootstrap sites → shared `scripts/release/install-dist.sh`: download dist 0.32.0's prebuilt tarball, verify against its published sha256 AND `gh attestation verify --repo axodotdev/cargo-dist`, then extract — fail-closed
- attest-sbom (deprecated) → actions/attest v4.2.2, full-SHA, 1:1 target↔SBOM pairing preserved
- alpine:3 → alpine:3.24 (17 sites; minor pin per the no-Cerberus rule); all 18 docker executor tests ran against a live engine pulling 3.24 — pass
- README installer one-liner notes verification from v0.1.2
- Panel: 1 major (48-line bootstrap block duplicated across jobs → extracted to the shared script), 1 minor (verification-report gaps → re-run + honestly explained: remaining grep hits are comment text, no live references)

Residual risks (need the release dry-run, listed in the head PR): `gh attestation verify` under Actions' GITHUB_TOKEN cross-repo; darwin installer arm population in real CI; macOS shasum branch untested on a mac.

Orchestrator gate: YAML×6, shellcheck, fmt, clippy, 24 suites ok, no-mutation — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4