### PR TITLE
W2: register opencode — routing verification, PATH line, orphan-suite guard

### DIFF
--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -93,3 +93,19 @@ cov_stage_end 1 "the codex_routing test binary must write its own profile"
 cov_stage_begin c2-opencode_backend
 cov_run cargo llvm-cov --no-report --test opencode_backend --locked || cov_fail "opencode_backend failed under instrumentation"
 cov_stage_end 1 "the opencode_backend test binary must write its own profile (StubOpencode's children are shell-script stand-ins, uninstrumented and no loss, per codex_backend's precedent)"
+
+# Added 2026-08-23, in the same commit that creates the suite (W2, opencode
+# registration wave) — codex_routing's exact rationale: in-process-only
+# throughout (no StubOpencode, no subprocess), so it sits in C2 rather than
+# needing C3's ≥2-profile floor. Floor 1.
+cov_stage_begin c2-opencode_routing
+cov_run cargo llvm-cov --no-report --test opencode_routing --locked || cov_fail "opencode_routing failed under instrumentation"
+cov_stage_end 1 "the opencode_routing test binary must write its own profile"
+
+# Added 2026-08-23, same commit that creates the suite (W2, opencode
+# registration wave, item 6 / #231(b)): a plain static-scan test, no
+# subprocess, no daemon — sits in C2 for the same reason codex_routing does.
+# Floor 1.
+cov_stage_begin c2-coverage_stage_membership
+cov_run cargo llvm-cov --no-report --test coverage_stage_membership --locked || cov_fail "coverage_stage_membership failed under instrumentation"
+cov_stage_end 1 "the coverage_stage_membership test binary must write its own profile"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -39,6 +39,7 @@ use crate::backend::claude::{CLAUDE_BACKEND_NAME, ClaudeBackend, ClaudeConfig};
 use crate::backend::codex::{CODEX_BACKEND_NAME, CodexBackend, CodexConfig};
 use crate::backend::docker::{DOCKER_BACKEND_NAME, DockerBackend, DockerConfig};
 use crate::backend::fake::FAKE_BACKEND_NAME;
+use crate::backend::opencode::{OPENCODE_BACKEND_NAME, OpencodeBackend, OpencodeConfig};
 use crate::backend::{BackendRegistry, EventSink};
 use crate::domain::estate::Estate;
 use crate::domain::event::{EventDraft, EventSource};
@@ -336,6 +337,10 @@ pub struct DaemonConfig {
     /// itself. `None` is the system `codex`, adapter state under this data
     /// dir — mirrors `claude`/`docker` above for the same reason.
     pub codex: Option<CodexConfig>,
+    /// Launch configuration for the Opencode adapter this daemon registers
+    /// itself. `None` is the system `opencode`, adapter state under this data
+    /// dir — mirrors `claude`/`docker`/`codex` above for the same reason.
+    pub opencode: Option<OpencodeConfig>,
     /// §28 OpenTelemetry export. `None` is **off**, and off is the default:
     /// with no pipeline here the daemon builds no provider, spawns no
     /// exporter task, and subscribes nothing to the event stream.
@@ -423,6 +428,7 @@ impl Default for DaemonConfig {
             claude: None,
             docker: None,
             codex: None,
+            opencode: None,
             telemetry: None,
             completion_poll: COMPLETION_POLL_INTERVAL,
             turn_ceiling: crate::runtime::engine::DEFAULT_TURN_CEILING,
@@ -816,6 +822,25 @@ pub async fn start_with(
     } else {
         None
     };
+    // W2 (opencode-adapter sprint, mirrors the codex block directly above):
+    // the Opencode executor, registered the same way and for the same reason
+    // as Claude/Docker/Codex. No `seed_capability_provenance_from` call here
+    // either — that method exists only on `ClaudeBackend`, and
+    // `OpencodeBackend::capabilities().ask` is `false` unconditionally
+    // (opencode.rs's own ADMISSION_ROWS `ask` row: no measured
+    // actor-authored-question record on this transport), so there is no
+    // journaled withdrawal to seed.
+    let opencode = if config.backends.get(OPENCODE_BACKEND_NAME).is_none() {
+        let opencode_config = config
+            .opencode
+            .clone()
+            .unwrap_or_else(|| OpencodeConfig::new(data_dir));
+        let adapter = Arc::new(OpencodeBackend::new(opencode_config));
+        backends = backends.with(adapter.clone());
+        Some(adapter)
+    } else {
+        None
+    };
     let backends = Arc::new(backends);
 
     // 4b-ii. The capability/version probe, recorded at registration (M4
@@ -955,6 +980,11 @@ pub async fn start_with(
     // (same reasoning as Claude's/Docker's, directly above).
     if let Some(codex) = codex {
         codex.set_event_sink(journaling_sink(state.core.clone()));
+    }
+    // The Opencode adapter's normalized events flow through the identical
+    // sink (same reasoning as Claude's/Docker's/Codex's, directly above).
+    if let Some(opencode) = opencode {
+        opencode.set_event_sink(journaling_sink(state.core.clone()));
     }
     let app = router(state.clone());
 

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -54,12 +54,21 @@ const ORIGIN_CLIENT_ENV: &str = "SGT_ORIGIN_CLIENT";
 /// attempt to replicate a login shell's full startup environment — sourcing
 /// `.bashrc`/`.profile` would make sergeant responsible for parsing and
 /// running arbitrary shell config it does not own (proposal §8.1's
-/// over-specification warning); this instead states two concrete, measured
-/// directories and stops.
+/// over-specification warning); this instead states each directory by name,
+/// with its own measured evidence, and stops.
+///
+/// - `~/.cargo/bin`, `~/.local/bin` — measured (`docs/environments/
+///   cerberus.md`), see the module doc above.
+/// - `~/.opencode/bin` — measured (`knowledge/evidence/
+///   opencode-adapter-probes-2026-08-23.md`, "Installation facts"):
+///   opencode's own binary lives there on Cerberus, absent from a
+///   non-interactive shell's default PATH — the identical #60 failure class
+///   `~/.cargo/bin`/`~/.local/bin` were added to fix.
 pub fn toolchain_path_dirs(home: &Path) -> Vec<PathBuf> {
     vec![
         home.join(".cargo").join("bin"),
         home.join(".local").join("bin"),
+        home.join(".opencode").join("bin"),
     ]
 }
 
@@ -249,13 +258,14 @@ mod tests {
     }
 
     #[test]
-    fn toolchain_path_dirs_names_cargo_and_local_bin() {
+    fn toolchain_path_dirs_names_cargo_local_and_opencode_bin() {
         let home = Path::new("/home/x");
         assert_eq!(
             toolchain_path_dirs(home),
             vec![
                 PathBuf::from("/home/x/.cargo/bin"),
-                PathBuf::from("/home/x/.local/bin")
+                PathBuf::from("/home/x/.local/bin"),
+                PathBuf::from("/home/x/.opencode/bin"),
             ]
         );
     }

--- a/tests/coverage_stage_membership.rs
+++ b/tests/coverage_stage_membership.rs
@@ -76,10 +76,19 @@ fn all_suites() -> Vec<String> {
 }
 
 /// Suite names invoked via `--test <name>` in one coverage stage script.
+///
+/// Only counts lines that are actually executed by the shell: a line whose
+/// first non-whitespace character is `#` is a comment (whether it's a prose
+/// comment mentioning `--test`, or a whole `cov_run ... --test <name> ...`
+/// invocation commented out to disable a suite — the more realistic
+/// maintenance action) and must not register as "wired", or this guard would
+/// silently stop catching the exact #231 failure class it exists to catch:
+/// a suite that no coverage stage actually runs, however green it looks.
 fn wired_suites(script: &str) -> Vec<String> {
     let text = std::fs::read_to_string(repo_root().join("scripts/coverage").join(script))
         .unwrap_or_else(|e| panic!("read {script}: {e}"));
     text.lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
         .filter_map(|line| line.split_once("--test "))
         .map(|(_, rest)| rest.split_whitespace().next().unwrap_or("").to_string())
         .filter(|name| !name.is_empty())

--- a/tests/coverage_stage_membership.rs
+++ b/tests/coverage_stage_membership.rs
@@ -1,0 +1,111 @@
+//! #231(b): a structural guard against a *new* orphaned test suite — one
+//! present in `tests/*.rs` but wired into neither coverage stage script, so
+//! it contributes nothing to Gate D however green it runs (the #231 lesson,
+//! also cited by scripts/coverage/c2-suites.sh's own 2026-08-23 comment).
+//! This is a floor-maintenance guard, not an audit of the suites it finds
+//! already missing at authorship time — those are named in ALLOWLIST below,
+//! each with its own reason, and #231(a) is the tracked follow-up to judge
+//! them one by one.
+//!
+//! Must live in a suite wired into C2 or C3 itself (no self-orphaning) —
+//! this file is added to c2-suites.sh in the same commit.
+
+use std::path::PathBuf;
+
+/// Pre-existing orphans at authorship time (2026-08-23, opencode W2), each
+/// present in neither `scripts/coverage/c2-suites.sh` nor
+/// `c3-spawning-suites.sh`. #231(a) is the tracked follow-up to judge each
+/// one; this guard's job is only to stop the set from growing silently.
+const ALLOWLIST: &[(&str, &str)] = &[
+    ("a1_floor_awareness", "pre-existing, #231(a) audit pending"),
+    ("a4_blob_ref_pinning", "pre-existing, #231(a) audit pending"),
+    ("c11_injectable_git", "pre-existing, #231(a) audit pending"),
+    ("c4_repo_lock", "pre-existing, #231(a) audit pending"),
+    (
+        "e_admission_uses_no_network_git",
+        "pre-existing, #231(a) audit pending",
+    ),
+    ("e_git_admission", "pre-existing, #231(a) audit pending"),
+    (
+        "e_sweep_uses_only_local_git",
+        "pre-existing, #231(a) audit pending",
+    ),
+    ("e_work_sweep", "pre-existing, #231(a) audit pending"),
+    ("f_doctrine_skew", "pre-existing, #231(a) audit pending"),
+    ("i9_floor_pinning", "pre-existing, #231(a) audit pending"),
+    ("w2_startup_cache", "pre-existing, #231(a) audit pending"),
+    (
+        "w2_startup_measurement",
+        "pre-existing, #231(a) audit pending",
+    ),
+    (
+        "w3_allowlist_equivalence",
+        "pre-existing, #231(a) audit pending",
+    ),
+    (
+        "w3_prune_crash_windows",
+        "pre-existing, #231(a) audit pending",
+    ),
+    ("w3_prune_engine", "pre-existing, #231(a) audit pending"),
+    (
+        "w3_prune_measurement",
+        "pre-existing, #231(a) audit pending",
+    ),
+    (
+        "w4_doctor_journal_growth",
+        "pre-existing, #231(a) audit pending",
+    ),
+    ("w4_read_surfaces", "pre-existing, #231(a) audit pending"),
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Every `tests/*.rs` basename (minus extension) — Cargo auto-discovers each
+/// as its own test binary (no `[[test]]` table in Cargo.toml narrows this).
+fn all_suites() -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(repo_root().join("tests"))
+        .expect("read tests/")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("rs"))
+        .map(|e| e.path().file_stem().unwrap().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Suite names invoked via `--test <name>` in one coverage stage script.
+fn wired_suites(script: &str) -> Vec<String> {
+    let text = std::fs::read_to_string(repo_root().join("scripts/coverage").join(script))
+        .unwrap_or_else(|e| panic!("read {script}: {e}"));
+    text.lines()
+        .filter_map(|line| line.split_once("--test "))
+        .map(|(_, rest)| rest.split_whitespace().next().unwrap_or("").to_string())
+        .filter(|name| !name.is_empty())
+        .collect()
+}
+
+#[test]
+fn every_suite_is_wired_or_explicitly_allowlisted() {
+    let wired: std::collections::BTreeSet<String> = wired_suites("c2-suites.sh")
+        .into_iter()
+        .chain(wired_suites("c3-spawning-suites.sh"))
+        .collect();
+    let allowlist: std::collections::BTreeSet<&str> =
+        ALLOWLIST.iter().map(|(name, _)| *name).collect();
+
+    let mut unexplained = Vec::new();
+    for suite in all_suites() {
+        if !wired.contains(&suite) && !allowlist.contains(suite.as_str()) {
+            unexplained.push(suite);
+        }
+    }
+    assert!(
+        unexplained.is_empty(),
+        "new orphaned suite(s) wired into neither c2-suites.sh nor \
+         c3-spawning-suites.sh, and not named in this test's ALLOWLIST with a \
+         reason: {unexplained:?} — wire it into a coverage stage, or add an \
+         allowlist entry with a specific reason (#231(b))"
+    );
+}

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -836,15 +836,15 @@ async fn event_history_from_seq_returns_exactly_the_tail() {
     cancel(&http, &handle, &work_id, &ulid()).await;
 
     // daemon.started + backend.probed (one per registered backend: fake,
-    // claude, docker, and codex as of N4/W2 — DaemonConfig::default's
-    // registry plus the three adapters `start_with` always adds)
-    // + 2×(work.submitted, command.accepted) + work.canceled
+    // claude, docker, codex, and opencode as of N4/W2/opencode-W2 —
+    // DaemonConfig::default's registry plus the four adapters `start_with`
+    // always adds) + 2×(work.submitted, command.accepted) + work.canceled
     // + command.accepted.
     let all = history_seqs(&http, &handle, None).await;
-    assert_eq!(all.len(), 11, "unexpected history: {all:?}");
+    assert_eq!(all.len(), 12, "unexpected history: {all:?}");
     assert_eq!(
         all,
-        (1..=11).collect::<Vec<u64>>(),
+        (1..=12).collect::<Vec<u64>>(),
         "seqs are 1..n in order"
     );
 

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -1790,7 +1790,11 @@ async fn t7_routing_precedence_and_structured_failure() {
         &plain_handle,
         &plain,
         "unknown backend",
-        json!({"backend": "opencode"}),
+        // Since W2 the daemon registers a real Opencode adapter by default
+        // (codex forced the identical swap one wave earlier, for the same
+        // reason), so naming "opencode" here would no longer demonstrate an
+        // unknown backend — use "goose" instead, still never registered.
+        json!({"backend": "goose"}),
     )
     .await;
     assert_eq!(status, 422);
@@ -1802,7 +1806,7 @@ async fn t7_routing_precedence_and_structured_failure() {
     // "docker", so nothing pre-empts it here.
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME])
+        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME, "opencode"])
     );
     plain_handle.shutdown().await;
 
@@ -1818,12 +1822,13 @@ async fn t7_routing_precedence_and_structured_failure() {
     assert_eq!(status, 422, "unroutable work must be refused: {body}");
     assert_eq!(body["error"]["code"], "no_backend_selected");
     // The scripted fake occupies the "claude" slot, so the daemon adds
-    // nothing there — but it still adds the real docker and codex adapters
-    // (N4/W2, nothing here is named "docker" or "codex"): codex is now the
-    // third real adapter the daemon registers by default, same as docker.
+    // nothing there — but it still adds the real docker, codex, and opencode
+    // adapters (N4/W2, nothing here is named "docker", "codex", or
+    // "opencode"): opencode is now the fourth real adapter the daemon
+    // registers by default, same as docker and codex.
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "codex", "docker"])
+        json!(["claude", "codex", "docker", "opencode"])
     );
     assert!(
         body["error"]["message"]
@@ -2030,19 +2035,19 @@ async fn t7c_an_unusable_stage_harness_fails_before_any_side_effect() {
     );
     handle.shutdown().await;
 
-    // Row 4, second shape: a harness no daemon here registers. Since W2 the
-    // daemon registers a real Codex adapter by default, so naming "codex"
-    // here would no longer demonstrate an unregistered harness (it would be
-    // host-dependent: `backend_unavailable` with no codex on `PATH`, or an
-    // actual routing success on a host with a real logged-in one) — use
-    // "opencode" instead, the name already used elsewhere in this file for
-    // exactly this meaning (an unregistered backend/harness name).
+    // Row 4, second shape: a harness no daemon here registers. Since W2 (the
+    // opencode-adapter sprint) the daemon registers a real Opencode adapter
+    // by default too, so naming "opencode" here would no longer demonstrate
+    // an unregistered harness (it would be host-dependent: `backend_
+    // unavailable` with no opencode on `PATH`, or an actual routing success
+    // on a host with a real logged-in one) — codex forced the identical swap
+    // one wave earlier; use "goose" instead, still never registered.
     let repos = TempDir::new().expect("tempdir");
     let data = TempDir::new().expect("tempdir");
     let estate = repos.path().join("solo-estate");
     mixed_harness_repo(
         &estate,
-        "\n[stage.\"10-b\"]\nkind = \"actor\"\nharness = \"opencode\"\n",
+        "\n[stage.\"10-b\"]\nkind = \"actor\"\nharness = \"goose\"\n",
     );
     let (registry, fake) = one_fake([]);
     let handle = start_with(
@@ -2062,13 +2067,13 @@ async fn t7c_an_unusable_stage_harness_fails_before_any_side_effect() {
     .await;
     assert_eq!(status, 422, "must be refused: {body}");
     assert_eq!(body["error"]["code"], "backend_not_found");
-    // The daemon registers the real Claude, Codex, and Docker adapters
-    // alongside the scripted fake, so the options list names all four;
-    // "opencode" is still never registered, which is exactly why naming it
-    // fails.
+    // The daemon registers the real Claude, Codex, Docker, and Opencode
+    // adapters alongside the scripted fake, so the options list names all
+    // five; "goose" is still never registered, which is exactly why naming
+    // it fails.
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME])
+        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME, "opencode"])
     );
     assert!(fake.starts().is_empty(), "no silent provider substitution");
     let list = get(&client, &handle, "/v1/work").await;
@@ -4686,6 +4691,11 @@ async fn a_submission_with_no_workspace_is_captured_but_still_routed() {
         &handle,
         elsewhere.path(),
         "route me nowhere",
+        // Deliberately not the bare canonical name "opencode": since the
+        // opencode-adapter sprint's W2 that name is registered for real, and
+        // this sentinel only needs to stay permanently unregistrable, not to
+        // demonstrate the unregistered-harness case (that's rows 1793/2045,
+        // above, which do use the bare name and were swapped to "goose").
         json!({"backend": "opencode-does-not-exist"}),
     )
     .await;
@@ -4695,12 +4705,13 @@ async fn a_submission_with_no_workspace_is_captured_but_still_routed() {
     );
     assert_eq!(body["error"]["code"], "backend_not_found");
     // Since M4 the daemon registers the real claude adapter alongside the
-    // scripted fake, since N4 the docker adapter too, and since W2 the
-    // codex adapter as well (registered names sort: claude, codex, docker,
-    // fake).
+    // scripted fake, since N4 the docker adapter too, since W2 the codex
+    // adapter as well, and since the opencode-adapter sprint's own W2 the
+    // opencode adapter too (registered names sort: claude, codex, docker,
+    // fake, opencode).
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME])
+        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME, "opencode"])
     );
 
     // Only two works exist: the refusal created none.

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -2092,12 +2092,12 @@ async fn the_capability_probe_is_journaled_at_registration() {
         .filter(|e| e.kind == daemon::KIND_BACKEND_PROBED)
         .collect();
     // One record per registered backend: claude (this test's subject),
-    // docker, and codex (N4/W2 — `start_with` always registers them
-    // alongside claude, same as claude is added here even though this
-    // test's registry started empty). Located by name rather than
-    // trusted-by-index, so this stays correct regardless of how many
-    // backends a future adapter adds the same way.
-    assert_eq!(probed.len(), 3, "one record per registered backend");
+    // docker, codex (N4/W2), and opencode (opencode-adapter sprint's own
+    // W2) — `start_with` always registers them alongside claude, same as
+    // claude is added here even though this test's registry started empty.
+    // Located by name rather than trusted-by-index, so this stays correct
+    // regardless of how many backends a future adapter adds the same way.
+    assert_eq!(probed.len(), 4, "one record per registered backend");
     let claude_probed = probed
         .iter()
         .find(|e| e.payload["backend"] == CLAUDE_BACKEND_NAME)

--- a/tests/opencode_backend.rs
+++ b/tests/opencode_backend.rs
@@ -22,6 +22,13 @@
 //! `support::wait_until_executable` is borrowed, for the ETXTBSY window a
 //! freshly-chmod'ed stub has.
 //!
+//! Two daemon-level tests (W2) prove registration itself — that
+//! `daemon::start_with` puts an "opencode" entry in the registry with no
+//! test-supplied stand-in — via in-process `daemon::start_with` +
+//! `handle.shutdown().await`, the same rig `tests/m3_execution.rs`/
+//! `tests/estate_routes.rs` use, so `tests/support::DataDir`'s reaper does
+//! not apply to them either (no subprocess is spawned).
+//!
 //! Every fixture under `tests/fixtures/opencode-1.18.19-*` is a **real
 //! capture** at opencode 1.18.19 — nothing in this file authors an event
 //! stream. Where a test needs a shape no probe recorded (an export document
@@ -44,9 +51,11 @@ use sergeant_rs::backend::{
     Backend, BackendError, BackendSignal, BindingSummary, ExecutionHandle, NativeState,
     ProbeReport, ResumeRequest, StartRequest,
 };
+use sergeant_rs::daemon::{self, DaemonConfig};
 use sergeant_rs::domain::estate::InstructionPolicy;
 use sergeant_rs::domain::event::EventDraft;
 use sergeant_rs::domain::profile::Profile;
+use sergeant_rs::runtime::journal::Journal;
 
 mod support;
 
@@ -1891,4 +1900,111 @@ fn live_opencode_history_exports_the_whole_session() {
         "the export names the served model per message (probe 7)"
     );
     backend.stop(&handle).expect("stop").wait();
+}
+
+// ------------------------------------------------------- W2 §1.4: registration
+
+/// A probeable opencode registers for real: `daemon::start_with`, with no
+/// test-supplied stand-in for the name "opencode", puts a real
+/// `OpencodeBackend` in its registry and journals its own probe evidence at
+/// registration — the direct proof of W2's registration change, not a repeat
+/// of any unit test on `OpencodeBackend` itself.
+#[tokio::test]
+async fn daemon_start_registers_opencode_and_journals_its_own_probe() {
+    let data = TempDir::new().expect("tempdir");
+    let stub = StubOpencode::passing(data.path());
+    let handle = daemon::start_with(
+        data.path(),
+        DaemonConfig {
+            backends: Arc::new(sergeant_rs::backend::BackendRegistry::new()),
+            default_backend: None,
+            opencode: Some(config_for(&stub, data.path())),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start with an unmeasured-nothing opencode must still start");
+    handle.shutdown().await;
+
+    let probed: Vec<_> = Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.kind == daemon::KIND_BACKEND_PROBED)
+        .collect();
+    let opencode_probed = probed
+        .iter()
+        .find(|e| e.payload["backend"] == OPENCODE_BACKEND_NAME)
+        .expect("a backend.probed record for opencode");
+    assert_eq!(opencode_probed.payload["available"], true);
+    assert_eq!(opencode_probed.payload["runtime_scope"], "per_execution");
+    assert_eq!(opencode_probed.payload["capabilities"]["ask"], false);
+    assert_eq!(
+        opencode_probed.payload["capabilities"]["persistent_sessions"],
+        true
+    );
+    assert_eq!(
+        opencode_probed.payload["capabilities"]["native_background"],
+        false
+    );
+    assert_eq!(opencode_probed.payload["capabilities"]["streaming"], true);
+    // NOTE: unlike codex (false), opencode's `history` is TRUE — R4, via
+    // `export`, per opencode.rs:2690's Capabilities literal.
+    assert_eq!(opencode_probed.payload["capabilities"]["history"], true);
+    assert_eq!(opencode_probed.payload["capabilities"]["resume"], true);
+    assert_eq!(opencode_probed.payload["capabilities"]["interrupt"], true);
+    assert_eq!(
+        opencode_probed.payload["capabilities"]["model_selection"],
+        true
+    );
+    assert_eq!(opencode_probed.payload["capabilities"]["profiles"], true);
+    assert_eq!(
+        opencode_probed.payload["capabilities"]["approval_flow"],
+        false
+    );
+    assert_eq!(
+        opencode_probed.payload["capabilities"]["human_attach"],
+        false
+    );
+    assert_eq!(opencode_probed.payload["capabilities"]["usage"], true);
+    assert_eq!(
+        opencode_probed.payload["capabilities"]["native_subagents"],
+        false
+    );
+}
+
+/// Opencode missing must not break daemon startup, and must be
+/// distinguishable from "unregistered": it registers anyway and journals
+/// honest, `available: false` evidence naming why it cannot run — the same
+/// posture Docker already takes for a host with no Docker installed.
+#[tokio::test]
+async fn daemon_start_with_no_opencode_installed_still_starts_and_says_why() {
+    let data = TempDir::new().expect("tempdir");
+    let handle = daemon::start_with(
+        data.path(),
+        DaemonConfig {
+            backends: Arc::new(sergeant_rs::backend::BackendRegistry::new()),
+            default_backend: None,
+            opencode: Some(OpencodeConfig {
+                executable: PathBuf::from("/nonexistent/definitely-not-opencode"),
+                ..OpencodeConfig::new(data.path())
+            }),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("a host with no opencode binary must still start a daemon");
+    handle.shutdown().await;
+
+    let opencode_probed = Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .find(|e| {
+            e.kind == daemon::KIND_BACKEND_PROBED && e.payload["backend"] == OPENCODE_BACKEND_NAME
+        })
+        .expect("opencode is registered — and probed — even though it cannot run");
+    assert_eq!(opencode_probed.payload["available"], false);
+    let detail = opencode_probed.payload["detail"]
+        .as_str()
+        .expect("probe detail recorded");
+    assert!(detail.contains("cannot run"), "{detail}");
 }

--- a/tests/opencode_routing.rs
+++ b/tests/opencode_routing.rs
@@ -1,0 +1,254 @@
+//! W2 §2 (A1 routing verification): proof that `daemon::start_with` **itself**
+//! — with no test-supplied stand-in for the name "opencode" — now puts a real
+//! `OpencodeBackend` in its registry, so the four-tier `RouteSource` chain
+//! (already unit-tested in `src/runtime/router.rs` and already exercised
+//! end-to-end with a *test-substituted* `FakeBackend::scripted("opencode",
+//! ...)` in `tests/m3_execution.rs`'s
+//! `t7_routing_precedence_and_structured_failure`) reaches opencode as the
+//! daemon's own default registration, not a fixture wearing its name.
+//!
+//! Every test here deliberately configures opencode with a nonexistent
+//! executable, so the outcome is deterministic on any host (a host with a
+//! real, logged-in `opencode` on `PATH` must not make these flaky or spend
+//! tokens): `resolve_tiers` calls `backend.probe()` before returning success,
+//! so an unavailable opencode makes every submission below fail with
+//! `RouteError::Unavailable` — the *stronger*, host-independent proof that
+//! each tier reached the registered adapter and stopped there (named,
+//! `backend_unavailable`), rather than falling through to a populated global
+//! default the way an unregistered "opencode" silently did before this wave.
+//!
+//! In-process `daemon::start_with` + `reqwest`, no subprocess — the same rig
+//! `tests/estate_routes.rs`/`tests/m3_execution.rs`/`tests/opencode_backend.rs`
+//! use, so `tests/support::DataDir`'s reaper does not apply here either.
+//!
+//! No new `RouteSource` variant, no new routing logic — `src/runtime/
+//! router.rs` is untouched by this wave. No CLI-subprocess test of `sgt run
+//! --backend opencode` or `sgt opencode` actually exec'ing either: `harness::
+//! prepare`/`exec` are already unit-tested and exec-boundary functions are
+//! not round-trippable through an integration test by design.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend};
+use sergeant_rs::backend::opencode::OpencodeConfig;
+use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
+
+mod support;
+
+// ---------------------------------------------------------------- helpers
+
+fn ulid() -> String {
+    ulid::Ulid::generate().to_string()
+}
+
+fn http() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("client")
+}
+
+/// An `OpencodeConfig` pointed at a definitely-nonexistent executable, so the
+/// probe always reports `available: false` regardless of what host runs
+/// this suite.
+fn deterministic_opencode_config(data_dir: &Path) -> OpencodeConfig {
+    OpencodeConfig {
+        executable: PathBuf::from("/nonexistent/definitely-not-opencode"),
+        ..OpencodeConfig::new(data_dir)
+    }
+}
+
+/// mirrors `tests/m3_execution.rs`'s `estate_with_manifest`: an estate at
+/// `root` from a verbatim `sergeant.toml`, with a real git checkout at
+/// `root/repos/<name>` for each of `repos`.
+fn estate_with_manifest(root: &Path, manifest: &str, repos: &[&str]) {
+    std::fs::create_dir_all(root).expect("estate root");
+    for repo in repos {
+        support::init_repo(&root.join("repos").join(repo));
+    }
+    std::fs::write(root.join("sergeant.toml"), manifest).expect("sergeant.toml");
+}
+
+/// Start a daemon with one scripted fake (the global default) and opencode
+/// registered for real, but deterministically unavailable.
+async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
+    daemon::start_with(
+        data_dir,
+        DaemonConfig {
+            backends: Arc::new(
+                BackendRegistry::new().with(Arc::new(FakeBackend::new(FAKE_BACKEND_NAME))),
+            ),
+            default_backend: global_default.map(str::to_string),
+            opencode: Some(deterministic_opencode_config(data_dir)),
+            estate_root: Some(estate_root.to_path_buf()),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start")
+}
+
+/// POST a JSON body to the daemon; returns status and parsed body.
+async fn post(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    path: &str,
+    body: Value,
+) -> (reqwest::StatusCode, Value) {
+    let resp = client
+        .post(format!("{}{path}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    let value: Value = resp.json().await.expect("json body");
+    (status, value)
+}
+
+/// GET a path from the daemon.
+async fn get(client: &reqwest::Client, handle: &DaemonHandle, path: &str) -> Value {
+    client
+        .get(format!("{}{path}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("request")
+        .json()
+        .await
+        .expect("json body")
+}
+
+/// Submit work whose origin is `cwd`, merging any extra request fields.
+async fn submit(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    cwd: &Path,
+    extra: Value,
+) -> (reqwest::StatusCode, Value) {
+    let mut body = json!({
+        "command_id": ulid(),
+        "intent": "route me",
+        "origin": {"client": "cli", "cwd": cwd},
+    });
+    if let Some(fields) = extra.as_object() {
+        for (key, value) in fields {
+            body[key] = value.clone();
+        }
+    }
+    post(client, handle, "/v1/work", body).await
+}
+
+// -------------------------------------------------------------------- tests
+
+/// (a) Explicit `--backend opencode` resolves to the registered adapter, not
+/// `backend_not_found`: opencode is *known and named*, and its own probe
+/// evidence is what fails the submission.
+#[tokio::test]
+async fn explicit_backend_opencode_reaches_the_registered_adapter_not_not_found() {
+    let root = TempDir::new().expect("tempdir");
+    support::scaffold_estate(root.path(), "plain", &["plain"]);
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"backend": "opencode", "origin": {"client": "cli", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(
+        body["error"]["code"], "backend_unavailable",
+        "opencode must be *known and named*, not `backend_not_found` — {body}"
+    );
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(
+        available.iter().any(|v| v == "opencode"),
+        "opencode must be offered as an option: {available:?}"
+    );
+    // Never silently ran on the global default fake instead.
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(list["works"].as_array().expect("works").is_empty());
+    handle.shutdown().await;
+}
+
+/// (b) `SGT_ORIGIN_CLIENT=opencode` (as `sgt opencode` sets, `src/harness.rs`'s
+/// `ORIGIN_CLIENT_ENV`) resolves `OriginAffinity` when no explicit flag is
+/// given — and, the case that actually catches the pre-registration bug,
+/// must NOT fall through to a populated global default.
+#[tokio::test]
+async fn origin_affinity_from_sgt_opencode_is_decisive_over_the_global_default() {
+    let root = TempDir::new().expect("tempdir");
+    support::scaffold_estate(root.path(), "plain", &["plain"]);
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"origin": {"client": "opencode", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(body["error"]["code"], "backend_unavailable");
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(available.iter().any(|v| v == "opencode"));
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(
+        list["works"].as_array().expect("works").is_empty(),
+        "must not have silently substituted the global default `fake`"
+    );
+    handle.shutdown().await;
+}
+
+/// (c) An estate `default_backend = "opencode"` resolves `WorkspaceDefault`,
+/// same decisiveness-over-global-default proof as (b).
+#[tokio::test]
+async fn estate_default_backend_opencode_is_decisive_over_the_global_default() {
+    let root = TempDir::new().expect("tempdir");
+    estate_with_manifest(
+        root.path(),
+        "[estate]\nname = \"configured\"\ndefault_backend = \"opencode\"\n\n\
+         [[repo]]\nname = \"plain\"\n",
+        &["plain"],
+    );
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"origin": {"client": "cli", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(body["error"]["code"], "backend_unavailable");
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(available.iter().any(|v| v == "opencode"));
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(
+        list["works"].as_array().expect("works").is_empty(),
+        "must not have silently substituted the global default `fake`"
+    );
+    handle.shutdown().await;
+}


### PR DESCRIPTION
Second wave of the *Sergeant speaks OpenCode* sprint (plan: `docs/proposals/opencode-adapter-2026-08-23.md` W2; head PR #243). Registration is verification, not invention (ADR 0020 A1): the selection machinery already shipped — this wave registers the W1 adapter and proves the existing chain resolves to it.

## What ships
- **Registration**: `DaemonConfig.opencode` + daemon.rs construction/registration block + event-sink wiring, mirroring codex's block exactly.
- **Routing proof** (`tests/opencode_routing.rs`, codex_routing template): explicit `--backend opencode`, origin-affinity from `SGT_ORIGIN_CLIENT=opencode`, estate `default_backend="opencode"` — each reaches the real registered adapter (`backend_unavailable`, never `backend_not_found`, never silent fallthrough).
- **Daemon-level pair**: registration journals `backend.probed` with every capability field; a host with no opencode still starts and says why.
- **m3 fixture swap**: the three `"opencode"`-as-unregistered fixtures → `"goose"`, comments in the codex-swap pattern; plus mechanical fixture widening in m2/m4 for the extra `backend.probed` record (recorded as a spec deviation, same class the spec anticipated for m3).
- **`harness.rs` PATH line** (the wave's one pre-ratified touch outside `src/backend/`, flagged for owner review at the head PR): `~/.opencode/bin` joins `toolchain_path_dirs` with measured evidence (probe packet: binary unfindable from a non-interactive shell); pinned test renamed and extended.
- **Coverage (owner 90-floor ruling)**: `opencode_routing` + the new guard suite wired into C2, and the **#231(b) structural guard** lands — `tests/coverage_stage_membership.rs` fails the build if any `tests/*.rs` suite is absent from every coverage stage list unless allowlisted with a reason (18 pre-existing orphans seeded `"pre-existing, #231(a) audit pending"`). A new suite can no longer silently skip Gate D.

## Review record (single workflow: spec → implement → 4-axis panel → refuters → fixer; sonnet fleet)
Spec stage enumerated 6 code-vs-contract contradictions, all resolved and recorded. Panel raised 1 finding, it survived refutation, fixed in `42f91ceb`: the orphan guard was fooled by commented-out `cov_run` lines — a latent hole that would have reproduced #231's accounting gap on the realistic disable path; now filtered with a doc comment.

## Gates
fmt/clippy(-D warnings)/full `cargo test --locked` green (incl. the new suites), pgrep daemon sweep clean. Coverage lane rerun deferred to W4 finalize: this wave adds tests only (coverage can only rise); the guard now enforces wiring structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4