### PR TITLE
W2: register codex; R1 version-refusal strike (surgical)

### DIFF
--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -141,8 +141,10 @@ pub const CLAUDE_BACKEND_NAME: &str = "claude";
 
 /// Minimum CLI version the M4 contract tests trust. The spike measured
 /// 2.1.220; this milestone re-measured everything on 2.1.226, so 2.1.226 is
-/// what "measured" means here. Older versions are refused, not assumed
-/// compatible (L1: differences are findings, not surprises).
+/// what "measured" means here. As of R1 (2026-08-21) an older version is not
+/// refused — it is honest, unmeasured provenance: the probe reports it
+/// usable and says plainly that nothing below this floor was re-measured
+/// (L1: differences are findings, not surprises).
 pub const MIN_TRUSTED_VERSION: (u64, u64, u64) = (2, 1, 226);
 
 /// Flags the capability probe requires to appear in `claude --help`.
@@ -1001,10 +1003,11 @@ impl ClaudeBackend {
     /// Run the capability/version probe once and cache the outcome.
     ///
     /// Both probes are offline and token-free: `--version` and `--help`.
-    /// Gates, in order: the binary runs; the version parses; the version is
-    /// at least [`MIN_TRUSTED_VERSION`]; every [`REQUIRED_FLAGS`] entry
-    /// appears in `--help`. Any failure names itself — a refusal an
-    /// operator cannot act on is not a refusal, it is an outage.
+    /// Gates, in order: the binary runs; the version parses; every
+    /// [`REQUIRED_FLAGS`] entry appears in `--help`. A version below
+    /// [`MIN_TRUSTED_VERSION`] is not a gate (R1) — it reports available,
+    /// with unmeasured-provenance detail. Any failure names itself — a
+    /// refusal an operator cannot act on is not a refusal, it is an outage.
     fn probe_outcome(&self) -> &ProbeOutcome {
         self.probe_outcome.get_or_init(|| self.run_probe())
     }
@@ -1039,17 +1042,30 @@ impl ClaudeBackend {
         };
         let canonical_version = format!("{}.{}.{}", version.0, version.1, version.2);
         if version < MIN_TRUSTED_VERSION {
+            // R1 (2026-08-21): below the measured floor is provenance, not a
+            // gate. Report the CLI usable and name the floor it fell below;
+            // do not fall through to the `--help` gate below with a
+            // synthesized "ok" — a below-floor build's grammar is also
+            // unmeasured, so this early `return` short-circuits that check
+            // exactly as the refusal did before.
             return ProbeOutcome {
-                available: false,
+                available: true,
                 detail: format!(
-                    "capability probe: version {}.{}.{} is below the minimum trusted \
-                     {}.{}.{} (the version these contract tests measured)",
-                    version.0,
-                    version.1,
-                    version.2,
+                    "claude {version_text}; usable, but BELOW the measured floor {}.{}.{} — \
+                     every behavioural claim this adapter's contract tests pinned \
+                     (stream-json event grammar, resume, model-pin verification, \
+                     tool/permission mapping) was measured at {}.{}.{} and has not been \
+                     re-measured here. Capabilities carry unmeasured provenance; upgrade to \
+                     >= {}.{}.{} or expect surprises to be findings, not failures.",
                     MIN_TRUSTED_VERSION.0,
                     MIN_TRUSTED_VERSION.1,
-                    MIN_TRUSTED_VERSION.2
+                    MIN_TRUSTED_VERSION.2,
+                    MIN_TRUSTED_VERSION.0,
+                    MIN_TRUSTED_VERSION.1,
+                    MIN_TRUSTED_VERSION.2,
+                    MIN_TRUSTED_VERSION.0,
+                    MIN_TRUSTED_VERSION.1,
+                    MIN_TRUSTED_VERSION.2,
                 ),
                 version: Some(canonical_version),
             };

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -36,6 +36,7 @@ use crate::api::{
     drive_completions, router,
 };
 use crate::backend::claude::{CLAUDE_BACKEND_NAME, ClaudeBackend, ClaudeConfig};
+use crate::backend::codex::{CODEX_BACKEND_NAME, CodexBackend, CodexConfig};
 use crate::backend::docker::{DOCKER_BACKEND_NAME, DockerBackend, DockerConfig};
 use crate::backend::fake::FAKE_BACKEND_NAME;
 use crate::backend::{BackendRegistry, EventSink};
@@ -331,6 +332,10 @@ pub struct DaemonConfig {
     /// tests point it at a scripted `docker_bin` to drive the real adapter's
     /// request path without a real Docker Engine.
     pub docker: Option<DockerConfig>,
+    /// Launch configuration for the Codex adapter this daemon registers
+    /// itself. `None` is the system `codex`, adapter state under this data
+    /// dir — mirrors `claude`/`docker` above for the same reason.
+    pub codex: Option<CodexConfig>,
     /// §28 OpenTelemetry export. `None` is **off**, and off is the default:
     /// with no pipeline here the daemon builds no provider, spawns no
     /// exporter task, and subscribes nothing to the event stream.
@@ -417,6 +422,7 @@ impl Default for DaemonConfig {
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             claude: None,
             docker: None,
+            codex: None,
             telemetry: None,
             completion_poll: COMPLETION_POLL_INTERVAL,
             turn_ceiling: crate::runtime::engine::DEFAULT_TURN_CEILING,
@@ -734,14 +740,23 @@ pub async fn start_with(
     // observed" property `CoreGuard` gives every other path.
     core.flush()?;
 
-    // 4b. Register the real adapter alongside whatever the config supplied
-    // (tests hand in scripted fakes; they keep them). It is added here, not
-    // in `default_registry`, because the Claude adapter needs this data dir
-    // for its raw-transcript archive and an event sink that only exists once
-    // the core does. A config that already registered the name wins — that
-    // is how tests substitute stubs. Codex is not registered at all: it is
-    // descoped by deviation D6, and a backend nothing has measured must not
-    // appear in routing output as something a user could ask for.
+    // 4b. Register the real adapters alongside whatever the config supplied
+    // (tests hand in scripted stubs/fakes; they keep them). Added here, not
+    // in `default_registry`, because each needs this data dir (raw-
+    // transcript/blob archive) and an event sink that only exists once the
+    // core does. A config that already registered the name wins — that is
+    // how tests substitute stubs.
+    //
+    // Codex is registered the same way as Claude and Docker as of the
+    // 2026-08-21 codex-adapter sprint (W2, closing the registration half of
+    // deviation D6 — `knowledge/rulings/deviations/d6-codex-descoped.md`):
+    // W1 landed `CodexBackend` measured against codex-cli 0.149.0 (H0
+    // evidence packet). An unavailable build (binary missing, unmeasured
+    // grammar) still registers and reports its own probe evidence at
+    // `backend.probed` — the same posture Docker already takes for a host
+    // with no Docker installed (§17.5's "degraded daemon, strict work
+    // admission"): routing *to* it is what fails, at submission time, not
+    // daemon startup.
     let mut backends = (*config.backends).clone();
     let claude = if config.backends.get(CLAUDE_BACKEND_NAME).is_none() {
         let claude_config = config
@@ -780,6 +795,22 @@ pub async fn start_with(
             .clone()
             .unwrap_or_else(|| DockerConfig::new(data_dir));
         let adapter = Arc::new(DockerBackend::new(docker_config)?);
+        backends = backends.with(adapter.clone());
+        Some(adapter)
+    } else {
+        None
+    };
+    // W2: the Codex executor, registered the same way and for the same
+    // reason as Claude/Docker above. No `seed_capability_provenance_from`
+    // call here — that method exists only on `ClaudeBackend`, seeding a
+    // journaled `ask`-withdrawal claim Codex's `Capabilities::ask` does not
+    // have (Codex's `ask` is `false` unconditionally, per W1's module doc).
+    let codex = if config.backends.get(CODEX_BACKEND_NAME).is_none() {
+        let codex_config = config
+            .codex
+            .clone()
+            .unwrap_or_else(|| CodexConfig::new(data_dir));
+        let adapter = Arc::new(CodexBackend::new(codex_config));
         backends = backends.with(adapter.clone());
         Some(adapter)
     } else {
@@ -919,6 +950,11 @@ pub async fn start_with(
     // above).
     if let Some(docker) = docker {
         docker.set_event_sink(journaling_sink(state.core.clone()));
+    }
+    // The Codex adapter's normalized events flow through the identical sink
+    // (same reasoning as Claude's/Docker's, directly above).
+    if let Some(codex) = codex {
+        codex.set_event_sink(journaling_sink(state.core.clone()));
     }
     let app = router(state.clone());
 

--- a/tests/codex_backend.rs
+++ b/tests/codex_backend.rs
@@ -13,9 +13,14 @@
 //!   logged-in `codex`. Every live turn pins `-m gpt-5.6-luna` and a bounded,
 //!   one-word-answer prompt.
 //!
-//! No daemon is spawned by any test here (`CodexBackend::new` is constructed
-//! directly, the way the claude stub tests do), so `tests/support::DataDir`'s
-//! reaper is not required.
+//! Two daemon-level tests (W2, §1.4) prove registration itself — that
+//! `daemon::start_with` puts a "codex" entry in the registry with no
+//! test-supplied stand-in — via in-process `daemon::start_with` +
+//! `handle.shutdown().await`, the same rig `tests/m3_execution.rs`/
+//! `tests/estate_routes.rs` use, so `tests/support::DataDir`'s reaper does
+//! not apply to them either (no subprocess is spawned). Every other test in
+//! this file constructs `CodexBackend::new` directly, the way the claude
+//! stub tests do.
 
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -31,8 +36,10 @@ use sergeant_rs::backend::{
     Backend, BackendError, BindingSummary, ExecutionHandle, NativeState, ProbeReport,
     ResumeRequest, StartRequest,
 };
+use sergeant_rs::daemon::{self, DaemonConfig};
 use sergeant_rs::domain::estate::InstructionPolicy;
 use sergeant_rs::domain::event::EventDraft;
+use sergeant_rs::runtime::journal::Journal;
 
 mod support;
 
@@ -1874,4 +1881,104 @@ fn live_codex_thread_survives_turns_and_a_restart() {
     );
     assert_eq!(handle.native_id.as_deref(), Some(thread_id.as_str()));
     fresh.stop(&handle).expect("stop").wait();
+}
+
+// ------------------------------------------------------- W2 §1.4: registration
+
+/// A probeable codex registers for real: `daemon::start_with`, with no
+/// test-supplied stand-in for the name "codex", puts a real `CodexBackend`
+/// in its registry and journals its own probe evidence at registration —
+/// the direct proof of W2's registration change, not a repeat of any unit
+/// test on `CodexBackend` itself.
+#[tokio::test]
+async fn daemon_start_registers_codex_and_journals_its_own_probe() {
+    let data = TempDir::new().expect("tempdir");
+    let home = TempDir::new().expect("tempdir");
+    let stub = StubCodex::passing(data.path());
+    let handle = daemon::start_with(
+        data.path(),
+        DaemonConfig {
+            backends: Arc::new(sergeant_rs::backend::BackendRegistry::new()),
+            default_backend: None,
+            codex: Some(config_for(&stub, data.path(), home.path())),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start with an unmeasured-nothing codex must still start");
+    handle.shutdown().await;
+
+    let probed: Vec<_> = Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.kind == daemon::KIND_BACKEND_PROBED)
+        .collect();
+    let codex_probed = probed
+        .iter()
+        .find(|e| e.payload["backend"] == CODEX_BACKEND_NAME)
+        .expect("a backend.probed record for codex");
+    assert_eq!(codex_probed.payload["available"], true);
+    assert_eq!(codex_probed.payload["runtime_scope"], "per_execution");
+    assert_eq!(codex_probed.payload["capabilities"]["ask"], false);
+    assert_eq!(
+        codex_probed.payload["capabilities"]["persistent_sessions"],
+        true
+    );
+    assert_eq!(
+        codex_probed.payload["capabilities"]["native_background"],
+        false
+    );
+    assert_eq!(codex_probed.payload["capabilities"]["streaming"], true);
+    assert_eq!(codex_probed.payload["capabilities"]["history"], false);
+    assert_eq!(codex_probed.payload["capabilities"]["resume"], true);
+    assert_eq!(codex_probed.payload["capabilities"]["interrupt"], true);
+    assert_eq!(
+        codex_probed.payload["capabilities"]["model_selection"],
+        true
+    );
+    assert_eq!(codex_probed.payload["capabilities"]["profiles"], true);
+    assert_eq!(codex_probed.payload["capabilities"]["approval_flow"], false);
+    assert_eq!(codex_probed.payload["capabilities"]["human_attach"], false);
+    assert_eq!(codex_probed.payload["capabilities"]["usage"], true);
+    assert_eq!(
+        codex_probed.payload["capabilities"]["native_subagents"],
+        false
+    );
+}
+
+/// Codex missing must not break daemon startup, and must be distinguishable
+/// from "unregistered": it registers anyway and journals honest, `available:
+/// false` evidence naming why it cannot run — the same posture Docker
+/// already takes for a host with no Docker installed.
+#[tokio::test]
+async fn daemon_start_with_no_codex_installed_still_starts_and_says_why() {
+    let data = TempDir::new().expect("tempdir");
+    let handle = daemon::start_with(
+        data.path(),
+        DaemonConfig {
+            backends: Arc::new(sergeant_rs::backend::BackendRegistry::new()),
+            default_backend: None,
+            codex: Some(CodexConfig {
+                executable: PathBuf::from("/nonexistent/definitely-not-codex"),
+                ..CodexConfig::new(data.path())
+            }),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("a host with no codex binary must still start a daemon");
+    handle.shutdown().await;
+
+    let codex_probed = Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .find(|e| {
+            e.kind == daemon::KIND_BACKEND_PROBED && e.payload["backend"] == CODEX_BACKEND_NAME
+        })
+        .expect("codex is registered — and probed — even though it cannot run");
+    assert_eq!(codex_probed.payload["available"], false);
+    let detail = codex_probed.payload["detail"]
+        .as_str()
+        .expect("probe detail recorded");
+    assert!(detail.contains("cannot run"), "{detail}");
 }

--- a/tests/codex_routing.rs
+++ b/tests/codex_routing.rs
@@ -1,0 +1,254 @@
+//! W2 §2 (A1 routing verification): proof that `daemon::start_with` **itself**
+//! — with no test-supplied stand-in for the name "codex" — now puts a real
+//! `CodexBackend` in its registry, so the four-tier `RouteSource` chain
+//! (already unit-tested in `src/runtime/router.rs` and already exercised
+//! end-to-end with a *test-substituted* `FakeBackend::scripted("codex", ...)`
+//! in `tests/m3_execution.rs`'s `t7_routing_precedence_and_structured_failure`)
+//! reaches codex as the daemon's own default registration, not a fixture
+//! wearing its name.
+//!
+//! Every test here deliberately configures codex with a nonexistent
+//! executable, so the outcome is deterministic on any host (a host with a
+//! real, logged-in `codex` on `PATH` must not make these flaky or spend
+//! tokens): `resolve_tiers` calls `backend.probe()` before returning success,
+//! so an unavailable codex makes every submission below fail with
+//! `RouteError::Unavailable` — the *stronger*, host-independent proof that
+//! each tier reached the registered adapter and stopped there (named,
+//! `backend_unavailable`), rather than falling through to a populated global
+//! default the way an unregistered "codex" silently did before this wave.
+//!
+//! In-process `daemon::start_with` + `reqwest`, no subprocess — the same rig
+//! `tests/estate_routes.rs`/`tests/m3_execution.rs`/`tests/codex_backend.rs`
+//! use, so `tests/support::DataDir`'s reaper does not apply here either.
+//!
+//! No new `RouteSource` variant, no new routing logic — `src/runtime/
+//! router.rs` is untouched by this wave. No CLI-subprocess test of `sgt run
+//! --backend codex` or `sgt codex` actually exec'ing either: `harness::
+//! prepare`/`exec` are already unit-tested and exec-boundary functions are
+//! not round-trippable through an integration test by design.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::backend::codex::CodexConfig;
+use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend};
+use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
+
+mod support;
+
+// ---------------------------------------------------------------- helpers
+
+fn ulid() -> String {
+    ulid::Ulid::generate().to_string()
+}
+
+fn http() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("client")
+}
+
+/// A `CodexConfig` pointed at a definitely-nonexistent executable, so the
+/// probe always reports `available: false` regardless of what host runs
+/// this suite.
+fn deterministic_codex_config(data_dir: &Path) -> CodexConfig {
+    CodexConfig {
+        executable: PathBuf::from("/nonexistent/definitely-not-codex"),
+        ..CodexConfig::new(data_dir)
+    }
+}
+
+/// mirrors `tests/m3_execution.rs`'s `estate_with_manifest`: an estate at
+/// `root` from a verbatim `sergeant.toml`, with a real git checkout at
+/// `root/repos/<name>` for each of `repos`.
+fn estate_with_manifest(root: &Path, manifest: &str, repos: &[&str]) {
+    std::fs::create_dir_all(root).expect("estate root");
+    for repo in repos {
+        support::init_repo(&root.join("repos").join(repo));
+    }
+    std::fs::write(root.join("sergeant.toml"), manifest).expect("sergeant.toml");
+}
+
+/// Start a daemon with one scripted fake (the global default) and codex
+/// registered for real, but deterministically unavailable.
+async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
+    daemon::start_with(
+        data_dir,
+        DaemonConfig {
+            backends: Arc::new(
+                BackendRegistry::new().with(Arc::new(FakeBackend::new(FAKE_BACKEND_NAME))),
+            ),
+            default_backend: global_default.map(str::to_string),
+            codex: Some(deterministic_codex_config(data_dir)),
+            estate_root: Some(estate_root.to_path_buf()),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start")
+}
+
+/// POST a JSON body to the daemon; returns status and parsed body.
+async fn post(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    path: &str,
+    body: Value,
+) -> (reqwest::StatusCode, Value) {
+    let resp = client
+        .post(format!("{}{path}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    let value: Value = resp.json().await.expect("json body");
+    (status, value)
+}
+
+/// GET a path from the daemon.
+async fn get(client: &reqwest::Client, handle: &DaemonHandle, path: &str) -> Value {
+    client
+        .get(format!("{}{path}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("request")
+        .json()
+        .await
+        .expect("json body")
+}
+
+/// Submit work whose origin is `cwd`, merging any extra request fields.
+async fn submit(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    cwd: &Path,
+    extra: Value,
+) -> (reqwest::StatusCode, Value) {
+    let mut body = json!({
+        "command_id": ulid(),
+        "intent": "route me",
+        "origin": {"client": "cli", "cwd": cwd},
+    });
+    if let Some(fields) = extra.as_object() {
+        for (key, value) in fields {
+            body[key] = value.clone();
+        }
+    }
+    post(client, handle, "/v1/work", body).await
+}
+
+// -------------------------------------------------------------------- tests
+
+/// (a) Explicit `--backend codex` resolves to the registered adapter, not
+/// `backend_not_found`: codex is *known and named*, and its own probe
+/// evidence is what fails the submission.
+#[tokio::test]
+async fn explicit_backend_codex_reaches_the_registered_adapter_not_not_found() {
+    let root = TempDir::new().expect("tempdir");
+    support::scaffold_estate(root.path(), "plain", &["plain"]);
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"backend": "codex", "origin": {"client": "cli", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(
+        body["error"]["code"], "backend_unavailable",
+        "codex must be *known and named*, not `backend_not_found` — {body}"
+    );
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(
+        available.iter().any(|v| v == "codex"),
+        "codex must be offered as an option: {available:?}"
+    );
+    // Never silently ran on the global default fake instead.
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(list["works"].as_array().expect("works").is_empty());
+    handle.shutdown().await;
+}
+
+/// (b) `SGT_ORIGIN_CLIENT=codex` (as `sgt codex` sets, `src/harness.rs`'s
+/// `ORIGIN_CLIENT_ENV`) resolves `OriginAffinity` when no explicit flag is
+/// given — and, the case that actually catches the pre-registration bug,
+/// must NOT fall through to a populated global default.
+#[tokio::test]
+async fn origin_affinity_from_sgt_codex_is_decisive_over_the_global_default() {
+    let root = TempDir::new().expect("tempdir");
+    support::scaffold_estate(root.path(), "plain", &["plain"]);
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"origin": {"client": "codex", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(body["error"]["code"], "backend_unavailable");
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(available.iter().any(|v| v == "codex"));
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(
+        list["works"].as_array().expect("works").is_empty(),
+        "must not have silently substituted the global default `fake`"
+    );
+    handle.shutdown().await;
+}
+
+/// (c) An estate `default_backend = "codex"` resolves `WorkspaceDefault`,
+/// same decisiveness-over-global-default proof as (b).
+#[tokio::test]
+async fn estate_default_backend_codex_is_decisive_over_the_global_default() {
+    let root = TempDir::new().expect("tempdir");
+    estate_with_manifest(
+        root.path(),
+        "[estate]\nname = \"configured\"\ndefault_backend = \"codex\"\n\n\
+         [[repo]]\nname = \"plain\"\n",
+        &["plain"],
+    );
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"origin": {"client": "cli", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(body["error"]["code"], "backend_unavailable");
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(available.iter().any(|v| v == "codex"));
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(
+        list["works"].as_array().expect("works").is_empty(),
+        "must not have silently substituted the global default `fake`"
+    );
+    handle.shutdown().await;
+}

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -836,15 +836,15 @@ async fn event_history_from_seq_returns_exactly_the_tail() {
     cancel(&http, &handle, &work_id, &ulid()).await;
 
     // daemon.started + backend.probed (one per registered backend: fake,
-    // claude, and docker as of N4 — DaemonConfig::default's registry plus
-    // the two adapters `start_with` always adds)
+    // claude, docker, and codex as of N4/W2 — DaemonConfig::default's
+    // registry plus the three adapters `start_with` always adds)
     // + 2×(work.submitted, command.accepted) + work.canceled
     // + command.accepted.
     let all = history_seqs(&http, &handle, None).await;
-    assert_eq!(all.len(), 10, "unexpected history: {all:?}");
+    assert_eq!(all.len(), 11, "unexpected history: {all:?}");
     assert_eq!(
         all,
-        (1..=10).collect::<Vec<u64>>(),
+        (1..=11).collect::<Vec<u64>>(),
         "seqs are 1..n in order"
     );
 

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -1630,12 +1630,12 @@ async fn t7_routing_precedence_and_structured_failure() {
     assert_eq!(status, 422, "unroutable work must be refused: {body}");
     assert_eq!(body["error"]["code"], "no_backend_selected");
     // The scripted fake occupies the "claude" slot, so the daemon adds
-    // nothing there — but it still adds the real docker adapter (N4, nothing
-    // here is named "docker"). Codex is descoped (D6) and never registered,
-    // and a backend that is not registered is not offered.
+    // nothing there — but it still adds the real docker and codex adapters
+    // (N4/W2, nothing here is named "docker" or "codex"): codex is now the
+    // third real adapter the daemon registers by default, same as docker.
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "docker"])
+        json!(["claude", "codex", "docker"])
     );
     assert!(
         body["error"]["message"]
@@ -1842,13 +1842,19 @@ async fn t7c_an_unusable_stage_harness_fails_before_any_side_effect() {
     );
     handle.shutdown().await;
 
-    // Row 4, second shape: a harness no daemon here registers.
+    // Row 4, second shape: a harness no daemon here registers. Since W2 the
+    // daemon registers a real Codex adapter by default, so naming "codex"
+    // here would no longer demonstrate an unregistered harness (it would be
+    // host-dependent: `backend_unavailable` with no codex on `PATH`, or an
+    // actual routing success on a host with a real logged-in one) — use
+    // "opencode" instead, the name already used elsewhere in this file for
+    // exactly this meaning (an unregistered backend/harness name).
     let repos = TempDir::new().expect("tempdir");
     let data = TempDir::new().expect("tempdir");
     let estate = repos.path().join("solo-estate");
     mixed_harness_repo(
         &estate,
-        "\n[stage.\"10-b\"]\nkind = \"actor\"\nharness = \"codex\"\n",
+        "\n[stage.\"10-b\"]\nkind = \"actor\"\nharness = \"opencode\"\n",
     );
     let (registry, fake) = one_fake([]);
     let handle = start_with(
@@ -1868,12 +1874,13 @@ async fn t7c_an_unusable_stage_harness_fails_before_any_side_effect() {
     .await;
     assert_eq!(status, 422, "must be refused: {body}");
     assert_eq!(body["error"]["code"], "backend_not_found");
-    // The daemon registers the real Claude and Docker adapters alongside the
-    // scripted fake, so the options list names all three; Codex is descoped
-    // (D6) and never registered, which is exactly why naming it fails.
+    // The daemon registers the real Claude, Codex, and Docker adapters
+    // alongside the scripted fake, so the options list names all four;
+    // "opencode" is still never registered, which is exactly why naming it
+    // fails.
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "docker", FAKE_BACKEND_NAME])
+        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME])
     );
     assert!(fake.starts().is_empty(), "no silent provider substitution");
     let list = get(&client, &handle, "/v1/work").await;
@@ -4284,12 +4291,12 @@ async fn a_submission_with_no_workspace_is_captured_but_still_routed() {
     );
     assert_eq!(body["error"]["code"], "backend_not_found");
     // Since M4 the daemon registers the real claude adapter alongside the
-    // scripted fake, and since N4 the docker adapter too (registered names
-    // sort: claude, docker, fake). Codex is descoped (D6): not registered,
-    // not offered.
+    // scripted fake, since N4 the docker adapter too, and since W2 the
+    // codex adapter as well (registered names sort: claude, codex, docker,
+    // fake).
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "docker", FAKE_BACKEND_NAME])
+        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME])
     );
 
     // Only two works exist: the refusal created none.

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -2067,8 +2067,9 @@ async fn a_crash_during_a_resumed_turn_is_re_derived_at_restart() {
 #[tokio::test]
 async fn the_capability_probe_is_journaled_at_registration() {
     let data = TempDir::new().expect("tempdir");
-    // A CLI below the minimum trusted version: the probe's verdict is
-    // "unavailable", and the record must say so with its evidence.
+    // A CLI below the minimum trusted version: the probe's verdict is now
+    // "usable, with unmeasured-provenance detail" (R1), and the record must
+    // say so with its evidence.
     let stub = StubClaude::new(data.path(), "2.1.220 (Claude Code)", ALL_FLAGS);
     let mut claude = ClaudeConfig::new(data.path());
     claude.executable = stub.path.clone();
@@ -2090,23 +2091,26 @@ async fn the_capability_probe_is_journaled_at_registration() {
         .map(|e| e.expect("event"))
         .filter(|e| e.kind == daemon::KIND_BACKEND_PROBED)
         .collect();
-    // One record per registered backend: claude (this test's subject) and
-    // docker (N4 — `start_with` always registers it alongside claude, same
-    // as claude is added here even though this test's registry started
-    // empty). Located by name rather than trusted-by-index, so this stays
-    // correct regardless of how many backends a future adapter adds the
-    // same way.
-    assert_eq!(probed.len(), 2, "one record per registered backend");
+    // One record per registered backend: claude (this test's subject),
+    // docker, and codex (N4/W2 — `start_with` always registers them
+    // alongside claude, same as claude is added here even though this
+    // test's registry started empty). Located by name rather than
+    // trusted-by-index, so this stays correct regardless of how many
+    // backends a future adapter adds the same way.
+    assert_eq!(probed.len(), 3, "one record per registered backend");
     let claude_probed = probed
         .iter()
         .find(|e| e.payload["backend"] == CLAUDE_BACKEND_NAME)
         .expect("a backend.probed record for claude");
     let payload = &claude_probed.payload;
     assert_eq!(payload["backend"], CLAUDE_BACKEND_NAME);
-    assert_eq!(payload["available"], false);
+    assert_eq!(payload["available"], true);
     let detail = payload["detail"].as_str().expect("probe detail recorded");
     assert!(detail.contains("2.1.220"), "{detail}");
-    assert!(detail.contains("minimum trusted 2.1.226"), "{detail}");
+    assert!(
+        detail.contains("BELOW the measured floor 2.1.226"),
+        "{detail}"
+    );
     assert_eq!(
         payload["capabilities"]["native_subagents"], false,
         "capabilities are recorded as advertised, and nothing unmeasured is advertised"
@@ -4472,26 +4476,37 @@ fn a4_a_turn_that_dies_without_an_envelope_is_ambiguous_not_a_verdict() {
 // ------------------------------------------------------- 7. version gate
 
 /// Acceptance 7: the adapter refuses to launch on a CLI the contract tests
-/// never measured — old version, missing flag, or unparseable version —
-/// and the structured error names the probe evidence each time.
+/// never measured — missing flag or unparseable version — and reports
+/// (never refuses) a version below the measured floor; the structured error
+/// names the probe evidence each time it does refuse.
 #[test]
 fn a7_version_gate_fails_closed_naming_the_probe() {
     let dir = TempDir::new().expect("tempdir");
     let request = start_request("e-gate", dir.path(), "irrelevant", None);
 
-    // Version below the measured minimum.
+    // Version below the measured minimum: R1 (2026-08-21) — this is
+    // provenance, not a gate. The probe reports the CLI usable and names the
+    // floor it fell below; it must NOT refuse to launch.
     let old = StubClaude::new(dir.path(), "2.1.220 (Claude Code)", ALL_FLAGS);
     let mut config = ClaudeConfig::new(dir.path());
     config.executable = old.path.clone();
     let backend = ClaudeBackend::new(config);
-    assert!(!backend.probe().available);
-    match backend.start(&request).expect_err("must refuse") {
-        BackendError::Unavailable { detail, .. } => {
-            assert!(detail.contains("2.1.220"), "{detail}");
-            assert!(detail.contains("minimum trusted 2.1.226"), "{detail}");
-        }
-        other => panic!("expected Unavailable, got {other}"),
-    }
+    let probe = backend.probe();
+    assert!(
+        probe.available,
+        "below the measured floor is honest provenance, never a refusal: {probe:?}"
+    );
+    let detail = probe.detail.clone().unwrap_or_default();
+    assert!(detail.contains("2.1.220"), "{detail}");
+    assert!(
+        detail.contains("BELOW the measured floor 2.1.226"),
+        "{detail}"
+    );
+    assert!(
+        detail.contains("unmeasured provenance"),
+        "the detail must say capabilities carry unmeasured provenance, not just \
+         that the version is low: {detail}"
+    );
 
     // A required flag missing from --help.
     let dir2 = TempDir::new().expect("tempdir");


### PR DESCRIPTION
Wave 2 of the codex sprint (plan: docs/proposals/codex-adapter-2026-08-21.md, head PR #224). Spec: `w2-spec.md` in the workspace h-series dir.

- **Codex registered** in daemon startup (`DaemonConfig.codex`, arm mirrors Claude/Docker byte-for-byte, event-sink wired; the D6 refusal comment replaced with a dated closes-D6 note citing W1's measured admission). A codex-less host starts clean — mirrored unavailable-backend handling, tested.
- **Routing proven, not rebuilt** (amendment A1): new `tests/codex_routing.rs` drives the daemon's own registration through the shipped four-tier chain — explicit `--backend codex`, `origin.client` affinity (what `sgt codex` sets), and estate `default_backend` each resolve to codex decisively over the global default (deterministic via a nonexistent-executable config → `backend_unavailable` naming codex, never silent fallthrough).
- **R1 strike, surgical** (amendment A2): only claude.rs's below-`MIN_TRUSTED_VERSION` branch changed — now `available: true` with unmeasured-provenance detail (worded to match codex.rs's below-floor clause); missing-flag and unparseable-version refusals byte-identical; both affected m4 tests rewritten to assert the honest report; TDD red-first proven.
- Registration fallout handled explicitly: startup-history length, three `available_backends` sites, one fixture renamed off "codex".

Panel: 4 axes + refuters — **0 raised**. Gates: fmt/clippy/test `--locked` all green.

Rulings: R1 (owner, "strike it"), A1/A2 (panel amendments); R2 satisfied by shipped code + these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4