### PR TITLE
agy W2: registration + routing + the sgt agy passthrough

### DIFF
--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -113,6 +113,14 @@ cov_stage_begin c2-agy_backend
 cov_run cargo llvm-cov --no-report --test agy_backend --locked || cov_fail "agy_backend failed under instrumentation"
 cov_stage_end 1 "the agy_backend test binary must write its own profile (StubAgy's children are shell-script stand-ins, uninstrumented and no loss, per codex_backend's precedent)"
 
+# Added 2026-08-23, in the same commit that creates the suite (W2, agy
+# registration wave) — codex_routing's/opencode_routing's exact rationale:
+# in-process-only throughout (no StubAgy, no subprocess), so it sits in C2
+# rather than needing C3's ≥2-profile floor. Floor 1.
+cov_stage_begin c2-agy_routing
+cov_run cargo llvm-cov --no-report --test agy_routing --locked || cov_fail "agy_routing failed under instrumentation"
+cov_stage_end 1 "the agy_routing test binary must write its own profile"
+
 # Added 2026-08-23, same commit that creates the suite (W2, opencode
 # registration wave, item 6 / #231(b)): a plain static-scan test, no
 # subprocess, no daemon — sits in C2 for the same reason codex_routing does.

--- a/src/backend/agy.rs
+++ b/src/backend/agy.rs
@@ -221,7 +221,7 @@
 //! contract-tested, and is reachable by nothing yet.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::SyncSender;
@@ -293,6 +293,23 @@ const INIT_LINE_BUDGET: Duration = Duration::from_secs(30);
 /// [W1 P0.6] are stderr-only facts, and the first of them is the *sole*
 /// evidence that a tool was denied at 1.1.19.
 const STDERR_DRAIN_BUDGET: Duration = Duration::from_secs(5);
+
+/// Wall-clock ceiling on [`AgyBackend::read_config_probe`]'s `-p "/config"`
+/// call. **Measured (W2, agy-registration wave): this call is not always
+/// zero-interaction the way the doc comment above it claims** — an
+/// unauthenticated `agy` (no cached credentials under the effective
+/// `settings_home`/`HOME`) answers it by printing an OAuth URL and blocking
+/// on an interactive login for up to 60s before giving up on its own. `run_probe`
+/// runs synchronously inside daemon registration (`daemon::start_with`,
+/// before the descriptor is published), so an unbounded wait here is exactly
+/// the class of regression this project already tracks for a blocking HTTP
+/// client built during registration — its subprocess analogue, on any host
+/// that has `agy` installed but not yet logged in. Five seconds is
+/// generous headroom over the sub-second reply a real, authenticated `agy`
+/// gave in measurement; a probe that cannot answer inside it is killed and
+/// treated exactly like any other probe failure — best-effort by
+/// construction either way.
+const CONFIG_PROBE_BUDGET: Duration = Duration::from_secs(5);
 
 /// Cap on the in-memory accumulation of one turn's raw stdout before it is
 /// archived to the blob store (§20), and of its stderr. Every line is still
@@ -2038,21 +2055,58 @@ impl AgyBackend {
 
     /// The zero-quota `/config` read. Best-effort by construction: a CLI that
     /// cannot answer it is not refused, it is a CLI whose effective
-    /// configuration this adapter cannot report.
+    /// configuration this adapter cannot report. Bounded by
+    /// [`CONFIG_PROBE_BUDGET`] — see its doc for why an unbounded wait here is
+    /// not safe to run inside registration.
     fn read_config_probe(&self) -> ConfigProbe {
         let mut command = Command::new(&self.config.executable);
         command
             .args(["-p", "/config", "--output-format", "json"])
-            .stdin(Stdio::null());
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
         apply_env(
             &mut command,
             &self.config.env,
             self.config.settings_home.as_deref(),
         );
-        let Ok(out) = command.output() else {
+        let Ok(mut child) = command.spawn() else {
             return ConfigProbe::default();
         };
-        serde_json::from_slice::<Value>(&out.stdout)
+        let Some(mut stdout) = child.stdout.take() else {
+            return ConfigProbe::default();
+        };
+        // Piped but deliberately unread here: a probe that never touches this
+        // is not a probe whose stderr this adapter has ever needed. Drained on
+        // its own thread purely so a child that writes to it does not block on
+        // (or SIGPIPE from) a closed pipe while this call is still waiting on
+        // stdout.
+        if let Some(mut stderr) = child.stderr.take() {
+            std::thread::spawn(move || {
+                let mut sink = Vec::new();
+                let _ = stderr.read_to_end(&mut sink);
+            });
+        }
+        let child = Arc::new(Mutex::new(child));
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(1);
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = stdout.read_to_end(&mut buf);
+            let _ = tx.send(buf);
+        });
+        let stdout_bytes = match rx.recv_timeout(CONFIG_PROBE_BUDGET) {
+            Ok(buf) => buf,
+            Err(_) => {
+                // Most likely cause, per the measurement in `CONFIG_PROBE_BUDGET`'s
+                // doc: an unauthenticated `agy` blocked this call on an
+                // interactive login prompt. Killed and treated as any other
+                // probe failure — never propagated as a hang.
+                let _ = child.lock().expect("agy config-probe child lock").kill();
+                Vec::new()
+            }
+        };
+        let _ = child.lock().expect("agy config-probe child lock").wait();
+        serde_json::from_slice::<Value>(&stdout_bytes)
             .map(|value| decode_config_probe(&value))
             .unwrap_or_default()
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,10 +13,10 @@
 //! `sgt doctor` as the remedy, not a daemon started just to have something
 //! to report. Bare `sgt` (no subcommand) is a third thing again: a static
 //! homepage that never touches the daemon at all (ADR 0010). `sgt
-//! claude`/`codex`/`opencode`/`goose` are a fourth thing: they never reach
-//! the daemon either, because they never return to this process at all —
-//! they compose an environment and `exec` into the harness (ADR 0006, D2;
-//! see `crate::harness`).
+//! claude`/`codex`/`opencode`/`goose`/`agy` are a fourth thing: they never
+//! reach the daemon either, because they never return to this process at
+//! all — they compose an environment and `exec` into the harness (ADR 0006,
+//! D2; see `crate::harness`).
 //!
 //! Stale-descriptor policy (contract): endpoint refuses *and* PID is dead →
 //! stale, replace it; PID alive but endpoint unresponsive → ambiguous, fail
@@ -328,6 +328,13 @@ enum Command {
     /// claude` (ADR 0006, D2).
     Goose {
         /// Arguments to pass through to `goose`, verbatim, after `--`.
+        #[arg(last = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Launch `agy` bound to this estate — the same passthrough as `sgt
+    /// claude` (ADR 0006, D2).
+    Agy {
+        /// Arguments to pass through to `agy`, verbatim, after `--`.
         #[arg(last = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -720,7 +727,7 @@ fn resolve_data_dir(
 ///
 /// Estate-scoped: `run`, `status`, `work *`, `respond`/`retry`/`extend`/
 /// `cancel`, `watch`, `analytics`, `tui`, `daemon`(+`stop`), `repo *`,
-/// `group *`, `workflow *`, and the four harnesses. Unscoped: bare `sgt`,
+/// `group *`, `workflow *`, and the five harnesses. Unscoped: bare `sgt`,
 /// `--help`, `--version`, `init`, `doctor` — nothing else.
 fn is_estate_scoped(command: &Command) -> bool {
     !matches!(command, Command::Doctor | Command::Init { .. })
@@ -1328,6 +1335,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             exec_harness("opencode", &args, &estate_root(&estate), &data_dir)
         }
         Command::Goose { args } => exec_harness("goose", &args, &estate_root(&estate), &data_dir),
+        Command::Agy { args } => exec_harness("agy", &args, &estate_root(&estate), &data_dir),
     }
 }
 
@@ -3314,7 +3322,7 @@ pub(crate) mod doctor {
     }
 
     /// ADR 0006's residual hole, named in the ADR and in proposal §5.2:
-    /// `sgt claude`/`codex`/`opencode`/`goose` only fix the environment for
+    /// `sgt claude`/`codex`/`opencode`/`goose`/`agy` only fix the environment for
     /// sessions that go through the front door. `sgt run` from a terminal
     /// that never did returns to #60. This is the complement the ADR names —
     /// issue #100 — checking the *current* process's own environment against
@@ -3331,7 +3339,7 @@ pub(crate) mod doctor {
             return Check::warn(
                 "environment",
                 "$HOME is not set — cannot check toolchain PATH enrichment",
-                "set HOME, or run through `sgt claude` (or codex/opencode/goose), which composes \
+                "set HOME, or run through `sgt claude` (or codex/opencode/goose/agy), which composes \
                  PATH before it needs HOME to be set at all",
             );
         };
@@ -3345,7 +3353,7 @@ pub(crate) mod doctor {
             Check::ok(
                 "environment",
                 "PATH already includes the toolchain directories `sgt claude` (and codex/\
-                 opencode/goose) compose — or none of them exist on this host",
+                 opencode/goose/agy) compose — or none of them exist on this host",
             )
         } else {
             let names: Vec<String> = missing.iter().map(|d| d.display().to_string()).collect();
@@ -3360,7 +3368,7 @@ pub(crate) mod doctor {
                     if names.len() == 1 { "is" } else { "are" },
                 ),
                 format!(
-                    "run this session through `sgt claude` (or codex/opencode/goose), which \
+                    "run this session through `sgt claude` (or codex/opencode/goose/agy), which \
                      composes PATH before exec'ing, or add {} to PATH yourself",
                     names.join(", ")
                 ),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -35,6 +35,7 @@ use crate::api::{
     API_REVISION, ApiState, COMPLETION_POLL_INTERVAL, Core, CoreError, CoreGuard,
     drive_completions, router,
 };
+use crate::backend::agy::{AGY_BACKEND_NAME, AgyBackend, AgyConfig};
 use crate::backend::claude::{CLAUDE_BACKEND_NAME, ClaudeBackend, ClaudeConfig};
 use crate::backend::codex::{CODEX_BACKEND_NAME, CodexBackend, CodexConfig};
 use crate::backend::docker::{DOCKER_BACKEND_NAME, DockerBackend, DockerConfig};
@@ -341,6 +342,11 @@ pub struct DaemonConfig {
     /// itself. `None` is the system `opencode`, adapter state under this data
     /// dir — mirrors `claude`/`docker`/`codex` above for the same reason.
     pub opencode: Option<OpencodeConfig>,
+    /// Launch configuration for the Agy adapter this daemon registers
+    /// itself. `None` is the system `agy`, adapter state under this data
+    /// dir — mirrors `claude`/`docker`/`codex`/`opencode` above for the same
+    /// reason.
+    pub agy: Option<AgyConfig>,
     /// §28 OpenTelemetry export. `None` is **off**, and off is the default:
     /// with no pipeline here the daemon builds no provider, spawns no
     /// exporter task, and subscribes nothing to the event stream.
@@ -429,6 +435,7 @@ impl Default for DaemonConfig {
             docker: None,
             codex: None,
             opencode: None,
+            agy: None,
             telemetry: None,
             completion_poll: COMPLETION_POLL_INTERVAL,
             turn_ceiling: crate::runtime::engine::DEFAULT_TURN_CEILING,
@@ -841,6 +848,24 @@ pub async fn start_with(
     } else {
         None
     };
+    // W2 (agy-adapter sprint, mirrors the opencode block directly above):
+    // the Agy executor, registered the same way and for the same reason
+    // as Claude/Docker/Codex/Opencode. No `seed_capability_provenance_from`
+    // call — `AgyBackend::capabilities().ask` is `false` unconditionally
+    // (agy.rs's own ADMISSION_ROWS `ask` row: no measured actor-authored-
+    // question record on this transport), so there is no journaled
+    // withdrawal to seed.
+    let agy = if config.backends.get(AGY_BACKEND_NAME).is_none() {
+        let agy_config = config
+            .agy
+            .clone()
+            .unwrap_or_else(|| AgyConfig::new(data_dir));
+        let adapter = Arc::new(AgyBackend::new(agy_config));
+        backends = backends.with(adapter.clone());
+        Some(adapter)
+    } else {
+        None
+    };
     let backends = Arc::new(backends);
 
     // 4b-ii. The capability/version probe, recorded at registration (M4
@@ -985,6 +1010,12 @@ pub async fn start_with(
     // sink (same reasoning as Claude's/Docker's/Codex's, directly above).
     if let Some(opencode) = opencode {
         opencode.set_event_sink(journaling_sink(state.core.clone()));
+    }
+    // The Agy adapter's normalized events flow through the identical sink
+    // (same reasoning as Claude's/Docker's/Codex's/Opencode's, directly
+    // above).
+    if let Some(agy) = agy {
+        agy.set_event_sink(journaling_sink(state.core.clone()));
     }
     let app = router(state.clone());
 

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1,5 +1,5 @@
 //! `sgt <harness> -- <args>` (ADR 0006, D2): `claude`, `codex`, `opencode`,
-//! `goose`. Composes an environment, binds the estate, then **exec**s —
+//! `goose`, `agy`. Composes an environment, binds the estate, then **exec**s —
 //! replacing this process image with the harness's, not forking and
 //! supervising it. That boundary is load-bearing (`NORTH-STAR.md`'s "Never"
 //! list: "reconstructed tmux-era supervision"): once the harness starts,

--- a/tests/agy_backend.rs
+++ b/tests/agy_backend.rs
@@ -49,9 +49,11 @@ use sergeant_rs::backend::{
     Backend, BackendError, BackendSignal, BindingSummary, ExecutionHandle, NativeState,
     Observation, ProbeReport, ResumeRequest, StartRequest,
 };
+use sergeant_rs::daemon::{self, DaemonConfig};
 use sergeant_rs::domain::estate::InstructionPolicy;
 use sergeant_rs::domain::event::EventDraft;
 use sergeant_rs::domain::profile::Profile;
+use sergeant_rs::runtime::journal::Journal;
 
 mod support;
 
@@ -1983,4 +1985,99 @@ fn live_agy_resume_recalls_a_nonce_and_echoes_the_same_conversation_id() {
             .any(|e| e.payload["phase"] == serde_json::json!("resume_identity_mismatch")),
         "a real resume must raise no identity mismatch"
     );
+}
+
+// ------------------------------------------------------- W2 §1.4: registration
+
+/// A probeable agy registers for real: `daemon::start_with`, with no
+/// test-supplied stand-in for the name "agy", puts a real `AgyBackend`
+/// in its registry and journals its own probe evidence at registration
+/// — the direct proof of W2's registration change, not a repeat of any
+/// unit test on `AgyBackend` itself.
+#[tokio::test]
+async fn daemon_start_registers_agy_and_journals_its_own_probe() {
+    let data = TempDir::new().expect("tempdir");
+    let stub = StubAgy::passing(data.path());
+    let handle = daemon::start_with(
+        data.path(),
+        DaemonConfig {
+            backends: Arc::new(sergeant_rs::backend::BackendRegistry::new()),
+            default_backend: None,
+            agy: Some(config_for(&stub, data.path())),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start with an unmeasured-nothing agy must still start");
+    handle.shutdown().await;
+
+    let probed: Vec<_> = Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.kind == daemon::KIND_BACKEND_PROBED)
+        .collect();
+    let agy_probed = probed
+        .iter()
+        .find(|e| e.payload["backend"] == AGY_BACKEND_NAME)
+        .expect("a backend.probed record for agy");
+    assert_eq!(agy_probed.payload["available"], true);
+    assert_eq!(agy_probed.payload["runtime_scope"], "per_execution");
+    assert_eq!(agy_probed.payload["capabilities"]["ask"], false);
+    assert_eq!(
+        agy_probed.payload["capabilities"]["persistent_sessions"],
+        true
+    );
+    assert_eq!(
+        agy_probed.payload["capabilities"]["native_background"],
+        false
+    );
+    assert_eq!(agy_probed.payload["capabilities"]["streaming"], true);
+    assert_eq!(agy_probed.payload["capabilities"]["history"], false);
+    assert_eq!(agy_probed.payload["capabilities"]["resume"], true);
+    assert_eq!(agy_probed.payload["capabilities"]["interrupt"], true);
+    assert_eq!(agy_probed.payload["capabilities"]["model_selection"], true);
+    assert_eq!(agy_probed.payload["capabilities"]["profiles"], true);
+    assert_eq!(agy_probed.payload["capabilities"]["approval_flow"], false);
+    assert_eq!(agy_probed.payload["capabilities"]["human_attach"], false);
+    assert_eq!(agy_probed.payload["capabilities"]["usage"], true);
+    assert_eq!(
+        agy_probed.payload["capabilities"]["native_subagents"],
+        false
+    );
+}
+
+/// Agy missing must not break daemon startup, and must be
+/// distinguishable from "unregistered": it registers anyway and
+/// journals honest, `available: false` evidence naming why it cannot
+/// run — the same posture Docker/Codex/Opencode already take for a
+/// host with no binary installed.
+#[tokio::test]
+async fn daemon_start_with_no_agy_installed_still_starts_and_says_why() {
+    let data = TempDir::new().expect("tempdir");
+    let handle = daemon::start_with(
+        data.path(),
+        DaemonConfig {
+            backends: Arc::new(sergeant_rs::backend::BackendRegistry::new()),
+            default_backend: None,
+            agy: Some(AgyConfig {
+                executable: PathBuf::from("/nonexistent/definitely-not-agy"),
+                ..AgyConfig::new(data.path())
+            }),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("a host with no agy binary must still start a daemon");
+    handle.shutdown().await;
+
+    let agy_probed = Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .find(|e| e.kind == daemon::KIND_BACKEND_PROBED && e.payload["backend"] == AGY_BACKEND_NAME)
+        .expect("agy is registered — and probed — even though it cannot run");
+    assert_eq!(agy_probed.payload["available"], false);
+    let detail = agy_probed.payload["detail"]
+        .as_str()
+        .expect("probe detail recorded");
+    assert!(detail.contains("cannot run"), "{detail}");
 }

--- a/tests/agy_backend.rs
+++ b/tests/agy_backend.rs
@@ -120,6 +120,7 @@ struct StubAgy {
     record: PathBuf,
     replay: PathBuf,
     config_answer: PathBuf,
+    config_hang: PathBuf,
     hang: PathBuf,
     stderr: PathBuf,
     exit_code: PathBuf,
@@ -134,6 +135,7 @@ impl StubAgy {
         let record = dir.join(format!("{name}-launches.txt"));
         let replay = dir.join(format!("{name}-replay.jsonl"));
         let config_answer = dir.join(format!("{name}-config.json"));
+        let config_hang = dir.join(format!("{name}-config-hang"));
         let hang = dir.join(format!("{name}-hang"));
         let stderr = dir.join(format!("{name}-stderr"));
         let exit_code = dir.join(format!("{name}-exit-code"));
@@ -148,7 +150,10 @@ impl StubAgy {
             "#!/bin/sh\n\
              if [ \"$1\" = \"--version\" ]; then echo \"{version}\"; exit 0; fi\n\
              if [ \"$1\" = \"--help\" ]; then printf '%s\\n' \"{help}\" >&2; exit 0; fi\n\
-             if [ \"$1\" = \"-p\" ] && [ \"$2\" = \"/config\" ]; then cat \"{config_answer}\"; exit 0; fi\n\
+             if [ \"$1\" = \"-p\" ] && [ \"$2\" = \"/config\" ]; then\n  \
+               if [ -f \"{config_hang}\" ]; then exec sleep 60; fi\n  \
+               cat \"{config_answer}\"; exit 0\n\
+             fi\n\
              {{ for arg in \"$@\"; do printf 'arg %s\\n' \"$(printf '%s' \"$arg\" | tr '\\n' '|')\"; done;\n\
              env | grep -E '^(HOME|SGT_[A-Z_]*|AGY_[A-Z_]*|PROBE_[A-Z_]*)=' | sed 's/^/env /' | tr -d '\\r';\n\
              printf 'cwd %s\\n' \"$(pwd)\";\n\
@@ -165,6 +170,7 @@ impl StubAgy {
             version = version,
             help = help,
             config_answer = config_answer.display(),
+            config_hang = config_hang.display(),
             record = record.display(),
             replay = replay.display(),
             stderr = stderr.display(),
@@ -183,6 +189,7 @@ impl StubAgy {
             record,
             replay,
             config_answer,
+            config_hang,
             hang,
             stderr,
             exit_code,
@@ -210,6 +217,18 @@ impl StubAgy {
     /// events must be observable *while the process is still running*.
     fn hangs_after_replay(&self) -> &Self {
         std::fs::write(&self.hang, b"hang\n").expect("write hang marker");
+        self
+    }
+
+    /// Makes the zero-quota `-p "/config"` read specifically hang — the
+    /// unauthenticated-CLI-blocks-on-an-interactive-login case
+    /// `CONFIG_PROBE_BUDGET`'s doc describes. Deliberately distinct from
+    /// `hangs_after_replay`: that marker is checked *after* the script's
+    /// recording arm, which the `/config` call never reaches (it returns from
+    /// its own arm first), so it cannot exercise `read_config_probe`'s
+    /// kill-on-timeout path at all.
+    fn hangs_on_config(&self) -> &Self {
+        std::fs::write(&self.config_hang, b"hang\n").expect("write config-hang marker");
         self
     }
 
@@ -629,6 +648,40 @@ fn an_unreadable_config_probe_is_reported_not_refused() {
             .detail
             .expect("detail")
             .contains("cannot report the harness's effective permission configuration")
+    );
+}
+
+/// The regression `CONFIG_PROBE_BUDGET` exists to prevent: an unauthenticated
+/// `agy` blocks the `/config` read on an interactive login prompt. This must
+/// never become an unbounded wait inside `daemon::start_with` — the exact
+/// class of registration-time hang this project's CI/CD sprint already
+/// tracked once for a blocking HTTP client (0.2.2 regression, commit
+/// c46152a2), now with a subprocess in place of a transport.
+#[test]
+fn a_hung_config_probe_is_killed_within_budget_and_falls_back() {
+    let dir = TempDir::new().expect("tempdir");
+    let stub = StubAgy::passing(dir.path());
+    stub.hangs_on_config();
+    let backend = AgyBackend::new(config_for(&stub, dir.path()));
+    let started = Instant::now();
+    let report = backend.probe();
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "read_config_probe must be bounded by CONFIG_PROBE_BUDGET (5s), not the stub's \
+         60s hang: probe() took {elapsed:?}"
+    );
+    assert!(
+        report.available,
+        "a killed /config read is a best-effort miss, never a refusal"
+    );
+    assert!(
+        report
+            .detail
+            .expect("detail")
+            .contains("cannot report the harness's effective permission configuration"),
+        "a timed-out config probe must fall back to the same ConfigProbe::default() detail \
+         as an unreadable one"
     );
 }
 

--- a/tests/agy_routing.rs
+++ b/tests/agy_routing.rs
@@ -1,0 +1,254 @@
+//! W2 §2 (A1 routing verification): proof that `daemon::start_with` **itself**
+//! — with no test-supplied stand-in for the name "agy" — now puts a real
+//! `AgyBackend` in its registry, so the four-tier `RouteSource` chain
+//! (already unit-tested in `src/runtime/router.rs` and already exercised
+//! end-to-end with a *test-substituted* `FakeBackend::scripted("agy",
+//! ...)` in `tests/m3_execution.rs`'s
+//! `t7_routing_precedence_and_structured_failure`) reaches agy as the
+//! daemon's own default registration, not a fixture wearing its name.
+//!
+//! Every test here deliberately configures agy with a nonexistent
+//! executable, so the outcome is deterministic on any host (a host with a
+//! real, logged-in `agy` on `PATH` must not make these flaky or spend
+//! tokens): `resolve_tiers` calls `backend.probe()` before returning success,
+//! so an unavailable agy makes every submission below fail with
+//! `RouteError::Unavailable` — the *stronger*, host-independent proof that
+//! each tier reached the registered adapter and stopped there (named,
+//! `backend_unavailable`), rather than falling through to a populated global
+//! default the way an unregistered "agy" silently did before this wave.
+//!
+//! In-process `daemon::start_with` + `reqwest`, no subprocess — the same rig
+//! `tests/estate_routes.rs`/`tests/m3_execution.rs`/`tests/opencode_routing.rs`
+//! use, so `tests/support::DataDir`'s reaper does not apply here either.
+//!
+//! No new `RouteSource` variant, no new routing logic — `src/runtime/
+//! router.rs` is untouched by this wave. No CLI-subprocess test of `sgt run
+//! --backend agy` or `sgt agy` actually exec'ing either: `harness::
+//! prepare`/`exec` are already unit-tested and exec-boundary functions are
+//! not round-trippable through an integration test by design.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::backend::agy::AgyConfig;
+use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend};
+use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
+
+mod support;
+
+// ---------------------------------------------------------------- helpers
+
+fn ulid() -> String {
+    ulid::Ulid::generate().to_string()
+}
+
+fn http() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("client")
+}
+
+/// An `AgyConfig` pointed at a definitely-nonexistent executable, so the
+/// probe always reports `available: false` regardless of what host runs
+/// this suite.
+fn deterministic_agy_config(data_dir: &Path) -> AgyConfig {
+    AgyConfig {
+        executable: PathBuf::from("/nonexistent/definitely-not-agy"),
+        ..AgyConfig::new(data_dir)
+    }
+}
+
+/// mirrors `tests/m3_execution.rs`'s `estate_with_manifest`: an estate at
+/// `root` from a verbatim `sergeant.toml`, with a real git checkout at
+/// `root/repos/<name>` for each of `repos`.
+fn estate_with_manifest(root: &Path, manifest: &str, repos: &[&str]) {
+    std::fs::create_dir_all(root).expect("estate root");
+    for repo in repos {
+        support::init_repo(&root.join("repos").join(repo));
+    }
+    std::fs::write(root.join("sergeant.toml"), manifest).expect("sergeant.toml");
+}
+
+/// Start a daemon with one scripted fake (the global default) and agy
+/// registered for real, but deterministically unavailable.
+async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
+    daemon::start_with(
+        data_dir,
+        DaemonConfig {
+            backends: Arc::new(
+                BackendRegistry::new().with(Arc::new(FakeBackend::new(FAKE_BACKEND_NAME))),
+            ),
+            default_backend: global_default.map(str::to_string),
+            agy: Some(deterministic_agy_config(data_dir)),
+            estate_root: Some(estate_root.to_path_buf()),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start")
+}
+
+/// POST a JSON body to the daemon; returns status and parsed body.
+async fn post(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    path: &str,
+    body: Value,
+) -> (reqwest::StatusCode, Value) {
+    let resp = client
+        .post(format!("{}{path}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    let value: Value = resp.json().await.expect("json body");
+    (status, value)
+}
+
+/// GET a path from the daemon.
+async fn get(client: &reqwest::Client, handle: &DaemonHandle, path: &str) -> Value {
+    client
+        .get(format!("{}{path}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("request")
+        .json()
+        .await
+        .expect("json body")
+}
+
+/// Submit work whose origin is `cwd`, merging any extra request fields.
+async fn submit(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    cwd: &Path,
+    extra: Value,
+) -> (reqwest::StatusCode, Value) {
+    let mut body = json!({
+        "command_id": ulid(),
+        "intent": "route me",
+        "origin": {"client": "cli", "cwd": cwd},
+    });
+    if let Some(fields) = extra.as_object() {
+        for (key, value) in fields {
+            body[key] = value.clone();
+        }
+    }
+    post(client, handle, "/v1/work", body).await
+}
+
+// -------------------------------------------------------------------- tests
+
+/// (a) Explicit `--backend agy` resolves to the registered adapter, not
+/// `backend_not_found`: agy is *known and named*, and its own probe
+/// evidence is what fails the submission.
+#[tokio::test]
+async fn explicit_backend_agy_reaches_the_registered_adapter_not_not_found() {
+    let root = TempDir::new().expect("tempdir");
+    support::scaffold_estate(root.path(), "plain", &["plain"]);
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"backend": "agy", "origin": {"client": "cli", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(
+        body["error"]["code"], "backend_unavailable",
+        "agy must be *known and named*, not `backend_not_found` — {body}"
+    );
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(
+        available.iter().any(|v| v == "agy"),
+        "agy must be offered as an option: {available:?}"
+    );
+    // Never silently ran on the global default fake instead.
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(list["works"].as_array().expect("works").is_empty());
+    handle.shutdown().await;
+}
+
+/// (b) `SGT_ORIGIN_CLIENT=agy` (as `sgt agy` sets, `src/harness.rs`'s
+/// `ORIGIN_CLIENT_ENV`) resolves `OriginAffinity` when no explicit flag is
+/// given — and, the case that actually catches the pre-registration bug,
+/// must NOT fall through to a populated global default.
+#[tokio::test]
+async fn origin_affinity_from_sgt_agy_is_decisive_over_the_global_default() {
+    let root = TempDir::new().expect("tempdir");
+    support::scaffold_estate(root.path(), "plain", &["plain"]);
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"origin": {"client": "agy", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(body["error"]["code"], "backend_unavailable");
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(available.iter().any(|v| v == "agy"));
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(
+        list["works"].as_array().expect("works").is_empty(),
+        "must not have silently substituted the global default `fake`"
+    );
+    handle.shutdown().await;
+}
+
+/// (c) An estate `default_backend = "agy"` resolves `WorkspaceDefault`,
+/// same decisiveness-over-global-default proof as (b).
+#[tokio::test]
+async fn estate_default_backend_agy_is_decisive_over_the_global_default() {
+    let root = TempDir::new().expect("tempdir");
+    estate_with_manifest(
+        root.path(),
+        "[estate]\nname = \"configured\"\ndefault_backend = \"agy\"\n\n\
+         [[repo]]\nname = \"plain\"\n",
+        &["plain"],
+    );
+    let data = TempDir::new().expect("tempdir");
+    let handle = start(data.path(), root.path(), Some(FAKE_BACKEND_NAME)).await;
+
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        root.path(),
+        json!({"origin": {"client": "cli", "cwd": root.path()}}),
+    )
+    .await;
+
+    assert_eq!(status, 422);
+    assert_eq!(body["error"]["code"], "backend_unavailable");
+    let available = body["error"]["available_backends"]
+        .as_array()
+        .expect("array");
+    assert!(available.iter().any(|v| v == "agy"));
+    let list = get(&http(), &handle, "/v1/work").await;
+    assert!(
+        list["works"].as_array().expect("works").is_empty(),
+        "must not have silently substituted the global default `fake`"
+    );
+    handle.shutdown().await;
+}

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -836,15 +836,15 @@ async fn event_history_from_seq_returns_exactly_the_tail() {
     cancel(&http, &handle, &work_id, &ulid()).await;
 
     // daemon.started + backend.probed (one per registered backend: fake,
-    // claude, docker, codex, and opencode as of N4/W2/opencode-W2 —
-    // DaemonConfig::default's registry plus the four adapters `start_with`
-    // always adds) + 2×(work.submitted, command.accepted) + work.canceled
-    // + command.accepted.
+    // claude, docker, codex, opencode, and agy as of N4/W2/opencode-W2/
+    // agy-W2 — DaemonConfig::default's registry plus the five adapters
+    // `start_with` always adds) + 2×(work.submitted, command.accepted) +
+    // work.canceled + command.accepted.
     let all = history_seqs(&http, &handle, None).await;
-    assert_eq!(all.len(), 12, "unexpected history: {all:?}");
+    assert_eq!(all.len(), 13, "unexpected history: {all:?}");
     assert_eq!(
         all,
-        (1..=12).collect::<Vec<u64>>(),
+        (1..=13).collect::<Vec<u64>>(),
         "seqs are 1..n in order"
     );
 

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -1803,10 +1803,18 @@ async fn t7_routing_precedence_and_structured_failure() {
     // `start_with` always registers the real docker adapter unless the
     // config already names one (N4), the same way it always adds claude
     // unless the config pre-empts it — none of these three fakes is named
-    // "docker", so nothing pre-empts it here.
+    // "docker", so nothing pre-empts it here. "agy" is present too, since
+    // the agy-adapter sprint's own W2, for the identical reason.
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME, "opencode"])
+        json!([
+            "agy",
+            "claude",
+            "codex",
+            "docker",
+            FAKE_BACKEND_NAME,
+            "opencode"
+        ])
     );
     plain_handle.shutdown().await;
 
@@ -1822,13 +1830,13 @@ async fn t7_routing_precedence_and_structured_failure() {
     assert_eq!(status, 422, "unroutable work must be refused: {body}");
     assert_eq!(body["error"]["code"], "no_backend_selected");
     // The scripted fake occupies the "claude" slot, so the daemon adds
-    // nothing there — but it still adds the real docker, codex, and opencode
-    // adapters (N4/W2, nothing here is named "docker", "codex", or
-    // "opencode"): opencode is now the fourth real adapter the daemon
-    // registers by default, same as docker and codex.
+    // nothing there — but it still adds the real docker, codex, opencode,
+    // and agy adapters (N4/W2/agy-W2, nothing here is named "docker",
+    // "codex", "opencode", or "agy"): agy is now the fifth real adapter the
+    // daemon registers by default, same as docker, codex, and opencode.
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "codex", "docker", "opencode"])
+        json!(["agy", "claude", "codex", "docker", "opencode"])
     );
     assert!(
         body["error"]["message"]
@@ -2067,13 +2075,20 @@ async fn t7c_an_unusable_stage_harness_fails_before_any_side_effect() {
     .await;
     assert_eq!(status, 422, "must be refused: {body}");
     assert_eq!(body["error"]["code"], "backend_not_found");
-    // The daemon registers the real Claude, Codex, Docker, and Opencode
-    // adapters alongside the scripted fake, so the options list names all
-    // five; "goose" is still never registered, which is exactly why naming
-    // it fails.
+    // The daemon registers the real Claude, Codex, Docker, Opencode, and
+    // Agy adapters alongside the scripted fake, so the options list names
+    // all six; "goose" is still never registered, which is exactly why
+    // naming it fails.
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME, "opencode"])
+        json!([
+            "agy",
+            "claude",
+            "codex",
+            "docker",
+            FAKE_BACKEND_NAME,
+            "opencode"
+        ])
     );
     assert!(fake.starts().is_empty(), "no silent provider substitution");
     let list = get(&client, &handle, "/v1/work").await;
@@ -4706,12 +4721,20 @@ async fn a_submission_with_no_workspace_is_captured_but_still_routed() {
     assert_eq!(body["error"]["code"], "backend_not_found");
     // Since M4 the daemon registers the real claude adapter alongside the
     // scripted fake, since N4 the docker adapter too, since W2 the codex
-    // adapter as well, and since the opencode-adapter sprint's own W2 the
-    // opencode adapter too (registered names sort: claude, codex, docker,
-    // fake, opencode).
+    // adapter as well, since the opencode-adapter sprint's own W2 the
+    // opencode adapter too, and since the agy-adapter sprint's own W2 the
+    // agy adapter as well (registered names sort: agy, claude, codex,
+    // docker, fake, opencode).
     assert_eq!(
         body["error"]["available_backends"],
-        json!(["claude", "codex", "docker", FAKE_BACKEND_NAME, "opencode"])
+        json!([
+            "agy",
+            "claude",
+            "codex",
+            "docker",
+            FAKE_BACKEND_NAME,
+            "opencode"
+        ])
     );
 
     // Only two works exist: the refusal created none.

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -2092,12 +2092,13 @@ async fn the_capability_probe_is_journaled_at_registration() {
         .filter(|e| e.kind == daemon::KIND_BACKEND_PROBED)
         .collect();
     // One record per registered backend: claude (this test's subject),
-    // docker, codex (N4/W2), and opencode (opencode-adapter sprint's own
-    // W2) — `start_with` always registers them alongside claude, same as
-    // claude is added here even though this test's registry started empty.
-    // Located by name rather than trusted-by-index, so this stays correct
-    // regardless of how many backends a future adapter adds the same way.
-    assert_eq!(probed.len(), 4, "one record per registered backend");
+    // docker, codex (N4/W2), opencode (opencode-adapter sprint's own W2),
+    // and agy (agy-adapter sprint's own W2) — `start_with` always registers
+    // them alongside claude, same as claude is added here even though this
+    // test's registry started empty. Located by name rather than
+    // trusted-by-index, so this stays correct regardless of how many
+    // backends a future adapter adds the same way.
+    assert_eq!(probed.len(), 5, "one record per registered backend");
     let claude_probed = probed
         .iter()
         .find(|e| e.payload["backend"] == CLAUDE_BACKEND_NAME)


### PR DESCRIPTION
Wave 2 of the agy adapter sprint (plan: docs/proposals/agy-adapter-2026-08-23.md, head PR #250). One workflow: spec → implement → 4-axis blind panel → refuters (default refuted) → fixer on confirmed only → gate. Roster: all sonnet (mechanical mirror wave; opus not earned). Zero live agy turns — stub-driven end to end.

## What ships
- **Registration**: `DaemonConfig.agy: Option<AgyConfig>` + construction/registration/event-sink block in `daemon.rs`, verbatim mirror of the opencode block (registration-as-verification — ADR 0020 A1 / ADR 0021 precedent).
- **Routing proof**: `tests/agy_routing.rs` (3 tests, opencode_routing template): explicit `--backend agy`, origin affinity via `SGT_ORIGIN_CLIENT=agy`, estate `default_backend = "agy"` — each reaching the real registered adapter, host-independent. `goose` stays the canonical unregistered fixture, untouched (K4).
- **The K2 pre-ratified exception**: `sgt agy` passthrough in `cli.rs` (+ a doc-only verb-list line in `harness.rs`) — exact goose mirror; `toolchain_path_dirs`/`prepare`/`exec` needed zero code change (already generic).
- **Daemon-boot posture pair** (the 0.2.2 daemon-panic lesson): stub-on-PATH boots and journals the probe; agy-absent still starts and says why. No serve-capable variant needed — agy is subprocess-only.
- Mechanical fixture fallout of a sixth registered backend (m2 12→13 events, m3 backend lists, m4 4→5 probed), all edited by name, same commit as nothing else.
- `c2-agy_routing` coverage stage wired in the same commit as the suite (#231 discipline).

## Real bug caught and fixed mid-wave (implementer, then fixer coverage)
W1's `read_config_probe` (`agy -p "/config"`) is documented zero-quota but **blocks up to 60s on an interactive OAuth prompt when agy is installed-but-unauthenticated** — and this wave's registration runs it synchronously at daemon start, which reproduced as a deterministic ~60s boot hang on this host (two real-subprocess m2 tests failed before the fix, pass after). Fix (`e1e6984b`, R2): bounded `CONFIG_PROBE_BUDGET` (5s) reusing the module's existing spawn+thread+recv_timeout pattern; probe falls back honestly, `available` stays true. Panel confirmed the timeout/kill path had zero coverage and the stub couldn't exercise it; fixer (`ea3caae6`) added `StubAgy::hangs_on_config()` + a budget test, **revert-verified** (unbounding the call makes the test fail at 60.007s naming CONFIG_PROBE_BUDGET).

## Panel → refuters → fixer
1 raw finding, 1 confirmed (the coverage gap above), fixed and revert-verified.

## Gates
- fmt --check clean; `clippy --locked --all-targets -- -D warnings` clean (CI's exact invocation)
- cargo test full: **1597 passed / 0 failed / 33 ignored**; agy_routing and the daemon-boot pair rerun 3× each, no flakes
- **Coverage (exact CI sequence): TOTAL 91.82% lines, gate exit 0 (+1.82 over floor).** Wave-touched files: `agy.rs` 94.95%, `daemon.rs` 92.45%. `cli.rs` (85.35%) and `harness.rs` (83.76%) sit below the per-file 90 mark, but the gate is TOTAL-only and both carry pre-existing whole-repo debt — this wave changed 26 and 2 lines in them respectively (the passthrough). Stated for honesty, not hidden behind the TOTAL.

## K2 ledger rows (for ADR 0022's table)
daemon.rs registration block (mirror, decides nothing new); the pre-ratified cli.rs/harness.rs passthrough; mechanical m2/m3/m4 widening (same-commit fallout of registration); tests+c2 wiring (template-pre-ratified); stale harness verb-list prose bump (drive-by, doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4