### PR TITLE
Release-path fixes: Gate E --locked placement + drop redundant post-merge CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,20 @@
 name: CI
 
-# ADR 0004 (D9): this is the cheap per-push tier — Linux fmt/clippy/test plus
-# a macOS lane, run on every push so wall-clock stays low (matrix jobs run
-# concurrently, so cost is max(job) not sum(job)). The full real-suite matrix
+# ADR 0004 (D9): this is the cheap per-PR tier — Linux fmt/clippy/test plus
+# a macOS lane, run on every pull request so wall-clock stays low (matrix
+# jobs run concurrently, so cost is max(job) not sum(job)). The full
+# real-suite matrix
 # across all measured targets (ADR 0001 D1) is a qualification capability, not
 # a routine trigger on this workflow — see matrix.yml (workflow_call /
 # workflow_dispatch, per ADR 0014 decision 9).
 on:
-  # `on: [push, pull_request]` ran this battery twice for every push to a PR
-  # branch — same commit, same result, twice the wait. Pushes are checked on
-  # `main` only; every other branch is checked through its pull request.
-  push:
-    branches: [main]
+  # No push trigger, deliberately. Every commit reaches main through a pull
+  # request whose head tree — for this repo's single-writer, up-to-date-merge
+  # flow — is byte-identical to the merge commit, so a post-merge re-run of
+  # this same battery proved nothing twice a day. Main's ongoing health is
+  # covered where it can actually change: the weekly canary (floating
+  # toolchain/runners) and release.yml's gates re-qualifying the exact SHA at
+  # dispatch. The README badge reads ?event=pull_request for the same reason.
   pull_request:
   # release.yml's Gate B calls this workflow rather than re-defining "tests
   # passed" (proposal §9.2 / §16 — release qualification never invents an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           tool: cargo-deny@0.20.2
       - name: cargo deny check (full — advisories, bans, licenses, sources)
-        run: cargo deny check --locked
+        run: cargo deny --locked check
 
   # ── Gate F — distro structural validator ───────────────────────────────
   # Does not execute here — see the top-of-file comment for why (workspace

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Sergeant is an AgentOS distro: instructions, skills, and conventions that turn a general-purpose coding harness into an operator of your estate, carried by `sgt` — a durable intent-execution engine that runs to completion whether or not anyone is watching.**
 
-[![CI](https://github.com/miztertea/sergeant-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/miztertea/sergeant-rs/actions/workflows/ci.yml)
+[![CI](https://github.com/miztertea/sergeant-rs/actions/workflows/ci.yml/badge.svg?event=pull_request)](https://github.com/miztertea/sergeant-rs/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 Clone it, put `sgt` on `PATH`, point it at your repos, and open your coding


### PR DESCRIPTION
Two fixes, both owner-requested tonight:

1. **Gate E** (caught by dry-run 32442475122): `cargo deny check --locked` → `cargo deny --locked check` — cargo-deny takes the flag globally, not on the subcommand. Only executes inside release.yml, so no earlier CI could exercise it. Corrected form verified locally with the pinned 0.20.2: advisories/bans/licenses/sources ok.
2. **Redundant post-merge CI dropped**: ci.yml loses `push: branches: [main]` — for this repo's single-writer up-to-date-merge flow the merge commit tree is identical to the PR head that just passed, so the re-run proved nothing. Canary + release gates keep covering main. README badge → `?event=pull_request` so it reflects real runs.

After merge: re-dispatch the release dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4