### PR TITLE
Answer work_graph for pruned Works by name (#221)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3757,7 +3757,14 @@ fn projection_unavailable(e: impl std::fmt::Display) -> Response {
 async fn work_graph(State(state): State<ApiState>, Path(id): Path<String>) -> Response {
     {
         let core = CoreGuard::acquire(&state.core).await;
-        if !core.registry.state().work_index.contains_key(&id) {
+        let registry = core.registry.state();
+        // #221: graph is a named read surface too. Its source events have
+        // gone after pruning, but the retained residue gives the same honest
+        // named answer as `work show` and `work transcript`.
+        if let Some(row) = registry.pruned_works.get(&id) {
+            return Json(pruned_work_view(row, &state.prune_policy)).into_response();
+        }
+        if !registry.work_index.contains_key(&id) {
             return error_response(
                 StatusCode::NOT_FOUND,
                 "work_not_found",

--- a/tests/w4_read_surfaces.rs
+++ b/tests/w4_read_surfaces.rs
@@ -550,6 +550,69 @@ async fn show_work_on_a_never_existing_id_still_404s() {
     handle.shutdown().await;
 }
 
+// ------------------------------------------------------- #221: graph pruned
+
+/// #221: the graph surface is a named read surface too. Once pruning has
+/// removed the Work's graph events, it must still answer from the same
+/// residue row as `work show`, rather than silently treating the id as one
+/// that never existed.
+#[tokio::test]
+async fn work_graph_on_a_pruned_id_answers_pruned_with_its_date_and_policy() {
+    let data = TempDir::new().expect("tempdir");
+    let root = TempDir::new().expect("tempdir");
+    let (handle, pruned, _retained, retention) = pruned_fixture(&data, &root).await;
+    let http = client();
+
+    let resp = http
+        .get(format!("{}/v1/graph/work/{pruned}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("graph pruned work");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "a pruned graph id is never indistinguishable from a 404"
+    );
+    let body: Value = resp.json().await.expect("json");
+    assert_eq!(body["state"], "pruned");
+    assert!(body["work"].is_null());
+    assert_eq!(body["id"], pruned);
+    assert!(
+        body["pruned_at"].as_str().is_some_and(|s| !s.is_empty()),
+        "pruned_at must be a real timestamp: {body}"
+    );
+    assert_eq!(
+        body["policy"]["retention"], retention,
+        "the reported policy must match this daemon's configured cap: {body}"
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn work_graph_on_a_never_existing_id_still_404s() {
+    let data = TempDir::new().expect("tempdir");
+    let root = TempDir::new().expect("tempdir");
+    let (handle, _pruned, _retained, _retention) = pruned_fixture(&data, &root).await;
+    let http = client();
+
+    let never_existed = ulid();
+    let resp = http
+        .get(format!("{}/v1/graph/work/{never_existed}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("graph unknown work");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "an id in neither work_index nor pruned_works must remain a graph 404"
+    );
+
+    handle.shutdown().await;
+}
+
 // -------------------------------------------- §1.3: `work transcript` pruned
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #221.

## The Work's story

`GET /v1/graph/work/{id}` (`work_graph` in `src/api.rs`) fell through to a plain 404 once a Work's graph events were pruned — indistinguishable from an id that had never existed. This diff makes `graph` a named read surface too, the same way W4 already made `work show` and `work transcript`: a pruned id now answers `200` from the retained `pruned_works` residue row (`state: "pruned"`, prune date, retention policy) instead of a blank 404.

This fix was authored by sergeant Work `01M0MSRZDYMSVWZF27K2QJV8YR` — codex backend, model `gpt-5.6-terra`, `diagnose-bug` workflow. The Work diagnosed and fixed the bug correctly, but retired `completed_dirty` without committing its work. Retirement preserved the diff as a dirty patch (`sergeant-rs.dirty.patch`) rather than losing it. This PR salvages that preserved patch: applied to current `main`, reviewed independently, and put through the full gate suite before being committed and opened here. The commit-expectation gap in the workflow that let a `completed_dirty` Work retire without committing is filed separately, not addressed by this PR.

## Review

- `src/api.rs`: the new `pruned_works` check in `work_graph` mirrors the same pattern already used by `show_work`/`work_transcript` and their shared `resolve_work`/`pruned_work_view` helpers — same lookup order, same `pruned_work_view(row, &state.prune_policy)` response shape.
- `tests/w4_read_surfaces.rs`: the two new tests (`work_graph_on_a_pruned_id_answers_pruned_with_its_date_and_policy`, `work_graph_on_a_never_existing_id_still_404s`) are near-exact mirrors of the existing `show_work_on_a_pruned_id_...` / `show_work_on_a_never_existing_id_still_404s` tests, using the same `pruned_fixture` helper and the real router path `/v1/graph/work/{id}` (`work_graph`'s actual route).
- No code changes were needed to the actor's diff — it was applied verbatim. The only correction made was to the *preserved patch file itself*: it was missing its trailing newline (a preservation/truncation artifact from retirement), which made `git apply` reject it as "corrupt patch at line 94" until a newline was appended.

## Gates (cold build)

- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean, 0 warnings
- `cargo test --locked` — all 37 test binaries green, 778+ unit tests plus all integration suites passing, including both new `work_graph_*` tests

## L7 revert check

With only the `src/api.rs` hunk reverted (tests left in place), `work_graph_on_a_pruned_id_answers_pruned_with_its_date_and_policy` fails as expected:

```
assertion `left == right` failed: a pruned graph id is never indistinguishable from a 404
  left: 404
 right: 200
```

Re-applying the hunk restores both new tests to green. This confirms the test actually exercises the fix rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4