### PR TITLE
W4: finalize 0.2.1 — CHANGELOG, README catalog truth, edition alignment

### DIFF
--- a/.sergeant/workflows/author-document/index.md
+++ b/.sergeant/workflows/author-document/index.md
@@ -3,7 +3,7 @@ kind: workflow
 name: author-document
 status: published
 version: 1
-edition: 0.2.0
+edition: 0.2.1
 description: >-
   Produce a document as the deliverable, with fidelity to the brief as
   the top-weighted review axis.

--- a/.sergeant/workflows/fix-defect/index.md
+++ b/.sergeant/workflows/fix-defect/index.md
@@ -3,7 +3,7 @@ kind: workflow
 name: fix-defect
 status: published
 version: 1
-edition: 0.2.0
+edition: 0.2.1
 description: >-
   Reproduce a defect before touching it, prove the cause, fix it with a
   regression test, and put the fix through the same review chain a

--- a/.sergeant/workflows/implement-change/index.md
+++ b/.sergeant/workflows/implement-change/index.md
@@ -3,7 +3,7 @@ kind: workflow
 name: implement-change
 status: published
 version: 1
-edition: 0.2.0
+edition: 0.2.1
 description: >-
   Take an intent for a change to code, produce the change with its tests,
   attack it on four axes, refute the attack, fix only what survives,

--- a/.sergeant/workflows/investigate/index.md
+++ b/.sergeant/workflows/investigate/index.md
@@ -3,7 +3,7 @@ kind: workflow
 name: investigate
 status: published
 version: 1
-edition: 0.2.0
+edition: 0.2.1
 description: >-
   Answer a bounded question against evidence, with a stated stopping
   condition, and leave a durable cited artifact.

--- a/.sergeant/workflows/remediate-findings/index.md
+++ b/.sergeant/workflows/remediate-findings/index.md
@@ -3,7 +3,7 @@ kind: workflow
 name: remediate-findings
 status: published
 version: 1
-edition: 0.2.0
+edition: 0.2.1
 description: >-
   Consume an approved typed finding set and account for every finding —
   accepted, rejected, superseded, or unverifiable — with the fixes

--- a/.sergeant/workflows/review-change/index.md
+++ b/.sergeant/workflows/review-change/index.md
@@ -3,7 +3,7 @@ kind: workflow
 name: review-change
 status: published
 version: 1
-edition: 0.2.0
+edition: 0.2.1
 description: >-
   Review a diff that arrives from outside a Work — a colleague's PR, a
   merge candidate, a change someone else built — on four axes, and emit

--- a/.sergeant/workflows/validate-and-ship/index.md
+++ b/.sergeant/workflows/validate-and-ship/index.md
@@ -3,7 +3,7 @@ kind: workflow
 name: validate-and-ship
 status: published
 version: 3
-edition: 0.1.0
+edition: 0.2.1
 description: >-
   The single final shipping boundary: validate a committed change through
 the pipeline to a terminal outcome, routing every finding, without the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,189 @@ released before a release can proceed.
 
 (nothing yet)
 
+## [0.2.1] - 2026-08-23
+
+Content-only release: the distro content rebuild commissioned 2026-08-22
+(`docs/proposals/distro-content-2026-08-22.md`; design record and every
+ratified item at `sergeant-rs-workspace/knowledge/evidence/resources/
+distro-content-series/design-proposal-2026-08-22.md`). Zero engine-behavior
+change: every content byte in this release lives under `skills/`,
+`.sergeant/workflows/`, `.sergeant/common/contexts/`, `.sergeant/index.md`,
+or `AGENTS.md`; `git diff --stat main -- src/ .github/` is empty, and this
+section's own version bump is the only `Cargo.toml`/`Cargo.lock` edit. The
+embedded `software-change` default loop is untouched — see "Deferred"
+below for why, and why this release is 0.2.1, not the sprint plan's
+originally proposed 0.3.0.
+
+### Workflow catalog rebuilt: 19 published workflows -> 7
+
+Owner ruling (2026-08-22), from direct knowledge of the estate's own
+history: "I never guided to select any other workflows because the ones we
+had never applied or sucked. They're like one stage or fragile." Sixty of
+the estate's own sixty-one dispatched Works ran the engine's embedded
+default and never selected a published workflow; nine of the nineteen fail
+the owner's own stated bar — genuinely multi-stage and robust — on
+inspection. The rebuild is ratified; every surviving and new package
+states a robustness argument: what each stage boundary buys under crash or
+stall, which stage attacks the previous stage's output, and what happens
+when a stage cannot complete.
+
+- **`implement-change`** (9 stages) — the flagship. Orient, baseline,
+  implement, validate, a 4-axis panel (spec-fidelity, invariants,
+  simplicity, test-honesty) run as isolated sub-agent seats spawned in one
+  message, per-axis refuters defaulting to refuted, fix on confirmed
+  findings only, re-verify over the fix commits, close. Absorbs
+  `implement` and `worker-mission`.
+- **`fix-defect`** (8 stages) — reproduce-first, hard-gated: no edit until
+  the defect reproduces; then hypothesize, instrument, fix with a
+  regression test, and the same panel -> refute -> re-verify chain.
+  Reshaped from `diagnose-bug` (6 stages, name changed); it remains the
+  only workflow a live Work has ever bound.
+- **`investigate`** (6 stages) — frame a bounded question with a stated
+  stopping condition, fan out N isolated evidence seats, synthesize one
+  cited document, challenge it with a refuter, record, close. Absorbs
+  `research` (shipped as a single stage) and `wayfinder` minus its
+  `00-name-destination` stage, deleted rather than carried forward:
+  naming a destination needs a live interview, which R-NS-6 places in
+  Captain, before dispatch, never in a dispatched stage.
+- **`review-change`** (6 stages) — the standalone, read-only panel for a
+  diff arriving from outside a Work: pin the revision, identify the spec
+  source, run the 4-axis panel, refute, independently verify each
+  survivor against current state, emit a typed finding set. Never fixes.
+  Reshaped from `code-review` (4 stages, 2 axes).
+- **`remediate-findings`** (6 stages, new) — consumes an approved typed
+  finding set and accounts for every one: verify against current state,
+  dispose (accept/reject/supersede, with a reason), fix accepted findings
+  only, re-verify over the fix commits, and a disposition matrix proving
+  nothing was silently dropped.
+- **`author-document`** (6 stages, new) — a document as the deliverable,
+  fidelity to the brief as the top-weighted review axis. Absorbs
+  `record-decisions` as a named profile section — a section, not a
+  construct, since sergeant has no profile mechanism yet (filed as an
+  engine ask, not silently assumed).
+- **`validate-and-ship`** (7 stages, `version: 3`) — kept and reshaped in
+  place: the one shipping invariant in the catalog, and the ancestor of
+  `review-change`'s never-edit rule.
+
+### Eighteen retired
+
+`code-review`, `cross-repo-work`, `deepen-module`, `diagnose-bug`,
+`dispatch`, `implement`, `prototype`, `record-decisions`,
+`recover-stalled-worker`, `repo-to-icm`, `research`,
+`resolving-merge-conflicts`, `to-tickets`, `triage`, `validate-intent`,
+`vet-external-skill`, `wayfinder`, `worker-mission`. Every disposition and
+its reason is recorded in `.sergeant/index.md`'s retirement log; each
+package's full content survives in git history. Two dispositions named
+here because they cost something rather than merely tidying:
+
+- **`dispatch`'s retirement removes the only place safety-sensitive
+  keyword routing (auth/secrets/payments/migrations/production) lived.**
+  This release does not replace it. Named as a live gap on the head PR's
+  ratify list, not silently absorbed.
+- **`repo-to-icm` relocates rather than retires** — to
+  `sergeant-rs-workspace/.sergeant/local/workflows/`, this project's own
+  doctrine-bootstrapping tool and never a product capability — and takes
+  with it the library's only `kind = "execute"` stage. This library no
+  longer exercises that stage kind anywhere.
+
+### Captain's kernel: 5 published skills -> 14
+
+Three ship byte-identical (`grilling`, `estate-navigation`,
+`sergeant-help` — edition bump only). Eleven are new or reshaped:
+`orient`, `brainstorm`, `clarify-intent`, `scope-intent`,
+`define-acceptance` (absorbing `validate-intent`'s eight-dimension check
+as an in-dialogue review — the cost is independence, stated rather than
+hidden), `decide` (carrying the one-question-per-turn discipline),
+`decompose`, **`select-workflow`** (reads `.sergeant/index.md` live, never
+restates it, and leaves a dated selection record naming what was passed
+over and why — the direct answer to the sixty unrecorded choices above),
+**`plan-sprint`** (the three-sprint-proven method, codified with its
+engine caveat stated honestly: its recon and panel seats are harness
+sub-agents, not Sergeant Works, until child-workflow dispatch lands),
+`review-outcome`, `retrospective`. `to-spec` and `grill-with-docs` retire
+into their successors.
+
+### AGENTS.md: the dispatch-time discipline
+
+- The `## Trigger -> skill/workflow routing table`'s dispatch row now
+  names **Captain**, not the `sgt run` command, as the workflow selector —
+  correcting the cell the sixty unrecorded selections trace back to.
+- New stable-operating-invariant text: "Before any `sgt run`, consult
+  `.sergeant/index.md` and name the workflow you selected. Omitting
+  `--workflow` binds the embedded default loop; that is a selection and
+  must be stated as one... An unnamed default is not a selection."
+- "**Captain owns ambiguity. Sergeant owns completion.**" stated beside
+  `R-NS-6`, which remains the enforcing rule where the two could disagree.
+
+### Contexts
+
+`.sergeant/common/contexts/` gains nine reusable stage contexts (shared
+panel/refute/fan-out-evidence/pin-fixed-point/identify-spec-source/
+resolve-conflicts machinery, authored once instead of re-derived per
+package) and four policy contexts: `test-first` (consolidating `tdd.md`
+and `test-quality.md`, both deleted this release, closing a dangling
+reference to the already-retired `tdd` package that had stood since
+ICM-R3), `independent-review`, `evidence-requirements`, and
+`model-assignment` — the last un-copy-pasted from three separate sprint
+plans' identical paragraph.
+
+### Fixed (docs)
+
+- `docs/glossary.md`'s Placement Ladder citation pointed at
+  `.sergeant/workflows/repo-to-icm/_config/icm-ladder.md`, a path this
+  release's `repo-to-icm` relocation removes from this repository;
+  repointed to the file's new home in `sergeant-rs-workspace`.
+- `NORTH-STAR.md`'s cross-repo delivery-ordering gap named the now-retired
+  `cross-repo-work` workflow as its current home; repointed to
+  `scope-intent`'s `targets.dependency_order` field, the claim's actual
+  owner since the dissolution (the underlying gap — no engine-side
+  dependency contract — is unchanged and still open).
+- `README.md`'s workflow-directory illustration and catalog summary named
+  `software-change` as an on-disk package and six retired workflows
+  (`code review`, `research`, `prototyping`, `cross-repository work`,
+  `intent validation`, `decision recording`) as the shipped set; both now
+  show the real seven, and the illustration uses `implement-change`, the
+  package actually on disk.
+- `edition` front matter aligned to `0.2.1` across all 21 shipped
+  templates (was a mix of `0.2.0` and one `0.1.0` outlier). Cosmetic —
+  `sgt init`/update always stamps the running binary's own version at
+  write time regardless of the checked-in value (ADR 0016) — fixed
+  because it was odd on sight, per W2's own ratify list.
+
+### Deferred (ratified at kickoff, not executed this release)
+
+The kickoff ruling retired the embedded `software-change` default outright
+("an old way of ensuring there's at least one workflow"; unspecified
+`--workflow` becomes bare intent execution) and granted the one
+engine-code exception that requires. **This sprint does not execute that
+retirement.** The owner's own scope ruling — "the only changes here should
+be to workflows/, skills/, and AGENTS.md" — bounds this sprint's diff to
+content, and a real `src/domain/workflow.rs` fallback change plus a
+`src/workflows/software-change/` deletion do not fit inside that boundary
+regardless of what the kickoff separately ratified. W2's spec deferred the
+retirement to a future release that actually touches `src/`; it remains
+ratified and outstanding, carried on this release's own ratify list (see
+the head PR). **This release's version number reflects the deferral**:
+`0.2.1`, a content-only patch — not the sprint plan's originally proposed
+`0.3.0`, which priced in the retirement this release does not ship.
+
+### Ratify-at-review (owner, at the head PR)
+
+Carried forward from W2 §8 and W3, restated here for the release record:
+the `tests/f_doctrine_skew.rs` edit (a fourth surface touched, under the
+plan's existing test rider); the two homeless-policy homes
+(`test-first`/`model-assignment` in shared contexts, AGENTS.md pointing
+rather than restating); the safety-sensitive routing gap `dispatch`'s
+retirement opens with no replacement; the `record-decisions` profile
+section standing in for a profile construct sergeant does not have yet
+(J.11); the `.sergeant/lib/` relocation and the finalize ruling (no
+shipped stage invokes a helper `sgt init` does not write); the unmeasured
+panel budget (four seats plus four refuters in one stage, against a
+two-seat precedent) — this release's proof obligations are on the head
+PR, not executed here (W4 is finalize, not proof; see the head PR's own
+scope note); and this section's own version-number correction (0.2.1, not
+the plan's 0.3.0) and the still-outstanding embedded-default retirement.
+
 ## [0.2.0] - 2026-08-22
 
 Sergeant speaks Codex: a second native backend, selectable the same way

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "sergeant-rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sergeant-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 # Keep in sync with the `msrv` job's `env.MSRV` in .github/workflows/ci.yml
 # (W1 spec §E) — cargo has no way to read this field back into that job's

--- a/NORTH-STAR.md
+++ b/NORTH-STAR.md
@@ -295,7 +295,10 @@ submit, and repeatable `--repo` plus client-side `--group` expansion,
 pinned by `tests/m3_execution.rs::t2_multi_repo_workspace_binds_one_worktree_per_repository`
 and `tests/m8_estate_cli.rs::run_group_expansion_itself_survives_an_unrelated_declared_repo_missing_from_disk`.
 What remains uncontracted is narrower: cross-repo *delivery ordering* is
-planned by hand in the `cross-repo-work` workflow with no engine-side
+planned by hand — since the 2026-08-22 distro rebuild dissolved
+`cross-repo-work` into `scope-intent`'s `targets.dependency_order` field
+(Captain-side intent-shaping) plus an unbuilt runtime fan-out
+(design-proposal-2026-08-22.md §I.3, J.14) — with no engine-side
 dependency contract, and the multi-repo execution cwd —
 `WorkSurface::execution_cwd` falls back to the surface root for
 two-or-more repositories — is construction, not a ruling), soak evidence (#19),

--- a/README.md
+++ b/README.md
@@ -127,22 +127,32 @@ Sergeant does not impose a memory system of its own: the estate carries durable 
 A workflow is a standard way of working expressed as a directory:
 
 ```text
-.sergeant/workflows/software-change/
+.sergeant/workflows/implement-change/
 ├── workflow.toml
 ├── CONTEXT.md
-├── 00-prepare/
+├── 00-orient/
+│   └── CONTEXT.md
+├── 05-baseline/
 │   └── CONTEXT.md
 ├── 10-implement/
 │   └── CONTEXT.md
-├── 20-review/
+├── 15-validate/
 │   └── CONTEXT.md
-└── 30-close/
+├── 20-panel/
+│   └── CONTEXT.md
+├── 25-refute/
+│   └── CONTEXT.md
+├── 30-fix-confirmed/
+│   └── CONTEXT.md
+├── 35-re-verify/
+│   └── CONTEXT.md
+└── 40-close/
     └── CONTEXT.md
 ```
 
 Every stage is its own execution with its own contract. A stage declares the context and inputs it needs, produces explicit outputs, and ends before the next stage begins — context moves between stages through declared artifacts, not through one enormous agent conversation that must remain alive forever. A stage can be a fresh agent execution when judgment is needed, a Docker execution for deterministic work, repository-native scripts and tests, or a human decision when authority runs out. Agents where reasoning helps. Containers where determinism helps.
 
-Sergeant ships with workflows for software changes, code review, research, diagnosing bugs, prototyping, cross-repository work, intent validation, decision recording, validation and shipping, and more — the [workflow catalog](.sergeant/index.md) lists them all. Captain discovers them through the catalog and selects one based on the accepted intent.
+Sergeant ships with seven named workflows — implementing a change (with an in-loop review panel, refuters, and a re-verify pass over the fix), fixing a defect, investigating a bounded question, reviewing a diff that arrives from outside a Work, remediating a typed set of findings, authoring a document, and validating and shipping — the [workflow catalog](.sergeant/index.md) lists them all. Captain discovers them through the catalog and selects one based on the accepted intent; omitting `--workflow` binds the embedded default loop, which the catalog is a set of deliberate alternatives to, never a silent fallback.
 
 ### Write your own workflows
 
@@ -261,7 +271,7 @@ You can also submit directly:
 
 ```sh
 sgt run "add retry handling to the settlement worker" \
-  --workflow software-change \
+  --workflow implement-change \
   --group payments
 ```
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,7 +17,9 @@ answering "what is the lowest-authority, smallest-surface representation
 that faithfully owns this behavior?" — applied to one source-cited
 behavior unit at a time, stopping at the first rung that honestly holds.
 Distinct from the pre-existing decomposition ladder in
-`.sergeant/workflows/repo-to-icm/_config/icm-ladder.md`: PL extends it
+`sergeant-rs-workspace/.sergeant/local/workflows/repo-to-icm/_config/icm-ladder.md`
+(relocated from this repository's own `.sergeant/workflows/repo-to-icm/`
+at the 2026-08-22 distro content rebuild): PL extends it
 with the driver/admission-boundary discriminator (Captain versus
 stage-actor versus deterministic versus runtime; pre-Work versus in-Work
 versus post-Work) the prior ladder lacked. Ratified as accepted vocabulary

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brainstorm
 description: Explore goals, approaches, constraints, non-goals, and consequences before an intent is precise enough to hand to clarify-intent. Use when what's wanted isn't yet settled enough to state as a candidate intent.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 **[external]** — new authorship, no estate evidence behind it. Carried

--- a/skills/clarify-intent/SKILL.md
+++ b/skills/clarify-intent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clarify-intent
 description: Turn "I want this thing" or "this seems broken" into a precise outcome or problem statement — synthesized from this conversation and codebase exploration, never a fresh interview. Use when desired outcome needs distinguishing from proposed implementation, fact from assumption, requirement from preference, known constraint from unresolved question.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 Merged; absorbs `to-spec`'s synthesis half (the "Problem Statement" /

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: decide
 description: Compare alternatives and make an explicit decision with the human — options, comparison dimensions, recommendation, human decision, rationale, rejected alternatives and why, and when the decision should be revisited. Use when alternatives need comparing and the human needs to make an explicit decision.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 Merged; carries J0's one-question discipline and absorbs the

--- a/skills/decompose/SKILL.md
+++ b/skills/decompose/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: decompose
 description: Split a large, already-approved intent into independently executable child intents, with dependencies and sequencing between them. Use when a large approved intent needs splitting into units of work before each goes to select-workflow.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 **[external]** — new authorship, no estate evidence behind it, same

--- a/skills/define-acceptance/SKILL.md
+++ b/skills/define-acceptance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: define-acceptance
 description: Turn subjective completion language ("done," "working," "fixed") into observable success — behavioral acceptance criteria, quality constraints, required tests/evidence, expected documentation, thresholds, and blocking conditions. Use once scope is drawn and acceptance still needs stating before an intent leaves the conversation.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 Merged; absorbs `validate-intent` as an in-dialogue review.

--- a/skills/estate-navigation/SKILL.md
+++ b/skills/estate-navigation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: estate-navigation
 description: Resolve an estate's declared repositories, groups, and health before acting in it, bring its working set up to date, register new repos/groups interactively, and file tracked work for gaps `sgt doctor` can't remedy — sergeant-rs's equivalent of upstream's sgt-context/sgt-sync/sergeant-setup.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 Provenance for this skill's citation record lives in

--- a/skills/grilling/SKILL.md
+++ b/skills/grilling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: grilling
 description: Grill the user relentlessly about a plan, decision, or idea, one question at a time. Use when the user wants to stress-test their thinking, or uses a 'grill' trigger phrase.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 Ported from `.sergeant/workflows/grilling` (N1 candidate W28), which

--- a/skills/orient/SKILL.md
+++ b/skills/orient/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: orient
 description: Establish shared terminology, actors, and the immediate decision in view before any other skill or `sgt run` touches this system this session. Use when a session opens on a project/system/estate the human and Captain have not yet established a shared model for.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 **[external]** — new authorship, no estate evidence behind it. This skill

--- a/skills/plan-sprint/SKILL.md
+++ b/skills/plan-sprint/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-sprint
 description: Run a multi-wave sprint end to end — recon, plan, panel, rulings, waves, finalize — codifying the integration-branch/wave-branch/blind-panel method this estate's completed sprints have actually used. Use when a body of work needs a sprint-shaped plan with an integration branch, wave branches, and a blind panel gate before waves run.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 **[proven]** — new authorship, this skill's protocol is VERBATIM-faithful

--- a/skills/retrospective/SKILL.md
+++ b/skills/retrospective/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: retrospective
 description: Discuss what happened, what was learned, and whether a process, workflow, policy, or product change should become a new intent. Use when discussing the conversation around a postmortem's findings, at sprint scale or smaller.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 **[proven]** — kept.

--- a/skills/review-outcome/SKILL.md
+++ b/skills/review-outcome/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-outcome
 description: Interpret something Sergeant returned — completed work, findings, blockers, conflicting evidence, or a suggested follow-up intent — against the intent's declared acceptance criteria, and state which disposition applies. Use when Sergeant returned something and it needs interpreting - accept, reject, revise, remediate, or redispatch.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 Merged, adopted into the kernel.

--- a/skills/scope-intent/SKILL.md
+++ b/skills/scope-intent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scope-intent
 description: Establish where the work applies and where it does not — repository/artifact targets, components/interfaces, dependency boundaries, explicit non-goals, blast radius, single-repo vs. estate topology. Use once a precise outcome exists and needs its scope and boundaries drawn before it leaves the conversation.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 Merged and load-bearing; absorbs `cross-repo-work`'s ownership/

--- a/skills/select-workflow/SKILL.md
+++ b/skills/select-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: select-workflow
 description: Read `.sergeant/index.md` live and recommend a workflow, the applicable shared-context policies, and a delivery posture for an intent that's ready to leave the conversation — never restating the catalog or deciding for the human. Use when an intent is ready to leave the conversation and needs a workflow, policy, and delivery recommendation before `sgt run`.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 Merged; the deliverable of ruling (b) — the `AGENTS.md` dispatch-time

--- a/skills/sergeant-help/SKILL.md
+++ b/skills/sergeant-help/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sergeant-help
 description: Answer a Sergeant usage/setup/troubleshooting question from repository-owned documentation with a fixed precedence order, read-only, never inventing behavior.
-edition: 0.2.0
+edition: 0.2.1
 ---
 
 # Sergeant Help


### PR DESCRIPTION
Wave 4 (final) of the distro-content sprint (plan: docs/proposals/distro-content-2026-08-22.md, head PR #235). Spec: `w4-spec.md`, every claim verified against the landed tree before writing.

- **0.2.1** (not the plan's 0.3.0 — that priced in the deferred embedded-default retirement; the landed diff touches zero bytes under src/.github/Cargo beyond the version line, so content-only patch, reasoning written into the CHANGELOG itself). Cargo.lock synced per precedent.
- CHANGELOG `[0.2.1]`: the catalog rebuild honestly framed (7 packages on the gauntlet roles, 18 retired, 14-skill kernel, AGENTS.md dispatch discipline; embedded default unchanged, retirement ratified-deferred).
- README's three stale sites fixed (the on-disk software-change illustration replaced with implement-change's real 9-stage tree; catalog sentence; example command). Two living-doc defects fixed (glossary's dead repo-to-icm path; NORTH-STar naming dissolved cross-repo-work as a live gap-owner).
- `edition` front-matter aligned 0.2.1 across all 21 templates (cosmetic — init stamps the binary's version — but consistent).
- Gates: fmt/clippy/test --locked green; validate-distro 6/6 selftest + zero findings; docs-consistency clean; diff-shape sanity verified.

Panel: 0 raised. Ratify items carried to #235: the version number, F.8 residuals, the retirement, NORTH-STAR's "(241 files, measured)" claim (flagged, out of mandate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4