### PR TITLE
release: set Latest in its own post-publish step via gh porcelain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -802,10 +802,23 @@ jobs:
             echo "::error::draft-release did not emit a release-id output — refusing to guess which draft to publish" >&2
             exit 1
           fi
-          gh api -X PATCH "repos/${{ github.repository }}/releases/$RELEASE_ID" -f draft=false -f make_latest=true
+          gh api -X PATCH "repos/${{ github.repository }}/releases/$RELEASE_ID" -f draft=false
+
+      # Separate step, by tag, via porcelain — measured on v0.1.2
+      # (2026-08-21): `make_latest=true` riding in the same PATCH as the
+      # draft flip is silently dropped (the release is still a draft when
+      # the flag is validated, and drafts cannot be latest), which left
+      # /releases/latest on the prior tag until `gh release edit --latest`
+      # fixed it by hand. By-tag is safe here where it isn't above: only
+      # one *published* release can carry a tag, so the draft-collision
+      # rationale for by-ID doesn't apply post-publish.
+      - name: mark the published release as latest (must be its own step — see comment)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$RELEASE_TAG" --repo "${{ github.repository }}" --latest
 
   # ── Verify latest ──────────────────────────────────────────────────────
-  # `make_latest=true` above is a request, not a guarantee — GitHub's
+  # `--latest` above is a request, not a guarantee — GitHub's
   # "latest" resolution is eventually consistent. Confirm this run's own
   # tag is what /releases/latest actually reports before we call the
   # publish durable, retrying to ride out the lag rather than racing it.


### PR DESCRIPTION
## What

One defect, measured live on v0.1.2's publish (run 32446915403): `make_latest=true` sent in the same PATCH as `draft=false` is **silently dropped** — the release is still a draft when the flag is validated ("drafts and prereleases cannot be set as latest"), so v0.1.2 published without becoming Latest and `verify-latest` failed the run, exactly as designed. `gh release edit v0.1.2 --latest` then fixed it by hand in one command — proving immutability was never the blocker (immutable releases lock assets and tags, not the Latest marker) and that the porcelain path works on a published release.

## Fix

- The publish PATCH flips `draft=false` only (still by release ID — the stale-draft-collision rationale for by-ID stands).
- A new separate step marks the release Latest **after** it is published: `gh release edit "$RELEASE_TAG" --latest`. By-tag is safe here where it isn't for the draft flip: only one *published* release can carry a tag.
- `verify-latest` unchanged — it caught this exact failure twice and stays as the assertion.

Hand-rolled `gh api` choreography is replaced by the standard `gh release` verb at the one point that bit us; the larger stop-owning-the-release-lifecycle question (dist-generated pipeline) stays open for a maintenance pass and is not attempted here.

## Verification

The failure mode only manifests at real publish time (dry-run deletes its draft before this job). Evidence chain: run #10's publish log shows the combined PATCH; `/releases/latest` stayed v0.1.1 for 6+ hours (not eventual-consistency lag); the porcelain command flipped it immediately. Next `publish` dispatch (0.1.3) is the live proof, with verify-latest asserting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4

---
**Rung citation (AGENTS.md R1–R7):** the original combined PATCH was an uncited R7 (hand-rolled API choreography) that never checked R5 — `gh release edit --latest` is the installed dependency's own verb for exactly this, measured working on v0.1.2 today. This PR moves the step down the ladder to R5 and logs why: porcelain sequences the draft-flip and Latest-marking correctly, which the raw combined PATCH provably does not.