### PR TITLE
Fix release 18's Gate D blocker: question.replied journal race under instrumentation

### DIFF
--- a/tests/opencode_backend.rs
+++ b/tests/opencode_backend.rs
@@ -2590,13 +2590,26 @@ fn serve_question_asked_parks_as_actor_authored_and_the_reply_relays_to_its_endp
         assert!(Instant::now() < deadline, "the gate never cleared");
         std::thread::sleep(Duration::from_millis(20));
     }
-    let replied = events_of_kind(&events, "conversation.turn.harness_error")
-        .into_iter()
-        .find(|e| e.payload["phase"] == "question_replied");
-    assert!(
-        replied.is_some(),
-        "the question.replied SSE frame must have been dispatched and journaled"
-    );
+    // Bounded wait, not an instantaneous read: the gate clearing (the reply
+    // POST landing) and the `question.replied` SSE frame's journaling ride
+    // different paths — the SSE reader journals asynchronously, and release
+    // run 18's instrumented Gate D runner observed the gate clear before the
+    // frame was journaled. The property stays the same (the frame MUST be
+    // dispatched and journaled); only the ordering assumption goes.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let replied = events_of_kind(&events, "conversation.turn.harness_error")
+            .into_iter()
+            .find(|e| e.payload["phase"] == "question_replied");
+        if replied.is_some() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the question.replied SSE frame must have been dispatched and journaled"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
     backend.stop(&handle).expect("stop").wait();
 }
 


### PR DESCRIPTION
Release run 18 (32718057967) failed at Gate D — the m3 fix (#255) held; this is the NEXT latent flake in line, in `tests/opencode_backend.rs` (0.2.2 sprint): the test read the `question_replied` journal event instantaneously after the NeedsInput gate cleared, but the reply POST (clears the gate) and the SSE reader (journals the frame) are asynchronous — the instrumented runner observed them out of order for the first time. All un-instrumented gates passed, again.

Fix: the assertion becomes a bounded 10s poll (the test's own existing deadline pattern, reused). The asserted property — the frame must be dispatched and journaled — is unchanged.

Verified: 3× instrumented single-test runs + full `opencode_backend` (69/69 deterministic) green.

Two consecutive releases each dying on a *different* instrumented-runner timing flake is a class, not a coincidence — companion issue filed for a one-pass audit of instant-after-async assertions and sub-second margins across the suites, so Gate D stops discovering these one release at a time.

After merge: re-dispatch the release; run 18 consumed no tag or artifact (died before `package`), lane restarts clean and auto-tags 0.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4