### PR TITLE
W1: decouple doctrine-skew tests and release notes from relocating files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -719,8 +719,7 @@ jobs:
             echo "**Co-versioning note:** this release ships the \`sgt\` binary only."
             echo "v${RELEASE_VERSION} does NOT yet ship an embedded distro — that"
             echo "is Phase 3 scope (reference/proposal-product-workspace-split.md),"
-            echo "not yet tracked by a dedicated open issue. See CHANGELOG.md and"
-            echo "NORTH-STAR.md's \"Not true yet\" note."
+            echo "not yet tracked by a dedicated open issue. See CHANGELOG.md."
             echo
             echo "**Gate F (distro structural validator) did not run in this workflow.**"
             echo "That property is proven continuously by sergeant-rs-workspace's own CI"

--- a/tests/f_doctrine_skew.rs
+++ b/tests/f_doctrine_skew.rs
@@ -378,48 +378,50 @@ fn no_shipped_workflow_or_skill_quotes_the_removed_workspace_flag() {
 
 // ------------------------------------------------- 3. manifest example skew
 
-/// The estate-root proposal's own canonical manifest shape (§13.1,
-/// `docs/proposals/estate-root-git.md`) still parses under the current
-/// schema — structurally (`Estate::from_config_structural`, which validates
+/// §13.1's canonical manifest shape, carried verbatim from
+/// `docs/proposals/estate-root-git.md` §13.1 as of 2026-08-24, ahead of
+/// that file's relocation to the workspace knowledge library
+/// (split-hardening series, sprint-plan-2026-08-24.md, W1). Fixture, not a
+/// live read, so this test no longer depends on the doc surviving in this
+/// repo.
+const PROPOSAL_MANIFEST_EXAMPLE: &str = r#"[estate]
+name = "payments"
+data_dir = ".sergeant/data"
+surfaces_dir = ".sergeant/data/surfaces"
+
+[[repo]]
+name = "payments-api"
+origin = "git@github.com:company/payments-api.git"
+instructions = "suppress"
+
+[[repo]]
+name = "auth"
+origin = "git@github.com:company/auth.git"
+instructions = "suppress"
+
+[[repo]]
+name = "payments-knowledge"
+origin = "git@github.com:company/payments-knowledge.git"
+instructions = "suppress"
+
+[group.payments]
+repos = ["payments-api", "auth", "payments-knowledge"]
+brief = "Payment authorization, settlement, and governing team knowledge."
+
+[[profile]]
+name = "sonnet"
+backend = "claude"
+default_model = "sonnet""#;
+
+/// The estate-root proposal's own canonical manifest shape (§13.1) still
+/// parses under the current schema — structurally
+/// (`Estate::from_config_structural`, which validates
 /// names/duplicates/groups/profiles without requiring `repos/<name>` to be
 /// real git checkouts on disk, exactly right for a doc example that names
 /// no real repository).
 #[test]
 fn the_proposals_canonical_manifest_example_parses_under_the_current_schema() {
-    let proposal = std::fs::read_to_string(repo_root().join("docs/proposals/estate-root-git.md"))
-        .expect("read estate-root-git.md");
-
-    let anchor = proposal
-        .find("13.1 Proposed manifest shape")
-        .expect("proposal must still have a §13.1 'Proposed manifest shape' heading");
-    let after_anchor = &proposal[anchor..];
-    let fence_start = after_anchor
-        .find("```toml")
-        .expect("§13.1 must be followed by a ```toml fence");
-    let block_start = fence_start + "```toml".len();
-    let block_end = after_anchor[block_start..]
-        .find("```")
-        .expect("the §13.1 toml fence must close");
-    let toml_text = after_anchor[block_start..block_start + block_end].trim();
-
-    // Structural sanity: this is the specific example this test means to
-    // pin, not whatever now happens to follow the same heading text.
-    assert!(
-        toml_text.contains("[estate]"),
-        "unexpected block: {toml_text}"
-    );
-    assert!(
-        toml_text.contains("[[repo]]"),
-        "unexpected block: {toml_text}"
-    );
-    assert!(
-        toml_text.contains("[group."),
-        "unexpected block: {toml_text}"
-    );
-    assert!(
-        toml_text.contains("[[profile]]"),
-        "unexpected block: {toml_text}"
-    );
+    let toml_text = PROPOSAL_MANIFEST_EXAMPLE;
 
     let dir = tempfile::TempDir::new().expect("scratch dir");
     let manifest_path = dir.path().join("sergeant.toml");
@@ -509,33 +511,22 @@ fn agents_md_carries_the_intent_section() {
 
 // --------------------------------------------------------- 6. #180 wording
 
-/// NORTH-STAR.md's live destination text states the ratified #180 contract
-/// — a declared mutation surface, observed and journaled, never an
-/// enforced one — and AGENTS.md's mirror sentence says the same thing.
-/// Quoted verbatim, same house pattern as above.
+/// AGENTS.md's mirror sentence states the ratified #180 contract — a
+/// declared mutation surface, observed and journaled, never an enforced
+/// one. Quoted verbatim, same house pattern as above.
+///
+/// This test used to also pin NORTH-STAR.md's copy of the same sentence,
+/// but NORTH-STAR.md is scheduled to leave this repo under the
+/// split-hardening series (sprint-plan-2026-08-24.md, W1); AGENTS.md is
+/// now the sole doctrine surface this repo's build and tests depend on.
 #[test]
-fn north_star_states_the_ratified_mutation_surface_contract() {
-    let north_star =
-        std::fs::read_to_string(repo_root().join("NORTH-STAR.md")).expect("read NORTH-STAR.md");
+fn agents_md_states_the_ratified_mutation_surface_contract() {
     let agents_md = std::fs::read_to_string(repo_root().join("AGENTS.md")).expect("read AGENTS.md");
-    // Both files soft-wrap; collapse whitespace so a sentence spanning a
+    // AGENTS.md soft-wraps; collapse whitespace so a sentence spanning a
     // line break still matches a `contains` check on its logical text
     // rather than its accidental line layout (same trick
     // `agents_md_session_start_matches_the_real_root_gate` uses above).
-    let north_star_flat = north_star.split_whitespace().collect::<Vec<_>>().join(" ");
     let agents_md_flat = agents_md.split_whitespace().collect::<Vec<_>>().join(" ");
-
-    assert!(
-        north_star_flat.contains(
-            "carried by a durable intent-execution engine that gives every Work its own \
-             worktree and a declared mutation surface — authorization, not a seal — runs \
-             intents to completion against it, and journals what core can prove happened \
-             outside that surface as dirty evidence at retirement rather than silently \
-             absorbing it."
-        ),
-        "NORTH-STAR.md's destination text no longer states the ratified #180 mutation-surface \
-         contract — update this test and the doctrine text together"
-    );
 
     assert!(
         agents_md_flat.contains(
@@ -545,22 +536,17 @@ fn north_star_states_the_ratified_mutation_surface_contract() {
              can prove happened outside that surface as dirty evidence at retirement rather \
              than silently absorbing it"
         ),
-        "AGENTS.md's mirror sentence no longer states the same #180 contract — update this \
+        "AGENTS.md's mirror sentence no longer states the ratified #180 contract — update this \
          test and the doctrine text together"
     );
 
     // Factual-not-exhortative framing (MUTATION_SURFACE_HEADER's own rule,
     // src/backend/claude.rs): the destination text must never claim the
     // mutation surface itself is enforced.
-    for (name, text) in [
-        ("NORTH-STAR.md", &north_star_flat),
-        ("AGENTS.md", &agents_md_flat),
-    ] {
-        assert!(
-            !text.contains("enforces the mutation surface")
-                && !text.contains("enforced mutation surface")
-                && !text.contains("mutation surface is enforced"),
-            "{name} must state the mutation surface as declared and observed, never enforced"
-        );
-    }
+    assert!(
+        !agents_md_flat.contains("enforces the mutation surface")
+            && !agents_md_flat.contains("enforced mutation surface")
+            && !agents_md_flat.contains("mutation surface is enforced"),
+        "AGENTS.md must state the mutation surface as declared and observed, never enforced"
+    );
 }


### PR DESCRIPTION
Split-hardening wave W1 (unblocks the W2c removal PR; part of head PR #263's plan).

Executed as Sergeant Work 01M0T0MFEYRK08PA5A7P9BDC1T (implement-change, sonnet, integrity clean; internal panel + refuters ran; kill probe passed: full suite green with NORTH-STAR.md/GAUNTLET.md/LESSONS.md renamed).

- f_doctrine_skew.rs: mutation-surface contract test re-binds to AGENTS.md alone (all positive and factual-not-exhortative assertions kept); the estate-root-git.md §13.1 TOML example inlined as a fixture, live schema-parse assertion kept; no filesystem read of any relocating file remains.
- release.yml: generated release-note text made self-contained (no NORTH-STAR.md citation).

Rungs: R2 (existing test/assertion machinery reused), J3 (plan + ADR 0014 d17 govern scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4