### PR TITLE
W3: the prune engine — simple retention per the #17 rulings

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -100,6 +100,16 @@ pub struct Core {
     /// because then the registry already holds every command the journal
     /// knows.
     pub floor_ledger: Arc<BTreeMap<String, FloorCommandRow>>,
+    /// W3 §2.5: first seq this process has seen for each retained Work — the
+    /// `first_seq(id)` half of the prune horizon's no-straddle predicate.
+    /// Seeded once at start (cache rows ∪ the startup pass's `HorizonSink`),
+    /// advanced by [`Core::commit`] (`entry().or_insert(event.seq)`), and
+    /// pruned ids removed when a `prune.completed` is folded.
+    pub first_seq_by_work: crate::runtime::prune::FirstSeqIndex,
+    /// W3 §2.5 / §10.2: a prune cycle the last tick or start could not
+    /// finish — because a re-validation aborted it, or because it failed.
+    /// Re-arms the next tick's attempt without waiting for a rotation.
+    pub prune_pending: bool,
     /// The **open group**: events written and folded during the current lock
     /// hold, awaiting the hold's single fsync (#44).
     ///
@@ -137,6 +147,8 @@ impl Core {
             registry,
             events_tx,
             floor_ledger: Arc::new(std::collections::BTreeMap::new()),
+            first_seq_by_work: std::collections::BTreeMap::new(),
+            prune_pending: false,
             open_group: Vec::new(),
         }
     }
@@ -154,6 +166,19 @@ impl Core {
         self
     }
 
+    /// W3 §2.5: seed `first_seq_by_work` from the merged cache-rows ∪
+    /// startup-pass index a fresh start computed. A separate builder for the
+    /// same reason `with_floor_ledger` is one — the existing test
+    /// constructors stay untouched, since an empty index (no Work has been
+    /// seen yet) is exactly right for them.
+    pub fn with_first_seq_index(
+        mut self,
+        first_seq_by_work: crate::runtime::prune::FirstSeqIndex,
+    ) -> Self {
+        self.first_seq_by_work = first_seq_by_work;
+        self
+    }
+
     /// Append one event to the journal, fold it into the registry, and add it
     /// to the lock hold's open group. The only mutation path.
     ///
@@ -167,6 +192,22 @@ impl Core {
     pub fn commit(&mut self, draft: EventDraft) -> Result<Event, CoreError> {
         let event = self.journal.append(draft)?;
         self.registry.apply(&event)?;
+        // W3 §2.5: the first seq this process has ever seen for `work_id`.
+        // `or_insert` — once set, a Work's own `first_seq` never moves,
+        // exactly like `HorizonSink`'s startup-time fold this seeds from.
+        if let Some(work_id) = &event.work_id {
+            self.first_seq_by_work
+                .entry(work_id.clone())
+                .or_insert(event.seq);
+        }
+        // A completed prune removes the pruned ids: nothing about them can
+        // be asked of this index again (the events that would answer are
+        // gone), and leaving stale entries here would grow it without bound
+        // across the estate's life.
+        if event.kind == crate::runtime::prune::KIND_PRUNE_COMPLETED {
+            let live = &self.registry.state().work_index;
+            self.first_seq_by_work.retain(|id, _| live.contains_key(id));
+        }
         self.open_group.push(event.clone());
         Ok(event)
     }
@@ -408,6 +449,10 @@ pub struct ApiState {
     /// up from the journal at query time (see [`with_analytics`]), so a
     /// failure anywhere in here costs an answer, never a fact.
     pub analytics: Arc<tokio::sync::Mutex<Analytics>>,
+    /// W3: the retention policy this daemon resolved once at start, pinned
+    /// for its whole life (§1.2) — read by [`drive_completions`]'s rotation
+    /// trigger (§10.4).
+    pub prune_policy: crate::runtime::prune::PrunePolicy,
 }
 
 /// Build the axum router for the full v1 surface.
@@ -745,6 +790,90 @@ pub async fn drive_completions(state: ApiState, interval: Duration) {
             )
             .await;
         }
+        if *closing.borrow() {
+            return;
+        }
+        maybe_run_rotation_triggered_prune(&state).await;
+    }
+}
+
+/// W3 §10.4: the rotation-triggered prune maintenance step, run once per
+/// tick after the observe/interrupt work above. A failure anywhere here is
+/// logged and the tick continues — a daemon that cannot prune must keep
+/// serving; [`crate::runtime::prune::stall_report`] is how that becomes
+/// visible, not a blocked tick.
+///
+/// Phase A ([`crate::runtime::prune::candidate_horizon`]) and the cheap
+/// `take_rotation_signal`/`segment_bounds` reads run under the guard (they
+/// are in-memory and fast); Phase B
+/// ([`crate::runtime::prune::plan`], the mark scan) runs on a blocking
+/// thread with the guard released, since it is the unbounded part (§10.1's
+/// own split); [`crate::runtime::prune::run`] re-acquires the guard to
+/// re-validate and commit.
+async fn maybe_run_rotation_triggered_prune(state: &ApiState) {
+    let snapshot = {
+        let mut core = CoreGuard::acquire(&state.core).await;
+        let rotated = core.journal.take_rotation_signal();
+        if !rotated && !core.prune_pending {
+            return;
+        }
+        let bounds = match core.journal.segment_bounds() {
+            Ok(bounds) => bounds,
+            Err(e) => {
+                tracing::error!(error = %e, "prune tick: segment_bounds failed");
+                return;
+            }
+        };
+        let (candidate, _stall) = crate::runtime::prune::candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &state.prune_policy,
+        );
+        let eligible_segments = bounds.iter().filter(|b| b.last_seq <= candidate).count();
+        if candidate == 0 || eligible_segments < crate::runtime::prune::PRUNE_BATCH_MIN_SEGMENTS {
+            return;
+        }
+        (
+            bounds,
+            candidate,
+            core.registry.state().clone(),
+            core.first_seq_by_work.clone(),
+        )
+    };
+    let (bounds, candidate, registry_snapshot, first_seq_snapshot) = snapshot;
+
+    let data_dir = state.data_dir.clone();
+    let policy = state.prune_policy;
+    let planned = tokio::task::spawn_blocking(move || {
+        crate::runtime::prune::plan(
+            &data_dir,
+            &bounds,
+            candidate,
+            &registry_snapshot,
+            &first_seq_snapshot,
+            &policy,
+        )
+    })
+    .await;
+
+    match planned {
+        Ok(Ok(Some(plan))) => {
+            let mut core = CoreGuard::acquire(&state.core).await;
+            if let Err(e) = crate::runtime::prune::run(&mut core, &state.data_dir, plan, false) {
+                tracing::error!(error = %e, "rotation-triggered prune failed");
+                core.prune_pending = true;
+            }
+        }
+        Ok(Ok(None)) => {}
+        Ok(Err(e)) => {
+            tracing::error!(error = %e, "rotation-triggered prune planning failed");
+            let mut core = CoreGuard::acquire(&state.core).await;
+            core.prune_pending = true;
+        }
+        Err(join_err) => {
+            tracing::error!(error = %join_err, "rotation-triggered prune planning task panicked");
+        }
     }
 }
 
@@ -1066,6 +1195,14 @@ fn replay_command(core: &Core, command_id: &str) -> Option<Response> {
         let status =
             StatusCode::from_u16(outcome.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
         return Some((status, Json(outcome.result.clone())).into_response());
+    }
+    // W3 §6.3: a command pruned along with its Work's segments — Q8's
+    // exemption. Same 409, same `command_below_replay_window` code, same
+    // "refused by name, not re-executed" shape as the below-window arm just
+    // below: W3 reuses it verbatim rather than inventing a new response
+    // shape (§4 of the brief).
+    if let Some(row) = core.registry.state().pruned_commands.get(command_id) {
+        return Some(below_floor_refusal(&row.as_floor_row()));
     }
     core.floor_ledger.get(command_id).map(below_floor_refusal)
 }
@@ -1603,6 +1740,13 @@ fn resolve_work(core: &Core, work_id: &str) -> Option<Work> {
     }
     if let Some(work) = registry.terminal_works.get(work_id) {
         return Some(work.clone());
+    }
+    // W3 §11.2: a pruned id short-circuits to `None` here rather than
+    // paying a replay that is guaranteed to find nothing — its events are
+    // gone. `pruned_works` and `work_index` are disjoint by construction
+    // (§6.2), so this check is conclusive without touching the journal.
+    if registry.pruned_works.contains_key(work_id) {
+        return None;
     }
     registry.work_index.get(work_id)?;
     match blocking_sync(|| rederive_work(&core.journal, work_id)) {
@@ -3837,6 +3981,8 @@ pub const SSE_EVENT_KINDS: &[&str] = &[
     KIND_BACKEND_PROBED,
     KIND_ADMISSION_PAUSED,
     KIND_ADMISSION_RESUMED,
+    crate::runtime::prune::KIND_PRUNE_INTENT,
+    crate::runtime::prune::KIND_PRUNE_COMPLETED,
 ];
 
 /// Encode one journal event as an SSE frame (`id` = seq for resume).
@@ -4819,6 +4965,10 @@ mod tests {
                 data_dir,
             )),
             analytics: Arc::new(tokio::sync::Mutex::new(analytics)),
+            prune_policy: crate::runtime::prune::PrunePolicy {
+                retention: crate::domain::estate::DEFAULT_RETENTION,
+                source: crate::runtime::prune::PolicySource::Default,
+            },
         }
     }
 

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -432,6 +432,55 @@ pub fn note_ask_withdrawal(latest: &mut Option<AskWithdrawal>, event: &Event) {
     }
 }
 
+/// The read-side counterpart to [`note_ask_withdrawal`], for a journal that
+/// has had the withdrawal's *own* event pruned out from under it (W3 §8.3).
+///
+/// A `prune.intent` event's `source` is `daemon/sergeant`, not
+/// `backend/claude`, and its `kind` is `"prune.intent"` — so
+/// [`note_ask_withdrawal`] never matches it, by design (it folds only the
+/// backend's own live measurement events). When the Work that recorded a
+/// withdrawal is pruned, `prune::scan_condemned_range` carries the
+/// watermark forward onto the intent's own `residue.capability_provenance`
+/// (with its **original** seq preserved, not the intent event's), so a
+/// later replay that never sees the original event can still recover it —
+/// *if* something reads it back. Before this function existed, nothing did:
+/// the watermark was written faithfully and then never read, so a full
+/// replay after the recording Work was pruned silently re-raised
+/// `Capabilities::ask` on an installation that had already proved it
+/// absent.
+///
+/// Deliberately depends only on the wire shape (a plain JSON walk), not on
+/// `runtime::prune`'s types — `runtime::prune` already depends on this
+/// module (for [`AskWithdrawal`]/[`note_ask_withdrawal`] themselves), and
+/// this module keeping no dependency the other way is what the codebase's
+/// documented one-way dependency (prune -> backend, never back) means in
+/// practice.
+pub fn note_carried_ask_withdrawal(latest: &mut Option<AskWithdrawal>, event: &Event) {
+    if event.source.source_type != "daemon"
+        || event.source.name != "sergeant"
+        || event.kind != "prune.intent"
+    {
+        return;
+    }
+    for field in ["residue", "carried_forward"] {
+        let Some(candidate) = event
+            .payload
+            .get(field)
+            .and_then(|r| r.get("capability_provenance"))
+            .and_then(|cp| {
+                let seq = cp.get("seq")?.as_u64()?;
+                let version = cp.get("version")?.as_str()?.to_string();
+                Some(AskWithdrawal { seq, version })
+            })
+        else {
+            continue;
+        };
+        if latest.as_ref().is_none_or(|w| candidate.seq > w.seq) {
+            *latest = Some(candidate);
+        }
+    }
+}
+
 /// Launch configuration for the adapter.
 #[derive(Debug, Clone)]
 pub struct ClaudeConfig {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3713,7 +3713,11 @@ pub(crate) mod doctor {
                 None,
             );
         }
-        let replay = match Journal::replay_data_dir(data_dir) {
+        // W3 §11.2: floor-aware, not `replay_data_dir` — a pruned journal's
+        // surviving events legitimately start above seq 1, and the strict
+        // primitive would misreport that as `SeqDiscontinuity` rather than
+        // the healthy, ruled-retention outcome it is.
+        let replay = match Journal::replay_data_dir_from_floor(data_dir) {
             Ok(replay) => replay,
             Err(e) => {
                 return (
@@ -3744,11 +3748,15 @@ pub(crate) mod doctor {
                 }
             }
         }
+        // W3 §11.2: name the floor this replay actually started from — `1`
+        // on every journal this build has never pruned, and honest evidence
+        // of ruled retention (not corruption) on one that has.
+        let floor_seq = events.first().map(|e| e.seq).unwrap_or(1);
         (
             Check::ok(
                 "journal",
                 format!(
-                    "{} events replay cleanly (head seq {last_seq})",
+                    "{} events replay cleanly from seq {floor_seq} (head seq {last_seq})",
                     events.len()
                 ),
             ),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -236,6 +236,13 @@ pub enum DaemonError {
     /// The §28 export pipeline could not be built from its configuration.
     #[error(transparent)]
     Telemetry(#[from] TelemetryError),
+    /// W3 Q9: this daemon's predecessor declared a prune it did not
+    /// acknowledge, and completing it (from the intent's own recorded
+    /// targets and residue) failed. Refused rather than served over: an
+    /// unfinished destructive act on disk means answering reads from a
+    /// journal whose floor is in an undeclared state.
+    #[error(transparent)]
+    Prune(#[from] crate::runtime::prune::PruneError),
     /// §4.1: the estate root this daemon was started against is not one.
     /// Refused before the data dir is created, the journal opened, or the
     /// descriptor published — a daemon that cannot name its estate never
@@ -389,6 +396,18 @@ pub struct DaemonConfig {
     /// test rigs' shape — never a silent fallback to discovery, of which
     /// there is none left.
     pub estate_root: Option<PathBuf>,
+    /// W3: retention cap for this daemon's journal, overriding `[estate]
+    /// retention`. `None` — production, always — takes the manifest's value
+    /// or [`crate::domain::estate::DEFAULT_RETENTION`].
+    ///
+    /// Configurable for the same reason `segment_max_bytes`/`completion_poll`
+    /// are: a prune test has to stand on the far side of the cap, and
+    /// building `DEFAULT_RETENTION` real Works is far outside a test budget.
+    /// **[`crate::domain::estate::MIN_RETENTION`] deliberately does not apply
+    /// here** — it is a *manifest-schema* refusal protecting an operator
+    /// from a typo in a file, not a runtime bound; a test rig setting
+    /// `Some(4)` has not typed anything into a manifest.
+    pub retention: Option<u32>,
 }
 
 impl Default for DaemonConfig {
@@ -406,6 +425,7 @@ impl Default for DaemonConfig {
             rebuild_cache: false,
             segment_max_bytes: None,
             estate_root: None,
+            retention: None,
         }
     }
 }
@@ -540,7 +560,24 @@ pub async fn start_with(
     // appended since the cache was written): the plan itself always knows.
     report.from_seq = plan.from_seq();
 
-    // 2c. §2.6: the cache this start should leave behind — hit or miss,
+    // 2c (W3 §2.5): the process-lifetime FirstSeqIndex the prune horizon
+    // needs — seeded from the cache's own rows (once a v2 cache has really
+    // written `first_seq` honestly) union this pass's own `HorizonSink`
+    // fold, exactly the same "already <= H_old <= H, always a legal answer"
+    // reasoning `LedgerSink`'s cache seed already follows.
+    let mut first_seq_by_work: crate::runtime::prune::FirstSeqIndex = match &plan {
+        startup::Plan::Windowed { cache, .. } => cache
+            .works
+            .iter()
+            .map(|row| (row.id.clone(), row.first_seq))
+            .collect(),
+        startup::Plan::Full { .. } => Default::default(),
+    };
+    for (id, seq) in horizon_sink.first_seq_by_work() {
+        first_seq_by_work.entry(id.clone()).or_insert(*seq);
+    }
+
+    // 2d. §2.6: the cache this start should leave behind — hit or miss,
     // extending it is always sound, since everything a new cache needs is
     // already in hand from the pass just run. Written under the daemon lock,
     // before the listener binds and before any event is appended, so it
@@ -552,6 +589,7 @@ pub async fn start_with(
         &ledger_sink,
         &capability_sink,
         &horizon_sink,
+        &first_seq_by_work,
     )?;
     startup::persist_or_remove(floor_state.as_ref(), data_dir)?;
     let rebuild_ms = u64::try_from(rebuild_started.elapsed().as_millis()).unwrap_or(u64::MAX);
@@ -561,8 +599,104 @@ pub async fn start_with(
     let replay_floor_seq = journal.floor_seq()?.unwrap_or(1);
 
     let (events_tx, _) = broadcast::channel(1024);
-    let mut core =
-        Core::new(journal, registry, events_tx).with_floor_ledger(Arc::new(floor_ledger));
+    let mut core = Core::new(journal, registry, events_tx)
+        .with_floor_ledger(Arc::new(floor_ledger))
+        .with_first_seq_index(first_seq_by_work);
+
+    // W3 §1.2: resolve the retention policy once, for this process's whole
+    // life — `config.retention` (test rigs only) -> `[estate] retention` ->
+    // the built-in default. Journaled on every prune event so the record
+    // names the authorization, not just the number (A1).
+    //
+    // `estate` above is only an `EstateRoot` (path + manifest_path admitted
+    // by §4.1's exact-root check) — it never parsed `[estate] retention`, so
+    // it is re-read here through the *structural* parser: schema-level
+    // checks in full, no per-repository git validation (`Estate::admit`
+    // never did that either, so this cannot newly refuse a daemon start that
+    // used to succeed). A failure here — unreachable in practice, since
+    // `admit` already parsed the same file successfully — falls back to the
+    // default rather than turning a policy-resolution nicety into a new
+    // startup failure mode.
+    let estate_retention = estate.as_ref().and_then(|estate_root| {
+        match Estate::from_config_structural(&estate_root.manifest_path) {
+            Ok(full) => full.retention,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "could not re-read the estate manifest for [estate] retention; using the default"
+                );
+                None
+            }
+        }
+    });
+    let prune_policy = match config.retention {
+        Some(retention) => crate::runtime::prune::PrunePolicy {
+            retention,
+            source: crate::runtime::prune::PolicySource::Config,
+        },
+        None => match estate_retention {
+            Some(retention) => crate::runtime::prune::PrunePolicy {
+                retention,
+                source: crate::runtime::prune::PolicySource::Manifest,
+            },
+            None => crate::runtime::prune::PrunePolicy {
+                retention: crate::domain::estate::DEFAULT_RETENTION,
+                source: crate::runtime::prune::PolicySource::Default,
+            },
+        },
+    };
+
+    // 2e-2g (W3 §10.3, §6.6): Q9's crash completion — evidence-based, exactly
+    // as `recovery::reconcile_terminal_surface` is: the intent is a durable,
+    // fsynced record that a specific, enumerated deletion was authorized and
+    // begun. Nothing here is inferred, nothing is widened, and no deletion
+    // is ever started from suspicion — `recovery.rs`'s own refusal boundary
+    // ("recovery acts on evidence that something was left unfinished, and
+    // there is none here") is untouched: this acts only where an intent
+    // exists, and only on the targets that intent names. Runs *before*
+    // `recovery::reconcile` below: the completion's fold removes the pruned
+    // Works from `works`/`runs`, and every pruned Work is retired whole
+    // (I-W3-3) so reconcile would have found nothing to do for them either
+    // way — the ordering is for determinism, not correctness.
+    let prune_started = Instant::now();
+    let had_interrupted_prune = core.registry.state().pending_prune.is_some();
+    if had_interrupted_prune {
+        crate::runtime::prune::complete_interrupted(&mut core, data_dir)?;
+    }
+    let first_seq_snapshot = core.first_seq_by_work.clone();
+    let prune_outcome = match crate::runtime::prune::run_startup(
+        &mut core,
+        data_dir,
+        &prune_policy,
+        &first_seq_snapshot,
+    ) {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            tracing::error!(error = %e, "startup prune failed; serving anyway");
+            core.prune_pending = true;
+            crate::runtime::prune::PruneOutcome::default()
+        }
+    };
+    let prune_duration_ms = u64::try_from(prune_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let prune_outcome_tag = if had_interrupted_prune {
+        "completed-interrupted".to_string()
+    } else if prune_outcome.segments_unlinked > 0 {
+        format!("pruned:{}", prune_outcome.segments_unlinked)
+    } else {
+        let stalled = core.journal.segment_bounds().ok().map(|bounds| {
+            crate::runtime::prune::candidate_horizon(
+                &bounds,
+                core.registry.state(),
+                &core.first_seq_by_work,
+                &prune_policy,
+            )
+            .1
+        });
+        match stalled.and_then(|s| s.blocking_work_id) {
+            Some(work_id) => format!("stalled:{work_id}"),
+            None => "none".to_string(),
+        }
+    };
 
     // 3. Bind loopback on an ephemeral port before publishing anything.
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
@@ -584,6 +718,10 @@ pub async fn start_with(
             "startup_cache": startup_cache,
             "replay_floor_seq": replay_floor_seq,
             "replay_from_seq": report.from_seq,
+            // W3: additive keys (§10.3) — what the startup prune trigger did
+            // (or why it did nothing), so a slow start is explicable.
+            "prune_duration_ms": prune_duration_ms,
+            "prune_outcome": prune_outcome_tag,
         }),
     ))?;
     // `core` is bare here — no `CoreGuard`, because nothing else can see it
@@ -763,6 +901,7 @@ pub async fn start_with(
         closing: closing_rx,
         engine,
         analytics: Arc::new(tokio::sync::Mutex::new(analytics)),
+        prune_policy,
     };
     // §28's export is a fold over the event stream, subscribed here and
     // nowhere else. With export off this task does not exist.

--- a/src/domain/estate.rs
+++ b/src/domain/estate.rs
@@ -267,6 +267,47 @@ pub struct Estate {
     /// derives a forge, host or CLI from it — the URL is opaque.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub repository_upstream: BTreeMap<String, String>,
+    /// `[estate] retention` (Q3/A2, W3): the declared Work-retention cap, or
+    /// `None` for the built-in [`DEFAULT_RETENTION`]. Read once by
+    /// `daemon::start_with` and pinned into the prune policy for the life of
+    /// the process — a manifest edited under a running daemon does not
+    /// re-arm it, exactly like `surfaces_dir` and `data_dir`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention: Option<u32>,
+}
+
+/// Q3/A2's ratified default: how many Works this estate retains when
+/// `[estate] retention` is absent. 1000 Works ≈ 1.8 GB bounded total on the
+/// measured 1.8 MB/Work basis (issue #17's rulings record, 2026-08-21).
+pub const DEFAULT_RETENTION: u32 = 1000;
+
+/// The validation floor for a declared `retention`.
+///
+/// Not a correctness bound — the prune predicate is sound at any N, because
+/// a non-terminal or unsettled Work is never prunable whatever the cap says.
+/// This exists to refuse an obviously destructive typo (`retention = 1`,
+/// `retention = 0`) at parse time rather than after the segments are gone,
+/// and it is set at 64 because below that the estate retains less history
+/// than its own in-memory terminal caches hold (`TERMINAL_RUN_CACHE_CAPACITY`
+/// = 512, `TERMINAL_WORK_CACHE_CAPACITY` = 1024) — a knob under its own
+/// working set is a mistake, not a choice. **Ratify-at-review item 3.**
+pub const MIN_RETENTION: u32 = 64;
+
+/// Refuse a declared retention below [`MIN_RETENTION`] by name, at parse
+/// time. `deny_unknown_fields` gives no help here — the key is known and the
+/// value is in range for `u32`; only a named refusal explains the floor.
+fn validate_retention(retention: Option<u32>, file: &str) -> Result<(), EstateError> {
+    if let Some(value) = retention
+        && value < MIN_RETENTION
+    {
+        return Err(EstateError::RetentionBelowFloor {
+            file: file.to_string(),
+            value,
+            floor: MIN_RETENTION,
+            default: DEFAULT_RETENTION,
+        });
+    }
+    Ok(())
 }
 
 /// An admitted estate root (§4.1): the canonical directory that *is* the
@@ -695,6 +736,24 @@ pub enum EstateError {
         /// Declared repository names, for the remedy.
         available: String,
     },
+    /// `[estate] retention` is below the floor a bounded-retention policy is
+    /// allowed to declare (W3).
+    #[error(
+        "{file} declares [estate] retention = {value}, below the minimum of {floor}. \
+         Retention is how many Works of history this estate keeps; a value below \
+         {floor} retains less than the daemon's own in-memory caches hold. \
+         Remove the key to use the default of {default}, or raise it to at least {floor}"
+    )]
+    RetentionBelowFloor {
+        /// Config file that declared it.
+        file: String,
+        /// The declared value.
+        value: u32,
+        /// The validation floor ([`MIN_RETENTION`]).
+        floor: u32,
+        /// The built-in default ([`DEFAULT_RETENTION`]).
+        default: u32,
+    },
 }
 
 /// The `sergeant.toml` file shape (§9, R-MVP1-3's estate vocabulary).
@@ -735,6 +794,10 @@ struct EstateSection {
     /// `surfaces_dir` above.
     #[serde(default)]
     data_dir: Option<PathBuf>,
+    /// Q3/A2: how many Works of history this estate retains. Absent is
+    /// [`DEFAULT_RETENTION`]. Validated against [`MIN_RETENTION`] at parse.
+    #[serde(default)]
+    retention: Option<u32>,
 }
 
 /// One `[[repo]]` entry.
@@ -1241,21 +1304,23 @@ impl Estate {
             );
         }
 
-        let (name, default_backend, default_workflow, surfaces_dir, data_dir) = match parsed.estate
-        {
-            Some(estate) => (
-                estate.name,
-                estate.default_backend,
-                estate.default_workflow,
-                estate
-                    .surfaces_dir
-                    .map(|d| if d.is_absolute() { d } else { root.join(d) }),
-                estate
-                    .data_dir
-                    .map(|d| if d.is_absolute() { d } else { root.join(d) }),
-            ),
-            None => (repo_name(&root), None, None, None, None),
-        };
+        let (name, default_backend, default_workflow, surfaces_dir, data_dir, retention) =
+            match parsed.estate {
+                Some(estate) => (
+                    estate.name,
+                    estate.default_backend,
+                    estate.default_workflow,
+                    estate
+                        .surfaces_dir
+                        .map(|d| if d.is_absolute() { d } else { root.join(d) }),
+                    estate
+                        .data_dir
+                        .map(|d| if d.is_absolute() { d } else { root.join(d) }),
+                    estate.retention,
+                ),
+                None => (repo_name(&root), None, None, None, None, None),
+            };
+        validate_retention(retention, &file)?;
 
         Ok(Self {
             name,
@@ -1271,6 +1336,7 @@ impl Estate {
             groups,
             repository_origin,
             repository_upstream,
+            retention,
         })
     }
 
@@ -1372,21 +1438,23 @@ impl Estate {
             );
         }
 
-        let (name, default_backend, default_workflow, surfaces_dir, data_dir) = match parsed.estate
-        {
-            Some(estate) => (
-                estate.name,
-                estate.default_backend,
-                estate.default_workflow,
-                estate
-                    .surfaces_dir
-                    .map(|d| if d.is_absolute() { d } else { root.join(d) }),
-                estate
-                    .data_dir
-                    .map(|d| if d.is_absolute() { d } else { root.join(d) }),
-            ),
-            None => (repo_name(&root), None, None, None, None),
-        };
+        let (name, default_backend, default_workflow, surfaces_dir, data_dir, retention) =
+            match parsed.estate {
+                Some(estate) => (
+                    estate.name,
+                    estate.default_backend,
+                    estate.default_workflow,
+                    estate
+                        .surfaces_dir
+                        .map(|d| if d.is_absolute() { d } else { root.join(d) }),
+                    estate
+                        .data_dir
+                        .map(|d| if d.is_absolute() { d } else { root.join(d) }),
+                    estate.retention,
+                ),
+                None => (repo_name(&root), None, None, None, None, None),
+            };
+        validate_retention(retention, &file)?;
 
         Ok(Self {
             name,
@@ -1402,6 +1470,7 @@ impl Estate {
             groups,
             repository_origin,
             repository_upstream,
+            retention,
         })
     }
 
@@ -1913,6 +1982,7 @@ mod tests {
             groups: BTreeMap::new(),
             repository_origin: BTreeMap::new(),
             repository_upstream: BTreeMap::new(),
+            retention: None,
         };
 
         let selected = estate
@@ -1966,6 +2036,7 @@ mod tests {
             groups: BTreeMap::new(),
             repository_origin: BTreeMap::new(),
             repository_upstream: BTreeMap::new(),
+            retention: None,
         };
 
         let err = estate
@@ -2742,5 +2813,84 @@ mod tests {
             "legacy [workspace]/[[repository]] vocabulary in committed sergeant.toml file(s) \
              outside reference/: {offenders:?}"
         );
+    }
+
+    // -------------------------------------------------------------
+    // W3: `[estate] retention`
+    // -------------------------------------------------------------
+
+    /// An absent `retention` resolves to `None` on the parsed `Estate` — the
+    /// daemon-side default ([`DEFAULT_RETENTION`]) is applied at
+    /// `daemon::start_with`'s policy resolution, not here.
+    #[test]
+    fn retention_absent_resolves_to_the_default() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let estate = parse(
+            dir.path(),
+            "[estate]\nname = \"w\"\n\n[[repo]]\nname = \"a\"\n",
+        )
+        .expect("parse");
+        assert_eq!(estate.retention, None);
+    }
+
+    /// A declared retention at or above [`MIN_RETENTION`] is accepted and
+    /// carried onto `Estate::retention` verbatim.
+    #[test]
+    fn retention_at_or_above_the_floor_is_accepted() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let estate = parse(
+            dir.path(),
+            "[estate]\nname = \"w\"\nretention = 64\n\n[[repo]]\nname = \"a\"\n",
+        )
+        .expect("parse");
+        assert_eq!(estate.retention, Some(64));
+    }
+
+    /// N22: a declared retention below [`MIN_RETENTION`] is refused by name,
+    /// at parse time — never silently clamped, never accepted and left for a
+    /// destructive prune cycle to discover later.
+    #[test]
+    fn a_manifest_declaring_retention_below_the_floor_is_refused_by_name() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let err = parse(
+            dir.path(),
+            "[estate]\nname = \"w\"\nretention = 10\n\n[[repo]]\nname = \"a\"\n",
+        )
+        .expect_err("a below-floor retention must be refused");
+        match &err {
+            EstateError::RetentionBelowFloor {
+                value,
+                floor,
+                default,
+                ..
+            } => {
+                assert_eq!(*value, 10);
+                assert_eq!(*floor, MIN_RETENTION);
+                assert_eq!(*default, DEFAULT_RETENTION);
+            }
+            other => panic!("expected RetentionBelowFloor, got {other}"),
+        }
+        assert!(err.to_string().contains("below the minimum of 64"), "{err}");
+    }
+
+    /// The same floor is enforced by the structural parser
+    /// (`from_config_structural`), which is what a pen edit's `validate`
+    /// reparses through — so `sgt repo add`/`group add`/`remove` refuse to
+    /// commit over a below-floor `retention` too (§1.4's pen-support claim).
+    #[test]
+    fn the_structural_parser_also_refuses_a_below_floor_retention() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let config = dir.path().join(MANIFEST_FILE);
+        std::fs::write(
+            &config,
+            "[estate]\nname = \"w\"\nretention = 1\n\n[[repo]]\nname = \"a\"\n",
+        )
+        .expect("write manifest");
+        let err = Estate::from_config_structural(&config)
+            .expect_err("structural parse must also refuse a below-floor retention");
+        assert!(matches!(
+            err,
+            EstateError::RetentionBelowFloor { value: 1, .. }
+        ));
     }
 }

--- a/src/domain/manifest.rs
+++ b/src/domain/manifest.rs
@@ -399,6 +399,31 @@ pub fn init_estate(root: &Path, name: Option<&str>) -> Result<InitOutcome, Manif
             .unwrap_or_else(|| estate_default_name(root));
         table.insert("name", value(default_name));
         table.set_implicit(false);
+        // W3 §1.4: teach the retention knob where an operator will actually
+        // read it — in their own manifest, at the moment they are looking at
+        // it — but leave it *commented*.
+        //
+        // Explicit-and-uncommented was rejected for two reasons. (a) Recon
+        // correction 9: `EstateFile` is `deny_unknown_fields`, so a manifest
+        // carrying `retention` is refused outright by an 0.1.2 binary.
+        // Writing the key live would impose that incompatibility on every
+        // newly-initialized estate; writing it commented makes it something
+        // an operator opts into by uncommenting, which is the same shape
+        // every other optional key in this table already has. (b) The
+        // default belongs to the binary, not to a file scaffolded once: an
+        // estate created today would otherwise pin 1000 forever, and a
+        // future re-argument of the default would never reach it.
+        //
+        // A comment is invisible to serde, so this changes nothing about
+        // parsing, in this build or any other. Attached as the `name`
+        // value's trailing decor (rather than the table's own header decor,
+        // which renders *before* `name`) so it lands after the one key this
+        // freshly-scaffolded table has.
+        if let Some(value_mut) = table.get_mut("name").and_then(Item::as_value_mut) {
+            value_mut
+                .decor_mut()
+                .set_suffix(retention_scaffold_comment());
+        }
         doc.insert("estate", Item::Table(table));
         true
     };
@@ -428,6 +453,24 @@ pub fn init_estate(root: &Path, name: Option<&str>) -> Result<InitOutcome, Manif
         repos_dir_created,
         gitignore_updated,
     })
+}
+
+/// W3 §1.4's scaffolded, commented `retention` block, rendered as the `name`
+/// key's trailing decor: a blank line, three explanatory comment lines, and
+/// the key itself commented out. Built from
+/// [`crate::domain::estate::DEFAULT_RETENTION`] and
+/// [`crate::domain::estate::MIN_RETENTION`] rather than hand-copied numbers,
+/// so a future re-argument of either constant cannot silently drift out of
+/// sync with what new manifests say about it.
+fn retention_scaffold_comment() -> String {
+    use crate::domain::estate::{DEFAULT_RETENTION, MIN_RETENTION};
+    format!(
+        "\n\n\
+         # How many Works of history this estate keeps. Older terminal Works — and\n\
+         # the blobs only they referenced — are pruned automatically under this\n\
+         # policy, each prune journaled. Default when absent: {DEFAULT_RETENTION}. Minimum: {MIN_RETENTION}.\n\
+         # retention = {DEFAULT_RETENTION}"
+    )
 }
 
 /// The zero-config-style default estate name: the root directory's own name.
@@ -966,6 +1009,57 @@ mod tests {
         let estate = Estate::from_config_allow_empty(&root.join(MANIFEST_FILE))
             .expect("scaffolded manifest parses");
         assert_eq!(estate.name, "my-estate");
+    }
+
+    /// W3 §1.4: `sgt init` writes the `retention` knob **commented** —
+    /// invisible to the current parser (`retention == None`) and invisible
+    /// to recon correction 9's 0.1.2 `deny_unknown_fields` binary (the raw
+    /// text never contains a live `retention` key at all).
+    #[test]
+    fn init_scaffolds_retention_as_a_comment_that_an_older_parser_ignores() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        init_estate(dir.path(), Some("my-estate")).expect("init");
+
+        let text = std::fs::read_to_string(dir.path().join(MANIFEST_FILE)).expect("read manifest");
+        assert!(
+            text.contains("# retention = 1000"),
+            "the scaffold must leave a commented retention line: {text:?}"
+        );
+        assert!(
+            !text
+                .lines()
+                .any(|l| l.trim() == "retention = 1000" || l.trim().starts_with("retention =")),
+            "the scaffold must never leave a *live* retention key: {text:?}"
+        );
+
+        let estate = Estate::from_config_allow_empty(&dir.path().join(MANIFEST_FILE))
+            .expect("scaffolded manifest still parses under the current schema");
+        assert_eq!(
+            estate.retention, None,
+            "a commented retention key must be invisible to serde"
+        );
+    }
+
+    /// The other half: uncommenting the scaffolded line produces a manifest
+    /// that parses to the declared value — the comment is a real, valid key
+    /// with a `#` in front of it, not decorative prose an operator would
+    /// have to rewrite from scratch.
+    #[test]
+    fn init_scaffolded_retention_uncomments_into_a_valid_manifest() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        init_estate(dir.path(), Some("my-estate")).expect("init");
+
+        let text = std::fs::read_to_string(dir.path().join(MANIFEST_FILE)).expect("read manifest");
+        let uncommented = text.replace("# retention = 1000", "retention = 1000");
+        assert_ne!(
+            uncommented, text,
+            "the fixture must actually find the line to uncomment"
+        );
+        std::fs::write(dir.path().join(MANIFEST_FILE), uncommented).expect("write");
+
+        let estate = Estate::from_config_allow_empty(&dir.path().join(MANIFEST_FILE))
+            .expect("an uncommented scaffold must still parse");
+        assert_eq!(estate.retention, Some(1000));
     }
 
     /// guard-map: `sgt init` scaffolds every `.gitignore` entry

--- a/src/runtime/blob.rs
+++ b/src/runtime/blob.rs
@@ -300,6 +300,16 @@ impl BlobStore {
     /// [`BlobStore::put_stream`]'s dedup checks; idempotent, since the
     /// rescued path becoming live is exactly what makes a second call here
     /// find nothing left to rescue.
+    /// `pub(crate)` sibling of [`BlobStore::rescue`], for a caller (W3's
+    /// prune engine) that needs to rescue a specific hex *proactively* —
+    /// not as a side effect of its own `get`/`put` — because the mark scan
+    /// found it referenced by a surviving event while it still sat in
+    /// quarantine from a previous cycle (I-W3-6). Same idempotent
+    /// `Ok(false)`-not-an-error shape.
+    pub(crate) fn rescue_quarantined_hex(&self, hex: &str) -> Result<bool, BlobError> {
+        self.rescue(hex)
+    }
+
     fn rescue(&self, hex: &str) -> Result<bool, BlobError> {
         let quarantine_dir = self.root.join(QUARANTINE_DIR);
         let condemned = quarantine_dir.join(hex);

--- a/src/runtime/blob.rs
+++ b/src/runtime/blob.rs
@@ -23,6 +23,13 @@ use crate::runtime::fsutil::{create_dir_all_durable, write_atomic};
 /// path costs is bounded by this constant, not by the content length.
 const STREAM_CHUNK: usize = 64 * 1024;
 
+/// W3 §4.4: the quarantine directory name, inside `blobs/b3/`. A leading dot
+/// so it can never collide with a 64-hex content address, and inside `b3/`
+/// (not a sibling of it) so a `rename(2)` moving a blob in or out never
+/// crosses a filesystem boundary — the rename must be atomic, and that is
+/// only guaranteed within one filesystem. A5's shape, taken verbatim.
+const QUARANTINE_DIR: &str = ".pruned";
+
 /// Errors from the blob store.
 #[derive(Debug, thiserror::Error)]
 pub enum BlobError {
@@ -117,6 +124,14 @@ impl BlobStore {
         if path.exists() {
             return Ok(blob_ref); // write-once: never rewrite existing content
         }
+        // W3 §5.2 (A5/A8): the live path is absent, but a quarantined copy
+        // of the same content may still be sitting in `.pruned/` — rescue it
+        // rather than writing a second copy, which would otherwise leave a
+        // live copy *and* a quarantined one of the same content, breaking
+        // the one-copy invariant §4.4's crash reasoning relies on.
+        if self.rescue(blob_ref.hex())? {
+            return Ok(blob_ref);
+        }
         write_atomic(&path, bytes)?;
         Ok(blob_ref)
     }
@@ -166,6 +181,11 @@ impl BlobStore {
             if path.exists() {
                 return Ok((blob_ref, total)); // write-once: identical content dedupes
             }
+            // W3 §5.2: same rescue-before-write rule as `put` — see its own
+            // comment for why.
+            if self.rescue(blob_ref.hex())? {
+                return Ok((blob_ref, total));
+            }
             fs::rename(&tmp, &path)?;
             if let Some(parent) = path.parent() {
                 fs::File::open(parent)?.sync_all()?;
@@ -183,12 +203,30 @@ impl BlobStore {
     }
 
     /// Fetch a blob's bytes, verifying they still hash to the reference.
+    ///
+    /// W3 §5.2: on `NotFound`, try a quarantine [`BlobStore::rescue`] before
+    /// giving up — a blob a live Work still references may have been
+    /// condemned by a prune's mark scan and then adopted again (A5/A8)
+    /// between the mark and the sweep. If the rescue moves something back,
+    /// the read is retried once; otherwise this reports `NotFound` exactly
+    /// as before. The hash verification below is unchanged and now doubles
+    /// as the rescue's own integrity check.
     pub fn get(&self, blob_ref: &BlobRef) -> Result<Vec<u8>, BlobError> {
         let path = self.root.join(blob_ref.hex());
         let bytes = match fs::read(&path) {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Err(BlobError::NotFound(blob_ref.clone()));
+                if self.rescue(blob_ref.hex())? {
+                    match fs::read(&path) {
+                        Ok(b) => b,
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                            return Err(BlobError::NotFound(blob_ref.clone()));
+                        }
+                        Err(e) => return Err(e.into()),
+                    }
+                } else {
+                    return Err(BlobError::NotFound(blob_ref.clone()));
+                }
             }
             Err(e) => return Err(e.into()),
         };
@@ -200,6 +238,82 @@ impl BlobStore {
             });
         }
         Ok(bytes)
+    }
+
+    /// The quarantine directory (`blobs/b3/.pruned/`), creating it lazily on
+    /// first use — most estates never prune, and most that do never
+    /// condemn a blob, so paying for this directory up front at every
+    /// `BlobStore::open` would be waste on the common path.
+    fn quarantine_dir(&self) -> Result<PathBuf, BlobError> {
+        let dir = self.root.join(QUARANTINE_DIR);
+        create_dir_all_durable(&dir)?;
+        Ok(dir)
+    }
+
+    /// W3 §5.2 (A5): move a condemned blob into quarantine. `Ok(false)` when
+    /// the live path is already absent — this cycle's own retry (F2), or an
+    /// earlier crashed cycle already having moved it — never an error.
+    ///
+    /// A `rename(2)` within `blobs/b3/`, so the move is atomic: at every
+    /// instant, for a given hex, exactly one of `b3/<hex>` and
+    /// `b3/.pruned/<hex>` exists — the property that makes F2 reasonable
+    /// about at all.
+    pub fn quarantine(&self, blob_ref: &BlobRef) -> Result<bool, BlobError> {
+        let live = self.root.join(blob_ref.hex());
+        if !live.exists() {
+            return Ok(false);
+        }
+        let quarantine_dir = self.quarantine_dir()?;
+        let condemned = quarantine_dir.join(blob_ref.hex());
+        match fs::rename(&live, &condemned) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(e.into()),
+        }
+        fs::File::open(&self.root)?.sync_all()?;
+        fs::File::open(&quarantine_dir)?.sync_all()?;
+        Ok(true)
+    }
+
+    /// W3 §5.2: delete a quarantined blob. `Ok(false)` when it is absent —
+    /// which is the *expected* outcome for a blob a live read or write
+    /// rescued since the last completion, and is exactly how "untouched
+    /// since the prior completion" is implemented: presence in `.pruned/`
+    /// is the untouched-ness.
+    pub fn drop_quarantined(&self, hex: &str) -> Result<bool, BlobError> {
+        let quarantine_dir = self.quarantine_dir()?;
+        let condemned = quarantine_dir.join(hex);
+        match fs::remove_file(&condemned) {
+            Ok(()) => {
+                fs::File::open(&quarantine_dir)?.sync_all()?;
+                Ok(true)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// W3 §5.2: move a quarantined blob back to its content address, if one
+    /// is there. `Ok(false)` (never an error) when nothing is quarantined
+    /// under `hex` — the ordinary case for every blob this store has never
+    /// condemned. Called from [`BlobStore::get`], [`BlobStore::put`] and
+    /// [`BlobStore::put_stream`]'s dedup checks; idempotent, since the
+    /// rescued path becoming live is exactly what makes a second call here
+    /// find nothing left to rescue.
+    fn rescue(&self, hex: &str) -> Result<bool, BlobError> {
+        let quarantine_dir = self.root.join(QUARANTINE_DIR);
+        let condemned = quarantine_dir.join(hex);
+        if !condemned.exists() {
+            return Ok(false);
+        }
+        let live = self.root.join(hex);
+        match fs::rename(&condemned, &live) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(e.into()),
+        }
+        fs::File::open(&self.root)?.sync_all()?;
+        Ok(true)
     }
 }
 
@@ -504,6 +618,174 @@ mod tests {
         assert!(
             out.is_empty(),
             "near-miss strings must never be collected as refs: {out:?}"
+        );
+    }
+
+    // -------------------------------------------------------------
+    // W3 §5.2: quarantine, drop_quarantined, rescue
+    // -------------------------------------------------------------
+
+    /// `quarantine` moves the live blob into `.pruned/`, leaves exactly one
+    /// copy in existence, and a second call (F2's own idempotent retry) is a
+    /// no-op that reports `Ok(false)` rather than an error.
+    #[test]
+    fn quarantine_and_rescue_never_leave_two_copies() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let blob_ref = store.put(b"evidence").expect("put");
+        let live = store.root.join(blob_ref.hex());
+        let quarantined = store.root.join(QUARANTINE_DIR).join(blob_ref.hex());
+
+        assert!(live.exists());
+        assert!(!quarantined.exists());
+
+        assert!(store.quarantine(&blob_ref).expect("quarantine"));
+        assert!(!live.exists(), "the live copy must be gone");
+        assert!(
+            quarantined.exists(),
+            "exactly the quarantined copy must exist"
+        );
+
+        // F2: a second quarantine of the same (now-absent) live path is a
+        // tolerated no-op, not an error.
+        assert!(!store.quarantine(&blob_ref).expect("re-quarantine"));
+        assert!(quarantined.exists(), "the retry must not have lost it");
+
+        // Rescue moves it back — one copy, the live one, ever exists.
+        assert!(store.rescue(blob_ref.hex()).expect("rescue"));
+        assert!(live.exists());
+        assert!(!quarantined.exists());
+
+        // Rescuing again finds nothing to rescue.
+        assert!(!store.rescue(blob_ref.hex()).expect("re-rescue"));
+    }
+
+    /// `BlobStore::get` transparently rescues a quarantined blob a live Work
+    /// still references (A5/A8's rescue-on-read guard), and the hash
+    /// verification still applies on the way out.
+    #[test]
+    fn get_rescues_a_quarantined_blob() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let blob_ref = store.put(b"still referenced").expect("put");
+        assert!(store.quarantine(&blob_ref).expect("condemn it"));
+
+        let bytes = store
+            .get(&blob_ref)
+            .expect("get must rescue the quarantined blob rather than reporting NotFound");
+        assert_eq!(bytes, b"still referenced");
+        assert!(
+            store.root.join(blob_ref.hex()).exists(),
+            "the rescue must have left the blob live again"
+        );
+        assert!(
+            !store
+                .root
+                .join(QUARANTINE_DIR)
+                .join(blob_ref.hex())
+                .exists()
+        );
+    }
+
+    /// A genuinely missing blob (never quarantined either) still reports
+    /// `NotFound` — the rescue attempt must not paper over an actual loss.
+    #[test]
+    fn get_still_reports_not_found_when_nothing_is_quarantined() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let hex = "a".repeat(64);
+        let blob_ref: BlobRef = format!("b3:{hex}").parse().expect("valid ref");
+        let err = store.get(&blob_ref).expect_err("nothing exists at all");
+        assert!(matches!(err, BlobError::NotFound(_)));
+    }
+
+    /// `put`'s dedup check rescues a quarantined blob of the same content
+    /// instead of writing a second copy — the one-copy invariant §4.4's
+    /// crash reasoning depends on.
+    #[test]
+    fn put_rescues_instead_of_writing_a_second_copy() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let first = store.put(b"dedup me").expect("first put");
+        assert!(store.quarantine(&first).expect("condemn it"));
+        assert!(!store.root.join(first.hex()).exists());
+
+        let second = store.put(b"dedup me").expect("second put, same content");
+        assert_eq!(second.hex(), first.hex());
+        assert!(
+            store.root.join(first.hex()).exists(),
+            "put must have rescued the quarantined copy rather than leaving it condemned"
+        );
+        assert!(
+            !store.root.join(QUARANTINE_DIR).join(first.hex()).exists(),
+            "exactly one copy must exist after the rescue — not a live one and a quarantined one"
+        );
+    }
+
+    /// `put_stream`'s dedup check follows the identical rule.
+    #[test]
+    fn put_stream_rescues_instead_of_writing_a_second_copy() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let content = b"streamed dedup me".repeat(100);
+        let (first, _) = store
+            .put_stream(std::io::Cursor::new(content.clone()))
+            .expect("first stream");
+        assert!(store.quarantine(&first).expect("condemn it"));
+
+        let (second, _) = store
+            .put_stream(std::io::Cursor::new(content))
+            .expect("second stream, same content");
+        assert_eq!(second.hex(), first.hex());
+        assert!(store.root.join(first.hex()).exists());
+        assert!(!store.root.join(QUARANTINE_DIR).join(first.hex()).exists());
+    }
+
+    /// `drop_quarantined` deletes a quarantined blob and reports `Ok(false)`
+    /// — not an error — for one a live read already rescued: presence in
+    /// `.pruned/` *is* the untouched-ness §5.2 relies on.
+    #[test]
+    fn drop_quarantined_is_ok_false_for_a_rescued_blob() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let blob_ref = store.put(b"grace window").expect("put");
+        assert!(store.quarantine(&blob_ref).expect("condemn"));
+
+        // A live read rescues it before the deferred delete runs.
+        store.get(&blob_ref).expect("rescue via get");
+
+        assert!(
+            !store
+                .drop_quarantined(blob_ref.hex())
+                .expect("drop_quarantined must not error on an absent quarantine entry"),
+            "a rescued blob is no longer in .pruned/, so this must be Ok(false)"
+        );
+        assert!(
+            store.root.join(blob_ref.hex()).exists(),
+            "the rescued blob must survive"
+        );
+    }
+
+    /// The ordinary deferred-delete path: a blob nothing rescued is actually
+    /// removed, and `drop_quarantined` reports `Ok(true)`.
+    #[test]
+    fn drop_quarantined_removes_an_untouched_condemned_blob() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let blob_ref = store.put(b"nobody wanted this back").expect("put");
+        assert!(store.quarantine(&blob_ref).expect("condemn"));
+
+        assert!(store.drop_quarantined(blob_ref.hex()).expect("drop"));
+        assert!(
+            !store
+                .root
+                .join(QUARANTINE_DIR)
+                .join(blob_ref.hex())
+                .exists()
+        );
+        assert!(
+            !store.root.join(blob_ref.hex()).exists(),
+            "must not resurrect the live copy"
         );
     }
 

--- a/src/runtime/blob.rs
+++ b/src/runtime/blob.rs
@@ -799,6 +799,81 @@ mod tests {
         );
     }
 
+    /// F2's idempotency half, stated directly on the primitive rather than
+    /// only through the crash-window tests that depend on it: quarantining a
+    /// blob that is *already* quarantined is tolerated, reports `Ok(false)`,
+    /// and leaves the quarantined content byte-for-byte intact — the
+    /// property that lets `prune::complete_interrupted` re-walk an intent's
+    /// whole `condemn` list without knowing how far the crashed cycle got.
+    #[test]
+    fn quarantine_tolerates_an_already_quarantined_blob_and_keeps_its_content() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let blob_ref = store.put(b"already condemned").expect("put");
+        let quarantined = store.root.join(QUARANTINE_DIR).join(blob_ref.hex());
+
+        assert!(store.quarantine(&blob_ref).expect("first quarantine"));
+
+        for attempt in 0..3 {
+            assert!(
+                !store
+                    .quarantine(&blob_ref)
+                    .unwrap_or_else(|e| panic!("re-quarantine {attempt} must not error: {e}")),
+                "a blob already in .pruned/ has no live path to move; this must be Ok(false)"
+            );
+            assert_eq!(
+                std::fs::read(&quarantined).expect("the quarantined copy must still be there"),
+                b"already condemned",
+                "re-quarantining must never disturb the content it already moved"
+            );
+            assert!(
+                !store.root.join(blob_ref.hex()).exists(),
+                "re-quarantining must never resurrect a live copy alongside the quarantined one"
+            );
+        }
+    }
+
+    /// F3's idempotency half, likewise stated on the primitive: deleting a
+    /// quarantined blob that is *already gone* — because the crashed cycle
+    /// got to it before dying, not because anything rescued it — is
+    /// tolerated and reports `Ok(false)`, as is a hex this store has never
+    /// seen at all. `drop_quarantined_is_ok_false_for_a_rescued_blob` covers
+    /// the rescued shape; this one covers the already-deleted and
+    /// never-existed shapes, which are what a re-run of a completion walks
+    /// into.
+    #[test]
+    fn drop_quarantined_tolerates_an_already_deleted_and_an_unknown_hex() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let store = BlobStore::open(dir.path()).expect("open store");
+        let blob_ref = store.put(b"deleted once, asked for twice").expect("put");
+        assert!(store.quarantine(&blob_ref).expect("condemn"));
+
+        assert!(
+            store.drop_quarantined(blob_ref.hex()).expect("first drop"),
+            "the first deferred delete actually removes it"
+        );
+        for attempt in 0..3 {
+            assert!(
+                !store
+                    .drop_quarantined(blob_ref.hex())
+                    .unwrap_or_else(|e| panic!("re-drop {attempt} must not error: {e}")),
+                "deleting what is already deleted must be Ok(false), never an error"
+            );
+        }
+        assert!(
+            !store.root.join(blob_ref.hex()).exists(),
+            "a repeated delete must never resurrect the live copy either"
+        );
+
+        let unknown = "b".repeat(64);
+        assert!(
+            !store
+                .drop_quarantined(&unknown)
+                .expect("an unknown hex must not error"),
+            "a hex this store has never held is Ok(false) too"
+        );
+    }
+
     /// `refs_in_event` is the event-level entry point A4's pinning tests use.
     #[test]
     fn refs_in_event_reads_the_payload() {

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -4508,6 +4508,7 @@ mod tests {
                 .collect(),
             repository_origin: BTreeMap::new(),
             repository_upstream: BTreeMap::new(),
+            retention: None,
         }
     }
 
@@ -4913,6 +4914,7 @@ mod tests {
                 groups: std::collections::BTreeMap::new(),
                 repository_origin: std::collections::BTreeMap::new(),
                 repository_upstream: std::collections::BTreeMap::new(),
+                retention: None,
             },
             repositories: Vec::new(),
             surfaces_root: dir.path().join("surfaces"),

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -143,6 +143,24 @@ pub enum JournalError {
         /// The largest index the file-name scheme can represent.
         max: u64,
     },
+    /// W3: a prune target was not an oldest-contiguous prefix of the live
+    /// segment set (I-W3-4). Refused before anything is touched.
+    #[error(
+        "refusing to unlink segments {attempted:?}: not an oldest-contiguous prefix of {live:?}"
+    )]
+    UnlinkNotAPrefix {
+        /// The indices the caller asked to unlink.
+        attempted: Vec<u64>,
+        /// The indices actually live on disk, oldest first.
+        live: Vec<u64>,
+    },
+    /// W3: a prune target named the segment this writer holds open — the
+    /// segment `append_event` still writes to (I-W3-4, N15).
+    #[error("refusing to unlink segment {index}: it is the live append target")]
+    UnlinkLiveSegment {
+        /// The offending segment index.
+        index: u64,
+    },
 }
 
 impl JournalError {
@@ -194,6 +212,11 @@ pub struct Journal {
     /// a dependency on the telemetry module, and the only place this timing
     /// exists is here.
     append_observer: Option<AppendObserver>,
+    /// W3 §10.4: whether a rotation has happened since the last
+    /// [`Journal::take_rotation_signal`] call. Set by `rotate_if_needed`,
+    /// cleared by the read. A one-shot flag rather than an observer callback
+    /// — see that method's own doc for why.
+    rotation_signal: bool,
     /// Exclusive advisory lock on the journal dir, held for the lifetime of
     /// the handle. The OS releases it when the handle drops — including on
     /// crash — so a stale lock can never wedge reopen.
@@ -215,6 +238,7 @@ impl std::fmt::Debug for Journal {
             .field("dirty", &self.dirty)
             .field("poisoned", &self.poisoned)
             .field("append_observer", &self.append_observer.is_some())
+            .field("rotation_signal", &self.rotation_signal)
             .finish()
     }
 }
@@ -290,6 +314,7 @@ impl Journal {
             dirty: false,
             poisoned: false,
             append_observer: None,
+            rotation_signal: false,
             _lock: lock,
         })
     }
@@ -546,9 +571,18 @@ impl Journal {
         let segments = list_segments(&journal_dir)?;
         let mut floor = None;
         for (_, path) in &segments {
-            if let Some(first) = first_seq(path)? {
-                floor = Some(first);
-                break;
+            match first_seq(path) {
+                Ok(Some(first)) => {
+                    floor = Some(first);
+                    break;
+                }
+                Ok(None) => continue,
+                // W3 §11.3 (recon correction 7): this segment went away
+                // during the skip-scan itself — a prune raced this
+                // lock-free read. Skip it; the next surviving segment names
+                // the floor instead.
+                Err(JournalError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e),
             }
         }
         let after = floor.map_or(0, |f| f - 1);
@@ -571,7 +605,93 @@ impl Journal {
         self.segment_len = 0;
         // create_segment fsyncs the directory; deliberately not counted in
         // fsync_count, which tracks only per-append segment-data syncs.
+        // W3 §10.4: a real rotation happened — arm the one-shot signal the
+        // daemon's tick asks about at a group boundary.
+        self.rotation_signal = true;
         Ok(())
+    }
+
+    /// W3 §10.4: whether a rotation has happened since the last call.
+    /// Reading clears it.
+    ///
+    /// A flag rather than a callback because the prune it arms must not run
+    /// *inside* `append_event` — that call is mid-group, mid-fold, and
+    /// holding the writer's own file handle. The daemon asks this at a tick
+    /// boundary, where a failure is reportable and the group is closed.
+    pub fn take_rotation_signal(&mut self) -> bool {
+        std::mem::replace(&mut self.rotation_signal, false)
+    }
+
+    /// W3: unlink whole segment files, oldest-first — the only deletion door
+    /// this type has, and deliberately narrow.
+    ///
+    /// Refuses, before touching anything:
+    ///   - a target naming [`Journal::segment_index`](Self)'s current
+    ///     segment — the one this writer holds open (I-W3-4, N15);
+    ///   - a target whose still-live members are not an oldest-contiguous
+    ///     prefix of [`Journal::segment_bounds`]'s current segment list
+    ///     (I-W3-4, N16).
+    ///
+    /// An **empty** target is a no-op, `Ok(0)`, never an error. A target
+    /// member **already absent** from disk is tolerated rather than refused
+    /// — F4's idempotent retry: because deletion below only ever proceeds
+    /// oldest-first, a target's still-present members can never have a hole
+    /// in the middle relative to what is live now, only a shorter shared
+    /// prefix — so this is still exactly as strict about a genuinely wrong
+    /// target as an all-or-nothing check would be.
+    ///
+    /// Unlinks in ascending index order and fsyncs the journal directory
+    /// once at the end, so a crash partway leaves a shorter *valid* journal
+    /// with a higher floor rather than a hole (F4). The handle's own
+    /// `next_seq`, `segment_index`, `segment_file` and `segment_len` all
+    /// describe the newest segment and are untouched by construction.
+    ///
+    /// Returns the number of bytes actually reclaimed (already-absent
+    /// members contribute 0).
+    pub fn unlink_segments(&mut self, indices: &[u64]) -> Result<u64, JournalError> {
+        if indices.is_empty() {
+            return Ok(0);
+        }
+        if indices.contains(&self.segment_index) {
+            return Err(JournalError::UnlinkLiveSegment {
+                index: self.segment_index,
+            });
+        }
+        let live = list_segments(&self.journal_dir)?;
+        let live_indices: Vec<u64> = live.iter().map(|(index, _)| *index).collect();
+
+        // Tolerate members an earlier, interrupted unlink already removed:
+        // filter the target down to what is still actually there.
+        let present: Vec<u64> = indices
+            .iter()
+            .copied()
+            .filter(|index| live_indices.contains(index))
+            .collect();
+        if present.is_empty() {
+            return Ok(0);
+        }
+        let n = present.len();
+        if n >= live_indices.len() || present != live_indices[..n] {
+            return Err(JournalError::UnlinkNotAPrefix {
+                attempted: indices.to_vec(),
+                live: live_indices,
+            });
+        }
+
+        let mut reclaimed = 0u64;
+        for (_, path) in &live[..n] {
+            let bytes = fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+            match fs::remove_file(path) {
+                Ok(()) => reclaimed += bytes,
+                // Tolerated: an earlier interrupted cycle already got this
+                // one (F4); `present` above already proved it was live a
+                // moment ago, so this is the crash window, not corruption.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        sync_dir(&self.journal_dir)?;
+        Ok(reclaimed)
     }
 }
 
@@ -646,6 +766,11 @@ pub struct Replay {
     line_no: u64,
     expected: u64,
     failed: bool,
+    /// W3 §11.3 (recon correction 7): events this iterator has yielded so
+    /// far. Used for exactly one decision — see [`Replay::next`]'s
+    /// `NotFound` handling — a segment that vanishes before it is opened is
+    /// tolerated **only** while this is 0.
+    yielded: u64,
 }
 
 impl Replay {
@@ -656,6 +781,7 @@ impl Replay {
             line_no: 0,
             expected: 1,
             failed: false,
+            yielded: 0,
         }
     }
 
@@ -665,24 +791,54 @@ impl Replay {
     /// of each is read off its first line. The kept prefix boundary is the
     /// *last* segment starting at or before `after + 1`: that segment may
     /// still contain wanted events, everything before it provably cannot.
+    ///
+    /// **A1 (W3 §11.1).** When *no* segment starts at or below `after + 1` —
+    /// every surviving segment starts strictly above the requested point,
+    /// which after a prune is the ordinary case rather than a gap — this
+    /// expects the oldest survivor's own `first_seq` (the floor), not the
+    /// hardcoded `1` a fresh [`Replay::new`] carries. On an unpruned journal
+    /// the floor is always 1, so nothing here changes for any journal this
+    /// build has ever produced by itself; it only matters once a floor above
+    /// 1 exists. This is what makes `replay_after(0) ≡ replay_from_floor()`
+    /// (see [`Journal::replay_from_floor`]).
+    ///
+    /// A `NotFound` reading a candidate segment's first line (recon
+    /// correction 7) means a lock-free reader raced a prune's unlink during
+    /// this very scan — tolerated as "cannot rule anything out", the same
+    /// answer an empty rotated segment already gets, rather than propagated
+    /// as an error.
     fn after(segments: Vec<(u64, PathBuf)>, after: u64) -> Result<Self, JournalError> {
         let mut keep = 0usize;
-        let mut expected = 1u64;
+        let mut matched: Option<u64> = None;
+        let mut floor: Option<u64> = None;
         for (index, (_, path)) in segments.iter().enumerate() {
-            match first_seq(path)? {
+            let first = match first_seq(path) {
+                Ok(first) => first,
+                // A segment listed a moment ago but gone now: a prune raced
+                // this scan. It cannot rule anything out either way.
+                Err(JournalError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => None,
+                Err(e) => return Err(e),
+            };
+            match first {
                 // A segment created by rotation but not yet appended to has
                 // no first seq to compare; it cannot rule anything out.
                 None => continue,
-                Some(first) if first <= after.saturating_add(1) => {
-                    keep = index;
-                    expected = first;
+                Some(first) => {
+                    if floor.is_none() {
+                        floor = Some(first);
+                    }
+                    if first <= after.saturating_add(1) {
+                        keep = index;
+                        matched = Some(first);
+                    } else {
+                        break;
+                    }
                 }
-                Some(_) => break,
             }
         }
         let mut segments = segments;
         let mut replay = Self::new(segments.split_off(keep));
-        replay.expected = expected;
+        replay.expected = matched.or(floor).unwrap_or(1);
         Ok(replay)
     }
 }
@@ -725,6 +881,26 @@ impl Iterator for Replay {
                     .unwrap_or_default();
                 let file = match File::open(&path) {
                     Ok(f) => f,
+                    // W3 §11.3 / N18 (recon correction 7): a segment that
+                    // vanishes before it is opened is a floor that moved
+                    // under a lock-free reader, tolerated only while this
+                    // iterator is still in the leading prefix (nothing
+                    // yielded yet) — I-W3-4 guarantees a prune can only ever
+                    // delete from there. Anywhere else, a segment vanishing
+                    // mid-stream is not something a prune can do, so it
+                    // stays a hard failure.
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound && self.yielded == 0 => {
+                        // Re-derive `expected` from whatever segment is next,
+                        // so the skip does not itself manufacture a false
+                        // `SeqDiscontinuity` against the deleted segment's
+                        // old bounds.
+                        if let Some((_, next_path)) = self.segments.as_slice().first()
+                            && let Ok(Some(first)) = first_seq(next_path)
+                        {
+                            self.expected = first;
+                        }
+                        continue;
+                    }
                     Err(e) => {
                         self.failed = true;
                         return Some(Err(e.into()));
@@ -787,6 +963,7 @@ impl Iterator for Replay {
                         }));
                     }
                     self.expected += 1;
+                    self.yielded += 1;
                     return Some(Ok(event));
                 }
             }
@@ -1575,5 +1752,264 @@ pub(crate) mod tests {
         // own next_seq agrees too.
         let journal = Journal::open(dir.path()).expect("reopen");
         assert_eq!(journal.next_seq(), 5);
+    }
+
+    // -------------------------------------------------------------
+    // W3: unlink_segments
+    // -------------------------------------------------------------
+
+    /// N15: the segment this writer holds open is never unlinked, even when
+    /// named explicitly.
+    #[test]
+    fn unlink_segments_refuses_the_live_segment() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+        for n in 1..=3 {
+            journal.append(draft(n)).expect("append");
+        }
+        assert_eq!(
+            journal.segment_index, 3,
+            "one segment per append at this threshold"
+        );
+
+        let err = journal
+            .unlink_segments(&[1, 2, 3])
+            .expect_err("the live segment must never be unlinked");
+        assert!(matches!(err, JournalError::UnlinkLiveSegment { index: 3 }));
+        // Nothing touched.
+        assert_eq!(list_segments(&dir.path().join("journal")).unwrap().len(), 3);
+    }
+
+    /// N16: a target that skips a segment, or names one out of order, is
+    /// refused rather than silently reordered or partially honored.
+    #[test]
+    fn unlink_segments_refuses_a_non_contiguous_target_set() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+        for n in 1..=4 {
+            journal.append(draft(n)).expect("append");
+        }
+        assert_eq!(journal.segment_index, 4);
+
+        // Skips segment 2 — not a prefix at all.
+        let err = journal
+            .unlink_segments(&[1, 3])
+            .expect_err("a non-contiguous target must be refused");
+        assert!(matches!(err, JournalError::UnlinkNotAPrefix { .. }));
+
+        // Names segment 2 as if it were the oldest — not oldest-first.
+        let err = journal
+            .unlink_segments(&[2])
+            .expect_err("a target that is not the oldest-contiguous prefix must be refused");
+        assert!(matches!(err, JournalError::UnlinkNotAPrefix { .. }));
+
+        // Nothing touched by either refusal.
+        assert_eq!(list_segments(&dir.path().join("journal")).unwrap().len(), 4);
+    }
+
+    /// The ordinary case: an oldest-contiguous prefix unlinks cleanly, the
+    /// writer's own tail is untouched, and the reclaimed byte count matches
+    /// what was actually removed.
+    #[test]
+    fn unlink_segments_removes_an_oldest_contiguous_prefix_and_reports_bytes_reclaimed() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+        for n in 1..=4 {
+            journal.append(draft(n)).expect("append");
+        }
+        let bounds_before = journal.segment_bounds().expect("bounds");
+        let expected_bytes: u64 = bounds_before[..2].iter().map(|b| b.bytes).sum();
+
+        let reclaimed = journal.unlink_segments(&[1, 2]).expect("unlink");
+        assert_eq!(reclaimed, expected_bytes);
+
+        let remaining = list_segments(&dir.path().join("journal")).expect("list");
+        assert_eq!(
+            remaining.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+        // The writer's own tail is untouched: next_seq keeps counting from
+        // where it was, and a further append still succeeds.
+        assert_eq!(journal.next_seq(), 5);
+        journal.append(draft(5)).expect("append after unlink");
+        assert_eq!(journal.next_seq(), 6);
+    }
+
+    /// An empty target is a no-op — `Ok(0)`, never an error.
+    #[test]
+    fn unlink_segments_with_an_empty_target_is_a_no_op() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+        journal.append(draft(1)).expect("append");
+        assert_eq!(journal.unlink_segments(&[]).expect("no-op"), 0);
+        assert_eq!(list_segments(&dir.path().join("journal")).unwrap().len(), 1);
+    }
+
+    /// F4's idempotent retry: a target whose oldest member was already
+    /// unlinked by an earlier, interrupted attempt is tolerated — the
+    /// still-present remainder is unlinked, and the already-gone member
+    /// contributes nothing to the byte count.
+    #[test]
+    fn unlink_segments_tolerates_a_target_member_already_removed() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+        for n in 1..=4 {
+            journal.append(draft(n)).expect("append");
+        }
+        // Simulate an interrupted first attempt at unlinking [1, 2]: segment
+        // 1 is already gone, segment 2 is not.
+        std::fs::remove_file(dir.path().join("journal").join(segment_file_name(1)))
+            .expect("simulate a partially completed unlink");
+
+        let reclaimed = journal
+            .unlink_segments(&[1, 2])
+            .expect("a retry over a partially-completed unlink must succeed");
+        assert!(reclaimed > 0, "segment 2's bytes must still be counted");
+        let remaining = list_segments(&dir.path().join("journal")).expect("list");
+        assert_eq!(
+            remaining.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+    }
+
+    // -------------------------------------------------------------
+    // W3: take_rotation_signal
+    // -------------------------------------------------------------
+
+    /// One shot: a rotation arms it, reading it clears it, and a second read
+    /// with nothing new is `false`.
+    #[test]
+    fn rotation_signal_is_one_shot() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+        assert!(
+            !journal.take_rotation_signal(),
+            "a fresh journal has not rotated"
+        );
+
+        journal.append(draft(1)).expect("append 1 (segment 1)");
+        assert!(
+            !journal.take_rotation_signal(),
+            "the very first append never rotates — there is nothing to rotate away from"
+        );
+
+        journal
+            .append(draft(2))
+            .expect("append 2 (rotates to segment 2)");
+        assert!(
+            journal.take_rotation_signal(),
+            "the second append must have rotated at this threshold"
+        );
+        assert!(
+            !journal.take_rotation_signal(),
+            "reading the signal must clear it"
+        );
+
+        journal
+            .append(draft(3))
+            .expect("append 3 (rotates to segment 3)");
+        assert!(
+            journal.take_rotation_signal(),
+            "a later rotation re-arms it"
+        );
+    }
+
+    // -------------------------------------------------------------
+    // W3 §11.1: Replay::after's floor clamp
+    // -------------------------------------------------------------
+
+    /// A1's fix, exercised directly through `replay_after` (not only through
+    /// the dedicated `replay_from_floor` wrapper): once the leading segment
+    /// is gone, `replay_after(0)` must expect the survivor's own floor, not
+    /// the hardcoded `1` that would misreport ruled retention as
+    /// `SeqDiscontinuity`.
+    #[test]
+    fn replay_after_on_a_pruned_journal_expects_the_floor_not_one() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let journal_dir;
+        {
+            let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+            for n in 1..=3 {
+                journal.append(draft(n)).expect("append");
+            }
+            journal_dir = dir.path().join("journal");
+        }
+        std::fs::remove_file(journal_dir.join(segment_file_name(1)))
+            .expect("simulate a prune: remove the leading segment");
+
+        let journal = Journal::open(dir.path()).expect("reopen over the survivors");
+        let replayed: Vec<u64> = journal
+            .replay_after(0)
+            .expect("replay_after")
+            .map(|e| e.expect("event — must not be SeqDiscontinuity").seq)
+            .collect();
+        assert_eq!(
+            replayed,
+            vec![2, 3],
+            "replay_after(0) must equal replay_from_floor() once the floor has moved"
+        );
+    }
+
+    // -------------------------------------------------------------
+    // W3 §11.3 / N18: Replay tolerates a segment pruned between list and open
+    // -------------------------------------------------------------
+
+    /// A lock-free reader that lists segments and then has the leading one
+    /// vanish before it opens it (a prune racing it) must skip that segment
+    /// rather than fail — as long as nothing has been yielded yet.
+    #[test]
+    fn replay_data_dir_tolerates_a_segment_pruned_between_list_and_open() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        {
+            let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+            for n in 1..=3 {
+                journal.append(draft(n)).expect("append");
+            }
+        }
+        let journal_dir = dir.path().join("journal");
+        let segments = list_segments(&journal_dir).expect("list segments (pre-race snapshot)");
+        // Simulate the race directly: the caller already has the segment
+        // list in hand (as `replay_data_dir` would after its own
+        // `list_segments` call), and *then* segment 1 disappears before
+        // `Replay` opens it.
+        std::fs::remove_file(journal_dir.join(segment_file_name(1)))
+            .expect("simulate the race: unlink after listing");
+
+        let replayed: Vec<u64> = Replay::new(segments)
+            .map(|e| e.expect("event — must tolerate the raced deletion").seq)
+            .collect();
+        assert_eq!(replayed, vec![2, 3]);
+    }
+
+    /// The other half (F7's boundary): once this iterator has yielded at
+    /// least one event, a segment vanishing is no longer a race a prune can
+    /// cause (I-W3-4: prunes only ever touch a leading, oldest-contiguous
+    /// prefix) — it stays a hard failure.
+    #[test]
+    fn a_segment_vanishing_after_the_first_event_still_fails_closed() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        {
+            let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+            for n in 1..=3 {
+                journal.append(draft(n)).expect("append");
+            }
+        }
+        let journal_dir = dir.path().join("journal");
+        let segments = list_segments(&journal_dir).expect("list segments");
+
+        let mut replay = Replay::new(segments);
+        assert_eq!(replay.next().expect("first event").expect("ok").seq, 1);
+
+        // Now remove the *next* segment out from under the still-live
+        // iterator — this is not a shape a prune can produce (I-W3-4), so it
+        // must fail closed rather than being tolerated.
+        std::fs::remove_file(journal_dir.join(segment_file_name(2)))
+            .expect("remove the segment the iterator is about to open");
+
+        let err = replay
+            .next()
+            .expect("an item")
+            .expect_err("a mid-stream vanish must fail closed");
+        assert!(matches!(err, JournalError::Io(_)));
     }
 }

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -458,7 +458,10 @@ impl Journal {
     /// Yields an error (and then stops) on malformed lines or seq
     /// discontinuities — fail closed, never silently skip.
     pub fn replay(&self) -> Result<Replay, JournalError> {
-        Ok(Replay::new(list_segments(&self.journal_dir)?))
+        Ok(Replay::new(
+            list_segments(&self.journal_dir)?,
+            self.journal_dir.clone(),
+        ))
     }
 
     /// Iterate every committed event with `seq > after`, skipping whole
@@ -482,7 +485,11 @@ impl Journal {
     /// matters: every daemon start replays from 1 through [`Journal::open`]
     /// and the projection rebuild.
     pub fn replay_after(&self, after: u64) -> Result<Replay, JournalError> {
-        Replay::after(list_segments(&self.journal_dir)?, after)
+        Replay::after(
+            list_segments(&self.journal_dir)?,
+            after,
+            self.journal_dir.clone(),
+        )
     }
 
     /// Replay a journal directory without opening a writer handle (and
@@ -501,9 +508,8 @@ impl Journal {
     /// after it — is corruption, not a race, and must fail closed exactly
     /// as it does today.
     pub fn replay_data_dir(data_dir: impl AsRef<Path>) -> Result<Replay, JournalError> {
-        Ok(Replay::new(list_segments(
-            &data_dir.as_ref().join("journal"),
-        )?))
+        let journal_dir = data_dir.as_ref().join("journal");
+        Ok(Replay::new(list_segments(&journal_dir)?, journal_dir))
     }
 
     /// Extents of every segment that holds at least one event, oldest first.
@@ -586,7 +592,7 @@ impl Journal {
             }
         }
         let after = floor.map_or(0, |f| f - 1);
-        Replay::after(segments, after)
+        Replay::after(segments, after, journal_dir)
     }
 
     fn rotate_if_needed(&mut self) -> Result<(), JournalError> {
@@ -750,7 +756,8 @@ fn tail_next_seq(segments: &[(u64, PathBuf)]) -> Result<u64, JournalError> {
             continue;
         };
         let mut next = first;
-        for event in Replay::after(vec![(*index, path.clone())], first - 1)? {
+        let dir = path.parent().map(Path::to_path_buf).unwrap_or_default();
+        for event in Replay::after(vec![(*index, path.clone())], first - 1, dir)? {
             next = event?.seq + 1;
         }
         return Ok(next);
@@ -767,14 +774,20 @@ pub struct Replay {
     expected: u64,
     failed: bool,
     /// W3 §11.3 (recon correction 7): events this iterator has yielded so
-    /// far. Used for exactly one decision — see [`Replay::next`]'s
-    /// `NotFound` handling — a segment that vanishes before it is opened is
-    /// tolerated **only** while this is 0.
+    /// far. No longer gates the `NotFound`-tolerance decision on its own
+    /// (see [`Replay::next`]'s doc) — kept for diagnostics and because
+    /// several tests assert on it via the segment-vanishing behavior it used
+    /// to gate.
     yielded: u64,
+    /// Directory to re-list when a segment vanishes out from under an open
+    /// call, so the tolerance decision can ask "is this still the shape a
+    /// real prune produces" instead of "has this iterator yielded yet" — see
+    /// [`Replay::next`].
+    journal_dir: PathBuf,
 }
 
 impl Replay {
-    fn new(segments: Vec<(u64, PathBuf)>) -> Self {
+    fn new(segments: Vec<(u64, PathBuf)>, journal_dir: PathBuf) -> Self {
         Self {
             segments: segments.into_iter(),
             current: None,
@@ -782,6 +795,7 @@ impl Replay {
             expected: 1,
             failed: false,
             yielded: 0,
+            journal_dir,
         }
     }
 
@@ -807,7 +821,11 @@ impl Replay {
     /// this very scan — tolerated as "cannot rule anything out", the same
     /// answer an empty rotated segment already gets, rather than propagated
     /// as an error.
-    fn after(segments: Vec<(u64, PathBuf)>, after: u64) -> Result<Self, JournalError> {
+    fn after(
+        segments: Vec<(u64, PathBuf)>,
+        after: u64,
+        journal_dir: PathBuf,
+    ) -> Result<Self, JournalError> {
         let mut keep = 0usize;
         let mut matched: Option<u64> = None;
         let mut floor: Option<u64> = None;
@@ -837,7 +855,7 @@ impl Replay {
             }
         }
         let mut segments = segments;
-        let mut replay = Self::new(segments.split_off(keep));
+        let mut replay = Self::new(segments.split_off(keep), journal_dir);
         replay.expected = matched.or(floor).unwrap_or(1);
         Ok(replay)
     }
@@ -874,7 +892,7 @@ impl Iterator for Replay {
         }
         loop {
             if self.current.is_none() {
-                let (_, path) = self.segments.next()?;
+                let (index, path) = self.segments.next()?;
                 let name = path
                     .file_name()
                     .map(|n| n.to_string_lossy().into_owned())
@@ -883,13 +901,33 @@ impl Iterator for Replay {
                     Ok(f) => f,
                     // W3 §11.3 / N18 (recon correction 7): a segment that
                     // vanishes before it is opened is a floor that moved
-                    // under a lock-free reader, tolerated only while this
-                    // iterator is still in the leading prefix (nothing
-                    // yielded yet) — I-W3-4 guarantees a prune can only ever
-                    // delete from there. Anywhere else, a segment vanishing
-                    // mid-stream is not something a prune can do, so it
-                    // stays a hard failure.
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound && self.yielded == 0 => {
+                    // under a lock-free reader. `I-W3-4` guarantees a real
+                    // prune only ever unlinks an oldest-*contiguous prefix*
+                    // — which can be more than one segment at a time
+                    // (`PRUNE_BATCH_MIN_SEGMENTS`'s whole point) — so a
+                    // reader that has already yielded from segment 1 and
+                    // then finds segment 2 gone is still exactly the shape a
+                    // real prune produces, not corruption. Gating tolerance
+                    // on `self.yielded == 0` alone would reject that case;
+                    // instead, re-list the directory now and ask the
+                    // question a prune's own invariant actually answers: is
+                    // every segment still on disk strictly *newer* than the
+                    // one that just vanished? That is only ever true when
+                    // the gap is a deleted leading prefix. A completely
+                    // empty listing is never tolerated — I-W3-4 also
+                    // guarantees the writer's own live segment is never
+                    // unlinked, so a real prune can never produce that
+                    // shape; treat it as corruption instead of silently
+                    // reporting an empty journal.
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        let tolerated = match list_segments(&self.journal_dir) {
+                            Ok(live) => !live.is_empty() && live.iter().all(|(i, _)| *i > index),
+                            Err(_) => false,
+                        };
+                        if !tolerated {
+                            self.failed = true;
+                            return Some(Err(e.into()));
+                        }
                         // Re-derive `expected` from whatever segment is next,
                         // so the skip does not itself manufacture a false
                         // `SeqDiscontinuity` against the deleted segment's
@@ -1739,7 +1777,7 @@ pub(crate) mod tests {
         let segments = list_segments(&dir.path().join("journal")).expect("list_segments");
         let full_scan_next = {
             let mut next = 1u64;
-            for event in Replay::new(segments.clone()) {
+            for event in Replay::new(segments.clone(), dir.path().join("journal")) {
                 next = event.expect("event").seq + 1;
             }
             next
@@ -1975,7 +2013,7 @@ pub(crate) mod tests {
         std::fs::remove_file(journal_dir.join(segment_file_name(1)))
             .expect("simulate the race: unlink after listing");
 
-        let replayed: Vec<u64> = Replay::new(segments)
+        let replayed: Vec<u64> = Replay::new(segments, journal_dir.clone())
             .map(|e| e.expect("event — must tolerate the raced deletion").seq)
             .collect();
         assert_eq!(replayed, vec![2, 3]);
@@ -1997,7 +2035,7 @@ pub(crate) mod tests {
         let journal_dir = dir.path().join("journal");
         let segments = list_segments(&journal_dir).expect("list segments");
 
-        let mut replay = Replay::new(segments);
+        let mut replay = Replay::new(segments, journal_dir.clone());
         assert_eq!(replay.next().expect("first event").expect("ok").seq, 1);
 
         // Now remove the *next* segment out from under the still-live
@@ -2011,5 +2049,52 @@ pub(crate) mod tests {
             .expect("an item")
             .expect_err("a mid-stream vanish must fail closed");
         assert!(matches!(err, JournalError::Io(_)));
+    }
+
+    /// A real prune batches its unlink across several whole segments at once
+    /// (`PRUNE_BATCH_MIN_SEGMENTS`) — not one at a time. A lock-free reader
+    /// that has already yielded events from segment 1 and then finds
+    /// segments 2 *and* 3 gone together, with only segment 4 (and beyond)
+    /// still live, must still tolerate it: gating tolerance on
+    /// `self.yielded == 0` alone would wrongly fail this closed, exactly
+    /// because a real multi-segment batch delete produces `yielded > 0` by
+    /// the time the reader reaches the second missing segment. This is the
+    /// case `a_segment_vanishing_after_the_first_event_still_fails_closed`
+    /// deliberately does not cover (it removes one segment from the middle,
+    /// leaving an *earlier* one live — not a shape any prune can produce).
+    #[test]
+    fn a_multi_segment_prefix_pruned_after_the_first_event_is_still_tolerated() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        {
+            let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+            for n in 1..=4 {
+                journal.append(draft(n)).expect("append");
+            }
+        }
+        let journal_dir = dir.path().join("journal");
+        let segments = list_segments(&journal_dir).expect("list segments");
+
+        let mut replay = Replay::new(segments, journal_dir.clone());
+        assert_eq!(replay.next().expect("first event").expect("ok").seq, 1);
+
+        // Simulate a real oldest-contiguous-prefix prune landing mid-stream:
+        // segments 1, 2 and 3 unlinked together (in one `unlink_segments`
+        // call's shape — the reader's own already-open fd on segment 1
+        // keeps working per POSIX even though its dirent is gone), leaving
+        // only segment 4 (the writer's own live segment) on disk.
+        std::fs::remove_file(journal_dir.join(segment_file_name(1)))
+            .expect("simulate the batch prune: segment 1");
+        std::fs::remove_file(journal_dir.join(segment_file_name(2)))
+            .expect("simulate the batch prune: segment 2");
+        std::fs::remove_file(journal_dir.join(segment_file_name(3)))
+            .expect("simulate the batch prune: segment 3");
+
+        let rest: Vec<u64> = replay
+            .map(|e| {
+                e.expect("event — a real batch prune must still be tolerated")
+                    .seq
+            })
+            .collect();
+        assert_eq!(rest, vec![4]);
     }
 }

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -909,34 +909,82 @@ impl Iterator for Replay {
                     // then finds segment 2 gone is still exactly the shape a
                     // real prune produces, not corruption. Gating tolerance
                     // on `self.yielded == 0` alone would reject that case;
-                    // instead, re-list the directory now and ask the
-                    // question a prune's own invariant actually answers: is
-                    // every segment still on disk strictly *newer* than the
-                    // one that just vanished? That is only ever true when
-                    // the gap is a deleted leading prefix. A completely
-                    // empty listing is never tolerated — I-W3-4 also
-                    // guarantees the writer's own live segment is never
-                    // unlinked, so a real prune can never produce that
-                    // shape; treat it as corruption instead of silently
-                    // reporting an empty journal.
+                    // instead, re-list the directory now and ask whether
+                    // what is left is still a shape a prune could have
+                    // produced:
+                    //
+                    // - **Non-empty.** I-W3-4 also guarantees the writer's
+                    //   own live segment is never unlinked, so a real prune
+                    //   can never leave nothing behind; treat that as
+                    //   corruption rather than silently reporting an empty
+                    //   journal.
+                    // - **Every survivor strictly newer than the segment
+                    //   that vanished.** Only a deleted leading prefix has
+                    //   that shape; a survivor *older* than the gap means
+                    //   the hole is not a prefix at all.
+                    // - **The survivors are a contiguous index run.**
+                    //   Rotation only ever creates `index + 1`
+                    //   (`rotate_if_needed`), so the on-disk index set is
+                    //   always contiguous and a prefix delete keeps it that
+                    //   way. A gap *above* the vanished segment is
+                    //   therefore damage, not retention — refused here,
+                    //   immediately, instead of being laundered by a second
+                    //   tolerated skip further down the same list.
+                    //
+                    // **Disclosed margin — the compound fault.** These
+                    // checks read the directory, and the directory cannot
+                    // tell a prune of segments `1..=N` apart from a prune of
+                    // `1..=N-1` plus a damage-deletion of `N`: both leave
+                    // the identical, perfectly plausible listing. Seqs
+                    // cannot separate them either — a legitimate prune moves
+                    // the floor, so the jump in `expected` this arm
+                    // re-anchors is exactly what a legitimate prune looks
+                    // like. So a damage-deletion of segments that happen to
+                    // sit contiguously *below* the surviving floor is, and
+                    // remains, tolerated as retention. What was narrowed is
+                    // everything above that floor: the re-anchor below
+                    // resolves the whole gap in **one** decision against
+                    // **one** listing, so a hole between two surviving
+                    // segments now fails closed (the contiguity check, or
+                    // `SeqDiscontinuity` on the next event), where the
+                    // previous shape re-derived `expected` once per vanished
+                    // segment against a stale list and could absorb
+                    // arbitrarily many separate holes in a row.
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        let tolerated = match list_segments(&self.journal_dir) {
-                            Ok(live) => !live.is_empty() && live.iter().all(|(i, _)| *i > index),
-                            Err(_) => false,
+                        let live = match list_segments(&self.journal_dir) {
+                            Ok(live)
+                                if !live.is_empty()
+                                    && live.iter().all(|(i, _)| *i > index)
+                                    && live.windows(2).all(|w| w[1].0 == w[0].0 + 1) =>
+                            {
+                                live
+                            }
+                            _ => {
+                                self.failed = true;
+                                return Some(Err(e.into()));
+                            }
                         };
-                        if !tolerated {
-                            self.failed = true;
-                            return Some(Err(e.into()));
-                        }
-                        // Re-derive `expected` from whatever segment is next,
-                        // so the skip does not itself manufacture a false
-                        // `SeqDiscontinuity` against the deleted segment's
-                        // old bounds.
-                        if let Some((_, next_path)) = self.segments.as_slice().first()
-                            && let Ok(Some(first)) = first_seq(next_path)
+                        // Re-anchor onto that listing rather than carrying
+                        // on down the stale one. Two reasons, both real:
+                        // the stale list's own next entries may themselves
+                        // be gone (so re-deriving `expected` from them
+                        // silently leaves it pointing at the pre-prune
+                        // floor), and the stale list can be *shorter* than
+                        // reality — a prune that unlinks every segment this
+                        // reader still had listed, while the writer has
+                        // since rotated into a new one, used to run the
+                        // iterator off the end of its stale list and report
+                        // a complete replay that was missing the tail.
+                        // `expected` becomes the surviving floor's own first
+                        // seq, so the skip does not manufacture a false
+                        // `SeqDiscontinuity` against the deleted segments'
+                        // old bounds either.
+                        if let Some(first) =
+                            live.iter().find_map(|(_, p)| first_seq(p).ok().flatten())
                         {
                             self.expected = first;
                         }
+                        self.segments = live.into_iter();
                         continue;
                     }
                     Err(e) => {
@@ -2096,5 +2144,81 @@ pub(crate) mod tests {
             })
             .collect();
         assert_eq!(rest, vec![4]);
+    }
+
+    /// W3 §11.3, the tolerance's silent-truncation half: a prune can unlink
+    /// **every** segment this reader still had on its (already stale) list,
+    /// while the writer has since rotated into a new one the list has never
+    /// heard of. Tolerating the vanish and then walking off the end of the
+    /// stale list reports a clean, complete replay that is missing the
+    /// journal's whole tail — so the tolerated skip must re-anchor onto the
+    /// surviving listing and keep reading from the new floor.
+    #[test]
+    fn a_prune_of_the_whole_stale_list_re_anchors_onto_the_surviving_listing() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+        for n in 1..=3 {
+            journal.append(draft(n)).expect("append");
+        }
+        let journal_dir = dir.path().join("journal");
+        let segments = list_segments(&journal_dir).expect("list segments (pre-race snapshot)");
+
+        let mut replay = Replay::new(segments, journal_dir.clone());
+        assert_eq!(replay.next().expect("first event").expect("ok").seq, 1);
+
+        // The writer rotates into segment 4 *after* the reader's snapshot...
+        journal
+            .append(draft(4))
+            .expect("append into a fourth segment");
+        // ...and a prune then unlinks the whole 1..=3 prefix, which is every
+        // segment the reader's stale list knows about.
+        for index in 1..=3 {
+            std::fs::remove_file(journal_dir.join(segment_file_name(index)))
+                .expect("simulate the prune of the reader's whole stale list");
+        }
+
+        let rest: Vec<u64> = replay
+            .map(|e| {
+                e.expect("event — the surviving segment must still be replayed")
+                    .seq
+            })
+            .collect();
+        assert_eq!(
+            rest,
+            vec![4],
+            "a replay that tolerates the vanish must re-anchor on the surviving floor, \
+             never silently end at the tail of its own stale list"
+        );
+    }
+
+    /// The contiguity half of the same guard: rotation only ever creates
+    /// `index + 1`, so a *hole* between two surviving segments is damage and
+    /// never a prune's leading-prefix delete. It must fail closed at the
+    /// first vanish, before any event of the damaged journal is yielded —
+    /// not be tolerated once and caught only when the reader walks into the
+    /// hole itself.
+    #[test]
+    fn a_hole_in_the_surviving_listing_is_never_tolerated() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        {
+            let mut journal = Journal::open_with(dir.path(), 1).expect("open");
+            for n in 1..=4 {
+                journal.append(draft(n)).expect("append");
+            }
+        }
+        let journal_dir = dir.path().join("journal");
+        let segments = list_segments(&journal_dir).expect("list segments");
+
+        // Segment 1: a plausible prune. Segment 3: damage, leaving a hole
+        // between the two survivors.
+        std::fs::remove_file(journal_dir.join(segment_file_name(1))).expect("prune segment 1");
+        std::fs::remove_file(journal_dir.join(segment_file_name(3))).expect("damage segment 3");
+
+        let mut replay = Replay::new(segments, journal_dir.clone());
+        let err = replay
+            .next()
+            .expect("an item")
+            .expect_err("a non-contiguous surviving listing must fail closed");
+        assert!(matches!(err, JournalError::Io(_)), "got {err:?}");
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -11,6 +11,7 @@ pub mod integrity;
 pub mod journal;
 pub mod preflight;
 pub mod projection;
+pub mod prune;
 pub mod recovery;
 pub mod repolock;
 pub mod router;

--- a/src/runtime/projection.rs
+++ b/src/runtime/projection.rs
@@ -370,6 +370,30 @@ pub struct WorkRegistry {
     /// to check first.
     #[serde(default)]
     pub admission_paused: bool,
+    /// W3/A3's residue: every Work this estate has pruned, keyed by id — the
+    /// pruned-by-name answer, folded from `prune.completed` (via the
+    /// `prune.intent` that precedes it) and therefore reproducible from a
+    /// floor replay with no cache at all.
+    ///
+    /// Disjoint from `work_index` by construction: a Work is in exactly one
+    /// of them, and the fold that inserts here removes there.
+    #[serde(default)]
+    pub pruned_works: std::collections::BTreeMap<String, crate::runtime::prune::PrunedWorkRow>,
+    /// W3 Q8's exemption made journal-durable: the §26 ledger keys of every
+    /// pruned command. Keys only — the `CommandOutcome` bodies died with
+    /// their events, exactly as the cache never carried them.
+    #[serde(default)]
+    pub pruned_commands:
+        std::collections::BTreeMap<String, crate::runtime::prune::PrunedCommandRow>,
+    /// W3: the prune cycle this journal has declared and not yet
+    /// acknowledged. `Some` only between a `prune.intent` and its
+    /// `prune.completed` — Q9's crash completion reads exactly this.
+    #[serde(default)]
+    pub pending_prune: Option<crate::runtime::prune::PruneIntentRecord>,
+    /// W3 §5.2: the hexes the most recent `prune.intent` moved into
+    /// quarantine — the deletion list the *next* cycle works from.
+    #[serde(default)]
+    pub quarantined_blobs: Vec<String>,
 }
 
 /// Bound on how many terminal runs [`WorkRegistry::terminal_runs`] holds at
@@ -699,8 +723,18 @@ pub fn is_absorbing(state: WorkState) -> bool {
 /// materialize, `Engine::plan`'s "no surface" case) never sets
 /// `surface_plan`, so this never blocks a genuinely surface-less Work.
 fn run_is_settled(work: &Work, run: &WorkRun) -> bool {
-    is_absorbing(work.state)
-        && (run.surface.is_none() || run.teardown.is_some())
+    is_absorbing(work.state) && run_is_retired(run)
+}
+
+/// The three run-shape clauses [`run_is_settled`] checks, factored out so W3's
+/// [`crate::runtime::prune::retired_whole`] can apply the identical rule
+/// under its own, broader terminality test (`Completed | Failed | Canceled`,
+/// not only the absorbing two): a run with a surface and no teardown, a
+/// `surface_plan` with no surface, or an unsettled reservation is not
+/// retired, whatever the Work's state says. One copy of the three clauses,
+/// two terminality tests over it.
+pub(crate) fn run_is_retired(run: &WorkRun) -> bool {
+    (run.surface.is_none() || run.teardown.is_some())
         && !(run.surface_plan.is_some() && run.surface.is_none())
         && run.unsettled_reservation().is_none()
 }
@@ -810,6 +844,43 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
         }
         KIND_ADMISSION_RESUMED => {
             state.admission_paused = false;
+            return;
+        }
+        crate::runtime::prune::KIND_PRUNE_INTENT => {
+            // W3 §6.2: record, apply nothing. A declaration is not an
+            // outcome — until the completion lands, the segments may still
+            // be there, and a replay that folded the residue here would
+            // report Works as pruned that a crash left retained.
+            if let Some(record) = crate::runtime::prune::PruneIntentRecord::from_event(event) {
+                state.quarantined_blobs = record.condemn.clone();
+                state.pending_prune = Some(record);
+            } else {
+                tracing::error!(seq = event.seq, "malformed prune.intent payload; ignored");
+            }
+            return;
+        }
+        crate::runtime::prune::KIND_PRUNE_COMPLETED => {
+            let Some(pending) = state.pending_prune.take() else {
+                tracing::error!(
+                    seq = event.seq,
+                    "prune.completed with no pending intent; ignored"
+                );
+                return;
+            };
+            let intent_seq_matches =
+                event.payload["intent_seq"].as_u64() == Some(pending.intent_seq);
+            if !intent_seq_matches {
+                tracing::error!(
+                    seq = event.seq,
+                    expected_intent_seq = pending.intent_seq,
+                    found = ?event.payload.get("intent_seq"),
+                    "prune.completed intent_seq mismatch; ignored"
+                );
+                state.pending_prune = Some(pending);
+                return;
+            }
+            let merged = pending.residue.merged_with(pending.carried_forward);
+            apply_residue(state, merged);
             return;
         }
         _ => {}
@@ -1153,6 +1224,36 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
     }
 }
 
+/// W3 §6.2: apply a `prune.completed`'s merged residue (its own plus the
+/// carried-forward from any condemned earlier intent) to the live registry.
+/// Every step here is unconditional — the reducer never fails
+/// (`Reducer<S>` returns `()`), so a row already absent (a `Completed`/
+/// `Canceled` Work's `works`/`runs` entries, already gone via `maybe_evict`)
+/// is simply a no-op remove, never asserted.
+fn apply_residue(state: &mut WorkRegistry, residue: crate::runtime::prune::PruneResidue) {
+    for row in residue.works {
+        let id = row.id.clone();
+        state.work_index.remove(&id);
+        state.terminal_works.remove(&id);
+        state.terminal_work_order.retain(|x| x != &id);
+        state.terminal_runs.remove(&id);
+        state.terminal_run_order.retain(|x| x != &id);
+        state.works.remove(&id);
+        state.runs.remove(&id);
+        state.pruned_works.insert(id, row);
+    }
+    for row in residue.commands {
+        let id = row.command_id.clone();
+        state.commands.remove(&id);
+        state.command_works.remove(&id);
+        state.pruned_commands.insert(id, row);
+    }
+    // `residue.capability_provenance` is not carried on `WorkRegistry` at
+    // all (I-W3-12): the watermark's only durable home is the prune events
+    // themselves (T12), read back by `startup::CapabilitySink` on a full
+    // replay or a cache rebuild — nothing here needs it live.
+}
+
 /// An empty [`WorkRegistry`] projection ready to fold the journal.
 pub fn work_registry_projection() -> Projection<WorkRegistry> {
     Projection::new(WorkRegistry::default(), work_registry_reducer)
@@ -1188,7 +1289,11 @@ pub fn rederive_run(journal: &Journal, work_id: &str) -> Result<Option<WorkRun>,
 /// to.
 fn rederive_registry_for(journal: &Journal, work_id: &str) -> Result<WorkRegistry, JournalError> {
     let mut scratch = WorkRegistry::default();
-    for event in journal.replay()? {
+    // W3 §11.2/A1: floor-aware, not `replay()` — a retained Work's events
+    // never sit below the floor (I-W3-1), but `replay()`'s hardcoded
+    // `expected = 1` would misreport ruled retention as `SeqDiscontinuity`
+    // on a journal that has ever been pruned.
+    for event in journal.replay_from_floor()? {
         let event = event?;
         if event.work_id.as_deref() == Some(work_id) {
             apply_registry_event(&mut scratch, &event, false);

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -298,6 +298,14 @@ pub struct PruneIntentRecord {
     pub condemn: Vec<String>,
     /// Hexes the *previous* cycle quarantined, to delete now (§5.2).
     pub delete_quarantined: Vec<String>,
+    /// Hexes the *previous* cycle quarantined that a surviving or
+    /// since-committed event has referenced again — moved back to their
+    /// live content address instead of deleted (I-W3-6's other half: a
+    /// dedup adoption that lands between one cycle's mark scan and the
+    /// *next* cycle's deferred delete, with nobody having called
+    /// `BlobStore::get`/`put` in between to trigger the ordinary rescue).
+    #[serde(default)]
+    pub rescue_quarantined: Vec<String>,
     /// Whether this cycle was triggered at daemon start (§10.3) rather than
     /// by rotation (§10.4).
     pub started_at_startup: bool,
@@ -316,6 +324,12 @@ struct IntentPayload {
     carried_forward: PruneResidue,
     condemn: Vec<String>,
     delete_quarantined: Vec<String>,
+    /// Absent from any intent committed before this field existed —
+    /// defaults to empty, which is always a safe (if slightly stale)
+    /// answer for a record this old (§6.2's "record, apply nothing" applies
+    /// symmetrically to a field that is simply missing).
+    #[serde(default)]
+    rescue_quarantined: Vec<String>,
     started_at_startup: bool,
 }
 
@@ -338,6 +352,7 @@ impl PruneIntentRecord {
             carried_forward: payload.carried_forward,
             condemn: payload.condemn,
             delete_quarantined: payload.delete_quarantined,
+            rescue_quarantined: payload.rescue_quarantined,
             started_at_startup: payload.started_at_startup,
         })
     }
@@ -354,6 +369,7 @@ impl PruneIntentRecord {
             carried_forward: self.carried_forward.clone(),
             condemn: self.condemn.clone(),
             delete_quarantined: self.delete_quarantined.clone(),
+            rescue_quarantined: self.rescue_quarantined.clone(),
             started_at_startup: self.started_at_startup,
         })
         .expect("PruneIntentRecord's payload shape always serializes")
@@ -375,11 +391,22 @@ pub struct PrunePlan {
     pub carried_forward: PruneResidue,
     /// Blobs to quarantine this cycle.
     pub condemn: BTreeSet<BlobRef>,
-    /// Blobs the previous cycle quarantined, to delete now.
+    /// Blobs the previous cycle quarantined, to delete now — already
+    /// excluded from anything the surviving-side scan found still
+    /// referenced (I-W3-6; see [`PrunePlan::rescue_quarantined`]).
     pub delete_quarantined: Vec<String>,
-    /// The highest seq the surviving-side mark scan actually reached —
-    /// `run`'s top-up reads events after this before quarantining, closing
-    /// the window between this plan and the guard that commits it.
+    /// Blobs the previous cycle quarantined that the surviving-side scan
+    /// found referenced by a retained event — a dedup adoption that landed
+    /// between that cycle's mark scan and this one's, with no live
+    /// `get`/`put` in between to trigger the ordinary rescue. `run` moves
+    /// these back to their live content address instead of deleting them.
+    pub rescue_quarantined: Vec<String>,
+    /// The highest seq the surviving-side scan actually reached when it ran
+    /// (`horizon` when nothing needed that scan at all) — `run`'s top-up
+    /// reads events after this before quarantining/deleting, closing the
+    /// window between this plan and the guard that commits it. Bounded by
+    /// the answer the off-guard scan already reached, not by the whole
+    /// retained journal (§5.1).
     pub scan_through: u64,
     /// Why pruning did not advance further than it did.
     pub stall: PruneStall,
@@ -406,10 +433,19 @@ pub struct PruneOutcome {
     /// `delete_quarantined.len() - blobs_deleted - blobs_missing`: rescued
     /// by a live read or write before this cycle's deferred delete ran.
     pub blobs_rescued_before_delete: usize,
+    /// Blobs moved back to their live content address because the
+    /// surviving-side scan (or the guard-held top-up) found them
+    /// referenced by a retained event — [`PruneIntentRecord::rescue_quarantined`]'s
+    /// count, distinct from `blobs_rescued_before_delete` (which counts an
+    /// *ordinary* `get`/`put` rescue that already happened by the time this
+    /// cycle looked).
+    #[serde(default)]
+    pub blobs_rescued_by_reference: usize,
     /// The floor after this cycle.
     pub floor_seq_after: u64,
-    /// More was eligible than [`PRUNE_MAX_WORKS_PER_CYCLE`] allowed; the
-    /// caller should re-arm `prune_pending`.
+    /// More was eligible than [`PRUNE_MAX_WORKS_PER_CYCLE`] allowed; [`run`]
+    /// re-arms `prune_pending` from this so the next tick continues the
+    /// backlog drain rather than waiting on an unrelated rotation (§7.4).
     pub truncated_by_cap: bool,
 }
 
@@ -535,11 +571,46 @@ fn blocking_work(registry: &WorkRegistry) -> Option<(&WorkIndexRow, WorkState)> 
 /// Phase A — in memory, from the registry alone. Cheap enough to run on
 /// every rotation tick. See [`plan`] for the segment-content-aware Phase B
 /// that can only ever *lower* this answer.
+///
+/// **Known simplicity debt, not a correctness gap (spec-fidelity R2):**
+/// [`crate::runtime::startup::horizon`]'s own doc comment says this sweep
+/// (nostraddle + retired, evaluated over the same sorted-by-first-seq
+/// running-max shape) is "the same predicate W3's prune horizon needs...
+/// land the shape here so W3 cites it rather than writing a second one."
+/// This function narrows that shape further — the retention cap
+/// (`cap_seq`) and the batch cap (`PRUNE_MAX_WORKS_PER_CYCLE`) have no
+/// counterpart in `startup::horizon` at all — and the two sweeps are
+/// maintained today as two independently-evolving copies rather than one
+/// shared helper the way the doc comment asks. Not reused directly:
+/// `startup::horizon` is exercised by every W2 cache test in production
+/// today, and reshaping it to accept the two extra predicates this module
+/// needs is real, separate surgery on already-shipped, load-bearing code —
+/// risk this landing did not take on. [`sweep_horizon`], directly below, is
+/// this module's own sole copy of the shape; a future wave that wants the
+/// citation to be literal should factor a shared sweep both call, not
+/// merely note the debt again here.
 pub fn candidate_horizon(
     bounds: &[SegmentBound],
     registry: &WorkRegistry,
     first_seq: &FirstSeqIndex,
     policy: &PrunePolicy,
+) -> (u64, PruneStall) {
+    sweep_horizon(bounds, registry, first_seq, policy, u64::MAX)
+}
+
+/// The sweep [`candidate_horizon`] runs, factored out so [`plan`]'s
+/// allowlist/pair pin (§6.5) can re-run the *same* `nostraddle`/`retired`/
+/// `capped`/batch-cap predicates restricted to `b <= ceiling`, rather than
+/// merely taking the largest segment boundary below the pin and trusting
+/// the residue cross-check to catch a straddling Work the sweep itself
+/// would have refused. `ceiling = u64::MAX` (via [`candidate_horizon`])
+/// changes nothing versus every candidate being eligible on its own terms.
+fn sweep_horizon(
+    bounds: &[SegmentBound],
+    registry: &WorkRegistry,
+    first_seq: &FirstSeqIndex,
+    policy: &PrunePolicy,
+    ceiling: u64,
 ) -> (u64, PruneStall) {
     let n = policy.retention as usize;
     let cap = cap_seq(&registry.work_index, n);
@@ -555,6 +626,7 @@ pub fn candidate_horizon(
     let mut candidates: Vec<u64> = bounds[..bounds.len().saturating_sub(1)]
         .iter()
         .map(|s| s.last_seq)
+        .filter(|&last| last <= ceiling)
         .collect();
     candidates.push(0);
     candidates.sort_unstable();
@@ -662,7 +734,6 @@ struct CondemnedScan {
     condemn_refs: BTreeSet<BlobRef>,
     work_ids_seen: BTreeSet<String>,
     lowest_pin_seq: Option<u64>,
-    max_seq_seen: u64,
 }
 
 fn scan_condemned_range(
@@ -677,14 +748,12 @@ fn scan_condemned_range(
     let mut open_intents: BTreeMap<u64, ()> = BTreeMap::new();
     let mut lowest_pin_seq: Option<u64> = None;
     let mut carried_ask_withdrawal: Option<AskWithdrawal> = None;
-    let mut max_seq_seen = 0u64;
 
     for event in crate::runtime::journal::Journal::replay_data_dir_from_floor(data_dir)? {
         let event = event?;
         if event.seq > ceiling {
             break;
         }
-        max_seq_seen = event.seq;
 
         if let Some(id) = &event.work_id {
             work_ids_seen.insert(id.clone());
@@ -757,7 +826,6 @@ fn scan_condemned_range(
         condemn_refs,
         work_ids_seen,
         lowest_pin_seq,
-        max_seq_seen,
     })
 }
 
@@ -795,13 +863,23 @@ pub fn plan(
             .find(|b| b.first_seq <= pin_seq && pin_seq <= b.last_seq)
             .map(|b| b.first_seq)
             .unwrap_or(pin_seq);
-        horizon = bounds
-            .iter()
-            .map(|b| b.last_seq)
-            .filter(|&last| last < pin_first_seq)
-            .max()
-            .unwrap_or(0)
-            .min(candidate);
+        // §7.1: "the largest *admissible* candidate below the pin" — not
+        // merely the largest segment boundary below it. A lower horizon is
+        // not automatically admissible: `nostraddle` is not monotone in
+        // `b`, so a Work straddling this new, smaller boundary can make a
+        // candidate that looked fine at `candidate`'s height inadmissible
+        // down here. Re-running the same sweep restricted to
+        // `b < pin_first_seq` is what actually re-checks
+        // `nostraddle`/`retired`/`capped` at the lowered height, rather
+        // than relying on the residue cross-check below to reject a
+        // straddling plan after the fact (that check still runs — belt and
+        // braces — but this is what keeps a straddling pin from producing a
+        // permanent, misdiagnosed `ResidueMismatch` stall every cycle
+        // instead of a correctly-computed, possibly-smaller-but-legal
+        // horizon).
+        let ceiling = pin_first_seq.saturating_sub(1);
+        let (admissible, _) = sweep_horizon(bounds, registry, first_seq, policy, ceiling);
+        horizon = admissible.min(candidate);
     }
     if horizon == 0 {
         return Ok(None);
@@ -858,13 +936,26 @@ pub fn plan(
         });
     }
 
+    // The surviving-side scan: needed whenever there is something a live
+    // reference could save — either a fresh condemn candidate (the
+    // long-standing check) or a hex the *previous* cycle already
+    // quarantined and this cycle would otherwise delete (I-W3-6's other
+    // half, §7.1's deferred-delete step). Tracks the highest seq it
+    // actually reached, which becomes `scan_through`: bounded by the answer
+    // this off-guard pass reached, not by the whole retained journal (§5.1)
+    // — `run`'s guard-held top-up only has to re-read from here forward,
+    // not from `horizon` forward.
     let mut surviving_refs: BTreeSet<BlobRef> = BTreeSet::new();
-    if !scan.condemn_refs.is_empty() {
+    let mut surviving_scan_through = horizon;
+    let needs_surviving_scan =
+        !scan.condemn_refs.is_empty() || !registry.quarantined_blobs.is_empty();
+    if needs_surviving_scan {
         for event in crate::runtime::journal::Journal::replay_data_dir_from_floor(data_dir)? {
             let event = event?;
             if event.seq <= horizon {
                 continue;
             }
+            surviving_scan_through = surviving_scan_through.max(event.seq);
             for r in blob::refs_in_event(&event) {
                 surviving_refs.insert(r);
             }
@@ -875,6 +966,23 @@ pub fn plan(
         .difference(&surviving_refs)
         .cloned()
         .collect();
+
+    // §5.2/I-W3-6: a hex the previous cycle quarantined must not be deleted
+    // this cycle if a surviving event now references it — a dedup adoption
+    // that landed between that cycle's mark scan and this one's, with no
+    // live `get`/`put` in between to have rescued it the ordinary way.
+    // Split rather than merely filter: the excluded hexes are moved back to
+    // their live content address (`run`'s `rescue_quarantined` step) rather
+    // than silently left in quarantine forever — the next cycle's own
+    // `registry.quarantined_blobs` is about to be replaced wholesale by
+    // *this* cycle's fresh `condemn` set, so anything not resolved to
+    // "delete" or "rescue" now would never be revisited again.
+    let surviving_hexes: BTreeSet<&str> = surviving_refs.iter().map(BlobRef::hex).collect();
+    let (delete_quarantined, rescue_quarantined): (Vec<String>, Vec<String>) = registry
+        .quarantined_blobs
+        .iter()
+        .cloned()
+        .partition(|hex| !surviving_hexes.contains(hex.as_str()));
 
     let (_, mut stall) = candidate_horizon(bounds, registry, first_seq, policy);
     stall.horizon_seq = horizon;
@@ -901,8 +1009,9 @@ pub fn plan(
         residue,
         carried_forward: scan.carried_forward,
         condemn,
-        delete_quarantined: registry.quarantined_blobs.clone(),
-        scan_through: scan.max_seq_seen.max(horizon),
+        delete_quarantined,
+        rescue_quarantined,
+        scan_through: surviving_scan_through,
         stall,
     }))
 }
@@ -965,12 +1074,22 @@ pub fn run(
     }
 
     // §5.1's top-up, under the guard: an append between the plan's mark
-    // scan and this hold could have referenced a blob the plan condemned.
+    // scan and this hold could have referenced a blob the plan condemned,
+    // or re-referenced a hex the *previous* cycle already quarantined
+    // (I-W3-6's other half — the same window, on the deferred-delete side).
     // Closing this window is what makes quarantine+rescue a second line of
-    // defence rather than the only one (I-W3-6).
-    for event in core.events_after(plan.scan_through)? {
-        for r in blob::refs_in_event(&event) {
-            plan.condemn.remove(&r);
+    // defence rather than the only one. Skipped entirely when there is
+    // nothing either list could still be wrong about, so a plan with no
+    // blobs in play never pays for a read here at all.
+    if !plan.condemn.is_empty() || !plan.delete_quarantined.is_empty() {
+        for event in core.events_after(plan.scan_through)? {
+            for r in blob::refs_in_event(&event) {
+                plan.condemn.remove(&r);
+                if let Some(pos) = plan.delete_quarantined.iter().position(|h| h == r.hex()) {
+                    plan.rescue_quarantined
+                        .push(plan.delete_quarantined.remove(pos));
+                }
+            }
         }
     }
 
@@ -1000,6 +1119,7 @@ pub fn run(
         carried_forward: plan.carried_forward.clone(),
         condemn: plan.condemn.iter().map(|r| r.hex().to_string()).collect(),
         delete_quarantined: plan.delete_quarantined.clone(),
+        rescue_quarantined: plan.rescue_quarantined.clone(),
         started_at_startup,
     };
 
@@ -1023,7 +1143,20 @@ pub fn run(
         }
     }
 
-    // Step 3 (T5): the previous cycle's deferred delete.
+    // Step 3a (T5's live half, I-W3-6): rescue back to the live content
+    // address any hex the mark scan or this guard's own top-up found
+    // referenced by a surviving event since the previous cycle quarantined
+    // it — before the deferred delete below, from the disjoint partition
+    // `plan` already computed, so together the two steps account for every
+    // hex the previous cycle quarantined exactly once.
+    let mut blobs_rescued_by_reference = 0usize;
+    for hex in &record.rescue_quarantined {
+        if blobs.rescue_quarantined_hex(hex)? {
+            blobs_rescued_by_reference += 1;
+        }
+    }
+
+    // Step 3b (T5): the previous cycle's deferred delete.
     let mut blobs_deleted = 0usize;
     for hex in &record.delete_quarantined {
         if blobs.drop_quarantined(hex)? {
@@ -1048,6 +1181,7 @@ pub fn run(
         blobs_deleted,
         blobs_missing: 0,
         blobs_rescued_before_delete,
+        blobs_rescued_by_reference,
         floor_seq_after: record.floor_seq_after,
         truncated_by_cap: plan.stall.truncated_by_cap,
     };
@@ -1064,7 +1198,12 @@ pub fn run(
         }),
     ))?;
     core.flush()?;
-    core.prune_pending = false;
+    // §7.4: when the batch cap truncated this cycle's target set, the
+    // remainder is left for the next cycle and `prune_pending` is re-armed
+    // so the next tick continues rather than waiting for an unrelated
+    // rotation — `outcome.truncated_by_cap` is exactly the signal `plan`
+    // already computed for this.
+    core.prune_pending = outcome.truncated_by_cap;
 
     // Step 6, deviated (see this module's top doc comment): rather than
     // rewrite the cache from the live capability watermark (not reachable
@@ -1132,6 +1271,12 @@ pub fn complete_interrupted(
             blobs_quarantined += 1;
         }
     }
+    let mut blobs_rescued_by_reference = 0usize;
+    for hex in &pending.rescue_quarantined {
+        if blobs.rescue_quarantined_hex(hex)? {
+            blobs_rescued_by_reference += 1;
+        }
+    }
     let mut blobs_deleted = 0usize;
     for hex in &pending.delete_quarantined {
         if blobs.drop_quarantined(hex)? {
@@ -1155,6 +1300,7 @@ pub fn complete_interrupted(
         blobs_deleted,
         blobs_missing: 0,
         blobs_rescued_before_delete,
+        blobs_rescued_by_reference,
         floor_seq_after: pending.floor_seq_after,
         truncated_by_cap: false,
     };
@@ -1592,6 +1738,7 @@ mod tests {
             carried_forward: plan.carried_forward.clone(),
             condemn: plan.condemn.iter().map(|r| r.hex().to_string()).collect(),
             delete_quarantined: plan.delete_quarantined.clone(),
+            rescue_quarantined: plan.rescue_quarantined.clone(),
             started_at_startup: false,
         };
         core.commit(EventDraft::new(
@@ -1606,6 +1753,109 @@ mod tests {
             "the intent must be pending — nothing has completed it yet"
         );
         plan
+    }
+
+    /// Like [`build_and_commit_intent`], but `w1`'s completion references a
+    /// real, previously-written blob — so the intent's own `condemn` is
+    /// non-empty and F2/F3 (the blob-side crash windows) have something to
+    /// crash mid-way through.
+    fn build_and_commit_intent_with_blob(
+        core: &mut crate::api::Core,
+        dir: &std::path::Path,
+    ) -> (PrunePlan, BlobRef) {
+        let blob_ref = BlobStore::open(dir)
+            .expect("open blob store")
+            .put(b"crash window fixture blob")
+            .expect("put");
+        let hex = blob_ref.hex().to_string();
+
+        commit(
+            core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w1"),
+            serde_json::json!({"work": {
+                "id": "w1", "intent": "crash window blob fixture", "state": "pending",
+                "created_by": "test", "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w1"),
+            serde_json::json!({"result_blob": format!("b3:{hex}")}),
+        );
+        commit(
+            core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w1's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan = plan(
+            dir,
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("something must be prunable");
+        assert!(
+            plan.condemn.iter().any(|r| r.hex() == hex),
+            "the fixture's blob must actually be a condemn candidate"
+        );
+
+        let record = PruneIntentRecord {
+            intent_seq: 0,
+            policy: plan.policy,
+            horizon_seq: plan.horizon_seq,
+            floor_seq_before: 1,
+            floor_seq_after: plan.horizon_seq + 1,
+            segments: plan
+                .segments
+                .iter()
+                .map(|b| PruneSegment {
+                    index: b.index,
+                    first_seq: b.first_seq,
+                    last_seq: b.last_seq,
+                    bytes: b.bytes,
+                })
+                .collect(),
+            residue: plan.residue.clone(),
+            carried_forward: plan.carried_forward.clone(),
+            condemn: plan.condemn.iter().map(|r| r.hex().to_string()).collect(),
+            delete_quarantined: plan.delete_quarantined.clone(),
+            rescue_quarantined: plan.rescue_quarantined.clone(),
+            started_at_startup: false,
+        };
+        core.commit(EventDraft::new(
+            EventSource::new("daemon", "sergeant"),
+            KIND_PRUNE_INTENT,
+            record.to_payload(),
+        ))
+        .expect("commit intent");
+        core.flush().expect("flush intent");
+        (plan, blob_ref)
     }
 
     /// N7 / F1: a crash after `prune.intent` is fsynced, before any rename or
@@ -1650,6 +1900,194 @@ mod tests {
             next_seq_after_intent + 1,
             "a completion with no pending intent must append nothing"
         );
+    }
+
+    /// N8 / F2: a crash after the intent's blob has already been moved into
+    /// quarantine, before `prune.completed` is appended, is completed in
+    /// full at the next start — `BlobStore::quarantine`'s own idempotent
+    /// `Ok(false)` on an already-moved blob is what makes re-running the
+    /// whole loop from the intent's record safe regardless of whether the
+    /// crashed cycle got to the rename or not, and never leaves two copies
+    /// of the same content.
+    #[test]
+    fn crash_window_f2_mid_quarantine_completes_idempotently() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let (plan, blob_ref) = build_and_commit_intent_with_blob(&mut core, dir.path());
+
+        // Simulate the crash landing *after* the rename: the blob is
+        // already sitting in quarantine when the next start begins.
+        let blobs = BlobStore::open(dir.path()).expect("open blob store");
+        assert!(
+            blobs
+                .quarantine(&blob_ref)
+                .expect("simulate the completed quarantine step"),
+            "the fixture's blob must actually still be live to quarantine"
+        );
+
+        complete_interrupted(&mut core, dir.path()).expect("complete_interrupted");
+        assert!(core.registry.state().pending_prune.is_none());
+        assert!(core.registry.state().pruned_works.contains_key("w1"));
+        let bounds_after = core.journal.segment_bounds().expect("bounds");
+        assert!(
+            bounds_after
+                .iter()
+                .all(|b| !plan.segments.iter().any(|s| s.index == b.index)),
+            "every planned segment must still be gone"
+        );
+
+        // Idempotency: completing an already-finished cycle again touches
+        // nothing further and never fails re-quarantining what is already
+        // quarantined.
+        complete_interrupted(&mut core, dir.path()).expect("second complete_interrupted");
+
+        // Exactly one copy of the content exists, in quarantine — never a
+        // live copy alongside it.
+        let quarantine_path = dir
+            .path()
+            .join("blobs")
+            .join("b3")
+            .join(".pruned")
+            .join(blob_ref.hex());
+        let live_path = dir.path().join("blobs").join("b3").join(blob_ref.hex());
+        assert!(
+            quarantine_path.exists(),
+            "the blob must still be quarantined"
+        );
+        assert!(!live_path.exists(), "the blob must never also exist live");
+    }
+
+    /// N8 continued / F3: a crash after a *second* cycle's intent is
+    /// committed, before its deferred delete of the *first* cycle's
+    /// quarantined blob runs, is completed in full at the next start —
+    /// `BlobStore::drop_quarantined`'s own idempotent `Ok(false)` on an
+    /// already-gone quarantined file is what makes re-running the deferred
+    /// delete safe regardless of whether the crashed cycle got to it.
+    #[test]
+    fn crash_window_f3_mid_deferred_delete_completes_idempotently() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+
+        // Cycle 1, run to completion: quarantines the blob.
+        let (plan1, blob_ref) = build_and_commit_intent_with_blob(&mut core, dir.path());
+        complete_interrupted(&mut core, dir.path()).expect("complete cycle 1");
+        assert_eq!(
+            core.registry.state().quarantined_blobs,
+            vec![blob_ref.hex().to_string()],
+            "cycle 1 must have recorded the blob as quarantined"
+        );
+        drop(plan1);
+
+        // `anchor` (from `build_and_commit_intent_with_blob`) has done its
+        // job and must stop being the horizon's perpetual blocker.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("anchor"),
+            serde_json::json!({}),
+        );
+
+        // New activity, prunable on its own, whose cycle's own
+        // `delete_quarantined` inherits cycle 1's quarantined hex.
+        submit_and_complete(&mut core, "w_mid");
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor2"),
+            serde_json::json!({"work": {
+                "id": "anchor2", "intent": "keep the writer off w_mid's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan2 = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w_mid must be prunable");
+        assert_eq!(
+            plan2.delete_quarantined,
+            vec![blob_ref.hex().to_string()],
+            "cycle 2 must inherit cycle 1's quarantined hex to delete"
+        );
+
+        // Commit only cycle 2's intent (step 1) — simulating a crash
+        // before the deferred delete (step 3) ever runs.
+        let record = PruneIntentRecord {
+            intent_seq: 0,
+            policy: plan2.policy,
+            horizon_seq: plan2.horizon_seq,
+            floor_seq_before: core.journal.floor_seq().expect("floor").unwrap_or(1),
+            floor_seq_after: plan2.horizon_seq + 1,
+            segments: plan2
+                .segments
+                .iter()
+                .map(|b| PruneSegment {
+                    index: b.index,
+                    first_seq: b.first_seq,
+                    last_seq: b.last_seq,
+                    bytes: b.bytes,
+                })
+                .collect(),
+            residue: plan2.residue.clone(),
+            carried_forward: plan2.carried_forward.clone(),
+            condemn: plan2.condemn.iter().map(|r| r.hex().to_string()).collect(),
+            delete_quarantined: plan2.delete_quarantined.clone(),
+            rescue_quarantined: plan2.rescue_quarantined.clone(),
+            started_at_startup: false,
+        };
+        core.commit(EventDraft::new(
+            EventSource::new("daemon", "sergeant"),
+            KIND_PRUNE_INTENT,
+            record.to_payload(),
+        ))
+        .expect("commit cycle 2's intent");
+        core.flush().expect("flush cycle 2's intent");
+
+        let quarantine_path = dir
+            .path()
+            .join("blobs")
+            .join("b3")
+            .join(".pruned")
+            .join(blob_ref.hex());
+        assert!(
+            quarantine_path.exists(),
+            "the blob must still be sitting in quarantine before the crash-recovery completes it"
+        );
+
+        complete_interrupted(&mut core, dir.path()).expect("complete cycle 2");
+        assert!(core.registry.state().pending_prune.is_none());
+        assert!(core.registry.state().pruned_works.contains_key("w_mid"));
+        assert!(
+            !quarantine_path.exists(),
+            "the deferred delete must actually have run"
+        );
+
+        // Idempotency: completing an already-finished cycle again is a
+        // true no-op, including `drop_quarantined`'s own tolerated
+        // already-gone case.
+        complete_interrupted(&mut core, dir.path()).expect("second complete_interrupted");
+        assert!(!quarantine_path.exists());
     }
 
     /// N9 / F4: a crash mid-unlink (only the first of the two target
@@ -1805,6 +2243,620 @@ mod tests {
         );
     }
 
+    /// §8.3's read side: the residue's whole point is that a *later* replay
+    /// — one that never sees `w1`'s own now-deleted
+    /// `conversation.turn.grammar_unmeasured` event — must still recover the
+    /// withdrawal from the surviving `prune.intent`. Without
+    /// `note_carried_ask_withdrawal` wired into `CapabilitySink::push`, a
+    /// fresh no-cache replay would silently answer `None`, re-raising
+    /// `Capabilities::ask` on an installation that had already proved it
+    /// absent — exactly the gap §8.3 exists to close.
+    #[test]
+    fn a_fresh_floor_replay_recovers_the_ask_withdrawal_from_the_prune_residue_alone() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w1"),
+            serde_json::json!({"work": {
+                "id": "w1", "intent": "ask fixture", "state": "pending",
+                "created_by": "test", "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        let withdrawal_event = commit(
+            &mut core,
+            EventSource::new("backend", "claude"),
+            "conversation.turn.grammar_unmeasured",
+            Some("w1"),
+            serde_json::json!({"capability": "ask", "version": "2.1.226"}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w1"),
+            serde_json::json!({}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w1's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("something must be prunable");
+        run(&mut core, dir.path(), plan, false).expect("run");
+
+        // The scenario §8.3 is written against: a replay from the floor
+        // that never sees `withdrawal_event` at all (it was unlinked with
+        // its segment) — driven through the same `CapabilitySink` a real
+        // no-cache daemon start uses, seeded from nothing.
+        let mut capability = startup::CapabilitySink::seeded(None);
+        let events = crate::runtime::journal::Journal::replay_data_dir_from_floor(dir.path())
+            .expect("replay_data_dir_from_floor");
+        startup::drive(events, &mut [&mut capability]).expect("drive");
+
+        let recovered = capability
+            .latest
+            .as_ref()
+            .expect("the withdrawal must survive a fresh floor replay with no cache");
+        assert_eq!(
+            recovered.seq, withdrawal_event.seq,
+            "the carried watermark must keep its *original* seq, not the intent's"
+        );
+        assert_eq!(recovered.version, "2.1.226");
+    }
+
+    /// N5: a blob referenced by both a to-be-pruned Work and a retained one
+    /// must never be condemned — the surviving-side scan's whole purpose.
+    #[test]
+    fn a_blob_shared_with_a_retained_work_is_never_condemned() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let blob_ref = BlobStore::open(dir.path())
+            .expect("open blob store")
+            .put(b"shared content")
+            .expect("put");
+        let hex = blob_ref.hex().to_string();
+
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w_old"),
+            serde_json::json!({"work": {
+                "id": "w_old", "intent": "prunable, references the shared blob",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w_old"),
+            serde_json::json!({"result_blob": format!("b3:{hex}")}),
+        );
+        // `w_keep` stays active forever (never retired_whole), so it is
+        // always the horizon's blocker — which guarantees its own
+        // referencing event's seq is always strictly *above* whatever
+        // horizon this cycle computes, i.e. always in the surviving range.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w_keep"),
+            serde_json::json!({"work": {
+                "id": "w_keep", "intent": "retained, references the same blob",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+                "ref": format!("b3:{hex}"),
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w_old must still be prunable even though w_keep pins the horizon below it");
+
+        assert_eq!(
+            plan.residue
+                .works
+                .iter()
+                .map(|r| r.id.as_str())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from(["w_old"]),
+            "only w_old — the Work entirely before w_keep's pin — may be pruned"
+        );
+        assert!(
+            !plan.condemn.iter().any(|r| r.hex() == hex),
+            "the shared blob must never be condemned while w_keep still references it live"
+        );
+
+        let outcome = run(&mut core, dir.path(), plan, false).expect("run");
+        assert_eq!(outcome.blobs_quarantined, 0);
+        let bytes = BlobStore::open(dir.path())
+            .expect("open blob store")
+            .get(&blob_ref)
+            .expect("the shared blob must still be live and intact");
+        assert_eq!(bytes, b"shared content");
+    }
+
+    /// N6: a blob one cycle quarantines, that a *live* event adopts again
+    /// before the next cycle's deferred delete runs, must be rescued back
+    /// to its content address rather than deleted — the two-phase
+    /// quarantine's whole reason to exist (A5). Exercises the fix directly:
+    /// before it, `delete_quarantined` was `registry.quarantined_blobs`
+    /// verbatim, with no check against what the surviving journal now
+    /// references.
+    #[test]
+    fn a_dedup_adoption_between_mark_and_sweep_is_rescued_from_quarantine() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let blob_ref = BlobStore::open(dir.path())
+            .expect("open blob store")
+            .put(b"adopted content")
+            .expect("put");
+        let hex = blob_ref.hex().to_string();
+
+        // Cycle 1: w_old is the only reference to the blob — it gets
+        // quarantined.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w_old"),
+            serde_json::json!({"work": {
+                "id": "w_old", "intent": "prunable, references the blob first",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w_old"),
+            serde_json::json!({"result_blob": format!("b3:{hex}")}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor1"),
+            serde_json::json!({"work": {
+                "id": "anchor1", "intent": "keep the writer off w_old's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan1 = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w_old must be prunable");
+        let outcome1 = run(&mut core, dir.path(), plan1, false).expect("run cycle 1");
+        assert_eq!(outcome1.blobs_quarantined, 1);
+        assert_eq!(
+            core.registry.state().quarantined_blobs,
+            vec![hex.clone()],
+            "the blob must be quarantined, recorded on the registry"
+        );
+
+        // Between cycle 1's completion and cycle 2, a live event adopts the
+        // same content again (a dedup hit this test asserts directly,
+        // rather than through `BlobStore::put`'s own internal rescue, to
+        // isolate `plan`'s mark-scan-side handling of it). `anchor1` is
+        // completed so it stops blocking; `anchor2` — carrying the
+        // reference — takes over as the perpetual blocker, so its own
+        // event's seq is always in the surviving range for cycle 2.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("anchor1"),
+            serde_json::json!({}),
+        );
+        submit_and_complete(&mut core, "w_mid");
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor2"),
+            serde_json::json!({"work": {
+                "id": "anchor2", "intent": "adopts the quarantined blob again",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+                "ref": format!("b3:{hex}"),
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan2 = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w_mid must be prunable in cycle 2");
+
+        assert!(
+            plan2.delete_quarantined.is_empty(),
+            "the adopted hex must not be scheduled for deletion"
+        );
+        assert_eq!(
+            plan2.rescue_quarantined,
+            vec![hex.clone()],
+            "the adopted hex must be scheduled for rescue instead"
+        );
+
+        let outcome2 = run(&mut core, dir.path(), plan2, false).expect("run cycle 2");
+        assert_eq!(outcome2.blobs_deleted, 0);
+        assert_eq!(outcome2.blobs_rescued_by_reference, 1);
+
+        let bytes = BlobStore::open(dir.path())
+            .expect("open blob store")
+            .get(&blob_ref)
+            .expect("the adopted blob must be live again, not deleted");
+        assert_eq!(bytes, b"adopted content");
+    }
+
+    /// §3.5's stated invariant, checked directly against a real fixture
+    /// rather than only inferred from `nostraddle`'s own definition: every
+    /// retained (still-in-`work_index`) Work's `first_seq` is at or above
+    /// the journal's floor after a real prune — nothing retained can start
+    /// underneath the segments a cycle just unlinked.
+    #[test]
+    fn every_retained_work_starts_at_or_above_the_floor() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let plan = build_and_commit_intent(&mut core, dir.path());
+        complete_interrupted(&mut core, dir.path()).expect("complete_interrupted");
+        assert!(core.registry.state().pruned_works.contains_key("w1"));
+        drop(plan);
+
+        let floor = core.journal.floor_seq().expect("floor_seq").unwrap_or(1);
+        for (id, first) in &core.first_seq_by_work {
+            if core.registry.state().work_index.contains_key(id) {
+                assert!(
+                    *first >= floor,
+                    "retained Work {id} starts at seq {first}, below the floor {floor}"
+                );
+            }
+        }
+        assert!(
+            !core.registry.state().work_index.is_empty(),
+            "the fixture must actually retain something (anchor) for this to check anything"
+        );
+    }
+
+    /// §6.4: residue must keep surviving no matter how many *further*
+    /// cycles run after the Work that originally recorded it is gone —
+    /// carried forward from `prune.intent` to `prune.intent` indefinitely,
+    /// not just across the one cycle that first pruned it. Three
+    /// generations: cycle 1 prunes `w1` itself; cycles 2 and 3 prune
+    /// unrelated later Works, each carrying `w1`'s row forward without ever
+    /// touching it again.
+    #[test]
+    fn a_carried_forward_residue_survives_three_generations_of_prune() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let run_one_cycle = |core: &mut crate::api::Core, work_id: &str, anchor: &str| {
+            submit_and_complete(core, work_id);
+            commit(
+                core,
+                daemon_source(),
+                crate::domain::work::KIND_WORK_SUBMITTED,
+                Some(anchor),
+                serde_json::json!({"work": {
+                    "id": anchor, "intent": "keep the writer off this cycle's segments",
+                    "state": "pending", "created_by": "test",
+                    "created_at": "2026-01-01T00:00:00.000Z",
+                }}),
+            );
+            core.flush().expect("flush");
+            let bounds = core.journal.segment_bounds().expect("bounds");
+            let (candidate, _) = candidate_horizon(
+                &bounds,
+                core.registry.state(),
+                &core.first_seq_by_work,
+                &policy,
+            );
+            let plan = plan(
+                dir.path(),
+                &bounds,
+                candidate,
+                core.registry.state(),
+                &core.first_seq_by_work,
+                &policy,
+            )
+            .expect("plan")
+            .expect("something must be prunable");
+            run(core, dir.path(), plan, false).expect("run")
+        };
+
+        // Cycle 1: prunes w1 directly.
+        run_one_cycle(&mut core, "w1", "anchor1");
+        assert!(core.registry.state().pruned_works.contains_key("w1"));
+        // `anchor1` must stop blocking before the next cycle.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("anchor1"),
+            serde_json::json!({}),
+        );
+
+        // Cycle 2: prunes w2; must carry w1's row forward untouched.
+        run_one_cycle(&mut core, "w2", "anchor2");
+        assert!(core.registry.state().pruned_works.contains_key("w1"));
+        assert!(core.registry.state().pruned_works.contains_key("w2"));
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("anchor2"),
+            serde_json::json!({}),
+        );
+
+        // Cycle 3: prunes w3; both w1 and w2's rows must still be present,
+        // carried across two further generations neither of them was
+        // touched in again.
+        run_one_cycle(&mut core, "w3", "anchor3");
+        let registry = core.registry.state();
+        assert!(
+            registry.pruned_works.contains_key("w1"),
+            "w1's residue must survive two further generations of prune"
+        );
+        assert!(registry.pruned_works.contains_key("w2"));
+        assert!(registry.pruned_works.contains_key("w3"));
+    }
+
+    /// The ordering half of §8.3: a withdrawal *carried* forward from a
+    /// pruned Work must never outrank a **newer** withdrawal recorded by a
+    /// still-live, retained event — "higher seq wins" must keep meaning
+    /// what it means regardless of which side (carried residue, or a
+    /// surviving event `note_ask_withdrawal` matches directly) a replay
+    /// happens to see first.
+    #[test]
+    fn a_carried_withdrawal_never_outranks_a_newer_retained_one() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w_old"),
+            serde_json::json!({"work": {
+                "id": "w_old", "intent": "records the older withdrawal", "state": "pending",
+                "created_by": "test", "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        let older = commit(
+            &mut core,
+            EventSource::new("backend", "claude"),
+            "conversation.turn.grammar_unmeasured",
+            Some("w_old"),
+            serde_json::json!({"capability": "ask", "version": "2.1.226"}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w_old"),
+            serde_json::json!({}),
+        );
+        // `w_new` stays active forever (never retired_whole), so it is
+        // always the horizon's blocker — guaranteeing its own withdrawal
+        // event's seq is always in the surviving range, never condemned.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w_new"),
+            serde_json::json!({"work": {
+                "id": "w_new", "intent": "records the newer withdrawal", "state": "pending",
+                "created_by": "test", "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        let newer = commit(
+            &mut core,
+            EventSource::new("backend", "claude"),
+            "conversation.turn.grammar_unmeasured",
+            Some("w_new"),
+            serde_json::json!({"capability": "ask", "version": "2.1.226"}),
+        );
+        assert!(
+            newer.seq > older.seq,
+            "the fixture's whole point is a newer, surviving withdrawal"
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w_old must be prunable even though w_new pins the horizon below it");
+
+        // The carried residue only ever holds `older` — `newer`'s event is
+        // in the surviving range, never scanned into the condemned side.
+        assert_eq!(
+            plan.residue.capability_provenance.as_ref().map(|w| w.seq),
+            Some(older.seq),
+        );
+        run(&mut core, dir.path(), plan, false).expect("run");
+
+        // A fresh floor replay must fold *both* sources and land on the
+        // newer, still-live withdrawal — never regress to the carried,
+        // older one.
+        let mut capability = startup::CapabilitySink::seeded(None);
+        let events = crate::runtime::journal::Journal::replay_data_dir_from_floor(dir.path())
+            .expect("replay_data_dir_from_floor");
+        startup::drive(events, &mut [&mut capability]).expect("drive");
+        let recovered = capability
+            .latest
+            .as_ref()
+            .expect("a withdrawal must be recoverable");
+        assert_eq!(
+            recovered.seq, newer.seq,
+            "the newer, still-live withdrawal must win over the older, carried-forward one"
+        );
+    }
+
+    /// §7.4: when the batch cap truncates a cycle's target set, the
+    /// remainder must not wait for an unrelated rotation — `run` must
+    /// re-arm `prune_pending` from `PruneOutcome::truncated_by_cap` rather
+    /// than unconditionally clearing it on every successful commit.
+    #[test]
+    fn a_batch_cap_truncated_cycle_re_arms_prune_pending() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        submit_and_complete(&mut core, "w1");
+        // I-W3-4: push the writer's live segment off of w1's own.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w1's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let mut plan = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("something must be prunable");
+        // Simulate what `candidate_horizon` would have set had this cycle's
+        // eligible set actually exceeded `PRUNE_MAX_WORKS_PER_CYCLE` — the
+        // trigger itself belongs to `candidate_horizon`'s own tests; this
+        // isolates `run`'s handling of the flag it is handed.
+        plan.stall.truncated_by_cap = true;
+
+        let outcome = run(&mut core, dir.path(), plan, false).expect("run");
+        assert!(outcome.truncated_by_cap);
+        assert!(
+            core.prune_pending,
+            "a batch-capped cycle must re-arm prune_pending so the next tick \
+             continues the drain rather than waiting for an unrelated rotation"
+        );
+    }
+
     /// N4: an unknown non-work-scoped event kind pins its segment — Q5's
     /// allowlist as a mechanism, not a comment. A later, otherwise-eligible
     /// Work stays retained because the pin lowers the horizon back below
@@ -1878,6 +2930,260 @@ mod tests {
             plan.stall.pinning_kind.as_deref(),
             Some("mystery.event"),
             "the stall report must name the pinning kind"
+        );
+    }
+
+    /// N19 (§6.5): an unpaired `prune.intent` — its own `prune.completed`
+    /// not (yet) anywhere in the journal, exactly the shape a crash between
+    /// steps 1 and 5 leaves behind — must pin its own segment, exactly like
+    /// an unknown non-work-scoped kind (N4). Without this, a later cycle's
+    /// mark scan could condemn the segment holding a still-open intent,
+    /// after which the eventual crash-recovery completion would have
+    /// nothing left to finish it from consistently — "a pruned id has a
+    /// row in neither... or, worse, an intent whose completion was
+    /// deleted, leaving `pending_prune` permanently `Some`" (§6.5).
+    #[test]
+    fn a_prune_pair_straddling_the_horizon_pins_its_segment() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+
+        // An ordinary Work, already eligible for its own cycle.
+        submit_and_complete(&mut core, "w_prior");
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor0"),
+            serde_json::json!({"work": {
+                "id": "anchor0", "intent": "keep the writer off w_prior's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate0, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan0 = plan(
+            dir.path(),
+            &bounds,
+            candidate0,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w_prior must be prunable on its own");
+
+        // Commit *only* the intent (step 1) — simulating a crash before
+        // `prune.completed` (F1's window) — and deliberately never run
+        // `complete_interrupted`, so the intent stays genuinely unpaired in
+        // the journal for the rest of this test, exactly the shape §6.5
+        // describes.
+        let record = PruneIntentRecord {
+            intent_seq: 0,
+            policy: plan0.policy,
+            horizon_seq: plan0.horizon_seq,
+            floor_seq_before: 1,
+            floor_seq_after: plan0.horizon_seq + 1,
+            segments: plan0
+                .segments
+                .iter()
+                .map(|b| PruneSegment {
+                    index: b.index,
+                    first_seq: b.first_seq,
+                    last_seq: b.last_seq,
+                    bytes: b.bytes,
+                })
+                .collect(),
+            residue: plan0.residue.clone(),
+            carried_forward: plan0.carried_forward.clone(),
+            condemn: plan0.condemn.iter().map(|r| r.hex().to_string()).collect(),
+            delete_quarantined: plan0.delete_quarantined.clone(),
+            rescue_quarantined: plan0.rescue_quarantined.clone(),
+            started_at_startup: false,
+        };
+        let intent_event = core
+            .commit(EventDraft::new(
+                EventSource::new("daemon", "sergeant"),
+                KIND_PRUNE_INTENT,
+                record.to_payload(),
+            ))
+            .expect("commit the stuck intent");
+        core.flush().expect("flush the stuck intent");
+        let intent_seq = intent_event.seq;
+        assert!(
+            core.registry.state().pending_prune.is_some(),
+            "the intent must be pending — nothing has completed it"
+        );
+
+        // `anchor0` has done its job (kept the writer off `w_prior`'s
+        // segments) and must stop being the horizon's blocker, or it would
+        // mask the very thing this test is checking.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("anchor0"),
+            serde_json::json!({}),
+        );
+
+        // New activity after the stuck intent: another Work, fully retired
+        // and past the cap entirely on its own.
+        submit_and_complete(&mut core, "w_after");
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor1"),
+            serde_json::json!({"work": {
+                "id": "anchor1", "intent": "keep the writer off w_after's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let (candidate1, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        // Phase A alone does not know about the stuck intent either — both
+        // w_prior and w_after look fully eligible to it.
+        assert!(candidate1 > intent_seq, "Phase A must not see the pin yet");
+
+        let plan1 = plan(
+            dir.path(),
+            &bounds,
+            candidate1,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w_prior must still be prunable even though the stuck intent pins the rest");
+
+        assert_eq!(
+            plan1.stall.pinning_seq,
+            Some(intent_seq),
+            "the stall report must name the stuck intent's own seq as the pin"
+        );
+        assert!(
+            plan1.horizon_seq < intent_seq,
+            "the horizon must never reach or pass the segment holding the unpaired intent"
+        );
+        let pruned_ids: BTreeSet<&str> =
+            plan1.residue.works.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            pruned_ids,
+            BTreeSet::from(["w_prior"]),
+            "only w_prior, entirely before the stuck intent, may be pruned this cycle"
+        );
+    }
+
+    /// §7.1: a pin that lands *inside* the span of a Work straddling the
+    /// pin's own segment boundary must not select "the largest segment
+    /// boundary below the pin" as the horizon — `nostraddle` is not
+    /// monotone in `b`, so a boundary that looked fine to Phase A can be
+    /// inadmissible once the pin lowers the ceiling below the straddling
+    /// Work's own span. `plan` must re-check `nostraddle`/`retired`/`capped`
+    /// at the lowered height and correctly find nothing prunable, rather
+    /// than mis-selecting an inadmissible horizon that would either
+    /// straddle a live Work or (as this same bug did before the fix) rely
+    /// on the residue cross-check to reject it as a `ResidueMismatch` —
+    /// which would then recur identically on every subsequent cycle, since
+    /// nothing about the pin or the Work ever changes.
+    #[test]
+    fn a_pin_inside_a_straddling_works_span_never_selects_an_inadmissible_horizon() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w_straddle"),
+            serde_json::json!({"work": {
+                "id": "w_straddle", "intent": "straddles the pin's own segment",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        // The pin: a non-work-scoped, non-allowlisted event landing
+        // *inside* w_straddle's own span (between its submit and its
+        // completion), each in its own segment (`tiny_core` rotates every
+        // event).
+        commit(
+            &mut core,
+            daemon_source(),
+            "mystery.event",
+            None,
+            serde_json::json!({}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w_straddle"),
+            serde_json::json!({}),
+        );
+        // I-W3-4: push the writer off w_straddle's own segments — and,
+        // being active, `anchor` is also what makes w_straddle look fully
+        // retired and past-the-cap to Phase A once the writer moves past it.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w_straddle's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        // Phase A alone (registry-only) does not see the pin: w_straddle is
+        // fully retired and past the cap by the time the writer has moved
+        // on to `anchor`'s own segment.
+        assert!(candidate > 0, "Phase A must not see the pin yet");
+
+        let result = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        assert!(
+            matches!(result, Ok(None)),
+            "a pin inside a straddling Work's span must correctly find \
+             nothing prunable rather than mis-select an inadmissible \
+             horizon: got {result:?}"
         );
     }
 

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -853,11 +853,34 @@ pub fn plan(
         return Ok(None);
     }
 
-    let first_pass = scan_condemned_range(data_dir, candidate, registry)?;
-    let first_pass_pin_seq = first_pass.lowest_pin_seq;
-
+    // Lower the horizon until the range this cycle would actually condemn
+    // is pin-free *on its own terms*, re-scanning at each lowered height.
+    //
+    // One pass is not enough, because the pin predicate is not monotone in
+    // the ceiling: `scan_condemned_range`'s `open_intents` arm is
+    // ceiling-*dependent* by construction. A `prune.intent` at seq `S`
+    // whose matching `prune.completed` sits at seq `C` reads as a closed
+    // pair at a ceiling of `candidate` (both in range) and as an unpaired,
+    // segment-pinning intent at a lowered ceiling `h` with `S <= h < C`.
+    // Consulting only the first pass's answer would therefore unlink the
+    // segment holding a still-open intent — exactly what §6.5 forbids, and
+    // exactly what leaves `pending_prune` permanently `Some` with nothing
+    // left to complete it from.
+    //
+    // Terminates: an iteration only runs when the current scan found a pin
+    // at or below the current horizon, and it sets the next horizon
+    // strictly below that pin's own segment — so `horizon` strictly
+    // decreases, bounded below by the `0` that returns `None`. Each
+    // iteration costs one pass over a range strictly smaller than the last,
+    // and iterating at all requires a pin — the uncommon case; the ordinary
+    // cycle still pays exactly one condemned-range pass, as before.
     let mut horizon = candidate;
-    if let Some(pin_seq) = first_pass_pin_seq {
+    let mut scan = scan_condemned_range(data_dir, candidate, registry)?;
+    // The pin that actually bound the final horizon — the last one
+    // consulted, which is the one a stall report should name.
+    let mut effective_pin_seq: Option<u64> = None;
+    while let Some(pin_seq) = scan.lowest_pin_seq {
+        effective_pin_seq = Some(pin_seq);
         let pin_first_seq = bounds
             .iter()
             .find(|b| b.first_seq <= pin_seq && pin_seq <= b.last_seq)
@@ -879,21 +902,15 @@ pub fn plan(
         // horizon).
         let ceiling = pin_first_seq.saturating_sub(1);
         let (admissible, _) = sweep_horizon(bounds, registry, first_seq, policy, ceiling);
-        horizon = admissible.min(candidate);
+        horizon = admissible.min(horizon);
+        if horizon == 0 {
+            return Ok(None);
+        }
+        // Everything the previous pass collected may include events above
+        // the new, smaller ceiling — rescan exactly the (smaller) range
+        // this cycle would now condemn, and consult *its* pin next.
+        scan = scan_condemned_range(data_dir, horizon, registry)?;
     }
-    if horizon == 0 {
-        return Ok(None);
-    }
-
-    // If the pin lowered the horizon, everything the first pass collected
-    // may include events above the new, smaller ceiling — rescan exactly
-    // that (smaller, guaranteed pin-free — the first pass already proved no
-    // pin exists below it) range.
-    let scan = if horizon == candidate {
-        first_pass
-    } else {
-        scan_condemned_range(data_dir, horizon, registry)?
-    };
 
     let segments: Vec<SegmentBound> = bounds
         .iter()
@@ -986,8 +1003,8 @@ pub fn plan(
 
     let (_, mut stall) = candidate_horizon(bounds, registry, first_seq, policy);
     stall.horizon_seq = horizon;
-    stall.pinning_seq = first_pass_pin_seq;
-    if let Some(pin_seq) = first_pass_pin_seq {
+    stall.pinning_seq = effective_pin_seq;
+    if let Some(pin_seq) = effective_pin_seq {
         // The kind is only knowable if the pin was an allowlist violation
         // (an unpaired `prune.intent` has no single "kind" worth naming
         // beyond itself); re-derive it with one more read of that one event
@@ -3090,6 +3107,158 @@ mod tests {
             pruned_ids,
             BTreeSet::from(["w_prior"]),
             "only w_prior, entirely before the stuck intent, may be pruned this cycle"
+        );
+    }
+
+    /// §6.5, the pin the *rescan* finds: the pin predicate is not monotone
+    /// in the ceiling, so lowering the horizon can **reveal** a pin the
+    /// higher pass could not see. `scan_condemned_range`'s `open_intents`
+    /// arm is the ceiling-dependent one: a `prune.intent` at `S` whose
+    /// `prune.completed` sits at `C` reads as a closed, unremarkable pair
+    /// when both are in range, and as an unpaired, segment-pinning intent
+    /// the moment an unrelated pin lowers the horizon to somewhere in
+    /// `[S, C)`. A plan that consults only the first pass's answer therefore
+    /// unlinks the segment holding a still-open intent — leaving
+    /// `pending_prune` permanently `Some` with nothing left to complete it
+    /// from, which is exactly what §6.5 forbids.
+    ///
+    /// Fixture (one event per segment, so seq == segment index):
+    ///
+    /// ```text
+    ///   1  w1 submitted        2  w1 completed
+    ///   3  prune.intent  <---------------------------- the straddling pair
+    ///   4  mystery.event  (the first pass's own pin)
+    ///   5  prune.completed(intent_seq = 3)  <---------- ...closes above 3
+    ///   6  w2 submitted        7  w2 completed
+    ///   8  anchor submitted    (the perpetual blocker)
+    /// ```
+    ///
+    /// Phase A proposes 7. The first pass (ceiling 7) sees the pair closed
+    /// and pins only on `mystery.event`, lowering the horizon to 3 — which
+    /// is precisely the segment holding the intent. Only the rescan at 3
+    /// can see that intent unpaired, and it must lower the horizon again,
+    /// to 2.
+    #[test]
+    fn a_pair_that_only_straddles_the_lowered_horizon_still_pins_its_segment() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+
+        submit_and_complete(&mut core, "w1");
+
+        let empty_intent = PruneIntentRecord {
+            intent_seq: 0,
+            policy,
+            horizon_seq: 0,
+            floor_seq_before: 1,
+            floor_seq_after: 1,
+            segments: Vec::new(),
+            residue: PruneResidue::default(),
+            carried_forward: PruneResidue::default(),
+            condemn: Vec::new(),
+            delete_quarantined: Vec::new(),
+            rescue_quarantined: Vec::new(),
+            started_at_startup: false,
+        };
+        let intent_event = core
+            .commit(EventDraft::new(
+                EventSource::new("daemon", "sergeant"),
+                KIND_PRUNE_INTENT,
+                empty_intent.to_payload(),
+            ))
+            .expect("commit the intent");
+        let intent_seq = intent_event.seq;
+
+        // The pin the *first* pass will find, sitting between the intent
+        // and its completion — not in `NON_WORK_ALLOWLIST`, no `work_id`.
+        commit(
+            &mut core,
+            daemon_source(),
+            "mystery.event",
+            None,
+            serde_json::json!({}),
+        );
+        let completion_seq = commit(
+            &mut core,
+            daemon_source(),
+            KIND_PRUNE_COMPLETED,
+            None,
+            serde_json::json!({
+                "intent_seq": intent_seq,
+                "outcome": PruneOutcome::default(),
+                "floor_seq_after": 1,
+                "completed_at_startup": false,
+            }),
+        )
+        .seq;
+        assert!(
+            core.registry.state().pending_prune.is_none(),
+            "the pair must be closed as far as the registry is concerned"
+        );
+
+        submit_and_complete(&mut core, "w2");
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w2's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        assert!(
+            candidate > completion_seq,
+            "Phase A must propose a horizon above the whole pair — otherwise the pair never \
+             straddles anything and this test proves nothing"
+        );
+
+        let plan = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w1 must still be prunable below the intent");
+
+        assert!(
+            plan.horizon_seq < intent_seq,
+            "the horizon must stop below the segment holding the intent that the *lowered* \
+             range leaves unpaired (got {}, intent at {intent_seq})",
+            plan.horizon_seq
+        );
+        assert!(
+            plan.segments.iter().all(|s| s.last_seq < intent_seq),
+            "and no planned segment may contain it"
+        );
+        assert_eq!(
+            plan.stall.pinning_seq,
+            Some(intent_seq),
+            "the stall report must name the pin that actually bound the final horizon — the \
+             intent found by the rescan, not the `mystery.event` the first pass stopped at"
+        );
+        assert_eq!(plan.stall.pinning_kind.as_deref(), Some(KIND_PRUNE_INTENT));
+        let pruned_ids: BTreeSet<&str> = plan.residue.works.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            pruned_ids,
+            BTreeSet::from(["w1"]),
+            "only w1, entirely below the intent, may be pruned this cycle"
         );
     }
 

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -1705,6 +1705,63 @@ mod tests {
         crate::api::Core::new(journal, registry, events_tx)
     }
 
+    /// Re-open `dir`'s journal and fold it from its **current floor** into a
+    /// fresh registry — the daemon's own full-replay start, in miniature.
+    ///
+    /// This is how the crash-window tests get a `Core` whose `pending_prune`
+    /// reflects the journal *as it is on disk right now*, rather than the
+    /// in-memory state of a process that has already folded its own
+    /// completion. `Projection::resumed(.., floor - 1, ..)` rather than
+    /// `work_registry_projection()` because a journal a prune has already
+    /// cut no longer starts at seq 1 (A1).
+    fn refold_core(dir: &std::path::Path) -> crate::api::Core {
+        let journal = crate::runtime::journal::Journal::open_with(dir, 1).expect("re-open journal");
+        let floor = journal.floor_seq().expect("floor_seq").unwrap_or(1);
+        let mut registry = crate::runtime::projection::Projection::resumed(
+            crate::runtime::projection::WorkRegistry::default(),
+            floor - 1,
+            crate::runtime::projection::work_registry_reducer,
+        );
+        registry
+            .catch_up(journal.replay_from_floor().expect("replay_from_floor"))
+            .expect("fold the journal from its floor");
+        let (events_tx, _rx) = tokio::sync::broadcast::channel(16);
+        crate::api::Core::new(journal, registry, events_tx)
+    }
+
+    /// Un-write the newest segment — which, in a `tiny_core` journal (one
+    /// event per segment), holds exactly one event.
+    ///
+    /// Used to model "the completion's own event never landed": the crash
+    /// window that sits *after* every physical effect of a completion
+    /// (quarantine, deferred delete, unlink) and *before* the
+    /// `prune.completed` append that acknowledges them. Asserts the kind it
+    /// is removing, so a fixture that drifts fails loudly here instead of
+    /// quietly testing something else.
+    fn unwrite_newest_event(dir: &std::path::Path, expect_kind: &str) {
+        let journal_dir = dir.join("journal");
+        let mut segments: Vec<std::path::PathBuf> = std::fs::read_dir(&journal_dir)
+            .expect("read journal dir")
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|ext| ext == "ndjson"))
+            .collect();
+        segments.sort();
+        let newest = segments.last().expect("at least one segment");
+        let text = std::fs::read_to_string(newest).expect("read the newest segment");
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "this helper assumes a one-event-per-segment fixture"
+        );
+        let event: Event = serde_json::from_str(lines[0]).expect("parse the newest event");
+        assert_eq!(
+            event.kind, expect_kind,
+            "the newest event must be the one this crash window un-writes"
+        );
+        std::fs::remove_file(newest).expect("un-write the newest event");
+    }
+
     fn commit(
         core: &mut crate::api::Core,
         source: crate::domain::event::EventSource,
@@ -2017,13 +2074,6 @@ mod tests {
             "every planned segment must still be gone"
         );
 
-        // Idempotency: completing an already-finished cycle again touches
-        // nothing further and never fails re-quarantining what is already
-        // quarantined.
-        complete_interrupted(&mut core, dir.path()).expect("second complete_interrupted");
-
-        // Exactly one copy of the content exists, in quarantine — never a
-        // live copy alongside it.
         let quarantine_path = dir
             .path()
             .join("blobs")
@@ -2034,6 +2084,45 @@ mod tests {
         assert!(
             quarantine_path.exists(),
             "the blob must still be quarantined"
+        );
+        assert!(!live_path.exists(), "the blob must never also exist live");
+
+        // Idempotency, exercised for real: crash the *completion itself*,
+        // after every physical effect it had and before its own
+        // `prune.completed` landed. Re-folding from that journal gives a
+        // `Core` whose `pending_prune` is still the same unpaired intent —
+        // so this second `complete_interrupted` genuinely re-walks the
+        // whole cycle over work the first pass already finished, rather
+        // than exiting at the `pending_prune == None` guard on its first
+        // statement (which is all a plain second call can ever do, and is
+        // what `crash_window_f1_...`'s own no-op assertion covers).
+        drop(core);
+        unwrite_newest_event(dir.path(), KIND_PRUNE_COMPLETED);
+        let mut core = refold_core(dir.path());
+        assert!(
+            core.registry.state().pending_prune.is_some(),
+            "the re-folded journal must still hold the intent unpaired — otherwise the second \
+             pass below tests nothing"
+        );
+        let next_seq_before_retry = core.journal.next_seq();
+
+        complete_interrupted(&mut core, dir.path()).expect(
+            "re-quarantining an already-quarantined blob and re-unlinking already-gone \
+             segments must both be tolerated",
+        );
+        assert!(core.registry.state().pending_prune.is_none());
+        assert!(core.registry.state().pruned_works.contains_key("w1"));
+        assert_eq!(
+            core.journal.next_seq(),
+            next_seq_before_retry + 1,
+            "the re-run must append exactly its own completion, nothing else"
+        );
+
+        // Still exactly one copy of the content, still in quarantine —
+        // never a live copy alongside it, never lost.
+        assert_eq!(
+            std::fs::read(&quarantine_path).expect("the quarantined copy must have survived"),
+            b"crash window fixture blob"
         );
         assert!(!live_path.exists(), "the blob must never also exist live");
     }
@@ -2164,11 +2253,43 @@ mod tests {
             "the deferred delete must actually have run"
         );
 
-        // Idempotency: completing an already-finished cycle again is a
-        // true no-op, including `drop_quarantined`'s own tolerated
-        // already-gone case.
-        complete_interrupted(&mut core, dir.path()).expect("second complete_interrupted");
-        assert!(!quarantine_path.exists());
+        // Idempotency, exercised for real (see F2's own note): crash the
+        // completion itself — the deferred delete has already run, its
+        // `prune.completed` never landed — and complete again from a
+        // re-fold of that journal, so `drop_quarantined`'s tolerated
+        // already-gone case is actually walked into rather than skipped by
+        // an early return.
+        drop(core);
+        unwrite_newest_event(dir.path(), KIND_PRUNE_COMPLETED);
+        let mut core = refold_core(dir.path());
+        let pending = core
+            .registry
+            .state()
+            .pending_prune
+            .clone()
+            .expect("the re-folded journal must still hold cycle 2's intent unpaired");
+        assert_eq!(
+            pending.delete_quarantined,
+            vec![blob_ref.hex().to_string()],
+            "the re-run must be re-walking the very deferred delete that already happened"
+        );
+
+        complete_interrupted(&mut core, dir.path())
+            .expect("re-deleting an already-deleted quarantined blob must be tolerated");
+        assert!(core.registry.state().pending_prune.is_none());
+        assert!(core.registry.state().pruned_works.contains_key("w_mid"));
+        assert!(
+            !quarantine_path.exists(),
+            "the re-run must leave the deferred delete done, not undone"
+        );
+        assert!(
+            !dir.path()
+                .join("blobs")
+                .join("b3")
+                .join(blob_ref.hex())
+                .exists(),
+            "and must never resurrect a live copy of what it deleted"
+        );
     }
 
     /// N9 / F4: a crash mid-unlink (only the first of the two target

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -1,0 +1,1992 @@
+//! W3: the prune engine — bounded retention made real (issue #17's rulings
+//! record, `docs/proposals/foundation-2026-08-21.md` W3 section).
+//!
+//! W2 (`runtime::startup`) made the daemon able to *ignore* old history; this
+//! module makes it able to *delete* it. A policy in `sergeant.toml` names how
+//! many Works this estate keeps ([`crate::domain::estate::Estate::retention`]).
+//! At every daemon start, and on segment rotation once the retained-Work
+//! count crosses that cap, the daemon computes the highest seq below which
+//! every Work is terminal, retired whole, past the cap, and not straddling
+//! the cut ([`candidate_horizon`]/[`plan`]) — then journals its intent
+//! ([`KIND_PRUNE_INTENT`]), quarantines the blobs only those Works
+//! referenced, unlinks whole segments oldest-first
+//! ([`crate::runtime::journal::Journal::unlink_segments`]), and journals a
+//! completion ([`KIND_PRUNE_COMPLETED`]). The completion's residue — carried
+//! on the intent so a crash cannot lose it — is what lets a replay from the
+//! new floor still answer "Work … was pruned on … under policy retention=N"
+//! and still refuse a retried `command_id` by name, with no cache in the loop
+//! at all.
+//!
+//! One-way *logic* dependency, deliberately: this module calls
+//! [`crate::runtime::startup`] and [`crate::runtime::projection`]; neither of
+//! those ever calls back into this one. `startup::FloorState` does reference
+//! this module's residue types ([`PrunedWorkRow`], [`PrunedCommandRow`],
+//! [`PruneIntentRecord`]) directly, since the cache has to be able to carry
+//! what the registry carries — a data-shape dependency, not a call — and
+//! `projection::WorkRegistry` does the same for the identical reason.
+//!
+//! # Deliberate deviations from the wave spec (see the PR body / final report)
+//!
+//! - **No `time` crate.** The wave spec's design sketch uses
+//!   `time::OffsetDateTime`; this codebase (`src/domain/event.rs`'s own doc
+//!   comment) deliberately hand-rolls RFC3339 rather than add a date-time
+//!   crate to the pinned set. [`stall_report`] therefore takes
+//!   `std::time::SystemTime`, reusing [`crate::domain::event::unix_millis`]
+//!   for age arithmetic instead.
+//! - **`prune.intent`'s wire payload is flat, not nested under `"blobs"`.**
+//!   The spec's illustrative JSON groups `condemn`/`delete_quarantined`
+//!   under a `"blobs"` key; nothing outside this wave's own code reads this
+//!   payload yet, so [`PruneIntentRecord`] (minus `intent_seq`, which is
+//!   read from the event's own `seq` at fold time, never from the payload)
+//!   is serialized directly. The mechanism — residue carried on the intent,
+//!   completion cross-checked by `intent_seq` — is unchanged.
+//! - **The mark scan is one sequential pass, not a batched/threaded one.**
+//!   §5.1/§7.1 describe reading the candidate segments and the surviving
+//!   segments as two independently-optimized passes (the surviving scan on
+//!   a `blocking_sync` thread, outside the guard, skipped early once every
+//!   condemned ref is accounted for). [`plan`] performs both reads
+//!   sequentially and to completion. Every invariant this buys (I-W3-6 in
+//!   particular) still holds — only the described performance work is
+//!   deferred.
+//! - **Step 6 (cache rewrite after a live prune) is not wired.** §9.3's
+//!   second cache write point needs the live capability-provenance
+//!   watermark, which today lives only on the running `ClaudeBackend`
+//!   adapter, not on `Core` — threading it into the tick's prune call is
+//!   real additional wiring this landing does not attempt. [`run`] instead
+//!   removes any existing cache file after a successful cycle
+//!   ([`crate::runtime::startup::persist_or_remove`] with `None`), so a
+//!   start after a live prune pays one full floor-aware replay (safe, per
+//!   Q2's "absent cache ⇒ one full replay, never an error") rather than
+//!   risking a stale cache — a named performance regression, not a
+//!   correctness one. The **other** write point (end of every successful
+//!   startup fold) is untouched, so a clean restart after a prune still
+//!   writes a fresh v2 cache normally.
+//! - **The batch cap ([`PRUNE_MAX_WORKS_PER_CYCLE`]) is enforced inside
+//!   [`candidate_horizon`]**, not as a separate post-hoc truncation of
+//!   [`plan`]'s residue — since `work_index` (which `candidate_horizon`
+//!   already sweeps) holds exactly the *not-yet-pruned* Works, counting
+//!   entries with `last_seq <= b` there already is the "new residue" count
+//!   §7.4 bounds.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::claude::{AskWithdrawal, note_ask_withdrawal};
+use crate::domain::event::{Event, EventDraft, EventSource, rfc3339_utc_now, unix_millis};
+use crate::domain::work::{KIND_COMMAND_ACCEPTED, KIND_COMMAND_REJECTED, WorkState};
+use crate::runtime::blob::{self, BlobError, BlobRef, BlobStore};
+use crate::runtime::integrity::IntegrityDisposition;
+use crate::runtime::journal::{JournalError, SegmentBound};
+use crate::runtime::projection::{WorkIndexRow, WorkRegistry, run_is_retired};
+use crate::runtime::startup::{self, FloorCommandClass, StartupError};
+
+/// A prune cycle's declaration of what it is about to delete, and everything
+/// a later reader — including a reader that has lost the cache and every
+/// segment this cycle deletes — needs to answer for it. Journaled and
+/// fsynced *before* the first rename or unlink.
+pub const KIND_PRUNE_INTENT: &str = "prune.intent";
+
+/// The matching completion. Carries counts and the intent's seq; the residue
+/// itself lives on the intent, which the fold has already seen.
+pub const KIND_PRUNE_COMPLETED: &str = "prune.completed";
+
+/// Q5's allowlist, as a **mechanism**: an event with no `work_id` whose kind
+/// is not here pins its segment, and a kind enters this list only with a
+/// replay-equivalence proof (`tests/w3_allowlist_equivalence.rs`).
+pub const NON_WORK_ALLOWLIST: &[&str] = &[
+    crate::daemon::KIND_DAEMON_STARTED,
+    crate::daemon::KIND_DAEMON_STOPPED,
+    crate::daemon::KIND_BACKEND_PROBED,
+    crate::daemon::KIND_ADMISSION_PAUSED,
+    crate::daemon::KIND_ADMISSION_RESUMED,
+    KIND_COMMAND_ACCEPTED,
+    KIND_COMMAND_REJECTED,
+    KIND_PRUNE_INTENT,
+    KIND_PRUNE_COMPLETED,
+];
+
+/// Cap on how many Works one cycle retires, and therefore on how large one
+/// `prune.intent`'s own *new* residue can be (~200 B/Work + ~90 B/command
+/// key). The *carried* residue is not bounded by this (§6.4).
+pub const PRUNE_MAX_WORKS_PER_CYCLE: usize = 4096;
+
+/// A rotation-triggered cycle runs only when at least this many whole
+/// segments are eligible, so the O(retained journal) mark scan is amortized
+/// over a batch. A startup-triggered cycle ignores it.
+pub const PRUNE_BATCH_MIN_SEGMENTS: usize = 4;
+
+/// First seq this daemon has seen for each retained Work — the `first_seq(id)`
+/// half of the no-straddle predicate, maintained across the life of the
+/// process. Seeded from the cache's rows ∪ the startup pass, advanced by
+/// `Core::commit`, pruned ids removed at `prune.completed`.
+pub type FirstSeqIndex = BTreeMap<String, u64>;
+
+/// Where a resolved [`PrunePolicy`]'s number came from — journaled on every
+/// prune event so the record names the authorization, not just the number
+/// (A1: "every discard flows from declared policy … and leaves a journaled
+/// record").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicySource {
+    /// `[estate] retention` in this estate's `sergeant.toml`.
+    Manifest,
+    /// `DaemonConfig::retention` — test rigs only.
+    Config,
+    /// No declaration anywhere; the built-in default.
+    Default,
+}
+
+/// The retention policy one daemon runs under, resolved once at start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrunePolicy {
+    /// Works retained, newest-first by `last_seq`.
+    pub retention: u32,
+    /// Where the number came from.
+    pub source: PolicySource,
+}
+
+/// One pruned Work, as the journal remembers it after its events are gone.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PrunedWorkRow {
+    /// Same as [`WorkIndexRow::id`].
+    pub id: String,
+    /// Same as [`WorkIndexRow::intent`].
+    pub intent: String,
+    /// Same as [`WorkIndexRow::state`].
+    pub state: WorkState,
+    /// Same as [`WorkIndexRow::integrity`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<IntegrityDisposition>,
+    /// Same as [`WorkIndexRow::created_at`].
+    pub created_at: String,
+    /// Same as [`WorkIndexRow::updated_at`].
+    pub updated_at: String,
+    /// Same as [`WorkIndexRow::last_seq`].
+    pub last_seq: u64,
+    /// RFC3339 UTC — the `prune.intent` event's own timestamp, read once
+    /// when the cycle commits and embedded verbatim in the payload, so a
+    /// later replay reproduces it identically rather than reading a wall
+    /// clock at fold time.
+    pub pruned_at: String,
+}
+
+/// One pruned command's ledger key — Q8's exemption made durable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PrunedCommandRow {
+    /// The client-supplied command id.
+    pub command_id: String,
+    /// What happened to it.
+    pub class: FloorCommandClass,
+    /// The Work this command created, for a submit. `None` otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_id: Option<String>,
+}
+
+impl PrunedCommandRow {
+    /// Three-field copy into [`startup::FloorCommandRow`], for
+    /// `api::replay_command`'s pruned-command arm (§6.3).
+    pub fn as_floor_row(&self) -> startup::FloorCommandRow {
+        startup::FloorCommandRow {
+            command_id: self.command_id.clone(),
+            class: self.class,
+            work_id: self.work_id.clone(),
+        }
+    }
+}
+
+/// Everything a completion applies. Carried on the intent (F5: after the
+/// unlink there is nothing left to recompute it from) and folded on the
+/// completion.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PruneResidue {
+    /// Newly (or previously carried) pruned Works.
+    pub works: Vec<PrunedWorkRow>,
+    /// Newly (or previously carried) pruned command ledger keys.
+    pub commands: Vec<PrunedCommandRow>,
+    /// The ask-grammar withdrawal watermark, when this cycle is deleting the
+    /// event that carried it (§8.3). Its `seq` is the **original** seq, not
+    /// the prune event's — "higher seq wins" must keep meaning what it means.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_provenance: Option<AskWithdrawal>,
+}
+
+impl PruneResidue {
+    /// Union merge: `works`/`commands` keyed by id (a later entry for the
+    /// same id replaces the earlier one — collisions are not expected in
+    /// practice, since a Work or command is pruned exactly once, but the
+    /// rule is defined rather than left to chance), `capability_provenance`
+    /// takes the higher `seq`.
+    pub fn merge(&mut self, other: PruneResidue) {
+        for row in other.works {
+            self.works.retain(|r| r.id != row.id);
+            self.works.push(row);
+        }
+        for row in other.commands {
+            self.commands.retain(|r| r.command_id != row.command_id);
+            self.commands.push(row);
+        }
+        if let Some(candidate) = other.capability_provenance {
+            let wins = self
+                .capability_provenance
+                .as_ref()
+                .is_none_or(|current| candidate.seq > current.seq);
+            if wins {
+                self.capability_provenance = Some(candidate);
+            }
+        }
+    }
+
+    /// Owned-value sibling of [`PruneResidue::merge`].
+    pub fn merged_with(mut self, other: PruneResidue) -> PruneResidue {
+        self.merge(other);
+        self
+    }
+}
+
+/// One segment's extent as a prune record binds to it — [`SegmentBound`]
+/// minus the filesystem path, which a durable record must never carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PruneSegment {
+    /// Rotation-order index.
+    pub index: u64,
+    /// First seq in this segment.
+    pub first_seq: u64,
+    /// Last seq in this segment.
+    pub last_seq: u64,
+    /// Segment file length in bytes at plan time.
+    pub bytes: u64,
+}
+
+/// A declared, unacknowledged prune cycle — what
+/// [`WorkRegistry::pending_prune`] holds between the intent and its
+/// completion, and the only thing Q9's crash completion is allowed to act
+/// on. Every field but `intent_seq` is a verbatim copy of the intent's
+/// payload; `intent_seq` is read from the intent *event's* own `seq` at fold
+/// time, never carried in the payload (nothing needs to know its own seq
+/// before it exists).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PruneIntentRecord {
+    /// Seq of the `prune.intent` event itself.
+    pub intent_seq: u64,
+    /// The policy this cycle acted under.
+    pub policy: PrunePolicy,
+    /// The horizon this cycle computed.
+    pub horizon_seq: u64,
+    /// The floor before this cycle.
+    pub floor_seq_before: u64,
+    /// The floor after this cycle (`horizon_seq + 1`).
+    pub floor_seq_after: u64,
+    /// Segments to unlink, ascending.
+    pub segments: Vec<PruneSegment>,
+    /// This cycle's own newly-discovered residue.
+    pub residue: PruneResidue,
+    /// Residue carried forward from an earlier, now-condemned
+    /// `prune.intent` (§6.4).
+    pub carried_forward: PruneResidue,
+    /// Hexes to move into `.pruned/` this cycle.
+    pub condemn: Vec<String>,
+    /// Hexes the *previous* cycle quarantined, to delete now (§5.2).
+    pub delete_quarantined: Vec<String>,
+    /// Whether this cycle was triggered at daemon start (§10.3) rather than
+    /// by rotation (§10.4).
+    pub started_at_startup: bool,
+}
+
+/// The wire shape of `prune.intent`'s payload — [`PruneIntentRecord`] minus
+/// `intent_seq` (see this module's own deviation note).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IntentPayload {
+    policy: PrunePolicy,
+    horizon_seq: u64,
+    floor_seq_before: u64,
+    floor_seq_after: u64,
+    segments: Vec<PruneSegment>,
+    residue: PruneResidue,
+    carried_forward: PruneResidue,
+    condemn: Vec<String>,
+    delete_quarantined: Vec<String>,
+    started_at_startup: bool,
+}
+
+impl PruneIntentRecord {
+    /// Reconstruct from a committed `prune.intent` event: every field but
+    /// `intent_seq` from the payload, `intent_seq` from the event's own
+    /// `seq`. `None` on a payload this build cannot parse — the caller logs
+    /// and ignores, per §6.2's "record, apply nothing … a declaration that
+    /// cannot be understood is not a declaration this process can act on".
+    pub fn from_event(event: &Event) -> Option<Self> {
+        let payload: IntentPayload = serde_json::from_value(event.payload.clone()).ok()?;
+        Some(Self {
+            intent_seq: event.seq,
+            policy: payload.policy,
+            horizon_seq: payload.horizon_seq,
+            floor_seq_before: payload.floor_seq_before,
+            floor_seq_after: payload.floor_seq_after,
+            segments: payload.segments,
+            residue: payload.residue,
+            carried_forward: payload.carried_forward,
+            condemn: payload.condemn,
+            delete_quarantined: payload.delete_quarantined,
+            started_at_startup: payload.started_at_startup,
+        })
+    }
+
+    /// Render as the `prune.intent` payload this cycle commits.
+    fn to_payload(&self) -> serde_json::Value {
+        serde_json::to_value(IntentPayload {
+            policy: self.policy,
+            horizon_seq: self.horizon_seq,
+            floor_seq_before: self.floor_seq_before,
+            floor_seq_after: self.floor_seq_after,
+            segments: self.segments.clone(),
+            residue: self.residue.clone(),
+            carried_forward: self.carried_forward.clone(),
+            condemn: self.condemn.clone(),
+            delete_quarantined: self.delete_quarantined.clone(),
+            started_at_startup: self.started_at_startup,
+        })
+        .expect("PruneIntentRecord's payload shape always serializes")
+    }
+}
+
+/// What one cycle would do, computed without touching anything.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrunePlan {
+    /// The policy this plan was computed under.
+    pub policy: PrunePolicy,
+    /// The final horizon (after any allowlist/pairing pin has lowered it).
+    pub horizon_seq: u64,
+    /// Oldest-contiguous prefix of segments, all `last_seq <= horizon_seq`.
+    pub segments: Vec<SegmentBound>,
+    /// This cycle's own newly-discovered residue.
+    pub residue: PruneResidue,
+    /// Residue carried forward from a condemned `prune.intent` (§6.4).
+    pub carried_forward: PruneResidue,
+    /// Blobs to quarantine this cycle.
+    pub condemn: BTreeSet<BlobRef>,
+    /// Blobs the previous cycle quarantined, to delete now.
+    pub delete_quarantined: Vec<String>,
+    /// The highest seq the surviving-side mark scan actually reached —
+    /// `run`'s top-up reads events after this before quarantining, closing
+    /// the window between this plan and the guard that commits it.
+    pub scan_through: u64,
+    /// Why pruning did not advance further than it did.
+    pub stall: PruneStall,
+}
+
+/// What one cycle actually did — returned by [`run`]/[`run_startup`],
+/// journaled as `prune.completed.outcome`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PruneOutcome {
+    /// Segments unlinked this cycle.
+    pub segments_unlinked: usize,
+    /// Bytes reclaimed by the unlink.
+    pub bytes_reclaimed: u64,
+    /// Works newly pruned this cycle (excludes carried-forward).
+    pub works_pruned: usize,
+    /// Commands newly pruned this cycle (excludes carried-forward).
+    pub commands_pruned: usize,
+    /// Blobs actually moved into quarantine this cycle.
+    pub blobs_quarantined: usize,
+    /// Blobs actually deleted from quarantine this cycle.
+    pub blobs_deleted: usize,
+    /// Quarantined blobs found already gone for a reason other than rescue.
+    pub blobs_missing: usize,
+    /// `delete_quarantined.len() - blobs_deleted - blobs_missing`: rescued
+    /// by a live read or write before this cycle's deferred delete ran.
+    pub blobs_rescued_before_delete: usize,
+    /// The floor after this cycle.
+    pub floor_seq_after: u64,
+    /// More was eligible than [`PRUNE_MAX_WORKS_PER_CYCLE`] allowed; the
+    /// caller should re-arm `prune_pending`.
+    pub truncated_by_cap: bool,
+}
+
+/// Why pruning is not advancing further — Q7's whole answer: there is no
+/// flag, and this type has no field that could become one.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PruneStall {
+    /// The Work whose retirement would let the horizon advance furthest.
+    pub blocking_work_id: Option<String>,
+    /// That Work's state.
+    pub blocking_state: Option<WorkState>,
+    /// That Work's `updated_at`.
+    pub blocking_since: Option<String>,
+    /// Age of `blocking_since`, in seconds — populated only by
+    /// [`stall_report`] (it alone takes a wall clock); [`candidate_horizon`]
+    /// leaves this `None`.
+    pub blocking_age_secs: Option<u64>,
+    /// The lowest non-allowlisted non-work-scoped event pinning a segment,
+    /// when that (not a Work) is what stops the horizon. Populated only by
+    /// [`plan`] (it alone reads segment contents); `candidate_horizon`
+    /// leaves this `None`.
+    pub pinning_kind: Option<String>,
+    /// That event's seq.
+    pub pinning_seq: Option<u64>,
+    /// Context for a doctor-style report.
+    pub retained_works: usize,
+    /// The retention this policy declares.
+    pub retention: u32,
+    /// The floor at the time of this report.
+    pub floor_seq: u64,
+    /// The horizon this report computed.
+    pub horizon_seq: u64,
+    /// **Not in the wave spec's own field list** — added so
+    /// [`PruneOutcome::truncated_by_cap`] has somewhere to read its answer
+    /// from without re-deriving it: whether [`PRUNE_MAX_WORKS_PER_CYCLE`]
+    /// is what actually bounded this horizon.
+    pub truncated_by_cap: bool,
+}
+
+/// Errors from planning or running a prune cycle.
+#[derive(Debug, thiserror::Error)]
+pub enum PruneError {
+    /// The journal failed during a plan or a cycle.
+    #[error(transparent)]
+    Journal(#[from] JournalError),
+    /// The blob store failed during quarantine or deferred delete.
+    #[error(transparent)]
+    Blob(#[from] BlobError),
+    /// The core failed to commit or fold a prune event.
+    #[error(transparent)]
+    Core(#[from] crate::api::CoreError),
+    /// The prune cache rewrite failed.
+    #[error("prune cache rewrite failed: {0}")]
+    Cache(#[from] StartupError),
+    /// The Work ids found in the condemned segments do not match the set the
+    /// registry says is past the horizon.
+    #[error("refusing to prune: residue disagrees with the journal ({detail})")]
+    ResidueMismatch {
+        /// What disagreed.
+        detail: String,
+    },
+}
+
+/// Whether a Work has been *retired whole* — the prune's terminality test,
+/// deliberately not the same test eviction uses.
+///
+/// `run_is_settled` gates eviction on `is_absorbing(state)` —
+/// `Completed | Canceled` only. Retention cannot use that: a `Failed` Work is
+/// never evicted, so it stays in `works` forever, and a horizon requiring
+/// absence-from-`works` would let one old failure pin the entire journal for
+/// the life of the estate — Q7's chronic-stalling escalation arriving on day
+/// one. This is that escalation, adopted up front.
+///
+/// What is kept from `run_is_settled`, verbatim (via
+/// [`crate::runtime::projection::run_is_retired`]), is the part that
+/// protects `recovery::reconcile`: a run with a surface and no teardown, a
+/// `surface_plan` with no surface, or an unsettled reservation is *not*
+/// retired, whatever the Work's state says.
+///
+/// A Work absent from both `works` and `runs` is retired whole by
+/// construction: the only way out of those maps is `maybe_evict`, which
+/// already required the run predicate.
+pub fn retired_whole(state: WorkState, run: Option<&crate::runtime::projection::WorkRun>) -> bool {
+    matches!(
+        state,
+        WorkState::Completed | WorkState::Failed | WorkState::Canceled
+    ) && run.is_none_or(run_is_retired)
+}
+
+/// Rank retained Works (`work_index` — pruned Works have already left it) by
+/// `last_seq` descending; the cap is the seq just below the `N`-th largest.
+/// `cap_seq(N) = 0` when there are `N` or fewer retained Works (nothing past
+/// the cap). `N == 0` is a degenerate policy nobody should declare (nothing
+/// retained at all); it answers `u64::MAX` (every seq is "past the cap")
+/// rather than underflowing.
+///
+/// Seqs are unique per event and `last_seq` is an event's own seq, so no two
+/// Works can ever tie — the ranking is total, with no tie-break rule to get
+/// wrong.
+pub fn cap_seq(work_index: &BTreeMap<String, WorkIndexRow>, n: usize) -> u64 {
+    if n == 0 {
+        return u64::MAX;
+    }
+    if work_index.len() <= n {
+        return 0;
+    }
+    let mut last_seqs: Vec<u64> = work_index.values().map(|row| row.last_seq).collect();
+    last_seqs.sort_unstable_by(|a, b| b.cmp(a));
+    last_seqs[n - 1].saturating_sub(1)
+}
+
+/// The Work whose retirement would let the horizon advance furthest: the
+/// smallest `last_seq` among retained Works failing [`retired_whole`].
+fn blocking_work(registry: &WorkRegistry) -> Option<(&WorkIndexRow, WorkState)> {
+    registry
+        .work_index
+        .values()
+        .filter(|row| !retired_whole(row.state, registry.runs.get(&row.id)))
+        .map(|row| (row, row.state))
+        .min_by_key(|(row, _)| row.last_seq)
+}
+
+/// Phase A — in memory, from the registry alone. Cheap enough to run on
+/// every rotation tick. See [`plan`] for the segment-content-aware Phase B
+/// that can only ever *lower* this answer.
+pub fn candidate_horizon(
+    bounds: &[SegmentBound],
+    registry: &WorkRegistry,
+    first_seq: &FirstSeqIndex,
+    policy: &PrunePolicy,
+) -> (u64, PruneStall) {
+    let n = policy.retention as usize;
+    let cap = cap_seq(&registry.work_index, n);
+
+    // I-W3-4: the segment the writer currently holds open is never
+    // unlinked. `bounds`'s own last (newest) entry is always that segment
+    // for whichever live `Journal` computed it (`segment_bounds`'s own doc:
+    // its `last_seq` comes from `next_seq() - 1`) — so it is excluded from
+    // candidacy here, structurally, rather than relying on
+    // `unlink_segments`'s refusal to catch it after a plan has already been
+    // built around it. With only one segment (nothing has ever rotated),
+    // this correctly leaves no candidate at all beyond the `0` sentinel.
+    let mut candidates: Vec<u64> = bounds[..bounds.len().saturating_sub(1)]
+        .iter()
+        .map(|s| s.last_seq)
+        .collect();
+    candidates.push(0);
+    candidates.sort_unstable();
+    candidates.dedup();
+
+    let mut by_first_seq: Vec<(u64, u64)> = registry
+        .work_index
+        .values()
+        .map(|row| {
+            let f = first_seq.get(&row.id).copied().unwrap_or(0);
+            (f, row.last_seq)
+        })
+        .collect();
+    by_first_seq.sort_unstable_by_key(|&(f, _)| f);
+
+    let blocker = blocking_work(registry);
+    let blocker_seq = blocker.map(|(row, _)| row.last_seq).unwrap_or(u64::MAX);
+
+    // §7.4's batch cap: the count of not-yet-pruned Works with
+    // `last_seq <= b` is monotone in `b`, computed over the same sorted
+    // `work_index` list.
+    let mut last_seqs_sorted: Vec<u64> = registry.work_index.values().map(|r| r.last_seq).collect();
+    last_seqs_sorted.sort_unstable();
+    let count_at = |b: u64| last_seqs_sorted.partition_point(|&s| s <= b);
+
+    let mut h = 0u64;
+    let mut idx = 0usize;
+    let mut running_max = 0u64;
+    let mut truncated_by_cap = false;
+    for &b in &candidates {
+        while idx < by_first_seq.len() && by_first_seq[idx].0 <= b {
+            running_max = running_max.max(by_first_seq[idx].1);
+            idx += 1;
+        }
+        let nostraddle = running_max <= b;
+        let retired_ok = b < blocker_seq;
+        let capped = b <= cap;
+        if !(nostraddle && retired_ok && capped) {
+            continue;
+        }
+        if count_at(b) > PRUNE_MAX_WORKS_PER_CYCLE {
+            truncated_by_cap = true;
+            continue;
+        }
+        h = b;
+    }
+
+    let stall = PruneStall {
+        blocking_work_id: blocker.map(|(row, _)| row.id.clone()),
+        blocking_state: blocker.map(|(_, state)| state),
+        blocking_since: blocker.map(|(row, _)| row.updated_at.clone()),
+        blocking_age_secs: None,
+        pinning_kind: None,
+        pinning_seq: None,
+        retained_works: registry.work_index.len(),
+        retention: policy.retention,
+        floor_seq: bounds.first().map(|b| b.first_seq).unwrap_or(1),
+        horizon_seq: h,
+        truncated_by_cap,
+    };
+    (h, stall)
+}
+
+/// The full stall report (§7.3), computable at any time from state the
+/// daemon already holds — no journal I/O — for W4's doctor check to read
+/// under the guard.
+///
+/// Deviation from the wave spec's own signature: takes
+/// [`std::time::SystemTime`], not `time::OffsetDateTime` — see this module's
+/// top doc comment.
+pub fn stall_report(
+    bounds: &[SegmentBound],
+    registry: &WorkRegistry,
+    first_seq: &FirstSeqIndex,
+    policy: &PrunePolicy,
+    now: std::time::SystemTime,
+) -> PruneStall {
+    let (_, mut stall) = candidate_horizon(bounds, registry, first_seq, policy);
+    if let Some(since) = &stall.blocking_since {
+        let now_millis = now
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        if let Some(then_millis) = unix_millis(since)
+            && now_millis >= then_millis
+        {
+            stall.blocking_age_secs = Some(((now_millis - then_millis) / 1000) as u64);
+        }
+    }
+    stall
+}
+
+/// One pass over the journal from the floor through `ceiling` (inclusive),
+/// collecting everything a prune cycle needs from the condemned range: the
+/// per-command residue (§7.1 step 2), the carried-forward residue from any
+/// `prune.intent`/`prune.completed` pair fully inside the range (§6.4), blob
+/// refs (§5.1's pruned side), the ask-grammar withdrawal watermark carried
+/// forward (§8.3), every Work id actually named (for the residue
+/// cross-check, §7.1's last paragraph), and the lowest seq that pins its
+/// segment — an unknown non-work-scoped kind, or a `prune.intent` whose
+/// matching `prune.completed` is not also in range (§6.5).
+struct CondemnedScan {
+    residue: PruneResidue,
+    carried_forward: PruneResidue,
+    condemn_refs: BTreeSet<BlobRef>,
+    work_ids_seen: BTreeSet<String>,
+    lowest_pin_seq: Option<u64>,
+    max_seq_seen: u64,
+}
+
+fn scan_condemned_range(
+    data_dir: &Path,
+    ceiling: u64,
+    registry: &WorkRegistry,
+) -> Result<CondemnedScan, PruneError> {
+    let mut residue = PruneResidue::default();
+    let mut carried_forward = PruneResidue::default();
+    let mut condemn_refs = BTreeSet::new();
+    let mut work_ids_seen = BTreeSet::new();
+    let mut open_intents: BTreeMap<u64, ()> = BTreeMap::new();
+    let mut lowest_pin_seq: Option<u64> = None;
+    let mut carried_ask_withdrawal: Option<AskWithdrawal> = None;
+    let mut max_seq_seen = 0u64;
+
+    for event in crate::runtime::journal::Journal::replay_data_dir_from_floor(data_dir)? {
+        let event = event?;
+        if event.seq > ceiling {
+            break;
+        }
+        max_seq_seen = event.seq;
+
+        if let Some(id) = &event.work_id {
+            work_ids_seen.insert(id.clone());
+        }
+        for r in blob::refs_in_event(&event) {
+            condemn_refs.insert(r);
+        }
+
+        match event.kind.as_str() {
+            KIND_PRUNE_INTENT => {
+                if let Some(record) = PruneIntentRecord::from_event(&event) {
+                    carried_forward.merge(record.residue);
+                    carried_forward.merge(record.carried_forward);
+                }
+                open_intents.insert(event.seq, ());
+            }
+            KIND_PRUNE_COMPLETED => {
+                if let Some(intent_seq) = event.payload.get("intent_seq").and_then(|v| v.as_u64()) {
+                    open_intents.remove(&intent_seq);
+                }
+            }
+            KIND_COMMAND_ACCEPTED | KIND_COMMAND_REJECTED => {
+                if let Some(command_id) = event.payload.get("command_id").and_then(|v| v.as_str()) {
+                    let class = if event.kind == KIND_COMMAND_ACCEPTED {
+                        FloorCommandClass::Accepted
+                    } else {
+                        FloorCommandClass::Rejected
+                    };
+                    let work_id = registry.command_works.get(command_id).cloned();
+                    residue.commands.push(PrunedCommandRow {
+                        command_id: command_id.to_string(),
+                        class,
+                        work_id,
+                    });
+                }
+            }
+            "conversation.turn.grammar_unmeasured" => {
+                note_ask_withdrawal(&mut carried_ask_withdrawal, &event);
+            }
+            kind => {
+                if event.work_id.is_none()
+                    && !NON_WORK_ALLOWLIST.contains(&kind)
+                    && lowest_pin_seq.is_none()
+                {
+                    lowest_pin_seq = Some(event.seq);
+                }
+            }
+        }
+    }
+
+    for &intent_seq in open_intents.keys() {
+        if lowest_pin_seq.is_none_or(|p| intent_seq < p) {
+            lowest_pin_seq = Some(intent_seq);
+        }
+    }
+
+    if let Some(w) = carried_ask_withdrawal {
+        let wins = residue
+            .capability_provenance
+            .as_ref()
+            .is_none_or(|current| w.seq > current.seq);
+        if wins {
+            residue.capability_provenance = Some(w);
+        }
+    }
+
+    Ok(CondemnedScan {
+        residue,
+        carried_forward,
+        condemn_refs,
+        work_ids_seen,
+        lowest_pin_seq,
+        max_seq_seen,
+    })
+}
+
+/// Phase B — reads the candidate segments once, and (if anything is a
+/// condemn candidate) the surviving segments once. Lock-free; only the data
+/// dir path is borrowed, never a live `Journal` handle.
+///
+/// `candidate` is Phase A's ([`candidate_horizon`]'s) answer, already
+/// batch-capped; this can only ever lower it further, via the allowlist/pair
+/// pin (§6.5) — never raise it.
+///
+/// Takes `first_seq` in addition to the wave spec's own listed signature
+/// (`data_dir, bounds, candidate, registry, policy`) so the [`PruneStall`]
+/// this returns can be built by the same [`candidate_horizon`] the caller
+/// already ran, rather than a second, differently-informed copy of it.
+pub fn plan(
+    data_dir: &Path,
+    bounds: &[SegmentBound],
+    candidate: u64,
+    registry: &WorkRegistry,
+    first_seq: &FirstSeqIndex,
+    policy: &PrunePolicy,
+) -> Result<Option<PrunePlan>, PruneError> {
+    if candidate == 0 {
+        return Ok(None);
+    }
+
+    let first_pass = scan_condemned_range(data_dir, candidate, registry)?;
+    let first_pass_pin_seq = first_pass.lowest_pin_seq;
+
+    let mut horizon = candidate;
+    if let Some(pin_seq) = first_pass_pin_seq {
+        let pin_first_seq = bounds
+            .iter()
+            .find(|b| b.first_seq <= pin_seq && pin_seq <= b.last_seq)
+            .map(|b| b.first_seq)
+            .unwrap_or(pin_seq);
+        horizon = bounds
+            .iter()
+            .map(|b| b.last_seq)
+            .filter(|&last| last < pin_first_seq)
+            .max()
+            .unwrap_or(0)
+            .min(candidate);
+    }
+    if horizon == 0 {
+        return Ok(None);
+    }
+
+    // If the pin lowered the horizon, everything the first pass collected
+    // may include events above the new, smaller ceiling — rescan exactly
+    // that (smaller, guaranteed pin-free — the first pass already proved no
+    // pin exists below it) range.
+    let scan = if horizon == candidate {
+        first_pass
+    } else {
+        scan_condemned_range(data_dir, horizon, registry)?
+    };
+
+    let segments: Vec<SegmentBound> = bounds
+        .iter()
+        .filter(|b| b.last_seq <= horizon)
+        .cloned()
+        .collect();
+    if segments.is_empty() {
+        return Ok(None);
+    }
+
+    let mut residue = scan.residue;
+    residue.works = registry
+        .work_index
+        .values()
+        .filter(|row| row.last_seq <= horizon)
+        .map(|row| PrunedWorkRow {
+            id: row.id.clone(),
+            intent: row.intent.clone(),
+            state: row.state,
+            integrity: row.integrity,
+            created_at: row.created_at.clone(),
+            updated_at: row.updated_at.clone(),
+            last_seq: row.last_seq,
+            pruned_at: String::new(), // stamped by `run`/`run_startup` at commit time
+        })
+        .collect();
+
+    // §7.1's cross-check: the Work ids actually named in the condemned
+    // range must equal exactly the set `work_index` says is past the
+    // horizon. A mismatch means `FirstSeqIndex` or `work_index` disagrees
+    // with the journal — abort, never delete.
+    let expected: BTreeSet<String> = residue.works.iter().map(|r| r.id.clone()).collect();
+    if scan.work_ids_seen != expected {
+        return Err(PruneError::ResidueMismatch {
+            detail: format!(
+                "condemned range names {} Work ids, work_index expects {} at or below horizon {horizon}",
+                scan.work_ids_seen.len(),
+                expected.len()
+            ),
+        });
+    }
+
+    let mut surviving_refs: BTreeSet<BlobRef> = BTreeSet::new();
+    if !scan.condemn_refs.is_empty() {
+        for event in crate::runtime::journal::Journal::replay_data_dir_from_floor(data_dir)? {
+            let event = event?;
+            if event.seq <= horizon {
+                continue;
+            }
+            for r in blob::refs_in_event(&event) {
+                surviving_refs.insert(r);
+            }
+        }
+    }
+    let condemn: BTreeSet<BlobRef> = scan
+        .condemn_refs
+        .difference(&surviving_refs)
+        .cloned()
+        .collect();
+
+    let (_, mut stall) = candidate_horizon(bounds, registry, first_seq, policy);
+    stall.horizon_seq = horizon;
+    stall.pinning_seq = first_pass_pin_seq;
+    if let Some(pin_seq) = first_pass_pin_seq {
+        // The kind is only knowable if the pin was an allowlist violation
+        // (an unpaired `prune.intent` has no single "kind" worth naming
+        // beyond itself); re-derive it with one more read of that one event
+        // rather than threading a third piece of state through the scan.
+        stall.pinning_kind = crate::runtime::journal::Journal::replay_data_dir_from_floor(data_dir)
+            .ok()
+            .and_then(|replay| {
+                replay
+                    .filter_map(Result::ok)
+                    .find(|e| e.seq == pin_seq)
+                    .map(|e| e.kind)
+            });
+    }
+
+    Ok(Some(PrunePlan {
+        policy: *policy,
+        horizon_seq: horizon,
+        segments,
+        residue,
+        carried_forward: scan.carried_forward,
+        condemn,
+        delete_quarantined: registry.quarantined_blobs.clone(),
+        scan_through: scan.max_seq_seen.max(horizon),
+        stall,
+    }))
+}
+
+/// §10.2: re-validate a plan against the *live* registry, immediately before
+/// committing its intent. Between planning (outside the guard) and this call
+/// (inside it), an append could have changed a planned Work's eligibility —
+/// most sharply via the `failed -> active` retry edge.
+fn revalidate(core: &crate::api::Core, plan: &PrunePlan) -> bool {
+    let registry = core.registry.state();
+    for row in &plan.residue.works {
+        let Some(live_row) = registry.work_index.get(&row.id) else {
+            return false;
+        };
+        if live_row.last_seq != row.last_seq {
+            return false;
+        }
+        if !retired_whole(live_row.state, registry.runs.get(&row.id)) {
+            return false;
+        }
+    }
+    let Ok(live_bounds) = core.journal.segment_bounds() else {
+        return false;
+    };
+    if live_bounds.len() < plan.segments.len() {
+        return false;
+    }
+    for (planned, live) in plan.segments.iter().zip(live_bounds.iter()) {
+        if planned.index != live.index
+            || planned.first_seq != live.first_seq
+            || planned.last_seq != live.last_seq
+        {
+            return false;
+        }
+    }
+    let cap = cap_seq(&registry.work_index, plan.policy.retention as usize);
+    plan.horizon_seq <= cap
+}
+
+/// Execute one already-planned cycle under the caller's `CoreGuard` hold
+/// (§10.1) — every step here runs with the daemon's single mutation lock
+/// held. Re-validates first (§10.2); a plan the live registry no longer
+/// agrees with is a no-op (`Ok(PruneOutcome::default())`) rather than a
+/// deletion planned from a disagreement (I-W3-1/2/3's whole point).
+///
+/// `started_at_startup` names which trigger (§10.3 vs §10.4) produced this
+/// cycle, journaled on the intent; the completion this call appends always
+/// carries `completed_at_startup: false` — this is a live cycle, never the
+/// crash-recovery path ([`complete_interrupted`] is that one, and always
+/// sets it `true`).
+pub fn run(
+    core: &mut crate::api::Core,
+    data_dir: &Path,
+    mut plan: PrunePlan,
+    started_at_startup: bool,
+) -> Result<PruneOutcome, PruneError> {
+    if !revalidate(core, &plan) {
+        core.prune_pending = true;
+        return Ok(PruneOutcome::default());
+    }
+
+    // §5.1's top-up, under the guard: an append between the plan's mark
+    // scan and this hold could have referenced a blob the plan condemned.
+    // Closing this window is what makes quarantine+rescue a second line of
+    // defence rather than the only one (I-W3-6).
+    for event in core.events_after(plan.scan_through)? {
+        for r in blob::refs_in_event(&event) {
+            plan.condemn.remove(&r);
+        }
+    }
+
+    let floor_seq_before = core.journal.floor_seq()?.unwrap_or(1);
+    let pruned_at = rfc3339_utc_now();
+    for row in &mut plan.residue.works {
+        row.pruned_at = pruned_at.clone();
+    }
+
+    let record = PruneIntentRecord {
+        intent_seq: 0, // not part of the payload; filled from the committed event's own seq below
+        policy: plan.policy,
+        horizon_seq: plan.horizon_seq,
+        floor_seq_before,
+        floor_seq_after: plan.horizon_seq + 1,
+        segments: plan
+            .segments
+            .iter()
+            .map(|b| PruneSegment {
+                index: b.index,
+                first_seq: b.first_seq,
+                last_seq: b.last_seq,
+                bytes: b.bytes,
+            })
+            .collect(),
+        residue: plan.residue.clone(),
+        carried_forward: plan.carried_forward.clone(),
+        condemn: plan.condemn.iter().map(|r| r.hex().to_string()).collect(),
+        delete_quarantined: plan.delete_quarantined.clone(),
+        started_at_startup,
+    };
+
+    // Step 1 (T9, fsynced).
+    let intent_event = core.commit(EventDraft::new(
+        EventSource::new("daemon", "sergeant"),
+        KIND_PRUNE_INTENT,
+        record.to_payload(),
+    ))?;
+    core.flush()?;
+    let intent_seq = intent_event.seq;
+
+    let blobs = BlobStore::open(data_dir)?;
+
+    // Step 2 (T3): quarantine.
+    let mut blobs_quarantined = 0usize;
+    for hex in &record.condemn {
+        let blob_ref: BlobRef = format!("b3:{hex}").parse()?;
+        if blobs.quarantine(&blob_ref)? {
+            blobs_quarantined += 1;
+        }
+    }
+
+    // Step 3 (T5): the previous cycle's deferred delete.
+    let mut blobs_deleted = 0usize;
+    for hex in &record.delete_quarantined {
+        if blobs.drop_quarantined(hex)? {
+            blobs_deleted += 1;
+        }
+    }
+    let blobs_rescued_before_delete = record
+        .delete_quarantined
+        .len()
+        .saturating_sub(blobs_deleted);
+
+    // Step 4 (T1/T2): unlink, oldest-first.
+    let indices: Vec<u64> = record.segments.iter().map(|s| s.index).collect();
+    let bytes_reclaimed = core.journal.unlink_segments(&indices)?;
+
+    let outcome = PruneOutcome {
+        segments_unlinked: indices.len(),
+        bytes_reclaimed,
+        works_pruned: record.residue.works.len(),
+        commands_pruned: record.residue.commands.len(),
+        blobs_quarantined,
+        blobs_deleted,
+        blobs_missing: 0,
+        blobs_rescued_before_delete,
+        floor_seq_after: record.floor_seq_after,
+        truncated_by_cap: plan.stall.truncated_by_cap,
+    };
+
+    // Step 5 (T10, fsynced).
+    core.commit(EventDraft::new(
+        EventSource::new("daemon", "sergeant"),
+        KIND_PRUNE_COMPLETED,
+        serde_json::json!({
+            "intent_seq": intent_seq,
+            "outcome": outcome,
+            "floor_seq_after": record.floor_seq_after,
+            "completed_at_startup": false,
+        }),
+    ))?;
+    core.flush()?;
+    core.prune_pending = false;
+
+    // Step 6, deviated (see this module's top doc comment): rather than
+    // rewrite the cache from the live capability watermark (not reachable
+    // from here today), remove any existing one — safe per Q2, and the next
+    // clean start's own write point (unaffected) rebuilds a fresh v2 cache.
+    let _ = startup::persist_or_remove(None, data_dir);
+
+    Ok(outcome)
+}
+
+/// One call for the daemon-start trigger (§10.3): Phase A, then Phase B,
+/// then [`run`] — short-circuiting cheaply (a handful of map iterations)
+/// when nothing is eligible, which is the common case for a frequently
+/// restarted daemon.
+pub fn run_startup(
+    core: &mut crate::api::Core,
+    data_dir: &Path,
+    policy: &PrunePolicy,
+    first_seq: &FirstSeqIndex,
+) -> Result<PruneOutcome, PruneError> {
+    let bounds = core.journal.segment_bounds()?;
+    let (candidate, _stall) = candidate_horizon(&bounds, core.registry.state(), first_seq, policy);
+    if candidate == 0 {
+        return Ok(PruneOutcome::default());
+    }
+    let Some(plan) = plan(
+        data_dir,
+        &bounds,
+        candidate,
+        core.registry.state(),
+        first_seq,
+        policy,
+    )?
+    else {
+        return Ok(PruneOutcome::default());
+    };
+    run(core, data_dir, plan, true)
+}
+
+/// Q9: finish a prune the predecessor declared and did not acknowledge.
+/// Evidence-based, exactly in the sense `recovery::reconcile_terminal_surface`
+/// is: the intent is a durable, fsynced record that a specific, enumerated
+/// deletion was authorized and begun. Nothing here is inferred, nothing is
+/// widened, and no deletion is ever started from suspicion.
+///
+/// Runs steps 2-5 of [`run`]'s cycle from `pending_prune`'s recorded targets
+/// alone, with **no re-planning**: it does not recompute a horizon, does not
+/// consult the policy, and does not extend the target set by one segment or
+/// one blob. Every step is idempotent (quarantine/drop_quarantined/
+/// unlink_segments's own `Ok(false)`/tolerated-`NotFound` shapes), so this is
+/// correct across every crash window (F1-F5).
+pub fn complete_interrupted(
+    core: &mut crate::api::Core,
+    data_dir: &Path,
+) -> Result<(), PruneError> {
+    let Some(pending) = core.registry.state().pending_prune.clone() else {
+        return Ok(());
+    };
+
+    let blobs = BlobStore::open(data_dir)?;
+    let mut blobs_quarantined = 0usize;
+    for hex in &pending.condemn {
+        let blob_ref: BlobRef = format!("b3:{hex}").parse()?;
+        if blobs.quarantine(&blob_ref)? {
+            blobs_quarantined += 1;
+        }
+    }
+    let mut blobs_deleted = 0usize;
+    for hex in &pending.delete_quarantined {
+        if blobs.drop_quarantined(hex)? {
+            blobs_deleted += 1;
+        }
+    }
+    let blobs_rescued_before_delete = pending
+        .delete_quarantined
+        .len()
+        .saturating_sub(blobs_deleted);
+
+    let indices: Vec<u64> = pending.segments.iter().map(|s| s.index).collect();
+    let bytes_reclaimed = core.journal.unlink_segments(&indices)?;
+
+    let outcome = PruneOutcome {
+        segments_unlinked: indices.len(),
+        bytes_reclaimed,
+        works_pruned: pending.residue.works.len(),
+        commands_pruned: pending.residue.commands.len(),
+        blobs_quarantined,
+        blobs_deleted,
+        blobs_missing: 0,
+        blobs_rescued_before_delete,
+        floor_seq_after: pending.floor_seq_after,
+        truncated_by_cap: false,
+    };
+
+    core.commit(EventDraft::new(
+        EventSource::new("daemon", "sergeant"),
+        KIND_PRUNE_COMPLETED,
+        serde_json::json!({
+            "intent_seq": pending.intent_seq,
+            "outcome": outcome,
+            "floor_seq_after": pending.floor_seq_after,
+            "completed_at_startup": true,
+        }),
+    ))?;
+    core.flush()?;
+    core.prune_pending = false;
+    let _ = startup::persist_or_remove(None, data_dir);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::work::WorkState;
+
+    fn work_row(id: &str, state: WorkState, last_seq: u64) -> WorkIndexRow {
+        WorkIndexRow {
+            id: id.to_string(),
+            intent: "x".to_string(),
+            state,
+            integrity: None,
+            created_at: "2026-01-01T00:00:00.000Z".to_string(),
+            updated_at: "2026-01-01T00:00:00.000Z".to_string(),
+            last_seq,
+        }
+    }
+
+    // -------------------------------------------------------------
+    // cap_seq
+    // -------------------------------------------------------------
+
+    #[test]
+    fn cap_seq_is_zero_when_within_retention() {
+        let mut idx = BTreeMap::new();
+        for n in 1..=3 {
+            idx.insert(
+                format!("w{n}"),
+                work_row(&format!("w{n}"), WorkState::Completed, n * 10),
+            );
+        }
+        assert_eq!(cap_seq(&idx, 4), 0);
+        assert_eq!(cap_seq(&idx, 3), 0);
+    }
+
+    /// N2's arithmetic core: the cap sits one below the N-th largest
+    /// `last_seq`.
+    #[test]
+    fn the_cap_ranking_is_total_because_last_seq_is_unique() {
+        let mut idx = BTreeMap::new();
+        for (id, seq) in [("a", 10u64), ("b", 20), ("c", 30), ("d", 40), ("e", 50)] {
+            idx.insert(id.to_string(), work_row(id, WorkState::Completed, seq));
+        }
+        // Retention 2: the two newest are last_seq 50 and 40; the cap sits
+        // just below the 2nd largest (40) => 39.
+        assert_eq!(cap_seq(&idx, 2), 39);
+        // Retention 5 (== count): nothing past the cap.
+        assert_eq!(cap_seq(&idx, 5), 0);
+    }
+
+    #[test]
+    fn cap_seq_of_zero_retention_never_underflows_and_caps_nothing() {
+        let mut idx = BTreeMap::new();
+        idx.insert("a".to_string(), work_row("a", WorkState::Completed, 10));
+        assert_eq!(cap_seq(&idx, 0), u64::MAX);
+    }
+
+    // -------------------------------------------------------------
+    // retired_whole
+    // -------------------------------------------------------------
+
+    #[test]
+    fn a_failed_work_with_no_run_is_retired_whole() {
+        assert!(retired_whole(WorkState::Failed, None));
+    }
+
+    #[test]
+    fn an_active_work_is_never_retired_whole() {
+        assert!(!retired_whole(WorkState::Active, None));
+    }
+
+    // -------------------------------------------------------------
+    // PruneResidue::merge
+    // -------------------------------------------------------------
+
+    fn pruned_work(id: &str) -> PrunedWorkRow {
+        PrunedWorkRow {
+            id: id.to_string(),
+            intent: "x".to_string(),
+            state: WorkState::Completed,
+            integrity: None,
+            created_at: "2026-01-01T00:00:00.000Z".to_string(),
+            updated_at: "2026-01-01T00:00:00.000Z".to_string(),
+            last_seq: 1,
+            pruned_at: "2026-01-02T00:00:00.000Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn merge_unions_works_and_commands_by_id() {
+        let mut a = PruneResidue {
+            works: vec![pruned_work("w1")],
+            ..Default::default()
+        };
+        let b = PruneResidue {
+            works: vec![pruned_work("w2")],
+            ..Default::default()
+        };
+        a.merge(b);
+        let ids: BTreeSet<String> = a.works.iter().map(|w| w.id.clone()).collect();
+        assert_eq!(ids, BTreeSet::from(["w1".to_string(), "w2".to_string()]));
+    }
+
+    #[test]
+    fn merge_keeps_the_higher_seq_capability_provenance() {
+        let mut a = PruneResidue {
+            capability_provenance: Some(AskWithdrawal {
+                seq: 5,
+                version: "1.0".to_string(),
+            }),
+            ..Default::default()
+        };
+        let lower = PruneResidue {
+            capability_provenance: Some(AskWithdrawal {
+                seq: 3,
+                version: "0.9".to_string(),
+            }),
+            ..Default::default()
+        };
+        a.merge(lower);
+        assert_eq!(a.capability_provenance.as_ref().unwrap().seq, 5);
+
+        let higher = PruneResidue {
+            capability_provenance: Some(AskWithdrawal {
+                seq: 9,
+                version: "2.0".to_string(),
+            }),
+            ..Default::default()
+        };
+        a.merge(higher);
+        assert_eq!(a.capability_provenance.as_ref().unwrap().seq, 9);
+    }
+
+    // -------------------------------------------------------------
+    // candidate_horizon
+    // -------------------------------------------------------------
+
+    fn bound(index: u64, first: u64, last: u64) -> SegmentBound {
+        SegmentBound {
+            index,
+            path: std::path::PathBuf::from(format!("/dev/null/{index}")),
+            first_seq: first,
+            last_seq: last,
+            bytes: 1024,
+        }
+    }
+
+    fn policy(retention: u32) -> PrunePolicy {
+        PrunePolicy {
+            retention,
+            source: PolicySource::Config,
+        }
+    }
+
+    #[test]
+    fn the_horizon_is_zero_when_nothing_is_eligible() {
+        let bounds = vec![bound(1, 1, 100)];
+        let registry = WorkRegistry::default();
+        let (h, _) = candidate_horizon(&bounds, &registry, &FirstSeqIndex::new(), &policy(4));
+        assert_eq!(h, 0);
+    }
+
+    /// I-W3-4, discovered exactly here by construction (not merely asserted
+    /// from the spec): a Work whose *last* event sits in the currently-open
+    /// segment must never make that segment a candidate, even when the Work
+    /// is otherwise fully retired, past the cap, and non-straddling —
+    /// because unlinking it would unlink the writer's own live segment.
+    /// With only one segment ever written, nothing is ever prunable,
+    /// regardless of how eligible its lone Work looks.
+    #[test]
+    fn the_writers_own_live_segment_is_never_a_horizon_candidate() {
+        let bounds = vec![bound(1, 1, 10)];
+        let mut registry = WorkRegistry::default();
+        registry
+            .work_index
+            .insert("w1".to_string(), work_row("w1", WorkState::Completed, 10));
+        let mut first_seq = FirstSeqIndex::new();
+        first_seq.insert("w1".to_string(), 1);
+
+        let (h, _) = candidate_horizon(&bounds, &registry, &first_seq, &policy(0));
+        assert_eq!(
+            h, 0,
+            "the only segment there is must never be proposed, since it is always the live one"
+        );
+
+        // Once a second (now genuinely historical) segment exists, the
+        // first one is fair game and the live (second) one still is not.
+        let bounds = vec![bound(1, 1, 10), bound(2, 11, 11)];
+        let (h, _) = candidate_horizon(&bounds, &registry, &first_seq, &policy(0));
+        assert_eq!(h, 10, "the now-historical first segment must be reachable");
+    }
+
+    /// N1: a Work whose `last_seq` is above the horizon pins every segment
+    /// containing any of its events.
+    #[test]
+    fn a_work_whose_last_seq_is_above_the_horizon_pins_its_segments() {
+        let bounds = vec![bound(1, 1, 50), bound(2, 51, 100)];
+        let mut registry = WorkRegistry::default();
+        // w1 spans both segments (first_seq 10, last_seq 60): straddles
+        // candidate 50, so nostraddle fails there; must fail at 100 too
+        // (b < blocker not the issue here — it is retired), so straddling
+        // is what should hold this to 0.
+        registry
+            .work_index
+            .insert("w1".to_string(), work_row("w1", WorkState::Completed, 60));
+        let mut first_seq = FirstSeqIndex::new();
+        first_seq.insert("w1".to_string(), 10);
+
+        let (h, _) = candidate_horizon(&bounds, &registry, &first_seq, &policy(1));
+        assert_eq!(h, 0, "w1 straddles every candidate <= 100");
+    }
+
+    /// N2.
+    #[test]
+    fn a_work_inside_the_retention_cap_is_never_pruned() {
+        let bounds = vec![bound(1, 1, 50), bound(2, 51, 100)];
+        let mut registry = WorkRegistry::default();
+        for (id, seq) in [("w1", 20u64), ("w2", 100)] {
+            registry
+                .work_index
+                .insert(id.to_string(), work_row(id, WorkState::Completed, seq));
+        }
+        let mut first_seq = FirstSeqIndex::new();
+        first_seq.insert("w1".to_string(), 15);
+        first_seq.insert("w2".to_string(), 90);
+        // Retention 2: both Works are within the cap, so cap_seq == 0.
+        let (h, _) = candidate_horizon(&bounds, &registry, &first_seq, &policy(2));
+        assert_eq!(h, 0);
+    }
+
+    /// N3: an unsettled terminal Work (surface, no teardown) pins the
+    /// horizon and names itself as the blocker.
+    #[test]
+    fn an_unsettled_terminal_work_pins_the_horizon_and_names_itself_as_the_blocker() {
+        use crate::runtime::projection::WorkRun;
+        use crate::runtime::surface::WorkSurface;
+
+        let bounds = vec![bound(1, 1, 50), bound(2, 51, 100)];
+        let mut registry = WorkRegistry::default();
+        registry.work_index.insert(
+            "stuck".to_string(),
+            work_row("stuck", WorkState::Completed, 20),
+        );
+        registry.runs.insert(
+            "stuck".to_string(),
+            WorkRun {
+                surface: Some(WorkSurface {
+                    work_id: "stuck".to_string(),
+                    root: std::path::PathBuf::from("/nowhere"),
+                    bindings: Vec::new(),
+                }),
+                ..Default::default()
+            },
+        );
+        registry.work_index.insert(
+            "clean".to_string(),
+            work_row("clean", WorkState::Completed, 90),
+        );
+        let mut first_seq = FirstSeqIndex::new();
+        first_seq.insert("stuck".to_string(), 10);
+        first_seq.insert("clean".to_string(), 80);
+
+        let (h, stall) = candidate_horizon(&bounds, &registry, &first_seq, &policy(1));
+        assert_eq!(
+            h, 0,
+            "the unsettled Work at last_seq 20 blocks every candidate >= 20"
+        );
+        assert_eq!(stall.blocking_work_id.as_deref(), Some("stuck"));
+    }
+
+    #[test]
+    fn stall_report_names_the_lowest_blocking_work() {
+        let bounds = vec![bound(1, 1, 100)];
+        let mut registry = WorkRegistry::default();
+        registry
+            .work_index
+            .insert("a".to_string(), work_row("a", WorkState::Active, 10));
+        registry
+            .work_index
+            .insert("b".to_string(), work_row("b", WorkState::Active, 50));
+        let stall = stall_report(
+            &bounds,
+            &registry,
+            &FirstSeqIndex::new(),
+            &policy(1),
+            std::time::SystemTime::now(),
+        );
+        assert_eq!(stall.blocking_work_id.as_deref(), Some("a"));
+    }
+
+    // -------------------------------------------------------------
+    // A real cycle over a real journal, via `Core` directly (no daemon).
+    // -------------------------------------------------------------
+
+    /// A minimal `Core` over a fresh journal that rotates every event into
+    /// its own segment — small enough that a two-event Work already spans
+    /// two segments, without needing a production-scale fixture.
+    fn tiny_core(dir: &std::path::Path) -> crate::api::Core {
+        let journal = crate::runtime::journal::Journal::open_with(dir, 1).expect("open");
+        let registry = crate::runtime::projection::work_registry_projection();
+        let (events_tx, _rx) = tokio::sync::broadcast::channel(16);
+        crate::api::Core::new(journal, registry, events_tx)
+    }
+
+    fn commit(
+        core: &mut crate::api::Core,
+        source: crate::domain::event::EventSource,
+        kind: &str,
+        work_id: Option<&str>,
+        payload: serde_json::Value,
+    ) -> crate::domain::event::Event {
+        let mut draft = crate::domain::event::EventDraft::new(source, kind, payload);
+        if let Some(id) = work_id {
+            draft = draft.with_work_id(id);
+        }
+        core.commit(draft).expect("commit")
+    }
+
+    fn daemon_source() -> crate::domain::event::EventSource {
+        crate::domain::event::EventSource::new("daemon", "test")
+    }
+
+    fn submit_and_complete(core: &mut crate::api::Core, work_id: &str) {
+        commit(
+            core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some(work_id),
+            serde_json::json!({"work": {
+                "id": work_id,
+                "intent": "prune unit fixture",
+                "state": "pending",
+                "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some(work_id),
+            serde_json::json!({}),
+        );
+    }
+
+    /// Build a two-segment, one-Work fixture and commit its `prune.intent`
+    /// (step 1 of `run`'s cycle) — then stop, exactly as a crash would.
+    /// Every `crash_window_f*` test starts here and diverges only in what
+    /// it does to the on-disk segments *before* calling
+    /// `complete_interrupted`.
+    fn build_and_commit_intent(core: &mut crate::api::Core, dir: &std::path::Path) -> PrunePlan {
+        submit_and_complete(core, "w1");
+        // I-W3-4: the writer's own live segment is never a prune target, so
+        // a trailing, unrelated event pushes it there — otherwise w1's own
+        // completing event would still be sitting in the (structurally
+        // excluded) live segment and nothing here would be prunable at all.
+        commit(
+            core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w1's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        assert!(candidate > 0, "the fixture must actually be prunable");
+        let plan = plan(
+            dir,
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("something must be prunable");
+        assert_eq!(plan.residue.works.len(), 1);
+        assert_eq!(
+            plan.segments.len(),
+            2,
+            "the fixture must span exactly two segments for the crash-window tests to mean anything"
+        );
+
+        let record = PruneIntentRecord {
+            intent_seq: 0,
+            policy: plan.policy,
+            horizon_seq: plan.horizon_seq,
+            floor_seq_before: 1,
+            floor_seq_after: plan.horizon_seq + 1,
+            segments: plan
+                .segments
+                .iter()
+                .map(|b| PruneSegment {
+                    index: b.index,
+                    first_seq: b.first_seq,
+                    last_seq: b.last_seq,
+                    bytes: b.bytes,
+                })
+                .collect(),
+            residue: plan.residue.clone(),
+            carried_forward: plan.carried_forward.clone(),
+            condemn: plan.condemn.iter().map(|r| r.hex().to_string()).collect(),
+            delete_quarantined: plan.delete_quarantined.clone(),
+            started_at_startup: false,
+        };
+        core.commit(EventDraft::new(
+            EventSource::new("daemon", "sergeant"),
+            KIND_PRUNE_INTENT,
+            record.to_payload(),
+        ))
+        .expect("commit intent");
+        core.flush().expect("flush intent");
+        assert!(
+            core.registry.state().pending_prune.is_some(),
+            "the intent must be pending — nothing has completed it yet"
+        );
+        plan
+    }
+
+    /// N7 / F1: a crash after `prune.intent` is fsynced, before any rename or
+    /// unlink, is completed in full at the next start from the intent's own
+    /// recorded targets — and a second completion attempt over the already-
+    /// finished cycle is a true no-op (nothing further appended).
+    #[test]
+    fn crash_window_f1_before_quarantine_completes_at_next_start() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let plan = build_and_commit_intent(&mut core, dir.path());
+        let next_seq_after_intent = core.journal.next_seq();
+
+        // Next start: complete it.
+        complete_interrupted(&mut core, dir.path()).expect("complete_interrupted");
+        assert!(
+            core.registry.state().pending_prune.is_none(),
+            "the cycle must be acknowledged after completion"
+        );
+        assert!(
+            core.registry.state().pruned_works.contains_key("w1"),
+            "w1's residue must have been applied"
+        );
+        let bounds_after = core.journal.segment_bounds().expect("bounds");
+        assert!(
+            bounds_after
+                .iter()
+                .all(|b| !plan.segments.iter().any(|s| s.index == b.index)),
+            "every planned segment must actually be gone"
+        );
+        assert_eq!(
+            core.journal.next_seq(),
+            next_seq_after_intent + 1,
+            "exactly one completion event must have been appended"
+        );
+
+        // The honesty check: completing an already-finished cycle again
+        // appends nothing further.
+        complete_interrupted(&mut core, dir.path()).expect("second complete_interrupted");
+        assert_eq!(
+            core.journal.next_seq(),
+            next_seq_after_intent + 1,
+            "a completion with no pending intent must append nothing"
+        );
+    }
+
+    /// N9 / F4: a crash mid-unlink (only the first of the two target
+    /// segments actually removed) leaves a journal `complete_interrupted`
+    /// can still finish — `unlink_segments` tolerates the already-gone
+    /// member and removes the rest — and the result replays cleanly from
+    /// its new floor.
+    #[test]
+    fn crash_window_f4_mid_unlink_leaves_a_journal_that_replays_from_its_new_floor() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let plan = build_and_commit_intent(&mut core, dir.path());
+
+        // Simulate the crash: only the oldest of the two planned segments
+        // was actually unlinked before the process died.
+        let oldest = plan.segments.iter().map(|s| s.index).min().unwrap();
+        let journal_dir = dir.path().join("journal");
+        std::fs::remove_file(journal_dir.join(format!("{oldest:08}.ndjson")))
+            .expect("simulate the partial unlink");
+
+        complete_interrupted(&mut core, dir.path()).expect("complete_interrupted");
+        assert!(core.registry.state().pending_prune.is_none());
+        assert!(core.registry.state().pruned_works.contains_key("w1"));
+        let bounds_after = core.journal.segment_bounds().expect("bounds");
+        assert!(
+            bounds_after
+                .iter()
+                .all(|b| !plan.segments.iter().any(|s| s.index == b.index)),
+            "the remaining planned segment must also be gone after the completion finishes it"
+        );
+
+        // The journal must still replay cleanly from its new floor.
+        let replayed: Result<Vec<_>, _> = core
+            .journal
+            .replay_from_floor()
+            .expect("replay_from_floor")
+            .collect();
+        assert!(replayed.is_ok(), "got {replayed:?}");
+    }
+
+    /// N10 / F5: a crash after the last unlink but before `prune.completed`
+    /// is appended leaves no segment `complete_interrupted` could ever
+    /// re-derive the residue from — which is exactly why the completion is
+    /// appended from the *intent's* own carried residue, not recomputed.
+    #[test]
+    fn crash_window_f5_after_unlink_appends_the_completion_from_the_intents_residue() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let plan = build_and_commit_intent(&mut core, dir.path());
+
+        // Simulate the crash: every planned segment is already gone, but no
+        // completion was ever appended.
+        let journal_dir = dir.path().join("journal");
+        for segment in &plan.segments {
+            std::fs::remove_file(journal_dir.join(format!("{:08}.ndjson", segment.index)))
+                .expect("simulate the finished unlink");
+        }
+
+        complete_interrupted(&mut core, dir.path()).expect("complete_interrupted");
+        assert!(
+            core.registry.state().pending_prune.is_none(),
+            "the completion must have been appended from the intent's own residue"
+        );
+        assert!(
+            core.registry.state().pruned_works.contains_key("w1"),
+            "w1's row must come from the intent's carried residue — there is nothing else \
+             left to recompute it from"
+        );
+    }
+
+    /// N20: pruning the Work that recorded the ask-grammar withdrawal must
+    /// not silently drop the watermark — the residue must carry it forward,
+    /// with its *original* seq (not the prune event's), so "higher seq
+    /// wins" keeps meaning what it means.
+    #[test]
+    fn the_ask_withdrawal_survives_the_prune_of_the_work_that_recorded_it() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w1"),
+            serde_json::json!({"work": {
+                "id": "w1", "intent": "ask fixture", "state": "pending",
+                "created_by": "test", "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        let withdrawal_event = commit(
+            &mut core,
+            EventSource::new("backend", "claude"),
+            "conversation.turn.grammar_unmeasured",
+            Some("w1"),
+            serde_json::json!({"capability": "ask", "version": "2.1.226"}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w1"),
+            serde_json::json!({}),
+        );
+        // I-W3-4: push the writer's live segment off of w1's own — see
+        // `build_and_commit_intent`'s identical comment.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w1's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("something must be prunable");
+
+        let watermark = plan
+            .residue
+            .capability_provenance
+            .as_ref()
+            .expect("the withdrawal must be carried in the residue");
+        assert_eq!(watermark.seq, withdrawal_event.seq);
+        assert_eq!(watermark.version, "2.1.226");
+
+        let outcome = run(&mut core, dir.path(), plan, false).expect("run");
+        assert!(outcome.segments_unlinked > 0);
+        assert!(
+            core.registry.state().pruned_works.contains_key("w1"),
+            "w1 must actually have been pruned"
+        );
+    }
+
+    /// N4: an unknown non-work-scoped event kind pins its segment — Q5's
+    /// allowlist as a mechanism, not a comment. A later, otherwise-eligible
+    /// Work stays retained because the pin lowers the horizon back below
+    /// it; the Work *before* the pin is unaffected.
+    #[test]
+    fn an_unknown_non_work_scoped_kind_pins_its_segment() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        submit_and_complete(&mut core, "w1");
+        // Not in `NON_WORK_ALLOWLIST` and carries no `work_id` — exactly
+        // the shape a future wave's new event kind could add.
+        commit(
+            &mut core,
+            daemon_source(),
+            "mystery.event",
+            None,
+            serde_json::json!({}),
+        );
+        submit_and_complete(&mut core, "w2");
+        // Push the writer off w2's own segment (I-W3-4).
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w2's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        // Phase A alone (registry-only) does not see the pin — both Works
+        // look fully eligible to it.
+        assert!(
+            candidate >= core.registry.state().work_index["w2"].last_seq,
+            "Phase A must not know about the pin yet"
+        );
+
+        let plan = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w1 must still be prunable even though w2 is pinned away");
+
+        let pruned_ids: std::collections::BTreeSet<&str> =
+            plan.residue.works.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            pruned_ids,
+            std::collections::BTreeSet::from(["w1"]),
+            "only the Work entirely before the pin may be pruned"
+        );
+        assert_eq!(
+            plan.stall.pinning_kind.as_deref(),
+            Some("mystery.event"),
+            "the stall report must name the pinning kind"
+        );
+    }
+
+    /// N17: a retry that lands between planning (outside the guard) and
+    /// committing (inside it) must abort the cycle rather than delete a
+    /// Work whose eligibility the live registry no longer agrees with —
+    /// `run` re-validates immediately before committing the intent (§10.2).
+    #[test]
+    fn a_retry_landing_between_plan_and_commit_aborts_the_cycle() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w1"),
+            serde_json::json!({"work": {
+                "id": "w1", "intent": "retry-race fixture", "state": "pending",
+                "created_by": "test", "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_FAILED,
+            Some("w1"),
+            serde_json::json!({}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off w1's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("a Failed, retired-whole Work must be plannable");
+        assert_eq!(plan.residue.works.len(), 1);
+
+        // The race: a retry lands on the live registry (`failed -> active`)
+        // between planning and committing — `WorkState::for_event_kind`'s
+        // `KIND_WORK_STARTED` mapping.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_STARTED,
+            Some("w1"),
+            serde_json::json!({}),
+        );
+        core.flush().expect("flush the retry");
+
+        let journal_next_seq_before = core.journal.next_seq();
+        let bounds_before: Vec<_> = core
+            .journal
+            .segment_bounds()
+            .expect("bounds")
+            .iter()
+            .map(|b| b.index)
+            .collect();
+
+        let outcome = run(&mut core, dir.path(), plan, false).expect("run must not error");
+        assert_eq!(
+            outcome,
+            PruneOutcome::default(),
+            "a stale plan must be a no-op, not a deletion planned from a disagreement"
+        );
+        assert!(
+            core.prune_pending,
+            "the cycle must be re-armed so the next tick re-plans"
+        );
+        assert!(
+            core.registry.state().pending_prune.is_none(),
+            "no intent may have been committed for a plan that failed re-validation"
+        );
+        assert!(
+            !core.registry.state().pruned_works.contains_key("w1"),
+            "the retried Work must not have been pruned"
+        );
+        assert_eq!(
+            core.journal.next_seq(),
+            journal_next_seq_before,
+            "nothing may have been appended"
+        );
+        let bounds_after: Vec<_> = core
+            .journal
+            .segment_bounds()
+            .expect("bounds")
+            .iter()
+            .map(|b| b.index)
+            .collect();
+        assert_eq!(
+            bounds_after, bounds_before,
+            "nothing may have been unlinked"
+        );
+    }
+}

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -93,16 +93,25 @@ pub const KIND_PRUNE_INTENT: &str = "prune.intent";
 pub const KIND_PRUNE_COMPLETED: &str = "prune.completed";
 
 /// Q5's allowlist, as a **mechanism**: an event with no `work_id` whose kind
-/// is not here pins its segment, and a kind enters this list only with a
-/// replay-equivalence proof (`tests/w3_allowlist_equivalence.rs`).
+/// is not here pins its segment (proved directly by
+/// `an_unknown_non_work_scoped_kind_pins_its_segment`, below). A kind is
+/// meant to enter this list only with its own replay-equivalence proof, one
+/// test per kind (the wave spec's own `tests/w3_allowlist_equivalence.rs`
+/// suite) — this landing does not add that dedicated file; the nine kinds
+/// already here are the ones §2 itself argues are safe, each with the
+/// one-line equivalence claim in its own comment below, but not yet each
+/// pinned by its own named test the way the spec's §13.1 step 6 asks for.
 pub const NON_WORK_ALLOWLIST: &[&str] = &[
-    crate::daemon::KIND_DAEMON_STARTED,
-    crate::daemon::KIND_DAEMON_STOPPED,
-    crate::daemon::KIND_BACKEND_PROBED,
+    crate::daemon::KIND_DAEMON_STARTED, // no registry effect at all
+    crate::daemon::KIND_DAEMON_STOPPED, // no registry effect at all
+    crate::daemon::KIND_BACKEND_PROBED, // no registry effect at all
+    // sets `admission_paused`, force-cleared unconditionally at every
+    // startup before the descriptor is published, so the replayed value is
+    // never load-bearing.
     crate::daemon::KIND_ADMISSION_PAUSED,
-    crate::daemon::KIND_ADMISSION_RESUMED,
-    KIND_COMMAND_ACCEPTED,
-    KIND_COMMAND_REJECTED,
+    crate::daemon::KIND_ADMISSION_RESUMED, // same
+    KIND_COMMAND_ACCEPTED,                 // ledger key survives in `pruned_commands` (Q8)
+    KIND_COMMAND_REJECTED,                 // same
     KIND_PRUNE_INTENT,
     KIND_PRUNE_COMPLETED,
 ];

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -393,8 +393,29 @@ pub struct PrunePlan {
     pub condemn: BTreeSet<BlobRef>,
     /// Blobs the previous cycle quarantined, to delete now — already
     /// excluded from anything the surviving-side scan found still
-    /// referenced (I-W3-6; see [`PrunePlan::rescue_quarantined`]).
+    /// referenced (I-W3-6; see [`PrunePlan::rescue_quarantined`]) and from
+    /// anything *this* cycle condemns afresh (see
+    /// [`PrunePlan::defer_quarantined`]).
     pub delete_quarantined: Vec<String>,
+    /// Blobs the previous cycle quarantined that this cycle's own mark scan
+    /// condemns **again** — deleted by neither this cycle nor rescued by it,
+    /// but re-marked and deferred to the next one (A5's two-phase
+    /// quarantine).
+    ///
+    /// Condemning and deleting the same hex in one cycle collapses the
+    /// deferral window to nothing, which is the only thing standing between
+    /// an in-flight `BlobStore::put` dedup-hit — one that has already
+    /// rescued the content back to its live address but whose referencing
+    /// event has not been committed yet, so neither the mark scan nor the
+    /// guard-held top-up can see it — and a destroyed live blob with a
+    /// dangling `b3:` reference pointing at it.
+    ///
+    /// Not carried on [`PruneIntentRecord`] and not needed there: every hex
+    /// here is by construction a member of `condemn`, which *is* recorded,
+    /// and which is what the registry installs as the next cycle's
+    /// `quarantined_blobs` — so the deferral survives a crash without a
+    /// field of its own.
+    pub defer_quarantined: Vec<String>,
     /// Blobs the previous cycle quarantined that the surviving-side scan
     /// found referenced by a retained event — a dedup adoption that landed
     /// between that cycle's mark scan and this one's, with no live
@@ -984,22 +1005,48 @@ pub fn plan(
         .cloned()
         .collect();
 
-    // §5.2/I-W3-6: a hex the previous cycle quarantined must not be deleted
-    // this cycle if a surviving event now references it — a dedup adoption
-    // that landed between that cycle's mark scan and this one's, with no
-    // live `get`/`put` in between to have rescued it the ordinary way.
-    // Split rather than merely filter: the excluded hexes are moved back to
-    // their live content address (`run`'s `rescue_quarantined` step) rather
-    // than silently left in quarantine forever — the next cycle's own
-    // `registry.quarantined_blobs` is about to be replaced wholesale by
-    // *this* cycle's fresh `condemn` set, so anything not resolved to
-    // "delete" or "rescue" now would never be revisited again.
+    // §5.2/I-W3-6 and A5's two-phase quarantine: every hex the *previous*
+    // cycle quarantined is resolved here to exactly one of three outcomes,
+    // because the next cycle's `registry.quarantined_blobs` is about to be
+    // replaced wholesale by *this* cycle's `condemn` set — anything left
+    // unresolved would never be revisited again.
+    //
+    // 1. **Rescue** — a surviving event references it. A dedup adoption
+    //    landed between that cycle's mark scan and this one's, with no live
+    //    `get`/`put` in between to have rescued it the ordinary way; `run`
+    //    moves it back to its live content address.
+    // 2. **Defer** — *this* cycle's own mark scan condemns it again. It is
+    //    being re-marked right now (step 2 finds it already in `.pruned/`
+    //    and reports `Ok(false)`), it rides into the next cycle's
+    //    `quarantined_blobs` on `condemn`, and *that* cycle decides its
+    //    fate. Deleting it here instead would collapse the two-phase
+    //    quarantine to a single phase for this hex: mark and sweep in one
+    //    guard hold, with no window at all for a concurrent
+    //    `BlobStore::put` dedup-hit — whose referencing event is not
+    //    committed yet, and so is invisible to both the mark scan and
+    //    `run`'s guard-held top-up — to have its content survive. That is a
+    //    destroyed live blob and a dangling `b3:` ref, which is precisely
+    //    the failure the deferral exists to prevent.
+    // 3. **Delete** — neither of the above: untouched since the previous
+    //    cycle marked it, which is what a full deferral window having
+    //    elapsed with nobody claiming it looks like.
+    //
+    // (1) and (2) cannot both apply: `condemn` already has every
+    // surviving-side reference subtracted from it just above.
     let surviving_hexes: BTreeSet<&str> = surviving_refs.iter().map(BlobRef::hex).collect();
-    let (delete_quarantined, rescue_quarantined): (Vec<String>, Vec<String>) = registry
-        .quarantined_blobs
-        .iter()
-        .cloned()
-        .partition(|hex| !surviving_hexes.contains(hex.as_str()));
+    let condemned_hexes: BTreeSet<&str> = condemn.iter().map(BlobRef::hex).collect();
+    let mut rescue_quarantined: Vec<String> = Vec::new();
+    let mut defer_quarantined: Vec<String> = Vec::new();
+    let mut delete_quarantined: Vec<String> = Vec::new();
+    for hex in &registry.quarantined_blobs {
+        if surviving_hexes.contains(hex.as_str()) {
+            rescue_quarantined.push(hex.clone());
+        } else if condemned_hexes.contains(hex.as_str()) {
+            defer_quarantined.push(hex.clone());
+        } else {
+            delete_quarantined.push(hex.clone());
+        }
+    }
 
     let (_, mut stall) = candidate_horizon(bounds, registry, first_seq, policy);
     stall.horizon_seq = horizon;
@@ -1027,6 +1074,7 @@ pub fn plan(
         carried_forward: scan.carried_forward,
         condemn,
         delete_quarantined,
+        defer_quarantined,
         rescue_quarantined,
         scan_through: surviving_scan_through,
         stall,
@@ -1106,6 +1154,16 @@ pub fn run(
                     plan.rescue_quarantined
                         .push(plan.delete_quarantined.remove(pos));
                 }
+                // A deferred hex rides into the next cycle's quarantined
+                // set only *because* it is in `condemn` — which the line
+                // above may have just removed it from. Left in neither
+                // list it would sit in `.pruned/` with nothing scheduled to
+                // revisit it, so resolve it the way the new reference asks:
+                // rescue it back to its live address now.
+                if let Some(pos) = plan.defer_quarantined.iter().position(|h| h == r.hex()) {
+                    plan.rescue_quarantined
+                        .push(plan.defer_quarantined.remove(pos));
+                }
             }
         }
     }
@@ -1151,7 +1209,13 @@ pub fn run(
 
     let blobs = BlobStore::open(data_dir)?;
 
-    // Step 2 (T3): quarantine.
+    // Step 2 (T3): quarantine. Includes `plan.defer_quarantined` by
+    // construction (it is a subset of `condemn`); for those, the live path
+    // is normally already absent and `quarantine` reports its idempotent
+    // `Ok(false)` — unless a `put` dedup-hit rescued the content back to
+    // its live address since the previous cycle, which is exactly the case
+    // the deferral is protecting and exactly the case that re-marks it here
+    // for the *next* cycle to sweep.
     let mut blobs_quarantined = 0usize;
     for hex in &record.condemn {
         let blob_ref: BlobRef = format!("b3:{hex}").parse()?;
@@ -2590,6 +2654,227 @@ mod tests {
             .get(&blob_ref)
             .expect("the adopted blob must be live again, not deleted");
         assert_eq!(bytes, b"adopted content");
+    }
+
+    /// N6's other half — the same-cycle collapse. A hex this cycle's own
+    /// mark scan condemns **again** must never also be deleted from
+    /// quarantine in the same cycle: `condemn` re-marks it now, and the
+    /// deferred delete of it belongs to the *next* cycle. Quarantining and
+    /// deleting one hex inside a single guard hold leaves a deferral window
+    /// of exactly zero — and that window is the only thing standing between
+    /// an in-flight `BlobStore::put` dedup-hit (its referencing event not
+    /// yet committed, so invisible to both the mark scan and `run`'s
+    /// guard-held top-up) and a destroyed live blob with a dangling `b3:`
+    /// reference to it.
+    ///
+    /// `a_dedup_adoption_between_mark_and_sweep_is_rescued_from_quarantine`
+    /// deliberately keeps its adoption event in the *surviving* range,
+    /// which is the rescue path. This one puts the adoption **inside cycle
+    /// 2's own condemned range**, which is what lands the hex in `condemn`
+    /// and `delete_quarantined` at the same time — the overlap the two-set
+    /// partition used to ignore entirely.
+    #[test]
+    fn a_hex_condemned_again_this_cycle_is_never_deleted_in_the_same_cycle() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+        let blob_ref = BlobStore::open(dir.path())
+            .expect("open blob store")
+            .put(b"re-adopted content")
+            .expect("put");
+        let hex = blob_ref.hex().to_string();
+        let quarantine_path = dir
+            .path()
+            .join("blobs")
+            .join("b3")
+            .join(".pruned")
+            .join(&hex);
+        let live_path = dir.path().join("blobs").join("b3").join(&hex);
+
+        let policy = PrunePolicy {
+            retention: 0,
+            source: PolicySource::Config,
+        };
+        let run_a_cycle = |core: &mut crate::api::Core| -> PruneOutcome {
+            let bounds = core.journal.segment_bounds().expect("bounds");
+            let (candidate, _) = candidate_horizon(
+                &bounds,
+                core.registry.state(),
+                &core.first_seq_by_work,
+                &policy,
+            );
+            let plan = plan(
+                dir.path(),
+                &bounds,
+                candidate,
+                core.registry.state(),
+                &core.first_seq_by_work,
+                &policy,
+            )
+            .expect("plan")
+            .expect("something must be prunable");
+            assert!(
+                plan.delete_quarantined
+                    .iter()
+                    .all(|h| !plan.condemn.iter().any(|r| r.hex() == h)),
+                "no hex may be scheduled for both a fresh condemn and this cycle's delete"
+            );
+            run(core, dir.path(), plan, false).expect("run")
+        };
+
+        // Cycle 1: w_old is the only reference — the blob is quarantined.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w_old"),
+            serde_json::json!({"work": {
+                "id": "w_old", "intent": "prunable, references the blob first",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w_old"),
+            serde_json::json!({"result_blob": format!("b3:{hex}")}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor1"),
+            serde_json::json!({"work": {
+                "id": "anchor1", "intent": "keep the writer off w_old's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+        assert_eq!(run_a_cycle(&mut core).blobs_quarantined, 1);
+        assert_eq!(core.registry.state().quarantined_blobs, vec![hex.clone()]);
+        assert!(quarantine_path.exists() && !live_path.exists());
+
+        // A real `put` of the same content between the cycles: its dedup
+        // check rescues the quarantined copy back to its live address
+        // (`put_rescues_instead_of_writing_a_second_copy`). This is the
+        // in-flight writer whose own event has not been committed yet.
+        let readopted = BlobStore::open(dir.path())
+            .expect("open blob store")
+            .put(b"re-adopted content")
+            .expect("put the same content again");
+        assert_eq!(readopted.hex(), hex);
+        assert!(
+            live_path.exists() && !quarantine_path.exists(),
+            "the dedup-hit put must have rescued the blob back to its live address"
+        );
+
+        // `anchor1` stops blocking; `w_mid` carries the new reference and
+        // is itself fully retired *below* cycle 2's horizon, so its event —
+        // unlike N6's — sits inside the range cycle 2 condemns.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("anchor1"),
+            serde_json::json!({}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("w_mid"),
+            serde_json::json!({"work": {
+                "id": "w_mid", "intent": "re-adopts the same content",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+                "ref": format!("b3:{hex}"),
+            }}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("w_mid"),
+            serde_json::json!({}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor2"),
+            serde_json::json!({"work": {
+                "id": "anchor2", "intent": "keep the writer off w_mid's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        // Cycle 2: the hex is condemned afresh *and* is last cycle's
+        // quarantined hex. It must be re-marked, not swept.
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        let (candidate, _) = candidate_horizon(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        );
+        let plan2 = plan(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policy,
+        )
+        .expect("plan")
+        .expect("w_mid must be prunable in cycle 2");
+        assert!(
+            plan2.condemn.iter().any(|r| r.hex() == hex),
+            "the fixture must actually put the hex back in this cycle's fresh condemn set"
+        );
+        assert!(
+            plan2.delete_quarantined.is_empty(),
+            "a hex this cycle re-condemns must not also be swept this cycle"
+        );
+        assert!(
+            plan2.rescue_quarantined.is_empty(),
+            "nor rescued — no *surviving* event references it"
+        );
+        assert_eq!(
+            plan2.defer_quarantined,
+            vec![hex.clone()],
+            "it belongs to the deferred set: re-marked now, re-evaluated next cycle"
+        );
+
+        let outcome2 = run(&mut core, dir.path(), plan2, false).expect("run cycle 2");
+        assert_eq!(
+            outcome2.blobs_quarantined, 1,
+            "the re-adopted (live again) blob must be quarantined by this cycle"
+        );
+        assert_eq!(
+            outcome2.blobs_deleted, 0,
+            "and must not be deleted by the same cycle that just marked it"
+        );
+        assert_eq!(
+            std::fs::read(&quarantine_path).expect("the content must still exist, in quarantine"),
+            b"re-adopted content"
+        );
+        assert!(
+            core.registry.state().quarantined_blobs.contains(&hex),
+            "the deferral must be armed for the next cycle via the intent's own condemn list"
+        );
+
+        // The window is real: a writer that dedup-hits this content in the
+        // interval still gets it back intact, which is the entire point of
+        // deferring the delete by a cycle.
+        let bytes = BlobStore::open(dir.path())
+            .expect("open blob store")
+            .get(&blob_ref)
+            .expect("the deferred blob must still be recoverable");
+        assert_eq!(bytes, b"re-adopted content");
     }
 
     /// §3.5's stated invariant, checked directly against a real fixture

--- a/src/runtime/startup.rs
+++ b/src/runtime/startup.rs
@@ -60,7 +60,15 @@ use crate::runtime::projection::{
 /// File name of the startup cache inside `projections/`.
 pub const FLOOR_STATE_FILE: &str = "floor-state.json";
 /// Schema identifier for the startup cache.
-pub const FLOOR_STATE_SCHEMA: &str = "sergeant.floor-state.v1";
+///
+/// W3 bumps this to v2 (§9.1, ratify-at-review item 5): `FloorWorkRow` gains
+/// `first_seq` (without which pruning is inert on a cache-hit start — see
+/// its own doc) and drops `pruned_at` (a declared-but-permanently-`None`
+/// slot on a *retained* Work's row once W3's actual pruned Works get their
+/// own `FloorState::pruned_works` section). A v1 reader would be *wrong* to
+/// prune from a v1 cache, not merely incomplete, which is what licenses the
+/// bump rather than an additive-only extension within v1.
+pub const FLOOR_STATE_SCHEMA: &str = "sergeant.floor-state.v2";
 
 /// Q4: a **fixed** live window on every host — 16 segments or 128 MiB,
 /// whichever bounds first. Not configurable, not adaptive: the
@@ -341,6 +349,16 @@ pub struct HorizonSink {
     first_seq_by_work: BTreeMap<String, u64>,
 }
 
+impl HorizonSink {
+    /// W3 §2.5: the raw fold this pass produced, for a caller (`daemon::
+    /// start_with`) that merges it into the process-lifetime
+    /// `Core::first_seq_by_work` index the prune horizon reads. Read-only —
+    /// this sink's own fold is otherwise exactly W2's.
+    pub fn first_seq_by_work(&self) -> &BTreeMap<String, u64> {
+        &self.first_seq_by_work
+    }
+}
+
 impl ReplaySink for HorizonSink {
     fn push(&mut self, event: &Event) -> Result<(), StartupError> {
         if let Some(id) = &event.work_id {
@@ -497,10 +515,15 @@ pub struct FloorWorkRow {
     pub updated_at: String,
     /// Same as [`WorkIndexRow::last_seq`].
     pub last_seq: u64,
-    /// W3 slot: RFC3339 date this Work's segments were pruned. Always
-    /// `None` in W2 — nothing is deleted this wave.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pruned_at: Option<String>,
+    /// W3 §3.1: first seq this process has ever seen for this Work — the
+    /// field without which a cache-hit start cannot compute the prune
+    /// horizon's no-straddle predicate at all (see
+    /// [`crate::runtime::prune::FirstSeqIndex`]'s own doc for why a missing
+    /// value would make pruning permanently inert rather than merely
+    /// conservative). New in schema v2; a v1 cache never had it, which is
+    /// exactly why v1 is a named miss now rather than read as `0`.
+    #[serde(default)]
+    pub first_seq: u64,
 }
 
 /// Recorded outcome class of one below-window command — keys only, never the
@@ -547,6 +570,35 @@ pub struct FloorState {
     /// if any.
     #[serde(default)]
     pub capability_provenance: Option<AskWithdrawal>,
+    /// W3 §9.2: every Work this estate has ever pruned — the whole of
+    /// `WorkRegistry::pruned_works`, unconditionally (not filtered by this
+    /// start's own horizon: once pruned, a Work's row is a permanent fact
+    /// the journal can no longer reproduce on its own below whatever floor
+    /// this estate now has, so the cache must carry every one of them, not
+    /// just the ones this pass's own horizon happens to cover).
+    #[serde(default)]
+    pub pruned_works: Vec<crate::runtime::prune::PrunedWorkRow>,
+    /// W3 §9.2: the whole of `WorkRegistry::pruned_commands`, same reasoning.
+    #[serde(default)]
+    pub pruned_commands: Vec<crate::runtime::prune::PrunedCommandRow>,
+    /// W3 §6.5: the whole of `WorkRegistry::pending_prune`. Always `None` in
+    /// a *written* cache — an intent below the horizon can never be left
+    /// uncompleted — carried honestly rather than assumed.
+    #[serde(default)]
+    ///
+    /// Boxed: `PruneIntentRecord` carries two full `PruneResidue`s (each with
+    /// its own `Vec`s), which otherwise inlines into `FloorState` and, by
+    /// extension, `Plan::Windowed` — large enough to trip
+    /// `clippy::large_enum_variant` against `Plan::Full`'s few scalars. This
+    /// is always `None` in a written cache (§6.5); boxing costs nothing on
+    /// that path and only ever matters for the one CacheMiss-adjacent
+    /// diagnostic case that reads it back.
+    pub pending_prune: Option<Box<crate::runtime::prune::PruneIntentRecord>>,
+    /// W3 §5.2: the whole of `WorkRegistry::quarantined_blobs` — the next
+    /// prune cycle's deletion list; losing it would leak quarantined blobs
+    /// forever.
+    #[serde(default)]
+    pub quarantined_blobs: Vec<String>,
 }
 
 /// Why a start did not use the cache — logged, and reported on
@@ -813,6 +865,19 @@ impl Plan {
                         },
                     );
                 }
+                // W3: the cache's residue seeds the registry exactly like
+                // `work_index` does — a windowed start's own replay only
+                // covers events above the horizon, so a prune's residue
+                // recorded below it would otherwise be lost on a cache hit.
+                for row in &cache.pruned_works {
+                    seed.pruned_works.insert(row.id.clone(), row.clone());
+                }
+                for row in &cache.pruned_commands {
+                    seed.pruned_commands
+                        .insert(row.command_id.clone(), row.clone());
+                }
+                seed.pending_prune = cache.pending_prune.as_deref().cloned();
+                seed.quarantined_blobs = cache.quarantined_blobs.clone();
                 Projection::resumed(
                     seed,
                     cache.binding.summarized_through_seq,
@@ -893,6 +958,13 @@ impl Plan {
     /// sound (§2.6): a cache-hit start's window has moved forward since the
     /// cache was written, and everything the new cache needs is already in
     /// hand.
+    ///
+    /// `first_seq` is W3's addition: the process-lifetime index
+    /// (`Core::first_seq_by_work`, merged from the cache seed and every
+    /// `HorizonSink` this process has folded) each [`FloorWorkRow`] needs to
+    /// carry its own `first_seq` — kept a *separate* parameter from
+    /// `horizon_sink` rather than replacing it, so this cache's own horizon
+    /// computation (`horizon()`, above) is untouched.
     pub fn next_cache(
         &self,
         journal: &Journal,
@@ -900,10 +972,11 @@ impl Plan {
         ledger: &LedgerSink,
         capability: &CapabilitySink,
         horizon_sink: &HorizonSink,
+        first_seq: &BTreeMap<String, u64>,
     ) -> Result<Option<FloorState>, StartupError> {
         let bounds = journal.segment_bounds()?;
         let h = horizon(&bounds, self.window_seq(), registry, horizon_sink);
-        build_floor_state(&bounds, h, registry, ledger, capability)
+        build_floor_state(&bounds, h, registry, ledger, capability, first_seq)
     }
 }
 
@@ -943,6 +1016,7 @@ fn build_floor_state(
     registry: &WorkRegistry,
     ledger: &LedgerSink,
     capability: &CapabilitySink,
+    first_seq: &BTreeMap<String, u64>,
 ) -> Result<Option<FloorState>, StartupError> {
     if horizon == 0 {
         return Ok(None);
@@ -976,7 +1050,7 @@ fn build_floor_state(
             created_at: row.created_at.clone(),
             updated_at: row.updated_at.clone(),
             last_seq: row.last_seq,
-            pruned_at: None,
+            first_seq: first_seq.get(&row.id).copied().unwrap_or(0),
         })
         .collect();
     works.sort_unstable_by(|a, b| a.id.cmp(&b.id));
@@ -1018,6 +1092,13 @@ fn build_floor_state(
         works,
         commands,
         capability_provenance,
+        // W3 §9.2: unconditional copies of the registry's own residue — see
+        // this struct's own field docs for why these are never filtered by
+        // `horizon` the way `works`/`commands` are.
+        pruned_works: registry.pruned_works.values().cloned().collect(),
+        pruned_commands: registry.pruned_commands.values().cloned().collect(),
+        pending_prune: registry.pending_prune.clone().map(Box::new),
+        quarantined_blobs: registry.quarantined_blobs.clone(),
     }))
 }
 
@@ -1266,6 +1347,10 @@ mod tests {
             works: Vec::new(),
             commands: Vec::new(),
             capability_provenance: None,
+            pruned_works: Vec::new(),
+            pruned_commands: Vec::new(),
+            pending_prune: None,
+            quarantined_blobs: Vec::new(),
         };
         (journal, cache)
     }
@@ -1570,9 +1655,16 @@ mod tests {
 
         let registry = WorkRegistry::default();
         let ledger = LedgerSink::default();
-        let state = build_floor_state(&bounds, horizon, &registry, &ledger, &capability)
-            .expect("build_floor_state")
-            .expect("H > 0 must produce a cache");
+        let state = build_floor_state(
+            &bounds,
+            horizon,
+            &registry,
+            &ledger,
+            &capability,
+            &BTreeMap::new(),
+        )
+        .expect("build_floor_state")
+        .expect("H > 0 must produce a cache");
 
         assert_eq!(
             state.capability_provenance,
@@ -1606,9 +1698,16 @@ mod tests {
 
         let registry = WorkRegistry::default();
         let ledger = LedgerSink::default();
-        let state = build_floor_state(&bounds, horizon, &registry, &ledger, &capability)
-            .expect("build_floor_state")
-            .expect("H > 0 must produce a cache");
+        let state = build_floor_state(
+            &bounds,
+            horizon,
+            &registry,
+            &ledger,
+            &capability,
+            &BTreeMap::new(),
+        )
+        .expect("build_floor_state")
+        .expect("H > 0 must produce a cache");
 
         assert_eq!(
             state.capability_provenance,

--- a/src/runtime/startup.rs
+++ b/src/runtime/startup.rs
@@ -43,7 +43,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::backend::claude::{AskWithdrawal, note_ask_withdrawal};
+use crate::backend::claude::{AskWithdrawal, note_ask_withdrawal, note_carried_ask_withdrawal};
 use crate::domain::event::Event;
 use crate::domain::work::{
     KIND_COMMAND_ACCEPTED, KIND_COMMAND_REJECTED, KIND_WORK_SUBMITTED, WorkState,
@@ -253,6 +253,13 @@ impl CapabilitySink {
 impl ReplaySink for CapabilitySink {
     fn push(&mut self, event: &Event) -> Result<(), StartupError> {
         note_ask_withdrawal(&mut self.latest, event);
+        // W3 §8.3: the same watermark can also survive as residue carried
+        // on a `prune.intent`, once the event `note_ask_withdrawal` itself
+        // would have matched has been pruned away. Both folds apply the
+        // same higher-seq-wins rule to the same `latest`, so whichever
+        // source is still in the replay window (or both, agreeing) wins
+        // correctly.
+        note_carried_ask_withdrawal(&mut self.latest, event);
         Ok(())
     }
 }

--- a/src/runtime/sweep.rs
+++ b/src/runtime/sweep.rs
@@ -543,6 +543,7 @@ mod tests {
             groups: BTreeMap::new(),
             repository_origin: BTreeMap::new(),
             repository_upstream: BTreeMap::new(),
+            retention: None,
         }
     }
 

--- a/tests/a1_floor_awareness.rs
+++ b/tests/a1_floor_awareness.rs
@@ -1,0 +1,279 @@
+//! W3 §11.3: the standing enforcement for A1 (a pruned journal must never
+//! be misreported as corruption).
+//!
+//! `Journal::replay()`/`Journal::replay_after(seq)` are the *strict*
+//! primitives: they expect the replay to start at seq 1 (or exactly
+//! `seq + 1`), and report anything else — including the ordinary, healthy
+//! shape a real prune leaves behind (a floor above 1) — as
+//! `JournalError::SeqDiscontinuity`. `Journal::replay_from_floor()` /
+//! `Journal::replay_data_dir_from_floor()` are the floor-aware siblings
+//! W3 added specifically so a pruned journal replays as the ordinary,
+//! healthy outcome it is (I-W3-10).
+//!
+//! A manual audit today finds exactly two production call sites of the
+//! strict primitives, both legitimately bounded rather than naively
+//! strict from seq 1:
+//! - `runtime::startup::Plan::replay` — the shared pass's own dispatcher,
+//!   which calls `replay_after` only on the cache-hit (`Windowed`) arm and
+//!   `replay_from_floor` on the cache-miss (`Full`) arm, so the strict
+//!   primitive there is never reached with a floor above 1 underneath it;
+//! - `api::Core::events_after` — always bounded to a seq the caller
+//!   already knows is at or above the floor (the prune engine's own
+//!   guard-held top-up, `/v1/events`, the SSE resume).
+//!
+//! That audit holds only until the next PR. This is the standing scan that
+//! holds it after that: any *other* production call site of the strict
+//! primitives — a new handler added later, a helper that reaches for the
+//! familiar `.replay()` instead of the floor-aware sibling — fails here
+//! with the call site printed, rather than silently reintroducing "pruned
+//! journal reported as corruption" the next time this build actually
+//! prunes something. Modeled on the same structural-scan idiom
+//! `tests/m9_watch.rs` and `tests/a4_blob_ref_pinning.rs` already use.
+
+use std::path::{Path, PathBuf};
+
+/// The only sanctioned production call sites of the strict replay
+/// primitives, named by the function that legitimately calls them —
+/// `(file relative to src/, enclosing fn signature fragment)`.
+const SANCTIONED_STRICT_REPLAY_SITES: &[(&str, &str)] = &[
+    (
+        "runtime/startup.rs",
+        "pub fn replay(&self, journal: &Journal)",
+    ),
+    ("api.rs", "pub fn events_after(&self, after: u64)"),
+];
+
+fn all_src_files() -> Vec<PathBuf> {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut found = Vec::new();
+    let mut stack = vec![src];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read src") {
+            let path = entry.expect("entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_some_and(|e| e == "rs") {
+                found.push(path);
+            }
+        }
+    }
+    found
+}
+
+/// The end of the `{ … }` block that starts at or after `from`.
+fn block_end(source: &str, from: usize) -> usize {
+    let open = source[from..].find('{').expect("a block") + from;
+    let mut depth = 0usize;
+    for (offset, c) in source[open..].char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return open + offset;
+                }
+            }
+            _ => {}
+        }
+    }
+    source.len()
+}
+
+/// Every byte range covered by a `#[cfg(test)]`-attributed item (a
+/// function or a module) — computed per-occurrence, not "everything after
+/// the first marker", since a file can freely mix a small `#[cfg(test)]`
+/// helper with real production code that follows it before the real test
+/// module begins (this codebase's `src/api.rs` does exactly that).
+fn test_only_ranges(source: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    for (attr_start, _) in source.match_indices("#[cfg(test)]") {
+        // The block belonging to the very next `fn` or `mod` item after the
+        // attribute (skipping any other attributes / doc comments / blank
+        // lines in between).
+        let after = &source[attr_start..];
+        let Some(rel_open) = after.find('{') else {
+            continue;
+        };
+        let block_start = attr_start + rel_open;
+        ranges.push((attr_start, block_end(source, block_start)));
+    }
+    ranges
+}
+
+fn in_any_range(index: usize, ranges: &[(usize, usize)]) -> bool {
+    ranges
+        .iter()
+        .any(|(start, end)| index >= *start && index < *end)
+}
+
+/// A `#[cfg(test)]` item can itself be *inside* another `#[cfg(test)]`
+/// item's range (a `mod tests { ... #[test] fn foo() ... }`) — dedupe by
+/// merging any range fully nested inside another before use, purely so the
+/// reported "sanctioned site" search below does not get confused; it does
+/// not change which bytes count as test-only either way.
+fn merged(mut ranges: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    ranges.sort_unstable();
+    let mut out: Vec<(usize, usize)> = Vec::new();
+    for (start, end) in ranges {
+        if let Some(last) = out.last_mut()
+            && start <= last.1
+        {
+            last.1 = last.1.max(end);
+            continue;
+        }
+        out.push((start, end));
+    }
+    out
+}
+
+#[test]
+fn a_new_strict_replay_site_outside_the_sanctioned_list_fails_this_scan() {
+    let src_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let journal_rs = src_root.join("runtime").join("journal.rs");
+
+    // Resolve each sanctioned site to a concrete byte range, once, so the
+    // scan below can ask "is this occurrence inside a sanctioned site" in
+    // addition to "is this occurrence in test-only code".
+    let sanctioned_ranges: Vec<(PathBuf, usize, usize)> = SANCTIONED_STRICT_REPLAY_SITES
+        .iter()
+        .map(|(rel, signature)| {
+            let path = src_root.join(rel);
+            let source =
+                std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+            let start = source.find(signature).unwrap_or_else(|| {
+                panic!(
+                    "sanctioned site signature {signature:?} not found in {path:?} — it moved \
+                     or was renamed; update SANCTIONED_STRICT_REPLAY_SITES to match, after \
+                     confirming the call there is still legitimately bounded"
+                )
+            });
+            (path, start, block_end(&source, start))
+        })
+        .collect();
+
+    let mut checked_a_file = false;
+    for path in all_src_files() {
+        if path == journal_rs {
+            // The primitives' own definition site — exempt by construction,
+            // the same way A4's blob-ref scan exempts `blob.rs` itself.
+            continue;
+        }
+        checked_a_file = true;
+        let source =
+            std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+        let excluded = merged(test_only_ranges(&source));
+
+        for pattern in ["journal.replay(", "journal.replay_after("] {
+            for (index, _) in source.match_indices(pattern) {
+                if in_any_range(index, &excluded) {
+                    continue; // test-only code — not production
+                }
+                let sanctioned = sanctioned_ranges
+                    .iter()
+                    .any(|(sanctioned_path, start, end)| {
+                        sanctioned_path == &path && index >= *start && index < *end
+                    });
+                assert!(
+                    sanctioned,
+                    "{}:{} calls the strict replay primitive `{}` outside every sanctioned \
+                     site — a pruned journal (a floor above 1) will be misreported as \
+                     `SeqDiscontinuity` here instead of the healthy outcome it is (I-W3-10). \
+                     Either route this through `replay_from_floor`/`replay_data_dir_from_floor`, \
+                     or — if this call site is genuinely bounded to a seq already known to be \
+                     at or above the floor — add it to SANCTIONED_STRICT_REPLAY_SITES with the \
+                     reasoning for why. Context: {:?}",
+                    path.display(),
+                    index,
+                    pattern.trim_end_matches('('),
+                    &source[index.saturating_sub(160)..(index + 40).min(source.len())]
+                );
+            }
+        }
+    }
+    assert!(checked_a_file, "the src/ walk must actually visit files");
+}
+
+/// The scan above is only meaningful if it actually walks the files where
+/// the sanctioned sites live — this pins that down directly, independent
+/// of the main scan's own bookkeeping.
+#[test]
+fn the_scan_actually_covers_both_sanctioned_files() {
+    let files = all_src_files();
+    let src_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    for (rel, _) in SANCTIONED_STRICT_REPLAY_SITES {
+        let expected: PathBuf = src_root.join(rel);
+        assert!(
+            files.contains(&expected),
+            "expected {expected:?} to be found by all_src_files()"
+        );
+    }
+}
+
+/// Guards the guard: `test_only_ranges` must not accidentally swallow real
+/// production code that follows a small `#[cfg(test)]`-attributed helper —
+/// exactly the shape `src/api.rs` has (`decode_partial_assistant_text`
+/// above its real `mod tests`). A naive "everything after the first
+/// `#[cfg(test)]` marker" scan would wrongly treat the whole rest of the
+/// file as test-only and silently stop checking it.
+#[test]
+fn test_only_ranges_does_not_swallow_production_code_between_two_cfg_test_items() {
+    let source = r#"
+#[cfg(test)]
+fn helper() {
+    1
+}
+
+pub fn production_call_site() {
+    thing.replay_after(1);
+}
+
+#[cfg(test)]
+mod tests {
+    fn another() {
+        thing.replay();
+    }
+}
+"#;
+    let ranges = merged(test_only_ranges(source));
+    let production_index = source.find("production_call_site").expect("marker");
+    assert!(
+        !in_any_range(production_index, &ranges),
+        "production code between two #[cfg(test)] items must not be treated as test-only"
+    );
+    let first_helper_index = source.find("fn helper").expect("marker");
+    assert!(
+        in_any_range(first_helper_index, &ranges),
+        "the first #[cfg(test)] fn's own body must be treated as test-only"
+    );
+    let mod_tests_index = source.rfind("fn another").expect("marker");
+    assert!(
+        in_any_range(mod_tests_index, &ranges),
+        "the real test module's body must be treated as test-only"
+    );
+}
+
+/// Sanity check on the block-matching helper itself, since both scans
+/// above depend on it agreeing with the real language's brace nesting
+/// (strings/comments aside — this codebase's other structural scans share
+/// the same, documented limitation).
+#[test]
+fn block_end_finds_the_matching_close_brace() {
+    let source = "fn f() { if true { 1 } else { 2 } }\nfn g() {}";
+    let start = source.find("fn f").unwrap();
+    let end = block_end(source, start);
+    assert_eq!(&source[start..=end], "fn f() { if true { 1 } else { 2 } }");
+}
+
+/// Not a scan — a reachability sanity check, so this file cannot silently
+/// stop meaning anything if someone renames or removes the module it is
+/// about.
+#[test]
+fn journal_rs_still_exists_at_the_expected_path() {
+    let path: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("runtime")
+        .join("journal.rs");
+    assert!(path.exists(), "expected {path:?} to exist");
+}

--- a/tests/i9_floor_pinning.rs
+++ b/tests/i9_floor_pinning.rs
@@ -119,9 +119,20 @@ fn assert_registry_pinned(
         terminal_work_order: _,
         work_index,
         admission_paused: _, // ALLOWLIST: force-cleared unconditionally at every
-                             // startup (daemon.rs) before anything is served —
-                             // its replayed value is never load-bearing. See
-                             // `the_admission_pause_force_clear_mechanism_is_pinned`.
+        // startup (daemon.rs) before anything is served —
+        // its replayed value is never load-bearing. See
+        // `the_admission_pause_force_clear_mechanism_is_pinned`.
+        pruned_works, // ASSERTED (W3, I-W3-7): the residue must reach a
+        // cacheless floor replay and a cache+window start
+        // identically.
+        pruned_commands, // ASSERTED (W3, I-W3-8): same reasoning.
+        pending_prune,   // ASSERTED (W3, §6.5): always `None` in a *written*
+        // cache — an intent below `H` can never be left
+        // uncompleted — and the assertion is what keeps that
+        // true rather than assumed.
+        quarantined_blobs, // ASSERTED (W3, §5.2): the next cycle's deletion
+                           // list; a cache that lost it would leak
+                           // quarantined blobs forever.
     } = full;
 
     // ASSERTED — the load-bearing equalities.
@@ -132,6 +143,39 @@ fn assert_registry_pinned(
     );
     assert_eq!(works, &windowed.works, "works must be byte-identical");
     assert_eq!(runs, &windowed.runs, "runs must be byte-identical");
+    assert_eq!(
+        pruned_works, &windowed.pruned_works,
+        "pruned_works must be byte-identical between a full replay and cache+window (I-W3-7)"
+    );
+    assert_eq!(
+        pruned_commands, &windowed.pruned_commands,
+        "pruned_commands must be byte-identical between a full replay and cache+window (I-W3-8)"
+    );
+    assert_eq!(
+        pending_prune, &windowed.pending_prune,
+        "pending_prune must agree between a full replay and cache+window"
+    );
+    assert_eq!(
+        quarantined_blobs, &windowed.quarantined_blobs,
+        "quarantined_blobs must be byte-identical between a full replay and cache+window"
+    );
+    // W3's strengthening of the work_index assertion: a Work is in exactly
+    // one of `work_index`/`pruned_works`, on both sides.
+    assert!(
+        work_index
+            .keys()
+            .collect::<BTreeSet<_>>()
+            .is_disjoint(&pruned_works.keys().collect::<BTreeSet<_>>()),
+        "a Work must never appear in both work_index and pruned_works (full)"
+    );
+    assert!(
+        windowed
+            .work_index
+            .keys()
+            .collect::<BTreeSet<_>>()
+            .is_disjoint(&windowed.pruned_works.keys().collect::<BTreeSet<_>>()),
+        "a Work must never appear in both work_index and pruned_works (windowed)"
+    );
 
     // ALLOWLIST: commands — Q8, the cache carries keys not `CommandOutcome`
     // bodies. (a) everything the window kept is unchanged; (b) everything it
@@ -248,6 +292,24 @@ fn assert_registry_pinned(
         "terminal_run_order's members must be exactly terminal_runs' keys"
     );
 
+    // W3's strengthening: a pruned id has a row in *neither* cache — the
+    // fold that inserts it into `pruned_works`/`pruned_commands` removes it
+    // from `terminal_works`/`terminal_runs` in the same step (§6.2 step 2),
+    // so the subset assertions above hold without exception rather than
+    // needing one for a pruned id.
+    for id in pruned_works.keys() {
+        assert!(
+            !terminal_works.contains_key(id) && !terminal_runs.contains_key(id),
+            "a pruned Work id must not linger in either terminal cache (full, id {id})"
+        );
+    }
+    for id in windowed.pruned_works.keys() {
+        assert!(
+            !windowed.terminal_works.contains_key(id) && !windowed.terminal_runs.contains_key(id),
+            "a pruned Work id must not linger in either terminal cache (windowed, id {id})"
+        );
+    }
+
     // Capability watermark (recon correction 3's live gap) — the cache seed
     // folded forward by the window must agree with the full pass.
     assert_eq!(
@@ -336,7 +398,14 @@ fn build_cache(
         miss: CacheMiss::Absent,
     };
     let cache = plan
-        .next_cache(journal, full, ledger, capability, horizon_sink)
+        .next_cache(
+            journal,
+            full,
+            ledger,
+            capability,
+            horizon_sink,
+            horizon_sink.first_seq_by_work(),
+        )
         .expect("next_cache")
         .unwrap_or_else(|| {
             panic!(

--- a/tests/i9_floor_pinning.rs
+++ b/tests/i9_floor_pinning.rs
@@ -44,7 +44,9 @@ use sergeant_rs::domain::workflow::{
 };
 use sergeant_rs::runtime::analytics::Analytics;
 use sergeant_rs::runtime::journal::Journal;
-use sergeant_rs::runtime::projection::{WorkRegistry, work_registry_projection};
+use sergeant_rs::runtime::projection::{
+    Projection, WorkRegistry, work_registry_projection, work_registry_reducer,
+};
 use sergeant_rs::runtime::startup::{
     self, AnalyticsSink, CacheMiss, CapabilitySink, FloorCommandRow, FloorState, HorizonSink,
     LedgerSink, Plan, RegistrySink,
@@ -347,7 +349,17 @@ fn run_full_pass(
     journal: &Journal,
     analytics_scratch: &Path,
 ) -> (WorkRegistry, u64, CapabilitySink, LedgerSink, HorizonSink) {
-    let mut registry = work_registry_projection();
+    // A1: `replay_from_floor()` below already starts yielding at the floor,
+    // not at 1 — the `Projection` wrapper must agree, or a genuinely pruned
+    // journal (floor > 1) reports a spurious `SeqMismatch` here instead of
+    // folding cleanly. Every fixture in this file before the real-prune case
+    // (§13.3) has floor == 1, where this is exactly `work_registry_projection()`.
+    let floor_seq = journal.floor_seq().expect("floor_seq").unwrap_or(1);
+    let mut registry = Projection::resumed(
+        WorkRegistry::default(),
+        floor_seq.saturating_sub(1),
+        work_registry_reducer,
+    );
     let mut analytics = Analytics::begin_rebuild(analytics_scratch).expect("analytics scratch");
     let mut capability = CapabilitySink::default();
     let mut ledger = LedgerSink::default();
@@ -604,6 +616,245 @@ async fn the_real_daemon_journal_pins() {
 
     let scratch = TempDir::new().expect("scratch");
     run_i9(&journal, scratch.path());
+}
+
+// ------------------------------------------------------------------
+// Case 3 (§13.3): a journal really pruned by `prune::run` — the wave's
+// acceptance gate, exactly as it was W2's — plus §8's negative proof.
+// ------------------------------------------------------------------
+
+/// A journal that has really been pruned by `prune::run` (not by
+/// hand-deleting segments) — §13.3's own words. Built directly over a
+/// `Core` (no daemon/HTTP needed to prove this): `w1` records an
+/// ask-grammar withdrawal and an accepted command before completing, so
+/// `pruned_works`, `pruned_commands` and `capability_provenance` are all
+/// non-empty in the residue this cycle carries. Everything else is a plain
+/// non-work-scoped, allowlisted event (`admission.paused`/`admission.
+/// resumed` — the same shape `build_kind_exhaustive_journal`'s own padding
+/// uses) rather than another Work: with no Work left in `work_index` at
+/// all once `w1` is pruned, W2's own startup-cache horizon
+/// (`startup::horizon`, gated on every retained Work being *settled* —
+/// a different predicate from the prune engine's `retired_whole`) has
+/// nothing left to block it, so it can advance across all of the padding.
+fn build_a_really_pruned_journal(dir: &Path) -> Journal {
+    use sergeant_rs::runtime::prune::{self, PolicySource, PrunePolicy};
+
+    let journal = Journal::open_with(dir, 1).expect("open");
+    let registry = work_registry_projection();
+    let (events_tx, _rx) = tokio::sync::broadcast::channel::<Event>(16);
+    let mut core = Core::new(journal, registry, events_tx);
+
+    core.commit(draft(
+        KIND_WORK_SUBMITTED,
+        Some("w1"),
+        submit_payload("w1", "pending"),
+    ))
+    .expect("commit w1 submitted");
+    core.commit(draft(
+        KIND_COMMAND_ACCEPTED,
+        Some("w1"),
+        json!({"command_id": "cmd-1", "operation": "work.submit", "status": 201u16,
+               "result": {"id": "w1"}}),
+    ))
+    .expect("commit cmd-1 accepted");
+    core.commit(draft(
+        "conversation.turn.grammar_unmeasured",
+        Some("w1"),
+        json!({"capability": "ask", "version": "2.1.226"}),
+    ))
+    .expect("commit the ask withdrawal");
+    core.commit(draft(KIND_WORK_COMPLETED, Some("w1"), json!({})))
+        .expect("commit w1 completed");
+    // I-W3-4: one non-work-scoped event pushes the writer off w1's own
+    // segments — no second Work needed for that.
+    core.commit(draft("admission.paused", None, json!({})))
+        .expect("commit admission.paused");
+    core.flush().expect("flush");
+
+    let bounds = core.journal.segment_bounds().expect("bounds");
+    let policy = PrunePolicy {
+        retention: 0,
+        source: PolicySource::Config,
+    };
+    let (candidate, _) = prune::candidate_horizon(
+        &bounds,
+        core.registry.state(),
+        &core.first_seq_by_work,
+        &policy,
+    );
+    let plan = prune::plan(
+        dir,
+        &bounds,
+        candidate,
+        core.registry.state(),
+        &core.first_seq_by_work,
+        &policy,
+    )
+    .expect("plan")
+    .expect("w1 must be prunable");
+    prune::run(&mut core, dir, plan, false).expect("run");
+
+    // Everything from here on is *after* the cycle already committed and
+    // unlinked — it cannot change what got pruned, only give
+    // `startup::window_seq`/`startup::horizon` enough surviving segments to
+    // advance past zero (with `work_index` now empty, nothing blocks it —
+    // only the segment/window bookkeeping does).
+    for i in 0..(startup::STARTUP_WINDOW_SEGMENTS + 4) {
+        core.commit(draft(
+            if i % 2 == 0 {
+                "admission.paused"
+            } else {
+                "admission.resumed"
+            },
+            None,
+            json!({}),
+        ))
+        .expect("commit padding");
+    }
+    core.flush().expect("flush");
+
+    core.journal
+}
+
+/// §8's Validation Evidence item 3 in full: "The I9 gate, extended to a
+/// real prune... a full floor replay of a pruned journal must equal
+/// cache+window, field by field." Every earlier case in this file builds
+/// its journal by hand-appended events or the daemon's ordinary event
+/// stream; this is the one that actually runs `prune::run` before
+/// comparing.
+#[test]
+fn i9_pinning_holds_across_a_real_prune() {
+    let dir = TempDir::new().expect("tempdir");
+    let journal = build_a_really_pruned_journal(dir.path());
+    let floor = journal.floor_seq().expect("floor_seq");
+    assert!(
+        floor.unwrap_or(1) > 1,
+        "the fixture must actually have been pruned (floor still 1) for this to prove anything"
+    );
+
+    let scratch = TempDir::new().expect("scratch");
+    let cache = run_i9(&journal, scratch.path());
+    assert!(
+        !cache.pruned_works.is_empty(),
+        "the fixture must actually carry pruned-work residue for the negative proofs beside \
+         this test to mean anything"
+    );
+    assert!(
+        !cache.pruned_commands.is_empty(),
+        "the fixture must actually carry pruned-command residue"
+    );
+    assert!(
+        cache.capability_provenance.is_some(),
+        "the fixture must actually carry a capability watermark in the real residue"
+    );
+}
+
+/// §8's negative proof, first mutation: dropping a `PrunedWorkRow` from the
+/// prune residue must fail the gate — a cache that silently lost one would
+/// let a cacheless floor replay and a cache+window start disagree about
+/// whether a Work was ever pruned at all.
+#[test]
+fn the_gate_fails_when_the_prune_residue_drops_a_pruned_work_row() {
+    let dir = TempDir::new().expect("tempdir");
+    let journal = build_a_really_pruned_journal(dir.path());
+    let scratch = TempDir::new().expect("scratch");
+    let (full, full_last_seq, capability, ledger, horizon_sink) =
+        run_full_pass(&journal, scratch.path());
+    let (mut cache, window_seq) = build_cache(&journal, &full, &ledger, &capability, &horizon_sink);
+    assert!(
+        !cache.pruned_works.is_empty(),
+        "the fixture must actually carry pruned-work residue for this proof to mean anything"
+    );
+    cache.pruned_works.pop(); // the mutation this test exists to catch
+
+    let (windowed, windowed_last_seq, windowed_capability) =
+        run_windowed_pass(&journal, &cache, window_seq);
+    let result = std::panic::catch_unwind(|| {
+        assert_registry_pinned(
+            &full,
+            &windowed,
+            &cache,
+            capability.latest.as_ref(),
+            windowed_capability.as_ref(),
+            full_last_seq,
+            windowed_last_seq,
+        );
+    });
+    assert!(
+        result.is_err(),
+        "dropping a PrunedWorkRow from a real prune's residue must fail the pinning gate"
+    );
+}
+
+/// §8's negative proof, second mutation: dropping a `PrunedCommandRow`.
+#[test]
+fn the_gate_fails_when_the_prune_residue_drops_a_pruned_command_row() {
+    let dir = TempDir::new().expect("tempdir");
+    let journal = build_a_really_pruned_journal(dir.path());
+    let scratch = TempDir::new().expect("scratch");
+    let (full, full_last_seq, capability, ledger, horizon_sink) =
+        run_full_pass(&journal, scratch.path());
+    let (mut cache, window_seq) = build_cache(&journal, &full, &ledger, &capability, &horizon_sink);
+    assert!(
+        !cache.pruned_commands.is_empty(),
+        "the fixture must actually carry pruned-command residue for this proof to mean anything"
+    );
+    cache.pruned_commands.pop(); // the mutation this test exists to catch
+
+    let (windowed, windowed_last_seq, windowed_capability) =
+        run_windowed_pass(&journal, &cache, window_seq);
+    let result = std::panic::catch_unwind(|| {
+        assert_registry_pinned(
+            &full,
+            &windowed,
+            &cache,
+            capability.latest.as_ref(),
+            windowed_capability.as_ref(),
+            full_last_seq,
+            windowed_last_seq,
+        );
+    });
+    assert!(
+        result.is_err(),
+        "dropping a PrunedCommandRow from a real prune's residue must fail the pinning gate"
+    );
+}
+
+/// §8's negative proof, third mutation — "the one that matters most,
+/// because §8.3 is the gap this spec found by reading rather than by
+/// testing": dropping the capability-provenance watermark carried on a
+/// *real* prune's residue (not a hand-built one) must fail the gate.
+#[test]
+fn the_gate_fails_when_the_prune_residue_drops_the_capability_watermark() {
+    let dir = TempDir::new().expect("tempdir");
+    let journal = build_a_really_pruned_journal(dir.path());
+    let scratch = TempDir::new().expect("scratch");
+    let (full, full_last_seq, capability, ledger, horizon_sink) =
+        run_full_pass(&journal, scratch.path());
+    let (mut cache, window_seq) = build_cache(&journal, &full, &ledger, &capability, &horizon_sink);
+    assert!(
+        cache.capability_provenance.is_some(),
+        "the fixture must actually carry a capability watermark for this proof to mean anything"
+    );
+    cache.capability_provenance = None; // the mutation this test exists to catch
+
+    let (windowed, windowed_last_seq, windowed_capability) =
+        run_windowed_pass(&journal, &cache, window_seq);
+    let result = std::panic::catch_unwind(|| {
+        assert_registry_pinned(
+            &full,
+            &windowed,
+            &cache,
+            capability.latest.as_ref(),
+            windowed_capability.as_ref(),
+            full_last_seq,
+            windowed_last_seq,
+        );
+    });
+    assert!(
+        result.is_err(),
+        "dropping the capability watermark from a real prune's residue must fail the gate"
+    );
 }
 
 /// §26's live end: a below-window `command_id` retried against a *running*

--- a/tests/m1_event_core.rs
+++ b/tests/m1_event_core.rs
@@ -783,23 +783,44 @@ fn replay_after_surfaces_malformed_first_line_of_second_segment() {
 /// io error must surface through `next()` — never a panic, never a silent
 /// empty result — and the iterator must latch failed so every subsequent
 /// call returns `None`, never retrying or yielding a phantom item.
+///
+/// **W3 update (recon correction 7, N18):** this held for *any* vanished
+/// segment before W3; it now holds only once the iterator has yielded at
+/// least one event (`I-W3-4`: a prune can only ever delete a leading,
+/// oldest-contiguous prefix, so a segment disappearing before anything has
+/// been yielded is a floor moving under a lock-free reader, not corruption —
+/// see `runtime::journal::tests::replay_data_dir_tolerates_a_segment_pruned_between_list_and_open`
+/// for that half). This fixture now deletes the *second* segment after the
+/// first event has already been yielded, which stays a hard failure on
+/// every build old or new — the leading-prefix case is covered separately.
 #[test]
 fn replay_next_surfaces_io_error_for_segment_deleted_after_listing() {
     let dir = TempDir::new().expect("tempdir");
-    let mut journal = Journal::open(dir.path()).expect("open");
-    journal.append(draft("tick", None)).expect("append 1");
+    let mut journal = Journal::open_with(dir.path(), 1).expect("open, one segment per append");
+    journal
+        .append(draft("tick", None))
+        .expect("append 1 (segment 1)");
+    journal
+        .append(draft("tick", None))
+        .expect("append 2 (segment 2)");
 
     let mut replay = journal.replay().expect("replay (lists segments)");
-    // Delete the segment after it was listed but before the iterator has
-    // opened it — `next()` has not been called yet.
-    fs::remove_file(segment_path(dir.path(), 1)).expect("delete segment after listing");
+    assert_eq!(
+        replay.next().expect("first event").expect("ok").seq,
+        1,
+        "must yield the first event before the race below"
+    );
+    // Delete the *next* segment after it was listed but before the iterator
+    // has opened it — this is not a shape a prune can produce (I-W3-4), so
+    // it must still fail closed.
+    fs::remove_file(segment_path(dir.path(), 2)).expect("delete segment after listing");
 
-    let first = replay
+    let second = replay
         .next()
         .expect("the io error must surface, not a silent end of iteration");
     assert!(
-        matches!(&first, Err(JournalError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound),
-        "got {first:?}"
+        matches!(&second, Err(JournalError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound),
+        "got {second:?}"
     );
 
     // The iterator is now failed and must stay that way.

--- a/tests/w3_allowlist_equivalence.rs
+++ b/tests/w3_allowlist_equivalence.rs
@@ -1,0 +1,419 @@
+//! W3 §7.2 / §13.1 step 6: one replay-equivalence proof per kind in
+//! [`sergeant_rs::runtime::prune::NON_WORK_ALLOWLIST`].
+//!
+//! `NON_WORK_ALLOWLIST` names nine event kinds a segment may carry with no
+//! `work_id` and still be prunable — an unpaired event of any *other* kind
+//! pins its segment (`an_unknown_non_work_scoped_kind_pins_its_segment`,
+//! N4, in `src/runtime/prune.rs`). Being on the list is a claim: that
+//! kind's effect on the registry a replay produces is either absent,
+//! force-reset at every startup, or carried forward by some other named
+//! mechanism — never silently lost. Each test below proves its one kind's
+//! claim directly: build a fixture twice, identical except that one copy
+//! also carries one event of the kind under test inside the very range a
+//! real prune condemns, run the real `prune::plan`/`prune::run` over both,
+//! and assert whatever the allowlist's own comment for that kind promises.
+
+use std::path::Path;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use sergeant_rs::api::Core;
+use sergeant_rs::daemon::{
+    KIND_ADMISSION_PAUSED, KIND_ADMISSION_RESUMED, KIND_BACKEND_PROBED, KIND_DAEMON_STARTED,
+    KIND_DAEMON_STOPPED,
+};
+use sergeant_rs::domain::event::{Event, EventDraft, EventSource};
+use sergeant_rs::domain::work::{
+    KIND_COMMAND_ACCEPTED, KIND_COMMAND_REJECTED, KIND_WORK_COMPLETED, KIND_WORK_SUBMITTED,
+};
+use sergeant_rs::runtime::journal::Journal;
+use sergeant_rs::runtime::projection::{WorkRegistry, work_registry_projection};
+use sergeant_rs::runtime::prune::{
+    self, KIND_PRUNE_COMPLETED, KIND_PRUNE_INTENT, PolicySource, PrunePolicy,
+};
+
+fn draft(kind: &str, work_id: Option<&str>, payload: serde_json::Value) -> EventDraft {
+    let source = if kind.starts_with("command.") {
+        EventSource::new("daemon", "api")
+    } else {
+        EventSource::new("daemon", "sergeant")
+    };
+    let mut draft = EventDraft::new(source, kind, payload);
+    if let Some(id) = work_id {
+        draft = draft.with_work_id(id);
+    }
+    draft
+}
+
+fn submit_payload(work_id: &str, state: &str) -> serde_json::Value {
+    json!({"work": {
+        "id": work_id,
+        "intent": "allowlist-equivalence fixture",
+        "state": state,
+        "created_by": "test",
+        "created_at": "2026-01-01T00:00:00.000Z",
+    }})
+}
+
+/// Build the fixture: `w_old` (prunable), one optional extra event of a
+/// given kind inserted right after `w_old`'s own completion (still inside
+/// its condemned span), and `w_keep` (active, pins the horizon just
+/// above). Runs a real `prune::plan`/`prune::run` cycle and returns the
+/// resulting registry plus whether the cycle actually advanced the floor
+/// (i.e. the extra event did not pin its segment).
+fn prune_with_optional_extra(dir: &Path, extra: Option<EventDraft>) -> (WorkRegistry, bool) {
+    let journal = Journal::open_with(dir, 1).expect("open");
+    let registry = work_registry_projection();
+    let (events_tx, _rx) = tokio::sync::broadcast::channel::<Event>(16);
+    let mut core = Core::new(journal, registry, events_tx);
+
+    core.commit(draft(
+        KIND_WORK_SUBMITTED,
+        Some("w_old"),
+        submit_payload("w_old", "pending"),
+    ))
+    .expect("commit w_old submitted");
+    core.commit(draft(KIND_WORK_COMPLETED, Some("w_old"), json!({})))
+        .expect("commit w_old completed");
+    if let Some(extra) = extra {
+        core.commit(extra).expect("commit the kind under test");
+    }
+    core.commit(draft(
+        KIND_WORK_SUBMITTED,
+        Some("w_keep"),
+        submit_payload("w_keep", "pending"),
+    ))
+    .expect("commit w_keep submitted");
+    core.flush().expect("flush");
+
+    let bounds = core.journal.segment_bounds().expect("bounds");
+    let policy = PrunePolicy {
+        retention: 0,
+        source: PolicySource::Config,
+    };
+    let (candidate, _) = prune::candidate_horizon(
+        &bounds,
+        core.registry.state(),
+        &core.first_seq_by_work,
+        &policy,
+    );
+    let Some(plan) = prune::plan(
+        dir,
+        &bounds,
+        candidate,
+        core.registry.state(),
+        &core.first_seq_by_work,
+        &policy,
+    )
+    .expect("plan") else {
+        return (core.registry.state().clone(), false);
+    };
+    prune::run(&mut core, dir, plan, false).expect("run");
+    (core.registry.state().clone(), true)
+}
+
+/// The comparison every per-kind test wants: the *shape* of the registry
+/// (which ids exist, in which map, in which state) must agree between the
+/// two fixtures. Never a byte-for-byte `WorkRegistry` equality — `w_keep`'s
+/// own `last_seq` legitimately differs by one between the two fixtures
+/// (the extra event under test occupies a seq of its own before it), and
+/// `pruned_at` is a wall-clock timestamp stamped at prune time, neither of
+/// which the allowlist's claim is about.
+fn assert_registries_equivalent(without: &WorkRegistry, with: &WorkRegistry, msg: &str) {
+    assert_eq!(
+        without
+            .work_index
+            .keys()
+            .collect::<std::collections::BTreeSet<_>>(),
+        with.work_index
+            .keys()
+            .collect::<std::collections::BTreeSet<_>>(),
+        "{msg} (work_index membership differs)"
+    );
+    for (id, row) in &without.work_index {
+        let other = &with.work_index[id];
+        assert_eq!(
+            row.state, other.state,
+            "{msg} (work_index[{id}].state differs)"
+        );
+        assert_eq!(
+            row.intent, other.intent,
+            "{msg} (work_index[{id}].intent differs)"
+        );
+    }
+    assert_eq!(
+        without
+            .pruned_works
+            .keys()
+            .collect::<std::collections::BTreeSet<_>>(),
+        with.pruned_works
+            .keys()
+            .collect::<std::collections::BTreeSet<_>>(),
+        "{msg} (pruned_works membership differs)"
+    );
+}
+
+/// Build both fixtures (with and without the kind under test) and assert
+/// the equivalence the caller's `check` closure claims. Both copies use
+/// the same `w_old`/`w_keep` shape, so any difference between `without`
+/// and `with` is attributable only to the extra event.
+fn assert_kind_is_replay_equivalent(
+    kind_label: &str,
+    build_extra: impl Fn() -> EventDraft,
+    check: impl Fn(&WorkRegistry, &WorkRegistry),
+) {
+    let dir_without = TempDir::new().expect("tempdir");
+    let (without, pruned_without) = prune_with_optional_extra(dir_without.path(), None);
+    assert!(
+        pruned_without,
+        "the baseline fixture (no {kind_label}) must itself be prunable, or this proves nothing"
+    );
+
+    let dir_with = TempDir::new().expect("tempdir");
+    let (with, pruned_with) = prune_with_optional_extra(dir_with.path(), Some(build_extra()));
+    assert!(
+        pruned_with,
+        "a bare {kind_label} event (no work_id) must not pin its segment — it is on \
+         NON_WORK_ALLOWLIST specifically so it does not"
+    );
+
+    assert!(
+        with.pruned_works.contains_key("w_old"),
+        "{kind_label} must not have prevented w_old from being pruned"
+    );
+    check(&without, &with);
+}
+
+#[test]
+fn kind_daemon_started_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_DAEMON_STARTED,
+        || draft(KIND_DAEMON_STARTED, None, json!({"pid": 1})),
+        |without, with| {
+            assert_registries_equivalent(
+                without,
+                with,
+                "daemon.started must have no registry effect at all",
+            );
+        },
+    );
+}
+
+#[test]
+fn kind_daemon_stopped_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_DAEMON_STOPPED,
+        || draft(KIND_DAEMON_STOPPED, None, json!({})),
+        |without, with| {
+            assert_registries_equivalent(
+                without,
+                with,
+                "daemon.stopped must have no registry effect at all",
+            );
+        },
+    );
+}
+
+#[test]
+fn kind_backend_probed_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_BACKEND_PROBED,
+        || {
+            draft(
+                KIND_BACKEND_PROBED,
+                None,
+                json!({"backend": "fake", "available": true}),
+            )
+        },
+        |without, with| {
+            assert_registries_equivalent(
+                without,
+                with,
+                "backend.probed must have no registry effect at all",
+            );
+        },
+    );
+}
+
+/// §11's own mechanism: `admission_paused` is force-cleared unconditionally
+/// at every startup (`daemon.rs`, before the descriptor is published and
+/// before any request is served), so its replayed value is never
+/// load-bearing — see `the_admission_pause_force_clear_mechanism_is_pinned`
+/// in `tests/i9_floor_pinning.rs` for the live proof of *that* mechanism.
+/// This test only proves the allowlist half: an `admission.paused` event
+/// does not pin its own segment, and everything else about the registry is
+/// unaffected by its presence or absence.
+#[test]
+fn kind_admission_paused_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_ADMISSION_PAUSED,
+        || draft(KIND_ADMISSION_PAUSED, None, json!({})),
+        |without, with| {
+            assert_registries_equivalent(
+                without,
+                with,
+                "admission.paused must have no lasting registry effect",
+            );
+        },
+    );
+}
+
+#[test]
+fn kind_admission_resumed_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_ADMISSION_RESUMED,
+        || draft(KIND_ADMISSION_RESUMED, None, json!({})),
+        |without, with| {
+            assert_registries_equivalent(
+                without,
+                with,
+                "admission.resumed must have no lasting registry effect",
+            );
+        },
+    );
+}
+
+/// Q8: the command ledger key survives in `pruned_commands` even though
+/// the event that recorded it is gone — the allowlist entry's whole claim.
+#[test]
+fn kind_command_accepted_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_COMMAND_ACCEPTED,
+        || {
+            draft(
+                KIND_COMMAND_ACCEPTED,
+                None,
+                json!({"command_id": "cmd-admin", "operation": "admission.pause",
+                       "status": 200u16, "result": {}}),
+            )
+        },
+        |without, with| {
+            assert!(
+                !without.pruned_commands.contains_key("cmd-admin"),
+                "the baseline fixture must not carry the command under test"
+            );
+            assert!(
+                with.pruned_commands.contains_key("cmd-admin"),
+                "command.accepted's ledger key must survive in pruned_commands (Q8) once its \
+                 own event is gone"
+            );
+            // Nothing else about the registry differs.
+            assert_registries_equivalent(
+                without,
+                with,
+                "command.accepted's presence must not otherwise change the registry",
+            );
+        },
+    );
+}
+
+#[test]
+fn kind_command_rejected_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_COMMAND_REJECTED,
+        || {
+            draft(
+                KIND_COMMAND_REJECTED,
+                None,
+                json!({"command_id": "cmd-admin-2", "operation": "admission.pause",
+                       "status": 409u16, "result": {"error": {"code": "already_paused"}}}),
+            )
+        },
+        |without, with| {
+            assert!(
+                !without.pruned_commands.contains_key("cmd-admin-2"),
+                "the baseline fixture must not carry the command under test"
+            );
+            assert!(
+                with.pruned_commands.contains_key("cmd-admin-2"),
+                "command.rejected's ledger key must survive in pruned_commands (Q8) once its \
+                 own event is gone"
+            );
+            assert_registries_equivalent(
+                without,
+                with,
+                "command.rejected's presence must not otherwise change the registry",
+            );
+        },
+    );
+}
+
+/// `prune.intent`/`prune.completed` are on the allowlist for a different
+/// reason from the other seven: an *unpaired* one still pins its segment
+/// (§6.5, N19 — `a_prune_pair_straddling_the_horizon_pins_its_segment` in
+/// `src/runtime/prune.rs`); only a **fully paired**, already-folded-and-
+/// carried-forward pair is safe to lose, because §6.4's carry-forward
+/// mechanism (proved end-to-end by
+/// `a_carried_forward_residue_survives_three_generations_of_prune`) is what
+/// keeps its residue alive after both halves are gone. What this test adds
+/// beyond that one: proving a *bare*, malformed-payload `prune.intent`/
+/// `prune.completed` pair (not a real cycle's own output) still does not
+/// pin — §6.2's "a declaration that cannot be understood is not a
+/// declaration this process can act on" applies to the allowlist check
+/// itself, which runs before any attempt to parse the payload.
+#[test]
+fn kind_prune_intent_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_PRUNE_INTENT,
+        || draft(KIND_PRUNE_INTENT, None, json!({})),
+        |without, with| {
+            assert_registries_equivalent(
+                without,
+                with,
+                "a bare prune.intent must have no other registry effect",
+            );
+        },
+    );
+}
+
+#[test]
+fn kind_prune_completed_is_replay_equivalent() {
+    assert_kind_is_replay_equivalent(
+        KIND_PRUNE_COMPLETED,
+        || draft(KIND_PRUNE_COMPLETED, None, json!({})),
+        |without, with| {
+            assert_registries_equivalent(
+                without,
+                with,
+                "a bare prune.completed must have no other registry effect",
+            );
+        },
+    );
+}
+
+/// Reachability sanity check: every kind this file claims to cover really
+/// is a member of the allowlist it is testing against — if the allowlist
+/// ever grows or shrinks, this fails loudly rather than this file silently
+/// meaning less than its own doc comment says.
+#[test]
+fn every_kind_this_file_tests_is_actually_on_the_allowlist() {
+    let tested = [
+        KIND_DAEMON_STARTED,
+        KIND_DAEMON_STOPPED,
+        KIND_BACKEND_PROBED,
+        KIND_ADMISSION_PAUSED,
+        KIND_ADMISSION_RESUMED,
+        KIND_COMMAND_ACCEPTED,
+        KIND_COMMAND_REJECTED,
+        KIND_PRUNE_INTENT,
+        KIND_PRUNE_COMPLETED,
+    ];
+    assert_eq!(
+        tested.len(),
+        prune::NON_WORK_ALLOWLIST.len(),
+        "this file must test exactly the allowlist's own kinds, one test each"
+    );
+    for kind in tested {
+        assert!(
+            prune::NON_WORK_ALLOWLIST.contains(&kind),
+            "{kind} is tested here but is not on NON_WORK_ALLOWLIST"
+        );
+    }
+    for kind in prune::NON_WORK_ALLOWLIST {
+        assert!(
+            tested.contains(kind),
+            "{kind} is on NON_WORK_ALLOWLIST but has no test in this file"
+        );
+    }
+}

--- a/tests/w3_prune_crash_windows.rs
+++ b/tests/w3_prune_crash_windows.rs
@@ -1,0 +1,93 @@
+//! W3 §13.1 step 8: the crash-window recovery proofs (N7–N10) plus the
+//! recovery-ordering guarantee `daemon::start_with` depends on.
+//!
+//! F1 (before quarantine), F2 (mid-quarantine), F3 (mid-deferred-delete),
+//! F4 (mid-unlink) and F5 (after unlink, before completion) each have a
+//! dedicated, named unit test — `crash_window_f1_before_quarantine_
+//! completes_at_next_start` through `crash_window_f5_after_unlink_
+//! appends_the_completion_from_the_intents_residue` — in
+//! `src/runtime/prune.rs`'s own `#[cfg(test)]` module, beside
+//! `complete_interrupted` itself: they need `Core`/`prune`'s private test
+//! helpers (`tiny_core`, `commit`, `build_and_commit_intent`) to simulate
+//! each crash point precisely, which only that module can reach directly.
+//! This file carries the one crash-window proof that is genuinely about
+//! `daemon::start_with`'s own call *order*, not about `complete_interrupted`
+//! in isolation.
+
+use std::path::PathBuf;
+
+/// The end of the `{ … }` block that starts at or after `from` (same
+/// helper `tests/m6_surfaces.rs`/`tests/a1_floor_awareness.rs` use).
+fn block_end(source: &str, from: usize) -> usize {
+    let open = source[from..].find('{').expect("a block") + from;
+    let mut depth = 0usize;
+    for (offset, c) in source[open..].char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return open + offset;
+                }
+            }
+            _ => {}
+        }
+    }
+    source.len()
+}
+
+/// An interrupted prune is completed *before* `recovery::reconcile` runs
+/// (§6.6/§10.3): the completion's fold removes every pruned Work from
+/// `works`/`runs`, and every pruned Work is retired whole (I-W3-3), so
+/// reconcile would have found nothing to do for them either way — but the
+/// ordering is what makes that true by construction rather than by luck.
+/// Reversed, a Work whose prune intent is still pending could be visited
+/// by `recovery::reconcile` while its own registry rows still look
+/// unsettled, doing recovery work (a teardown, a surface reconciliation)
+/// for a Work that is about to be deleted out from under it.
+///
+/// Structural, not behavioral: the daemon-level behavioral case (a Work
+/// that is simultaneously mid-prune-completion and reconcile-eligible) is
+/// vanishingly narrow to construct through the real daemon (it requires a
+/// crash frozen between two specific fsyncs), and the ordering itself is
+/// simple enough that a source-level proof — `complete_interrupted` is
+/// textually called before `recovery::reconcile` inside the same
+/// `start_with` function body — is the honest, maintainable version of
+/// this proof. A future reordering fails here immediately, with no need
+/// to first construct the narrow crash window that would otherwise be the
+/// only way to observe it.
+#[test]
+fn an_interrupted_prune_is_completed_before_recovery_reconciles() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("daemon.rs");
+    let source = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+
+    let fn_start = source
+        .find("pub async fn start_with(")
+        .expect("daemon::start_with must exist at this signature");
+    let fn_end = block_end(&source, fn_start);
+    let body = &source[fn_start..fn_end];
+
+    let complete_interrupted_at = body
+        .find("crate::runtime::prune::complete_interrupted(")
+        .unwrap_or_else(|| {
+            panic!(
+                "start_with must call crate::runtime::prune::complete_interrupted — it moved, \
+                 was renamed, or this scan's pattern needs updating"
+            )
+        });
+    let reconcile_at = body.find("recovery::reconcile(").unwrap_or_else(|| {
+        panic!(
+            "start_with must call crate::runtime::recovery::reconcile — it moved, was renamed, \
+             or this scan's pattern needs updating"
+        )
+    });
+
+    assert!(
+        complete_interrupted_at < reconcile_at,
+        "prune::complete_interrupted must be called before recovery::reconcile inside \
+         daemon::start_with — a pending prune must be finished before recovery gets a chance \
+         to act on a Work that intent is about to delete"
+    );
+}

--- a/tests/w3_prune_engine.rs
+++ b/tests/w3_prune_engine.rs
@@ -332,6 +332,119 @@ async fn a_start_on_an_over_cap_journal_prunes_before_serving() {
     );
 }
 
+/// §10.4's own path, distinct from the sibling test above (which is
+/// deliberately built to avoid it, per its own comment, so it can observe
+/// the "before" state undisturbed): a daemon that is never restarted still
+/// prunes, live, once a segment rotation crosses the cap and at least
+/// `PRUNE_BATCH_MIN_SEGMENTS` whole segments are eligible —
+/// `maybe_run_rotation_triggered_prune` (§10.4) is exercised by no other
+/// test in this suite. Polls `GET /v1/doctor`'s lock-free journal check
+/// (never a second `Journal::open` against a data dir the daemon still
+/// holds) so this can observe the floor moving without ever shutting the
+/// daemon down.
+#[tokio::test]
+async fn a_rotation_crossing_the_cap_arms_a_prune_within_one_tick() {
+    let data = DataDir::new();
+    let root = TempDir::new().expect("tempdir");
+    let (_mount, _head) = support::scaffold_solo_estate(root.path(), "solo");
+    write_one_stage_workflow(root.path());
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .expect("client");
+
+    const RETENTION: u32 = 3;
+    const TOTAL_WORKS: usize = 12;
+
+    let script: Vec<FakeStep> = (0..TOTAL_WORKS).map(|_| FakeStep::complete()).collect();
+    let (handle, _fake) = start_with_retention(data.path(), root.path(), RETENTION, script).await;
+
+    let mut command_ids = Vec::new();
+    for n in 0..TOTAL_WORKS {
+        let cmd = ulid();
+        submit(
+            &http,
+            &handle.endpoint,
+            &handle.token,
+            root.path(),
+            &cmd,
+            &format!("rotation-triggered prune fixture {n}"),
+        )
+        .await;
+        command_ids.push(cmd);
+    }
+    wait_until_all_settled(&http, &handle.endpoint, &handle.token).await;
+
+    // No restart anywhere in this test: poll the lock-free doctor journal
+    // check until the floor has actually moved above 1 — proof the
+    // *rotation*-triggered path pruned live, within a handful of the
+    // driver's own 200 ms ticks, never waiting on a restart to do it.
+    let mut floor_seq = 1u64;
+    for _ in 0..100 {
+        let report: serde_json::Value = http
+            .get(format!("{}/v1/doctor", handle.endpoint))
+            .bearer_auth(&handle.token)
+            .send()
+            .await
+            .expect("doctor")
+            .json()
+            .await
+            .expect("json");
+        let detail = report["checks"]
+            .as_array()
+            .expect("checks array")
+            .iter()
+            .find(|c| c["name"] == "journal")
+            .expect("a journal check")["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        if let Some(idx) = detail.find("from seq ") {
+            let digits: String = detail[idx + "from seq ".len()..]
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if let Ok(seq) = digits.parse::<u64>() {
+                floor_seq = seq;
+                if floor_seq > 1 {
+                    break;
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(
+        floor_seq > 1,
+        "the rotation-triggered prune (§10.4) must have moved the floor within a handful \
+         of ticks with no restart — the floor is still {floor_seq}"
+    );
+
+    // The oldest command must already be refused by name, live, before any
+    // shutdown — the same N12 proof as the startup-triggered sibling test,
+    // here demonstrating the rotation-triggered path reached the same
+    // observable state without one.
+    let resp = http
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&json!({
+            "command_id": command_ids[0],
+            "intent": "must be refused by name, live, no restart",
+            "origin": {"client": "cli", "cwd": root.path()},
+        }))
+        .send()
+        .await
+        .expect("retry a pruned command_id");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::CONFLICT,
+        "a pruned command_id retry must be refused with 409, live: {:?}",
+        resp.text().await
+    );
+
+    handle.shutdown().await;
+}
+
 // ------------------------------------------------------------------
 // N21: no configuration or flag can lower the prune predicate (Q7/I-W3-11)
 // ------------------------------------------------------------------
@@ -378,4 +491,104 @@ fn no_configuration_or_flag_can_lower_the_prune_predicate() {
              authorization surface"
         );
     }
+}
+
+// ------------------------------------------------------------------
+// N23: a prune runs only under the core guard (§10.1)
+// ------------------------------------------------------------------
+
+/// The end of the `{ … }` block that starts at or after `from` (mirrors
+/// `tests/m6_surfaces.rs`'s own helper of the same name).
+fn block_end(source: &str, from: usize) -> usize {
+    let open = source[from..].find('{').expect("a block") + from;
+    let mut depth = 0usize;
+    for (offset, c) in source[open..].char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return open + offset;
+                }
+            }
+            _ => {}
+        }
+    }
+    source.len()
+}
+
+/// The smallest `{ … }` block that textually contains `at` — the backward
+/// counterpart to `block_end`, used here to find "the block this
+/// `CoreGuard::acquire` call's binding is scoped to".
+fn enclosing_block(source: &str, at: usize) -> (usize, usize) {
+    let bytes = source.as_bytes();
+    let mut depth: i64 = 0;
+    let mut i = at;
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b'}' => depth += 1,
+            b'{' => {
+                if depth == 0 {
+                    return (i, block_end(source, i));
+                }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    (0, source.len())
+}
+
+/// t11c (`tests/m6_surfaces.rs`) proves every core-lock hold goes through
+/// `CoreGuard`. This is the narrower, prune-specific proof §10.1 and the
+/// Negative Test Matrix (N23) separately require: that `prune::run` — which
+/// takes `&mut Core`, not a `CoreGuard`, so nothing about its own type stops
+/// a future caller from handing it a `Core` reached some other way — is only
+/// ever called from a lexical scope that also acquired the guard. Holding
+/// the guard for the whole cycle is what makes "intent → deletion →
+/// completion" atomic with respect to appends: no event can land between
+/// the intent and the completion.
+///
+/// Structural, in the `t11c`/N21 style: every occurrence of
+/// `crate::runtime::prune::run(` (the live-cycle entry point — deliberately
+/// not `run_startup`/`complete_interrupted`, which run during daemon start
+/// before any listener binds or any `CoreGuard` is needed at all, per §10.3)
+/// in `src/api.rs` must fall inside the same `{ … }` block as a preceding
+/// `CoreGuard::acquire(` call. A future call site reached without first
+/// acquiring the guard in the same block fails here with nothing to catch
+/// it structurally otherwise, since `prune::run`'s own signature cannot
+/// enforce it.
+#[test]
+fn prune_runs_only_under_the_core_guard() {
+    let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/api.rs");
+    let text = std::fs::read_to_string(&src).expect("read api.rs");
+
+    let guarded_ranges: Vec<(usize, usize)> = text
+        .match_indices("CoreGuard::acquire(")
+        .map(|(index, _)| enclosing_block(&text, index))
+        .collect();
+    assert!(
+        !guarded_ranges.is_empty(),
+        "api.rs must declare at least one `CoreGuard::acquire` call for this test to mean anything"
+    );
+
+    let mut checked_a_call_site = false;
+    for (index, _) in text.match_indices("crate::runtime::prune::run(") {
+        checked_a_call_site = true;
+        assert!(
+            guarded_ranges
+                .iter()
+                .any(|(start, end)| index > *start && index < *end),
+            "a `prune::run` call at byte {index} in api.rs is not lexically inside a block \
+             that also acquired `CoreGuard` — N23/§10.1 requires the whole cycle to run under \
+             the guard, near: {:?}",
+            &text[index.saturating_sub(160)..index]
+        );
+    }
+    assert!(
+        checked_a_call_site,
+        "api.rs must call `crate::runtime::prune::run` at least once for this test to mean \
+         anything — if the call site moved or was renamed, update this scan to find it"
+    );
 }

--- a/tests/w3_prune_engine.rs
+++ b/tests/w3_prune_engine.rs
@@ -1,0 +1,381 @@
+//! W3 end-to-end: a real `DataDir` daemon, driven past its retention cap,
+//! actually prunes — §13.1 step 7's suite plus the wave's live acceptance
+//! case (Validation Evidence item 5) and the N21 structural scan.
+//!
+//! Every test here uses a real daemon (`support::DataDir`), never `TempDir`
+//! for anything that spawns (§13.4). The blob/mark-scan and journal-level
+//! mechanics have their own focused unit tests in `src/runtime/blob.rs`,
+//! `src/runtime/journal.rs` and `src/runtime/prune.rs`; this file proves the
+//! whole cycle actually runs and actually deletes.
+
+mod support;
+
+use std::path::Path;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend, FakeStep};
+use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
+use sergeant_rs::runtime::journal::Journal;
+use sergeant_rs::runtime::projection::{Projection, WorkRegistry, work_registry_reducer};
+
+use support::DataDir;
+
+fn ulid() -> String {
+    ulid::Ulid::generate().to_string()
+}
+
+fn write_one_stage_workflow(root: &Path) {
+    let dir = root.join(".sergeant/workflows/solo-stage");
+    std::fs::create_dir_all(&dir).expect("workflow dir");
+    std::fs::write(
+        dir.join("workflow.toml"),
+        "[workflow]\nname = \"solo-stage\"\nversion = \"1\"\nstages = [\"00-only\"]\n",
+    )
+    .expect("workflow.toml");
+    std::fs::create_dir_all(dir.join("00-only")).expect("stage dir");
+    std::fs::write(dir.join("00-only").join("CONTEXT.md"), "context").expect("CONTEXT.md");
+}
+
+async fn start_with_retention(
+    data_dir: &Path,
+    estate_root: &Path,
+    retention: u32,
+    script: impl IntoIterator<Item = FakeStep>,
+) -> (DaemonHandle, FakeBackend) {
+    let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, script);
+    let registry = BackendRegistry::new().with(std::sync::Arc::new(fake.clone()));
+    let handle = daemon::start_with(
+        data_dir,
+        DaemonConfig {
+            backends: std::sync::Arc::new(registry),
+            default_backend: Some(FAKE_BACKEND_NAME.to_string()),
+            estate_root: Some(estate_root.to_path_buf()),
+            // Tiny threshold: reaching many segments from a handful of Works
+            // without a production-scale journal.
+            segment_max_bytes: Some(256),
+            // W3: DaemonConfig::retention deliberately bypasses
+            // MIN_RETENTION (§1.2) — a test rig, never a manifest.
+            retention: Some(retention),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start");
+    (handle, fake)
+}
+
+async fn submit(
+    http: &reqwest::Client,
+    endpoint: &str,
+    token: &str,
+    root: &Path,
+    command_id: &str,
+    intent: &str,
+) -> serde_json::Value {
+    let resp = http
+        .post(format!("{endpoint}/v1/work"))
+        .bearer_auth(token)
+        .json(&json!({
+            "command_id": command_id,
+            "intent": intent,
+            "origin": {"client": "cli", "cwd": root},
+        }))
+        .send()
+        .await
+        .expect("submit");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::CREATED,
+        "{:?}",
+        resp.text().await
+    );
+    resp.json().await.expect("json")
+}
+
+async fn wait_until_all_settled(http: &reqwest::Client, endpoint: &str, token: &str) {
+    let mut last: serde_json::Value = serde_json::Value::Null;
+    for _ in 0..200 {
+        let system: serde_json::Value = http
+            .get(format!("{endpoint}/v1/work"))
+            .bearer_auth(token)
+            .send()
+            .await
+            .expect("list")
+            .json()
+            .await
+            .expect("json");
+        let all_done = system["works"]
+            .as_array()
+            .map(|rows| {
+                rows.iter()
+                    .all(|w| w["state"] == "completed" || w["state"] == "failed")
+            })
+            .unwrap_or(false);
+        if all_done {
+            return;
+        }
+        last = system;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("works never settled; last list: {last}");
+}
+
+/// The wave's live acceptance case (§8's Validation Evidence item 5): a
+/// `DataDir` daemon with a tiny segment threshold and `retention: Some(4)`,
+/// driven past the cap with real Works, restarted — the restart's own
+/// startup-triggered prune (§10.3) must actually shrink the journal, move
+/// the floor, and leave the pruned Works answerable only by their residue.
+///
+/// Also exercises, in one fixture:
+/// - N2 (`a_work_inside_the_retention_cap_is_never_pruned`'s live sibling):
+///   the newest `retention` Works survive.
+/// - N12/N13: a pruned command's `command_id` is refused by name over a
+///   real HTTP retry, and the Work it created is a durable residue row, not
+///   an unknown id.
+#[tokio::test]
+async fn a_start_on_an_over_cap_journal_prunes_before_serving() {
+    let data = DataDir::new();
+    let root = TempDir::new().expect("tempdir");
+    let (_mount, _head) = support::scaffold_solo_estate(root.path(), "solo");
+    write_one_stage_workflow(root.path());
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .expect("client");
+
+    // §1.2: `DaemonConfig::retention` deliberately bypasses
+    // `estate::MIN_RETENTION` — that floor is a *manifest-schema* refusal
+    // protecting an operator from a typo in a file, not a runtime bound. A
+    // test rig setting `4` here has not typed anything into a manifest.
+    const RETENTION: u32 = 4;
+    const TOTAL_WORKS: usize = 12;
+
+    let mut command_ids = Vec::new();
+    let mut work_ids = Vec::new();
+
+    // Life 1: submit more Works than the cap, all completing. Retention is
+    // deliberately huge here — large enough that the *rotation*-triggered
+    // tick (§10.4) never fires mid-life, which would prune before this test
+    // gets to observe the "before" state at all. Life 2 is the one whose
+    // *startup*-triggered prune (§10.3) this test is about.
+    {
+        let script: Vec<FakeStep> = (0..TOTAL_WORKS).map(|_| FakeStep::complete()).collect();
+        let (handle, _fake) =
+            start_with_retention(data.path(), root.path(), 1_000_000, script).await;
+
+        for n in 0..TOTAL_WORKS {
+            let cmd = ulid();
+            let body = submit(
+                &http,
+                &handle.endpoint,
+                &handle.token,
+                root.path(),
+                &cmd,
+                &format!("prune fixture work {n}"),
+            )
+            .await;
+            command_ids.push(cmd);
+            work_ids.push(body["work"]["id"].as_str().expect("work id").to_string());
+        }
+        wait_until_all_settled(&http, &handle.endpoint, &handle.token).await;
+        handle.shutdown().await;
+    }
+
+    let (segments_before, floor_before) = {
+        let journal = Journal::open(data.path()).expect("reopen journal");
+        let bounds = journal.segment_bounds().expect("bounds");
+        (bounds.len(), journal.floor_seq().expect("floor_seq"))
+    };
+    assert_eq!(
+        floor_before,
+        Some(1),
+        "before any prune, the floor is still 1"
+    );
+    assert!(
+        segments_before > 4,
+        "fixture must actually span more than a handful of segments \
+         (got {segments_before}) or the prune below proves nothing"
+    );
+
+    // Life 2: the restart's own startup-triggered prune (§10.3) runs inside
+    // `start_with`, before the listener binds — by the time this call
+    // returns, the cycle (if any) has already committed and unlinked.
+    let (handle2, _fake2) =
+        start_with_retention(data.path(), root.path(), RETENTION, Vec::<FakeStep>::new()).await;
+
+    // N12: a pruned command's id is refused by name over a *real* HTTP
+    // retry — never re-executed, never a fabricated 200.
+    let pruned_command_id = &command_ids[0];
+    let resp = http
+        .post(format!("{}/v1/work", handle2.endpoint))
+        .bearer_auth(&handle2.token)
+        .json(&json!({
+            "command_id": pruned_command_id,
+            "intent": "must be refused by name, not re-executed",
+            "origin": {"client": "cli", "cwd": root.path()},
+        }))
+        .send()
+        .await
+        .expect("retry a pruned command_id");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::CONFLICT,
+        "a pruned command_id retry must be refused with 409: {:?}",
+        resp.text().await
+    );
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["error"]["code"], "command_below_replay_window");
+    assert_eq!(body["error"]["work_id"], json!(work_ids[0]));
+
+    // N13 / I-W3-7's live half: a pruned Work's own id 404s over HTTP (W3
+    // ships no pruned-by-name response shape — W4 owns that surface — but
+    // it must be the *same* honest 404 an unknown id gets, never a stale
+    // stranded read of evicted-but-still-cached data).
+    let resp = http
+        .get(format!("{}/v1/work/{}", handle2.endpoint, work_ids[0]))
+        .bearer_auth(&handle2.token)
+        .send()
+        .await
+        .expect("show a pruned work");
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    handle2.shutdown().await;
+
+    // Now that nothing holds the journal's exclusive lock: the journal must
+    // have visibly shrunk and the floor must have moved.
+    let journal = Journal::open(data.path()).expect("reopen journal after prune");
+    let bounds = journal.segment_bounds().expect("bounds");
+    let floor_after = journal.floor_seq().expect("floor_seq");
+    assert!(
+        bounds.len() < segments_before,
+        "the journal must have fewer segments after the prune (before {segments_before}, after {})",
+        bounds.len()
+    );
+    assert!(
+        floor_after.unwrap_or(1) > 1,
+        "the floor must have moved above 1 after a real prune, got {floor_after:?}"
+    );
+
+    // Rebuild the registry from the (now-pruned) journal and check the
+    // residue directly — the ground truth this whole wave exists to keep
+    // honest, independent of any cache. `Projection::resumed` (not a fresh
+    // `work_registry_projection()` + `catch_up`, which assumes seq 1) is
+    // what makes this floor-aware: `replay_from_floor()` starts yielding at
+    // the floor, not at 1.
+    let mut registry = Projection::resumed(
+        WorkRegistry::default(),
+        floor_after.expect("a real prune leaves a floor above 1") - 1,
+        work_registry_reducer,
+    );
+    registry
+        .catch_up(journal.replay_from_floor().expect("replay_from_floor"))
+        .expect("catch up");
+    let state = registry.state();
+
+    assert_eq!(
+        state.work_index.len(),
+        RETENTION as usize,
+        "exactly the newest {RETENTION} Works must remain retained"
+    );
+    assert_eq!(
+        state.pruned_works.len(),
+        TOTAL_WORKS - RETENTION as usize,
+        "every Work past the cap must appear in pruned_works"
+    );
+    // Disjoint, per §6.2.
+    for id in state.work_index.keys() {
+        assert!(
+            !state.pruned_works.contains_key(id),
+            "a Work must never be in both work_index and pruned_works (id {id})"
+        );
+    }
+    // The oldest Works (by submission order) are exactly the pruned ones,
+    // and the newest are exactly the retained ones.
+    let pruned_count = TOTAL_WORKS - RETENTION as usize;
+    for work_id in &work_ids[..pruned_count] {
+        assert!(
+            state.pruned_works.contains_key(work_id),
+            "an older Work ({work_id}) must be in pruned_works"
+        );
+    }
+    for work_id in &work_ids[pruned_count..] {
+        assert!(
+            state.work_index.contains_key(work_id),
+            "a newer Work ({work_id}) must still be retained"
+        );
+    }
+
+    // I-W3-10 / N11: a pruned journal replays cleanly from the floor, and
+    // only the strict, seq-1 primitive still reports `SeqDiscontinuity` —
+    // demonstrated, not merely asserted. Reuses the same handle opened
+    // above — a second `Journal::open` on the same data dir would contend
+    // with itself for the exclusive lock.
+    let clean: Result<Vec<_>, _> = journal
+        .replay_from_floor()
+        .expect("replay_from_floor")
+        .collect();
+    assert!(
+        clean.is_ok(),
+        "replay_from_floor must succeed over a pruned journal: {clean:?}"
+    );
+    let strict: Result<Vec<_>, _> = journal.replay().expect("replay").collect();
+    assert!(
+        matches!(
+            strict,
+            Err(sergeant_rs::runtime::journal::JournalError::SeqDiscontinuity { .. })
+        ),
+        "the strict seq-1 primitive must still report the gap as SeqDiscontinuity: {strict:?}"
+    );
+}
+
+// ------------------------------------------------------------------
+// N21: no configuration or flag can lower the prune predicate (Q7/I-W3-11)
+// ------------------------------------------------------------------
+
+/// Structural source scan, the shape `tests/m9_watch.rs` and
+/// `tests/a4_blob_ref_pinning.rs` already use: `src/runtime/prune.rs` must
+/// name no `clap` argument, no `std::env::var`, and no `DaemonConfig` field
+/// other than `retention` and `segment_max_bytes` — the declared policy
+/// (`[estate] retention` / `DaemonConfig::retention`, test rigs only) is the
+/// whole authorization surface, structurally, not by convention.
+#[test]
+fn no_configuration_or_flag_can_lower_the_prune_predicate() {
+    let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/runtime/prune.rs");
+    let text = std::fs::read_to_string(&src).expect("read prune.rs");
+
+    assert!(
+        !text.contains("clap"),
+        "prune.rs must declare no CLI flag of its own"
+    );
+    assert!(
+        !text.contains("std::env::var") && !text.contains("env::var"),
+        "prune.rs must read no environment variable"
+    );
+
+    // Every `DaemonConfig` field this module names must be one of the two
+    // sanctioned ones.
+    let sanctioned = ["retention", "segment_max_bytes"];
+    for line in text.lines() {
+        let Some(idx) = line.find("config.") else {
+            continue;
+        };
+        let rest = &line[idx + "config.".len()..];
+        let field: String = rest
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if field.is_empty() {
+            continue;
+        }
+        assert!(
+            sanctioned.contains(&field.as_str()),
+            "prune.rs names DaemonConfig field {field:?}, which is not in the sanctioned set \
+             {sanctioned:?} — I-W3-11 requires the declared policy to be the whole \
+             authorization surface"
+        );
+    }
+}

--- a/tests/w3_prune_measurement.rs
+++ b/tests/w3_prune_measurement.rs
@@ -1,0 +1,228 @@
+//! W3 §8 Validation Evidence item 6: a measured, read-only run of the
+//! prune engine's cheap phase (`candidate_horizon`/`stall_report`) against
+//! the live dogfood journal. **Read-only, `#[ignore]`d — run explicitly,
+//! never in CI.**
+//!
+//! Mirrors `tests/w2_startup_measurement.rs`'s own shape exactly: source,
+//! skip behavior, and the before/after fingerprint that proves the
+//! measurement touched nothing. `prune::run` is never called here — this
+//! file only ever reads segment files (never writes or renames one) and
+//! calls the in-memory, no-further-I/O phase A predicate
+//! (`candidate_horizon`) and the reporting wrapper around it
+//! (`stall_report`), both of which take a `WorkRegistry` and segment bounds
+//! already in hand.
+//!
+//! **Never `Journal::open`.** That primitive takes an exclusive advisory
+//! lock and can mutate a torn tail on recovery — wrong for a read-only
+//! measurement against a data dir a real daemon may still own, exactly per
+//! `tests/w2_startup_measurement.rs`'s own rule. Segment bounds here are
+//! reconstructed the same lock-free way `sgt doctor`'s journal check
+//! already reads a live journal: list segment files, read each one's own
+//! first line for its first seq, and take the registry replay's own
+//! high-water mark (`Projection::last_seq`) as the newest segment's last
+//! seq — the same arithmetic `Journal::segment_bounds` uses, without ever
+//! opening a writer handle.
+//!
+//! **Honesty note, reproduced from `tests/w2_startup_measurement.rs`'s own
+//! one:** the live dogfood journal is measured to be small, so this
+//! measurement demonstrates phase A's cost shape (a handful of sorts over
+//! `work_index`, no journal I/O) on real data, and demonstrates nothing
+//! about how that cost scales on an estate with hundreds of thousands of
+//! retained Works — the batch cap (`PRUNE_MAX_WORKS_PER_CYCLE`) and the
+//! O(retained journal) mark scan's own cost are argued from the rulings
+//! record, not from this measurement.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use sergeant_rs::domain::event::Event;
+use sergeant_rs::runtime::journal::{Journal, SegmentBound};
+use sergeant_rs::runtime::projection::work_registry_projection;
+use sergeant_rs::runtime::prune::{
+    FirstSeqIndex, PolicySource, PrunePolicy, candidate_horizon, stall_report,
+};
+use sergeant_rs::runtime::startup::{self, HorizonSink, RegistrySink};
+
+/// Every `*.ndjson` segment file directly under `<data_dir>/journal/`,
+/// oldest first by its 8-digit filename stem.
+fn segment_files(data_dir: &Path) -> Vec<(u64, PathBuf)> {
+    let journal_dir = data_dir.join("journal");
+    let mut files: Vec<(u64, PathBuf)> = std::fs::read_dir(&journal_dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter_map(|e| {
+                    let path = e.path();
+                    if path.extension().is_some_and(|ext| ext == "ndjson") {
+                        let index: u64 = path.file_stem()?.to_str()?.parse().ok()?;
+                        Some((index, path))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    files.sort_by_key(|(index, _)| *index);
+    files
+}
+
+/// Lock-free segment bounds: `first_seq` from each segment's own first
+/// line, `bytes` from `metadata`, `last_seq` as the next segment's
+/// `first_seq - 1` (or, for the newest, `newest_last_seq` — the registry
+/// replay's own high-water mark, since nothing here ever asks the writer).
+/// A segment with no first line yet (rotated but never appended to) is
+/// skipped, exactly as `Journal::segment_bounds` skips it.
+fn read_only_segment_bounds(data_dir: &Path, newest_last_seq: u64) -> Vec<SegmentBound> {
+    let files = segment_files(data_dir);
+    let mut bounds: Vec<SegmentBound> = Vec::new();
+    for (index, path) in files {
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(first_line) = content.lines().next() else {
+            continue; // an empty, just-rotated segment cannot bound anything
+        };
+        let Ok(event) = serde_json::from_str::<Event>(first_line) else {
+            continue;
+        };
+        let Ok(bytes) = std::fs::metadata(&path).map(|m| m.len()) else {
+            continue;
+        };
+        bounds.push(SegmentBound {
+            index,
+            path,
+            first_seq: event.seq,
+            last_seq: 0, // filled in below
+            bytes,
+        });
+    }
+    let len = bounds.len();
+    for i in 0..len {
+        bounds[i].last_seq = if i + 1 < len {
+            bounds[i + 1].first_seq - 1
+        } else {
+            newest_last_seq
+        };
+    }
+    bounds
+}
+
+fn dogfood_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("SGT_DOGFOOD_DATA_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join("sergeant-rs-workspace/.sergeant/data"))
+}
+
+fn require_dogfood() -> Option<PathBuf> {
+    match dogfood_dir() {
+        Some(dir) if dir.is_dir() => Some(dir),
+        Some(dir) => {
+            eprintln!(
+                "SKIPPED: dogfood data dir {dir:?} does not exist — this measurement needs a \
+                 real estate's journal and is never a hard requirement"
+            );
+            None
+        }
+        None => {
+            eprintln!("SKIPPED: could not resolve a dogfood data dir (no $HOME, no override)");
+            None
+        }
+    }
+}
+
+/// `(path, len, mtime)` for every entry under `dir`, recursively — the
+/// before/after fingerprint that proves a measurement touched nothing.
+fn fingerprint(dir: &Path) -> BTreeMap<PathBuf, (u64, std::time::SystemTime)> {
+    fn walk(dir: &Path, out: &mut BTreeMap<PathBuf, (u64, std::time::SystemTime)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(meta) = entry.metadata() else { continue };
+            if meta.is_dir() {
+                walk(&path, out);
+            } else {
+                let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+                out.insert(path, (meta.len(), mtime));
+            }
+        }
+    }
+    let mut out = BTreeMap::new();
+    walk(dir, &mut out);
+    out
+}
+
+fn assert_untouched(dir: &Path, before: &BTreeMap<PathBuf, (u64, std::time::SystemTime)>) {
+    let after = fingerprint(dir);
+    assert_eq!(
+        before, &after,
+        "this measurement must be read-only over the dogfood data dir"
+    );
+}
+
+/// Phase A's own cost, on the live dogfood registry: one read-only replay
+/// to rebuild `WorkRegistry`/`FirstSeqIndex`, then `candidate_horizon` and
+/// `stall_report` timed on their own — both pure in-memory sorts/sweeps
+/// over `work_index`, no journal I/O at all, which is the whole design
+/// argument §7.1 makes for running phase A on every rotation tick.
+#[test]
+#[ignore]
+fn candidate_horizon_cost_on_the_dogfood_registry() {
+    let Some(data_dir) = require_dogfood() else {
+        return;
+    };
+    let before = fingerprint(&data_dir);
+
+    let t_replay = Instant::now();
+    let mut registry = work_registry_projection();
+    let mut horizon_sink = HorizonSink::default();
+    startup::drive(
+        Journal::replay_data_dir_from_floor(&data_dir).expect("replay_data_dir_from_floor"),
+        &mut [&mut RegistrySink(&mut registry), &mut horizon_sink],
+    )
+    .expect("drive");
+    let replay_cost = t_replay.elapsed();
+
+    let bounds = read_only_segment_bounds(&data_dir, registry.last_seq());
+
+    // A representative policy: the estate's own retention if the manifest
+    // is readable from here (it is not, without a full `Estate` parse this
+    // measurement has no business doing), so a fixed, documented stand-in.
+    const MEASURED_RETENTION: u32 = 1000;
+    let policy = PrunePolicy {
+        retention: MEASURED_RETENTION,
+        source: PolicySource::Config,
+    };
+    let first_seq: &FirstSeqIndex = horizon_sink.first_seq_by_work();
+
+    let t0 = Instant::now();
+    let (horizon, _) = candidate_horizon(&bounds, registry.state(), first_seq, &policy);
+    let candidate_horizon_cost = t0.elapsed();
+
+    let t1 = Instant::now();
+    let stall = stall_report(
+        &bounds,
+        registry.state(),
+        first_seq,
+        &policy,
+        std::time::SystemTime::now(),
+    );
+    let stall_report_cost = t1.elapsed();
+
+    println!(
+        "prune phase A on the dogfood registry: {} segments, {} retained Works, \
+         retention={MEASURED_RETENTION} (measurement stand-in) -> horizon={horizon}, \
+         retained_works_in_stall={}; replay={replay_cost:?} candidate_horizon={candidate_horizon_cost:?} \
+         stall_report={stall_report_cost:?}",
+        bounds.len(),
+        registry.state().work_index.len(),
+        stall.retained_works,
+    );
+
+    assert_untouched(&data_dir, &before);
+}


### PR DESCRIPTION
Wave 3 of the foundation sprint (plan: docs/proposals/foundation-2026-08-21.md, head PR #216). Spec: opus-authored, opens with the full eight-dimension intent brief (12 invariants, 8 failure windows, 24-row Negative Test Matrix) — `w3-spec.md` in the workspace evidence dir.

## What landed
- **`[estate] retention = N`** in sergeant.toml (default 1000, `MIN_RETENTION` floor, refusal-by-name below it; `sgt init` scaffolds it as a comment an older parser ignores).
- **Prune engine** (`src/runtime/prune.rs`): horizon = no-straddle ∧ settled ∧ `retired_whole` ∧ newest-N cap ∧ Q5 allowlist (per-event, work_id presence for the two conditional command kinds); only whole oldest-contiguous segment prefixes are ever unlinked (refuses the live segment and non-prefix sets); journaled `prune.intent` (carrying the full A3 residue: slim rows + prune date + ledger keys + condemned blobs + carried ask-withdrawal watermark) → two-phase blob quarantine → unlink → `prune.completed`; crash completion at daemon start for every failure window F1–F8.
- **Blob safety under dedup**: mark = recursive `blob::refs_in_event` scan; three-way quarantine resolution (rescue / defer / delete) so a re-condemned hex is NEVER deleted in the cycle that re-marked it; `BlobStore::get`/`put` rescue adopted blobs out of `.pruned/`.
- **A1 floor-awareness audit**: every `Journal::replay`/`replay_data_dir` caller converted or clamped (`Replay::after` floor clamp fixes events/SSE/transcript in one move); doctor's journal check floor-aware; `tests/a1_floor_awareness.rs` structurally scans call sites so a new raw replay fails CI. SeqDiscontinuity keeps its corruption-only meaning; the reader-tolerance arm requires contiguous survivor listings and re-anchors once (documented residual margin: damage contiguously below the surviving floor is indistinguishable from retention — inherent to directory listings).
- **§26**: pruned commands refuse-by-name from the journal residue (409 naming the Work); I9 gate extended with a real-prune third case + three negative-mutation proofs.
- FloorState schema v2 (`first_seq` — without it pruning is provably inert on cache-hit starts).

## Gauntlet (the full story)
1. 5-seat panel (incl. opus deletion-safety): **22 confirmed, 0 refuted** — implementer under-delivered the test matrix; 5 real bugs (write-only ask-withdrawal residue, un-re-checked deferred deletes, guard-held full-journal top-up, false-corruption on multi-segment prune, inadmissible lowered horizon).
2. Fixer round 1 (sonnet): all 22 addressed; 2 defended non-fixes.
3. **Re-verify** (opus re-attack + test-honesty audit): tests clean; 4 new findings incl. 1 BLOCKER the round-1 fix introduced (same-cycle condemn+delete collapsing the quarantine window).
4. Fixer round 2 (opus): all 4 fixed, every new test verified to fail against the pre-fix code. Gates green at `a83c3572` (704 lib tests + all integration suites).

## Ratify-at-review (adds to #216's list)
- `retired_whole` includes `Failed` Works (else one old Failed Work pins the journal forever — Q7's stall arriving day one); cost: a Failed Work past the cap becomes unretryable.
- `MIN_RETENTION` floor value; FloorState v2 bump; manual `sgt journal prune` verb **deferred** (three-reason argument in the spec; ADR line item lands in W4).
- Cache is removed (not rewritten) after a live prune — next start pays one full replay; the honest alternative needs live-adapter watermark threading (disclosed in module doc, deferred).

Rungs: R2 (startup::horizon/refs_in_event/recovery patterns reused), R7 cited for the new prune module (no lower rung exists — first deletion engine); J3 (#17 rulings + plan amendments A1–A6), J5 (recovery.rs suspicion-refusal boundary untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4