### PR TITLE
Fix the Gate D release blocker: never-arrives test's 150ms ceiling races instrumented runners

### DIFF
--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -2681,7 +2681,15 @@ async fn a_known_never_forgotten_execution_whose_signal_never_arrives_parks_rath
 
     let (registry, fake) = one_fake([FakeStep::never_arrives().with_native(NativeState::Exited)]);
     let poll = Duration::from_millis(50);
-    let ceiling = Duration::from_millis(150);
+    // 2s, not the sibling tests' 150ms: this test's mid-check asserts the
+    // Work is still `active` "well within the ceiling" after a ~100ms sleep
+    // plus two HTTP round-trips. With a 150ms ceiling that left a ~50ms
+    // margin, which release run 17's instrumented Gate D runner ate — the
+    // ceiling tripped first and the mid-check read `blocked` ("turn ceiling
+    // exceeded (0.15s)"). A 20x margin keeps the mid-check meaningful on the
+    // slowest measured runner; the ceiling-fires wait below stays bounded by
+    // `interrupt_budget`, which already carries CI's jitter allowance.
+    let ceiling = Duration::from_secs(2);
     let handle = daemon::start_with(
         data.path(),
         DaemonConfig {


### PR DESCRIPTION
Release run 17 (32689405973) failed at Gate D on a timing flake in a pre-existing test (landed by the codex sprint's W4 §1.7, 127a02cf) — not an agy 0.2.3 defect. `a_known_never_forgotten_execution_whose_signal_never_arrives_parks_rather_than_concluding` asserts the Work is still `active` after a ~100ms sleep, against a 150ms turn ceiling: a 50ms margin the instrumented coverage runner ate (`turn ceiling exceeded (0.15s)` → `blocked` before the assertion). All un-instrumented gates in the same run passed (Gate B ci, both Gate C matrix legs); every prior Gate D pass simply won the race.

Fix: 2s ceiling for this one test (20× margin for the early-active check). The ceiling-fires wait stays bounded by `interrupt_budget`'s existing CI jitter allowance. The sibling 150ms-ceiling test has no early-active assertion and is deliberately untouched.

Verified: 3× instrumented single-test runs + full `m3_execution` (55 tests) green.

After merge: re-dispatch the release — run 17's failure consumed no tag or artifact (Gate D failed before `package`), so the lane restarts clean and auto-tags 0.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4