### PR TITLE
W4 — Deps/docs/contracts: reqwest 0.13.4, docs-consistency gate, version policy, schema fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,17 @@ jobs:
       - name: cargo test
         run: cargo test --locked
 
+      - name: docs-consistency (README release literals match the current version)
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 --locked | jq -r '.packages[0].version')
+          stale=$(grep -noE 'releases/(download|tag)/v[0-9]+\.[0-9]+\.[0-9]+|release download v[0-9]+\.[0-9]+\.[0-9]+' README.md \
+            | grep -v "v${version}\b" || true)
+          if [ -n "$stale" ]; then
+            echo "::error::README.md references a release version other than the current v${version}:"
+            echo "$stale"
+            exit 1
+          fi
+
       - name: git diff --exit-code (no step above should have mutated a tracked file)
         run: git diff --exit-code
 
@@ -55,7 +66,8 @@ jobs:
     # it does NOT exercise scripts/demo.sh; the real enforcement of the
     # bash-3.2 floor is matrix.yml's full-suite `cargo test` on macos-26
     # (via tests/m6_surfaces.rs t4's scripts/demo.sh subprocess), which runs
-    # on PR-to-main, nightly, and release — not on every push. Gated at
+    # via workflow_call from release.yml's Gate C, or by manual
+    # workflow_dispatch — never on a routine push. Gated at
     # --severity=error only: a 2026-08-14 sweep of all 25 scripts/**/*.sh
     # found the tree clean at that threshold but carrying ~84 pre-existing
     # warning/note/style findings (mostly SC2154 false positives from the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,10 +599,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -639,6 +681,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -873,6 +925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1065,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1272,7 +1336,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1510,6 +1573,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,7 +1650,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1882,6 +1994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,7 +2009,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1904,7 +2022,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -1919,8 +2037,8 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
- "thiserror 2.0.19",
+ "reqwest",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1947,7 +2065,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -2204,7 +2322,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2216,6 +2334,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -2226,7 +2345,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2369,7 +2488,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -2491,44 +2610,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2542,13 +2623,22 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2619,6 +2709,7 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2626,6 +2717,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2639,11 +2742,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2662,10 +2793,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2762,11 +2934,11 @@ dependencies = [
  "opentelemetry_sdk",
  "ratatui",
  "ratatui-textarea",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "toml",
@@ -2838,6 +3010,22 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3004,7 +3192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3097,11 +3285,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3117,9 +3305,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3555,6 +3743,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,6 +3956,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ opentelemetry_sdk = { version = "0.32", default-features = false, features = ["t
 # a fact nobody re-decided.
 ratatui = "0.30.2"
 ratatui-textarea = "0.9.2"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 thiserror = "2.0.19"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ catalog](#workflows) below for what a workflow actually is.
 `dist` (cargo-dist) publishes a prebuilt `sgt` for each [release](https://github.com/miztertea/sergeant-rs/releases), plus a `curl | sh` convenience installer:
 
 ```sh
-curl -fsSL https://github.com/miztertea/sergeant-rs/releases/download/v0.1.0/sergeant-rs-installer.sh | sh
+curl -fsSL https://github.com/miztertea/sergeant-rs/releases/latest/download/sergeant-rs-installer.sh | sh
 ```
 
 **As of v0.1.2 this one-liner verifies the archive it downloads.** The
@@ -87,7 +87,7 @@ extra commands, run once per release:
 ```sh
 # 1. Download the archive for your platform, its checksum file, and the installer.
 mkdir -p /tmp/sgt-install && cd /tmp/sgt-install
-gh release download v0.1.0 --repo miztertea/sergeant-rs \
+gh release download --repo miztertea/sergeant-rs \
   -p 'sergeant-rs-x86_64-unknown-linux-gnu.tar.xz' \
   -p 'sergeant-rs-x86_64-unknown-linux-gnu.tar.xz.sha256'
 

--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -1,0 +1,145 @@
+# Version policy
+
+How sergeant-rs pins its dependencies, tools, and runners — and, just as
+importantly, what it deliberately does *not* pin and why. Written so a
+future audit does not re-litigate a decision already made here. Source:
+the CI/CD hardening sprint plan (`sprint-plan-2026-08-20.md`), "The
+one-rule target state":
+
+> Discover the newest acceptable version on an upgrade branch, qualify it
+> completely, commit the exact working state, and use non-blocking
+> canaries to discover the next change.
+
+## Pin at the correct layer
+
+| Layer | Mechanism | Example |
+|---|---|---|
+| Crate compatible range | `Cargo.toml` semver range, never `=x.y.z` | `reqwest = "0.13"`, `duckdb = "1"`, `axum = "0.8"` |
+| Crate exact graph | `Cargo.lock`, enforced everywhere with `--locked` | every `cargo` invocation in `ci.yml`, `matrix.yml`, `coverage.yml`, `release.yml` |
+| Compiler | `rust-toolchain.toml` exact channel | `channel = "1.98.0"` |
+| GitHub Actions | full 40-char SHA + a `# vX.Y.Z` comment | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`, `Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2` |
+| `install-action` helper tools | exact version per `tool:` input | `cargo-llvm-cov@0.9.0` (`coverage.yml`), `cargo-deny@0.20.2` and `cargo-cyclonedx@0.5.9` (`release.yml`) |
+| `cargo-dist` | exact version, `[workspace.metadata.dist]` | `cargo-dist-version = "0.32.0"` (`Cargo.toml`) |
+| CI/release runners | explicit OS generation, never the floating alias | `ubuntu-24.04`, `macos-26` — required in every job in `ci.yml`/`matrix.yml`/`coverage.yml`/`release.yml` |
+| Release artifacts | checksummed + attested | per-target `.sha256` sidecars, `actions/attest` provenance + SBOM, `gh attestation verify` (README's manual-verification section) |
+
+The floating `stable`/`ubuntu-latest`/`macos-latest` aliases appear in
+exactly one place on purpose: `canary.yml` (weekly schedule +
+`workflow_dispatch`). That is canary's whole job — notice the alias moving
+before required CI does. Required CI (`ci.yml`, `matrix.yml`) stays on the
+pinned toolchain and pinned runner generations regardless of canary state;
+a red canary triggers a deliberate upgrade PR, never a silent auto-bump. No
+`continue-on-error` on the canary job — a green run means nothing changed
+upstream; a red one is the signal, and GitHub's default scheduled-failure
+notification plus the workflow's own `if: failure()` "upstream drift"
+tracking-issue step both depend on the run actually going red when
+something moved.
+
+## Deliberate non-pins
+
+These are gaps only if you don't already know why. They're not gaps.
+
+**Alpine minor-line, not a manifest digest.** `PROD_PROBE_IMAGE` in
+`src/backend/docker.rs` and the matching test fixtures pin `alpine:3.24` —
+the current minor cycle (patch 3.24.1) — not a `sha256:` digest. This repo
+is designed for Linux/macOS/WSL and is never tuned to a specific self-hosted
+image generation ("Cerberus"); runner and base-image pinning stops at the
+OS/distro generation, not at a byte-exact manifest. A digest pin would swap
+"drifts with the next Alpine 3.24 patch" for "never gets a security patch
+without a manual bump" — the wrong trade for a probe image, not a supply
+chain artifact.
+
+**Crate versions stay ranges, never mass-`=x.y.z`.** `Cargo.lock` is already
+the exact pin every build actually uses (with `--locked` enforced
+everywhere). A blanket `=` policy in `Cargo.toml` would duplicate what the
+lockfile already guarantees while turning every transitive bump into a
+manual `Cargo.toml` edit for no added safety.
+
+**No machine-readable tool inventory.** The two shell installers
+(`scripts/*.sh`) and the four `install-action`/`cargo-dist` tool versions
+are not captured in a schema or manifest file of their own — this
+document's tables *are* the inventory. A structured format for four tools
+and two scripts is process for its own sake; this table is read by people,
+not parsed by tooling, and that's the right size for what it covers.
+
+## Duplicate transitives
+
+The pattern: two versions of the same crate resolve simultaneously because
+one dependency pins a different line than sergeant's own direct dependency.
+Worth naming explicitly so a future "why are there two X in the lockfile"
+question has an answer here instead of becoming a fresh investigation.
+
+- **Eliminated this wave**: `reqwest` 0.12.28 (sergeant's own direct
+  dependency) and 0.13.4 (transitively via `opentelemetry-otlp`) both
+  resolved simultaneously before the reqwest 0.13 migration. Collapsed to a
+  single `reqwest 0.13.4` by that migration (see the sprint's W4 wave) —
+  `cargo tree -i reqwest@0.12.28` now returns "did not match any packages".
+- **Surfaced by the same migration, understood, not a conflict**: `ring
+  0.17.14` (via `ureq 3.4.0`, a **build-dependency** of `libduckdb-sys`'s
+  `bundled` feature — compiled and run only inside that crate's `build.rs`,
+  never linked into the `sgt` binary) coexists with `aws-lc-rs 1.16.2` (via
+  reqwest 0.13.4's `rustls` feature, sergeant's actual runtime TLS
+  provider — reqwest 0.13's `rustls` feature is defined as
+  `__rustls-aws-lc-rs + rustls-platform-verifier + __rustls`, i.e. enabling
+  it is what first pulls `aws-lc-rs` into this tree at all). These are two
+  different processes with two different `rustls::crypto::CryptoProvider`
+  installs; a `CryptoProvider` conflict only matters within one process, and
+  grep of `src/` for `CryptoProvider`/`rustls::crypto`/`install_default`
+  returns zero hits — nothing in sergeant's own runtime code races to
+  install a provider either. Not a false alarm to re-discover; recorded here
+  once.
+
+## MSRV
+
+`Cargo.toml`'s `rust-version = "1.89.0"` is a **from-source-builder-only**
+floor — the `sgt` binary itself always ships prebuilt via `cargo-dist`, so
+this field serves nobody who installs a release. It exists for anyone
+building from a clone. The number is measured empirically, not predicted:
+`ci.yml`'s `msrv` job comment records that a static `cargo-metadata` scan of
+dependency `rust-version` fields under-predicted the floor by one minor
+version, because this crate's own use of
+`std::fs::File::try_lock`/`TryLockError` (stabilized 1.89.0) isn't visible
+to that kind of scan. `cargo +1.89.0 check --locked --all-targets` and
+`cargo +1.89.0 test --locked` were run directly to confirm the real floor
+before this field and the `msrv` CI job were added. That job runs
+`cargo check` only — no `clippy` — because lint policy belongs to the pinned
+dev compiler (`rust-toolchain.toml`), not to a deliberately-older
+from-source floor. Keep `Cargo.toml:8`'s `rust-version` and `ci.yml`'s
+`env.MSRV` hand-synced (no shared source of truth exists between TOML and
+YAML without added machinery); both carry a comment pointing at the other.
+
+## Canary
+
+`canary.yml`: weekly schedule + `workflow_dispatch`, deliberately floating
+`stable` Rust on `ubuntu-latest`/`macos-latest` (the one place in this repo
+those aliases are intentional — see "Pin at the correct layer" above), runs
+`check`/`clippy`/`test --locked`. No `continue-on-error`: it is a standalone
+scheduled workflow, not a required PR check, so a red run blocks nothing
+and GitHub's own scheduled-failure notification fires on it. An `if:
+failure()` step opens-or-updates a single tracking issue with the failing
+job link, so drift doesn't need someone to notice a red badge by chance. A
+red canary is the trigger for a deliberate, reviewed upgrade PR — never a
+silent auto-bump, and required CI stays on the pinned toolchain/runners
+throughout, unaffected by canary state.
+
+## Internal `/vN` identifiers are contracts, not update targets
+
+Four schema identifiers, each a compatibility contract:
+
+| Schema | Constant | Location | Current value |
+|---|---|---|---|
+| Watch | `WATCH_SCHEMA` | `src/watch.rs:34` | `sergeant.watch/v1` |
+| Event | `EVENT_SCHEMA` | `src/domain/event.rs:15` | `sergeant.event/v1` |
+| Execution | `SCHEMA_VERSION` | `src/backend/docker.rs:130` | `execution/v1` |
+| Runtime descriptor | `DESCRIPTOR_SCHEMA` | `src/daemon.rs:58` | `sergeant.runtime/v2` |
+
+Bumping any of these is a breaking-change event requiring an explicit
+compatibility decision — never a routine "current version" edit the way a
+`Cargo.toml` range or a README release literal is. The one identifier that
+*has* been bumped, the runtime descriptor (v1 → v2), models the expected
+shape of that decision: no compatibility shim, an old descriptor fails
+closed with a diagnostic naming both schema versions and the concrete
+remedy (`sgt daemon stop` then restart) — see `src/daemon.rs`'s
+`read_descriptor` and its `a_v1_descriptor_fails_closed_with_a_restart_remedy`
+test. A future bump to any of the other three should read as a deliberate
+repeat of that pattern, not a fresh design.

--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -77,7 +77,7 @@ question has an answer here instead of becoming a fresh investigation.
 - **Surfaced by the same migration, understood, not a conflict**: `ring
   0.17.14` (via `ureq 3.4.0`, a **build-dependency** of `libduckdb-sys`'s
   `bundled` feature — compiled and run only inside that crate's `build.rs`,
-  never linked into the `sgt` binary) coexists with `aws-lc-rs 1.16.2` (via
+  never linked into the `sgt` binary) coexists with `aws-lc-rs 1.18.0` (via
   reqwest 0.13.4's `rustls` feature, sergeant's actual runtime TLS
   provider — reqwest 0.13's `rustls` feature is defined as
   `__rustls-aws-lc-rs + rustls-platform-verifier + __rustls`, i.e. enabling

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -1319,6 +1319,14 @@ mod tests {
     }
 
     #[test]
+    fn execution_schema_label_is_the_pinned_contract_string() {
+        assert_eq!(
+            format!("{LABEL_SCHEMA}={SCHEMA_VERSION}"),
+            "io.sergeant.schema=execution/v1"
+        );
+    }
+
+    #[test]
     fn container_name_is_deterministic_from_execution_id() {
         let (_dir, config) = config();
         let backend = DockerBackend::new(config).expect("backend");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1220,6 +1220,46 @@ mod tests {
         );
     }
 
+    /// Complements `a_v1_descriptor_fails_closed_with_a_restart_remedy` above:
+    /// the positive case for the *current* schema, going through the same
+    /// on-disk file-write → `read_descriptor` path (not the in-memory
+    /// `descriptor_bound_to()` helper, which never touches disk).
+    #[test]
+    fn a_v2_descriptor_round_trips_through_read_descriptor() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(
+            dir.path().join(DESCRIPTOR_FILE),
+            serde_json::json!({
+                "schema": DESCRIPTOR_SCHEMA,
+                "endpoint": "http://127.0.0.1:1",
+                "pid": 1,
+                "api_revision": API_REVISION,
+                "token": "t",
+                "estate_root": "/estates/payments",
+                "manifest_path": "/estates/payments/sergeant.toml",
+            })
+            .to_string(),
+        )
+        .expect("write v2 descriptor");
+
+        let descriptor = read_descriptor(dir.path())
+            .expect("read must succeed")
+            .expect("descriptor must be present");
+        assert_eq!(descriptor.schema, DESCRIPTOR_SCHEMA);
+        assert_eq!(descriptor.endpoint, "http://127.0.0.1:1");
+        assert_eq!(descriptor.pid, 1);
+        assert_eq!(descriptor.api_revision, API_REVISION);
+        assert_eq!(descriptor.token, "t");
+        assert_eq!(
+            descriptor.estate_root.as_deref(),
+            Some(Path::new("/estates/payments"))
+        );
+        assert_eq!(
+            descriptor.manifest_path.as_deref(),
+            Some(Path::new("/estates/payments/sergeant.toml"))
+        );
+    }
+
     /// A minimal, directly-constructed [`Core`] over a fresh journal — no
     /// HTTP surface, no engine, just what the committer and the export loop
     /// actually touch.

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -701,6 +701,25 @@ mod tests {
     // ---- §9.1/§9.2: JSON shape -------------------------------------------
 
     #[test]
+    fn a_literal_watch_notice_blob_deserializes_with_the_pinned_schema() {
+        // Unlike `notice_json_shape_matches_the_contract...` above (which
+        // serializes a Rust-constructed WatchNotice), this parses a
+        // hand-written JSON blob as real input data — mirroring event.rs's
+        // `explicit_null_known_field_reads_as_unset_and_unknown_nulls_survive`
+        // pattern for its own schema string.
+        let blob = concat!(
+            r#"{"schema":"sergeant.watch/v1","reason":"state_transition","#,
+            r#""trigger":{"seq":1,"id":"01EVT","timestamp":"2026-08-13T18:42:31.417Z","kind":"work.completed"},"#,
+            r#""snapshot":{"work":{"state":"completed"}}}"#
+        );
+        let value: Value = serde_json::from_str(blob).expect("parse literal watch notice");
+        assert_eq!(value["schema"], WATCH_SCHEMA);
+        assert_eq!(value["reason"], "state_transition");
+        assert_eq!(value["trigger"]["kind"], "work.completed");
+        assert_eq!(value["snapshot"]["work"]["state"], "completed");
+    }
+
+    #[test]
     fn notice_json_shape_matches_the_contract_and_excludes_the_raw_payload() {
         let notice = WatchNotice {
             schema: WATCH_SCHEMA,


### PR DESCRIPTION
Wave 4 of the CI/CD-hardening sprint.

- reqwest 0.12→0.13.4: duplicate HTTP/TLS stack collapsed (cargo tree proves exactly one reqwest; 0.12.28 gone). Feature rename rustls-tls→rustls, plus 'query' (0.13 newly gates RequestBuilder::query(), used by tests — a recon miss caught in implementation)
- thiserror 2.0.19→2.0.20
- README installer URLs → /latest alias (works from v0.1.2's publish via the repaired make_latest + verify-latest path); new docs-consistency CI step (version from cargo metadata, fails on stale download-URL literals — negative-plant test proven both directions)
- Stale ci.yml topology comment corrected (matrix is workflow_call/dispatch — Gate C, not 'PR-to-main, nightly, release')
- docs/version-policy.md: pin-at-the-correct-layer policy incl. deliberate non-pins with rationale
- Golden contract tests for watch/v1, execution/v1, runtime/v2 (event/v1 already covered)

**Incident:** initial implement attempt hit the tmpfs-quota outage (a scratch cargo build in the /tmp scratchpad blew the user quota, killing Bash harness-wide); recovery agent shipped the full spec via the Monitor shell path; quota root-caused + cleaned; wave then RE-PANELED against the real tree: 2 findings (same defect — version-policy cited recon-era aws-lc-rs 1.16.2 vs shipped 1.18.0), fixed.

Orchestrator gate: YAML, fmt, tree proofs, clippy -D warnings, 24 suites, no-mutation — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4