### PR TITLE
W6: commit imperative in shared contexts, per-stage artifact retention, tool_use in transcripts (#232, #240)

### DIFF
--- a/.sergeant/common/contexts/fix-confirmed.md
+++ b/.sergeant/common/contexts/fix-confirmed.md
@@ -27,6 +27,12 @@ Fix exactly what survived attack. Nothing else.
 - **Re-run the targeted validation** after the last fix commit and record
   the real output, so whatever attacks the fixes next starts from a known
   state.
+- **Commit the fix.** `git add` and `git commit` each fix on the binding's
+  own `work_branch` (the `BindingSummary` handed to this stage already
+  names it). A fix that is correct but never committed is not fixed —
+  nothing downstream (`@@re-verify`, `@@close`, `@@evidence-requirements`)
+  can find or verify work that was never landed. Do not stop at a
+  described or staged-but-uncommitted change.
 
 ## What this context contributes when loaded inside a stage
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -2501,11 +2501,15 @@ async fn work_transcript(State(state): State<ApiState>, Path(id): Path<String>) 
     Json(json!({"work_id": id, "turns": turns})).into_response()
 }
 
-/// The pure decode: filter `events` to `work_id`'s `conversation.*` kinds and
-/// turn each into a `{seq, ts, role, text, source}` entry, in the journal's
-/// own causal (seq) order — factored out of the handler above so the
-/// role/source mapping and the blob-decode fallback can be pinned by a
-/// direct test without spinning up a daemon.
+/// The pure decode: filter `events` to `work_id`'s `conversation.*` and
+/// `tool.*` (#240) kinds and turn each into a `{seq, ts, role, text,
+/// source}` entry, in the journal's own causal (seq) order — factored out
+/// of the handler above so the role/source mapping and the blob-decode
+/// fallback can be pinned by a direct test without spinning up a daemon.
+/// `tool.*` events carry `role: "tool_use"` plus a `phase`
+/// (`"requested"`/`"completed"`) — previously these fell into the
+/// catch-all below and vanished, so a degraded run that silently invoked
+/// zero tools read identically to one that made real progress.
 fn transcript_turns(work_id: &str, events: Vec<Event>, data_dir: &std::path::Path) -> Vec<Value> {
     let mut turns = Vec::new();
     // Per-`execution_id` count of `conversation.assistant.completed` events
@@ -2556,6 +2560,44 @@ fn transcript_turns(work_id: &str, events: Vec<Event>, data_dir: &std::path::Pat
                 "text": event.payload["question"].as_str().unwrap_or(""),
                 "source": "event",
             })),
+            // #240: `tool.*` events were previously falling into the
+            // catch-all below and vanishing from the transcript entirely —
+            // a degraded run that silently skipped every tool call read
+            // identically to one that made real progress. Surfaced as
+            // `role: "tool_use"` with a `phase` distinguishing the request
+            // from its result, so a reader (or `render_transcript`) can
+            // tell the two apart without a second lookup.
+            KIND_TOOL_REQUESTED => {
+                let name = event.payload["name"].as_str().unwrap_or("tool");
+                let input = &event.payload["input"];
+                turns.push(json!({
+                    "seq": event.seq,
+                    "ts": event.timestamp,
+                    "role": "tool_use",
+                    "phase": "requested",
+                    "tool_use_id": event.payload["id"].as_str().unwrap_or(""),
+                    "name": name,
+                    "input": input,
+                    "text": format!("{name} {input}"),
+                    "source": "event",
+                }));
+            }
+            KIND_TOOL_COMPLETED => {
+                let is_error = event.payload["is_error"].as_bool().unwrap_or(false);
+                let name = event.payload["name"].as_str().unwrap_or("tool");
+                let outcome = if is_error { "error" } else { "ok" };
+                turns.push(json!({
+                    "seq": event.seq,
+                    "ts": event.timestamp,
+                    "role": "tool_use",
+                    "phase": "completed",
+                    "tool_use_id": event.payload["tool_use_id"].as_str().unwrap_or(""),
+                    "name": name,
+                    "is_error": is_error,
+                    "text": format!("{name} -> {outcome}"),
+                    "source": "event",
+                }));
+            }
             KIND_CONVERSATION_TURN_ENDED => {
                 // This turn's own boundary: whatever `assistant.completed`
                 // this execution emitted belongs to *this* turn (the two are
@@ -5678,6 +5720,56 @@ mod tests {
             ],
             "w2's event must be excluded and the rest must decode in seq order: {turns:?}"
         );
+    }
+
+    /// #240: `tool.requested`/`tool.completed` used to fall into
+    /// `transcript_turns`'s catch-all and vanish from the transcript
+    /// entirely — a degraded run that silently invoked zero tools read
+    /// identically to one that made real progress. Both kinds must now
+    /// decode as `role: "tool_use"` entries, distinguished by `phase`, in
+    /// the same causal order as every other turn kind.
+    #[test]
+    fn transcript_turns_surfaces_tool_requested_and_completed_events() {
+        let events = vec![
+            ev(
+                1,
+                "w1",
+                KIND_CONVERSATION_USER,
+                json!({"text": "run the tests"}),
+            ),
+            ev(
+                2,
+                "w1",
+                KIND_TOOL_REQUESTED,
+                json!({"id": "call-1", "name": "bash", "input": {"command": "cargo test"}}),
+            ),
+            ev(
+                3,
+                "w1",
+                KIND_TOOL_COMPLETED,
+                json!({"tool_use_id": "call-1", "name": "bash", "is_error": false}),
+            ),
+        ];
+        let data_dir = tempfile::TempDir::new().expect("tempdir");
+        let turns = transcript_turns("w1", events, data_dir.path());
+
+        let requested = turns
+            .iter()
+            .find(|t| t["seq"] == 2)
+            .expect("tool.requested must decode into a turn");
+        assert_eq!(requested["role"], "tool_use");
+        assert_eq!(requested["phase"], "requested");
+        assert_eq!(requested["tool_use_id"], "call-1");
+        assert_eq!(requested["name"], "bash");
+
+        let completed = turns
+            .iter()
+            .find(|t| t["seq"] == 3)
+            .expect("tool.completed must decode into a turn");
+        assert_eq!(completed["role"], "tool_use");
+        assert_eq!(completed["phase"], "completed");
+        assert_eq!(completed["tool_use_id"], "call-1");
+        assert_eq!(completed["is_error"], false);
     }
 
     /// The "minimal blob decode" itself, end to end through

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1683,6 +1683,8 @@ fn render_transcript(result: &Value) -> String {
             "user" => "User",
             "assistant" => "Assistant",
             "ask" => "Ask",
+            "tool_use" if turn["phase"].as_str() == Some("requested") => "Tool call",
+            "tool_use" => "Tool result",
             other => other,
         };
         let recovered = if turn["source"].as_str() == Some("blob_decode") {
@@ -3218,6 +3220,7 @@ pub(crate) mod doctor {
 
         let mut retained_worktrees = 0u64;
         let mut retained_patches = 0u64;
+        let mut retained_outputs = 0u64;
         let mut retained_bytes = 0u64;
         let mut terminal_dirty_works = 0u64;
 
@@ -3226,6 +3229,11 @@ pub(crate) mod doctor {
                 retained_bytes += binding.bytes;
                 if binding.reason == "retained_dirty" && binding.path.is_file() {
                     retained_patches += 1;
+                } else if binding.reason == "retained_output" {
+                    // #240: a per-stage output copy, not a worktree — kept
+                    // out of `retained_worktrees` so that count still means
+                    // what its label says.
+                    retained_outputs += 1;
                 } else {
                     retained_worktrees += 1;
                 }
@@ -3241,6 +3249,7 @@ pub(crate) mod doctor {
             format!("  active linked worktrees:   {active_worktrees}"),
             format!("  retained worktrees:        {retained_worktrees}"),
             format!("  retained patches:          {retained_patches}"),
+            format!("  retained stage outputs:    {retained_outputs}"),
             format!(
                 "  retained artifact size:    {}",
                 human_bytes(retained_bytes)

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -5574,6 +5574,7 @@ mod tests {
                 BindingDisposition::RetainedDirty {
                     changes: "M solo/wip.rs".to_string(),
                     patch: None,
+                    outputs: Vec::new(),
                 }
             };
             TeardownReport {

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -1556,16 +1556,28 @@ fn reap_binding(data_dir: &Path, surface: &WorkSurface, binding: &BindingTeardow
             // patch — `remove_surface_root` refuses a non-empty root, so
             // leaving these behind would leave the whole surface
             // undeletable after every retained patch was reaped.
+            //
+            // Patch removal is attempted *first*, deliberately: it is the
+            // one step here that can report a real, non-`NotFound` error,
+            // and the outputs are only destroyed once that step has
+            // already succeeded (or found nothing to remove). Destroying
+            // the outputs before the patch would leave `Failed` on a real
+            // patch-removal error indistinguishable from "nothing was
+            // reaped", when the irreversible output loss already
+            // happened.
+            let outcome = match std::fs::remove_file(&info.path) {
+                Ok(()) => ReapOutcome::Reaped { bytes: info.bytes },
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReapOutcome::NothingRetained,
+                Err(e) => {
+                    return ReapOutcome::Failed {
+                        detail: e.to_string(),
+                    };
+                }
+            };
             for output in outputs {
                 let _ = std::fs::remove_dir_all(&output.path);
             }
-            match std::fs::remove_file(&info.path) {
-                Ok(()) => ReapOutcome::Reaped { bytes: info.bytes },
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReapOutcome::NothingRetained,
-                Err(e) => ReapOutcome::Failed {
-                    detail: e.to_string(),
-                },
-            }
+            outcome
         }
         BindingDisposition::RetainedDirty { patch: None, .. } => {
             if !binding.worktree_path.exists() {
@@ -1789,7 +1801,7 @@ fn retain_stage_outputs(binding: &RepositoryBinding) -> Vec<RetainedStageOutput>
             continue;
         };
         let dest = dest_root.join(stage_name);
-        let bytes = copy_declared_output_artifacts(&output_dir, &dest);
+        let bytes = copy_declared_output_artifacts(&output_dir, &dest, &binding.worktree_path);
         if bytes > 0 {
             outputs.push(RetainedStageOutput {
                 stage: stage_name.to_string(),
@@ -1806,24 +1818,60 @@ fn retain_stage_outputs(binding: &RepositoryBinding) -> Vec<RetainedStageOutput>
     outputs
 }
 
-/// Copy every file directly under `src` except `README.md` (the
-/// declaration, not an artifact — Rule 4) into `dest`, creating `dest` on
-/// demand. Best-effort per file: a file this cannot read or write is
-/// skipped rather than aborting the whole stage's copy, matching
+/// Copy every real file under `src`, recursively, except the top-level
+/// `README.md` (the declaration, not an artifact — Rule 4), into the
+/// matching path under `dest`, creating directories on demand. A stage may
+/// legitimately write a nested artifact tree under `output/` — convention.md
+/// does not forbid it — so this descends into subdirectories rather than
+/// stopping at the top level.
+///
+/// A file `git add -A` would not stage (gitignored) is skipped too, the
+/// same exclusion [`capture_dirty_patch`] gets for free from `git add`
+/// itself: `output/` is declared to hold only real, trackable artifacts
+/// (convention.md §4/Rule 4), and a file Git itself would refuse to track
+/// is not one — copying it here would reintroduce the disk-bloat risk R4
+/// was written to prevent (#109) if that convention is ever violated.
+///
+/// Best-effort per file: a file this cannot read or write is skipped
+/// rather than aborting the whole stage's copy, matching
 /// [`capture_dirty_patch`]'s own best-effort posture toward anything past
 /// the point where failure can no longer lose already-durable evidence.
 /// Returns the total bytes actually copied.
-fn copy_declared_output_artifacts(src: &Path, dest: &Path) -> u64 {
+fn copy_declared_output_artifacts(src: &Path, dest: &Path, worktree_root: &Path) -> u64 {
+    copy_declared_output_artifacts_at(src, dest, worktree_root, true)
+}
+
+fn copy_declared_output_artifacts_at(
+    src: &Path,
+    dest: &Path,
+    worktree_root: &Path,
+    is_top_level: bool,
+) -> u64 {
     let Ok(entries) = std::fs::read_dir(src) else {
         return 0;
     };
     let mut bytes = 0u64;
     for entry in entries.flatten() {
         let path = entry.path();
+        if path.is_dir() {
+            bytes += copy_declared_output_artifacts_at(
+                &path,
+                &dest.join(entry.file_name()),
+                worktree_root,
+                false,
+            );
+            continue;
+        }
         if !path.is_file() {
             continue;
         }
-        if path.file_name().and_then(|n| n.to_str()) == Some("README.md") {
+        if is_top_level && path.file_name().and_then(|n| n.to_str()) == Some("README.md") {
+            continue;
+        }
+        if git_succeeds(
+            worktree_root,
+            &["check-ignore", "-q", &path.display().to_string()],
+        ) {
             continue;
         }
         let Ok(contents) = std::fs::read(&path) else {
@@ -4997,6 +5045,173 @@ mod tests {
         assert!(
             bindings.iter().any(|b| b.reason == "retained_dirty"),
             "the flat patch must still be reported alongside it: {bindings:?}"
+        );
+    }
+
+    /// W6 (F-IN-01): `copy_declared_output_artifacts` must descend into
+    /// subdirectories of a stage's `output/`, not just copy files sitting
+    /// directly inside it — convention.md does not forbid a stage from
+    /// writing a nested artifact tree, and a flat-only copy silently drops
+    /// those files from retention with no error.
+    #[test]
+    fn dirty_teardown_retains_a_stages_nested_output_artifacts() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01NESTED",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        let panel_output = worktree.join("20-panel").join("output");
+        let nested = panel_output.join("evidence");
+        std::fs::create_dir_all(&nested).expect("nested output dir");
+        std::fs::write(panel_output.join("README.md"), "declares findings.md")
+            .expect("panel README");
+        std::fs::write(nested.join("transcript.log"), "nested artifact").expect("nested file");
+
+        std::fs::write(worktree.join("wip.rs"), "// still working\n").expect("dirty edit");
+
+        let report = teardown_of(&surface);
+        let BindingDisposition::RetainedDirty { outputs, .. } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected RetainedDirty: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        assert_eq!(
+            outputs.len(),
+            1,
+            "the nested artifact must be retained: {outputs:?}"
+        );
+        let retained =
+            std::fs::read_to_string(outputs[0].path.join("evidence").join("transcript.log"))
+                .expect("nested artifact must survive teardown at its original relative path");
+        assert_eq!(retained, "nested artifact");
+    }
+
+    /// W6 (F-IN-02): `copy_declared_output_artifacts` must exclude files
+    /// Git would refuse to track (gitignored), the same exclusion
+    /// `capture_dirty_patch` gets for free from `git add -A` — otherwise a
+    /// stage that drops a gitignored file into `output/` reintroduces the
+    /// disk-bloat risk R4/#109 was written to prevent.
+    #[test]
+    fn dirty_teardown_excludes_gitignored_files_from_retained_output() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01IGNORED",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        let panel_output = worktree.join("20-panel").join("output");
+        std::fs::create_dir_all(&panel_output).expect("panel output dir");
+        std::fs::write(panel_output.join("README.md"), "declares findings.md")
+            .expect("panel README");
+        std::fs::write(panel_output.join("findings.md"), "real artifact").expect("real artifact");
+        std::fs::write(panel_output.join(".gitignore"), "junk.bin\n").expect("gitignore");
+        std::fs::write(panel_output.join("junk.bin"), "should never be retained")
+            .expect("ignored artifact");
+
+        std::fs::write(worktree.join("wip.rs"), "// still working\n").expect("dirty edit");
+
+        let report = teardown_of(&surface);
+        let BindingDisposition::RetainedDirty { outputs, .. } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected RetainedDirty: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        assert_eq!(outputs.len(), 1);
+        assert!(outputs[0].path.join("findings.md").is_file());
+        assert!(
+            !outputs[0].path.join("junk.bin").exists(),
+            "a gitignored file must not be copied into retained output"
+        );
+    }
+
+    /// W6 (F-IN-03): if the patch removal step of `reap_binding` fails with
+    /// a real (non-`NotFound`) error, the already-copied stage-output
+    /// retention must not have been destroyed first — otherwise `Failed`
+    /// would hide that irreversible data loss already happened. Forces the
+    /// failure by making the patch's parent directory read-only so
+    /// `remove_file` is denied, then asserts the output copy is still on
+    /// disk after `reap_binding` reports `Failed`.
+    #[test]
+    fn reap_failing_to_remove_the_patch_does_not_destroy_the_output_copy_first() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01REAPORD",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        let panel_output = worktree.join("20-panel").join("output");
+        std::fs::create_dir_all(&panel_output).expect("panel output dir");
+        std::fs::write(panel_output.join("findings.md"), "real artifact").expect("real artifact");
+        std::fs::write(worktree.join("wip.rs"), "// still working\n").expect("dirty edit");
+
+        let report = teardown_of(&surface);
+        let BindingDisposition::RetainedDirty {
+            patch: Some(info),
+            outputs,
+            ..
+        } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected a captured patch and retained output: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        assert_eq!(outputs.len(), 1);
+        let output_path = outputs[0].path.clone();
+        assert!(output_path.join("findings.md").is_file());
+
+        let patch_dir = info
+            .path
+            .parent()
+            .expect("patch has a parent dir")
+            .to_path_buf();
+        let original_perms = std::fs::metadata(&patch_dir)
+            .expect("stat patch dir")
+            .permissions();
+        let mut locked = original_perms.clone();
+        locked.set_mode(0o555);
+        std::fs::set_permissions(&patch_dir, locked).expect("lock patch dir");
+
+        let outcome = reap_binding(fixture_data_dir(&surface), &surface, &report.bindings[0]);
+
+        // Restore permissions before any assertion can panic and leave the
+        // tempdir uncleanable.
+        std::fs::set_permissions(&patch_dir, original_perms).expect("restore patch dir perms");
+
+        assert!(
+            matches!(outcome, ReapOutcome::Failed { .. }),
+            "expected patch removal to fail: {outcome:?}"
+        );
+        assert!(
+            output_path.join("findings.md").is_file(),
+            "the output copy must survive a failed patch removal, not be destroyed first"
         );
     }
 

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -431,6 +431,26 @@ pub struct PatchInfo {
     pub bytes: u64,
 }
 
+/// Where one stage's declared `output/` artifacts were retained
+/// separately from the flat dirty patch (#240): a per-stage-labeled copy
+/// of whatever real files existed under `<stage-dir>/output/` (excluding
+/// `README.md`, which is the declaration, not an artifact — Rule 4,
+/// `docs/icm/convention.md`) at the moment the worktree was about to be
+/// removed. Exists so a reader can retrieve one stage's evidence
+/// directly, without reconstructing it from the flat patch that already
+/// bundles it in with every other change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetainedStageOutput {
+    /// The stage directory name the artifacts were declared under (e.g.
+    /// `"20-panel"`), matching the workflow's own directory naming.
+    pub stage: String,
+    /// Where the copied artifacts were written, under the surface root,
+    /// sibling to the worktree they were copied out of.
+    pub path: PathBuf,
+    /// Total bytes copied.
+    pub bytes: u64,
+}
+
 /// What happened to one binding at teardown.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "disposition", rename_all = "snake_case")]
@@ -454,6 +474,14 @@ pub enum BindingDisposition {
         /// honest: those really did retain the whole directory.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         patch: Option<PatchInfo>,
+        /// #240: each stage's declared `output/` artifacts, copied out
+        /// separately and per-stage labeled, alongside `patch`. Empty
+        /// when `patch` is `None` — the whole worktree directory (output/
+        /// included) was left in place instead, so there is nothing extra
+        /// to copy. `#[serde(default)]` for the same replay reason as
+        /// `patch`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        outputs: Vec<RetainedStageOutput>,
     },
     /// The worktree path was already gone: recorded, not treated as success.
     Missing,
@@ -1307,7 +1335,10 @@ pub struct RetainedBinding {
     pub path: PathBuf,
     /// `retained_dirty` or `retained_error` — the same bare-tag spelling
     /// `sgt work show`'s output pointer already uses, so a client never has
-    /// to reconcile two vocabularies for the same fact.
+    /// to reconcile two vocabularies for the same fact. `retained_output`
+    /// (#240) is the one tag with no such counterpart: it names a
+    /// per-stage `output/` artifact copy, not a teardown disposition on
+    /// its own.
     pub reason: &'static str,
     /// The evidence teardown recorded: `git status --porcelain` output for
     /// `retained_dirty`, Git's own diagnostic for `retained_error`.
@@ -1328,67 +1359,103 @@ pub fn retained_bindings(teardown: &TeardownReport) -> Vec<RetainedBinding> {
     teardown
         .bindings
         .iter()
-        .filter_map(|b| match &b.disposition {
-            BindingDisposition::RetainedDirty {
-                changes,
-                patch: Some(info),
-            } => {
-                // Live check, not the size journaled at teardown time: a
-                // `sgt work reap` since then (or anything else that removed
-                // the file) must not keep showing up here — the same
-                // "report what is actually on disk right now" rule
-                // `directory_size`'s callers below already follow.
-                if !info.path.is_file() {
-                    return None;
-                }
-                Some(RetainedBinding {
+        .flat_map(retained_bindings_for)
+        .collect()
+}
+
+/// One binding's retained evidence: the primary retention
+/// ([`retained_bindings`]'s original single-entry shape) plus, when
+/// present, one further entry per `#240` stage-output copy — a `Vec`
+/// rather than an `Option` because a single binding can now carry more
+/// than one piece of independently retrievable evidence.
+fn retained_bindings_for(b: &BindingTeardown) -> Vec<RetainedBinding> {
+    let mut out = Vec::new();
+    match &b.disposition {
+        BindingDisposition::RetainedDirty {
+            changes,
+            patch: Some(info),
+            outputs,
+        } => {
+            // Live check, not the size journaled at teardown time: a
+            // `sgt work reap` since then (or anything else that removed
+            // the file) must not keep showing up here — the same
+            // "report what is actually on disk right now" rule
+            // `directory_size`'s callers below already follow.
+            if info.path.is_file() {
+                out.push(RetainedBinding {
                     repository: b.repository.clone(),
                     path: info.path.clone(),
                     reason: "retained_dirty",
                     detail: changes.clone(),
                     bytes: info.bytes,
-                })
+                });
             }
-            BindingDisposition::RetainedDirty {
-                changes,
-                patch: None,
-            } => {
-                if !b.worktree_path.exists() {
-                    return None;
-                }
-                Some(RetainedBinding {
+            out.extend(retained_output_bindings(b, outputs));
+        }
+        BindingDisposition::RetainedDirty {
+            changes,
+            patch: None,
+            outputs,
+        } => {
+            if b.worktree_path.exists() {
+                out.push(RetainedBinding {
                     repository: b.repository.clone(),
                     path: b.worktree_path.clone(),
                     reason: "retained_dirty",
                     detail: changes.clone(),
                     bytes: directory_size(&b.worktree_path),
-                })
+                });
             }
-            BindingDisposition::RetainedError { detail } => {
-                if !b.worktree_path.exists() {
-                    return None;
-                }
-                Some(RetainedBinding {
+            // `patch: None` means the whole worktree directory (output/
+            // included) was left in place instead of being reclaimed, so
+            // `outputs` is always empty here (see `retain_dirty`) — no
+            // separate copy exists to report.
+            out.extend(retained_output_bindings(b, outputs));
+        }
+        BindingDisposition::RetainedError { detail } => {
+            if b.worktree_path.exists() {
+                out.push(RetainedBinding {
                     repository: b.repository.clone(),
                     path: b.worktree_path.clone(),
                     reason: "retained_error",
                     detail: detail.clone(),
                     bytes: directory_size(&b.worktree_path),
-                })
+                });
             }
-            BindingDisposition::RetainedUnreferenced { evidence, .. } => {
-                if !b.worktree_path.exists() {
-                    return None;
-                }
-                Some(RetainedBinding {
+        }
+        BindingDisposition::RetainedUnreferenced { evidence, .. } => {
+            if b.worktree_path.exists() {
+                out.push(RetainedBinding {
                     repository: b.repository.clone(),
                     path: b.worktree_path.clone(),
                     reason: "retained_unreferenced",
                     detail: evidence.clone(),
                     bytes: directory_size(&b.worktree_path),
-                })
+                });
             }
-            BindingDisposition::Removed | BindingDisposition::Missing => None,
+        }
+        BindingDisposition::Removed | BindingDisposition::Missing => {}
+    }
+    out
+}
+
+/// #240: one [`RetainedBinding`] per stage-output copy still on disk,
+/// `reason: "retained_output"` — a distinct tag from `"retained_dirty"`
+/// so a reader (or `sgt work retained`'s own rendering) can tell a
+/// per-stage evidence copy apart from the flat patch it sits alongside.
+fn retained_output_bindings(
+    b: &BindingTeardown,
+    outputs: &[RetainedStageOutput],
+) -> Vec<RetainedBinding> {
+    outputs
+        .iter()
+        .filter(|o| o.path.exists())
+        .map(|o| RetainedBinding {
+            repository: b.repository.clone(),
+            path: o.path.clone(),
+            reason: "retained_output",
+            detail: format!("stage {} declared output/ artifacts", o.stage),
+            bytes: o.bytes,
         })
         .collect()
 }
@@ -1481,14 +1548,25 @@ pub fn reap(data_dir: &Path, surface: &WorkSurface, teardown: &TeardownReport) -
 fn reap_binding(data_dir: &Path, surface: &WorkSurface, binding: &BindingTeardown) -> ReapOutcome {
     match &binding.disposition {
         BindingDisposition::RetainedDirty {
-            patch: Some(info), ..
-        } => match std::fs::remove_file(&info.path) {
-            Ok(()) => ReapOutcome::Reaped { bytes: info.bytes },
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReapOutcome::NothingRetained,
-            Err(e) => ReapOutcome::Failed {
-                detail: e.to_string(),
-            },
-        },
+            patch: Some(info),
+            outputs,
+            ..
+        } => {
+            // #240: dispose of the stage-output copies alongside the
+            // patch — `remove_surface_root` refuses a non-empty root, so
+            // leaving these behind would leave the whole surface
+            // undeletable after every retained patch was reaped.
+            for output in outputs {
+                let _ = std::fs::remove_dir_all(&output.path);
+            }
+            match std::fs::remove_file(&info.path) {
+                Ok(()) => ReapOutcome::Reaped { bytes: info.bytes },
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReapOutcome::NothingRetained,
+                Err(e) => ReapOutcome::Failed {
+                    detail: e.to_string(),
+                },
+            }
+        }
         BindingDisposition::RetainedDirty { patch: None, .. } => {
             if !binding.worktree_path.exists() {
                 return ReapOutcome::NothingRetained;
@@ -1625,14 +1703,21 @@ fn retain_dirty(binding: &RepositoryBinding, changes: String) -> BindingDisposit
         return BindingDisposition::RetainedDirty {
             changes,
             patch: None,
+            outputs: Vec::new(),
         };
     }
     let Some(patch) = capture_dirty_patch(binding) else {
         return BindingDisposition::RetainedDirty {
             changes,
             patch: None,
+            outputs: Vec::new(),
         };
     };
+    // #240: copy each stage's declared `output/` artifacts out of the
+    // worktree in this same before-removal window the patch capture just
+    // used — the worktree's files are still on disk (git add/diff never
+    // remove anything), and this is the last point at which they are.
+    let outputs = retain_stage_outputs(binding);
     let path = binding.worktree_path.display().to_string();
     // The patch is already durable regardless of what happens next, so
     // nothing captured can be lost. But if the worktree removal below fails,
@@ -1644,7 +1729,9 @@ fn retain_dirty(binding: &RepositoryBinding, changes: String) -> BindingDisposit
     // reclaimable (`reap_binding`'s `patch: None` arm retries the same `git
     // worktree remove`); the now-redundant patch file (its content already
     // sitting uncommitted in the still-present directory) is removed
-    // best-effort so it does not become its own untracked leak.
+    // best-effort so it does not become its own untracked leak — the
+    // copied `outputs` are removed the same way, for the same reason: the
+    // originals are still sitting in the still-present directory.
     match git(
         &binding.source_path,
         &["worktree", "remove", "--force", &path],
@@ -1652,15 +1739,107 @@ fn retain_dirty(binding: &RepositoryBinding, changes: String) -> BindingDisposit
         Ok(_) => BindingDisposition::RetainedDirty {
             changes,
             patch: Some(patch),
+            outputs,
         },
         Err(_) => {
             let _ = std::fs::remove_file(&patch.path);
+            for output in &outputs {
+                let _ = std::fs::remove_dir_all(&output.path);
+            }
             BindingDisposition::RetainedDirty {
                 changes,
                 patch: None,
+                outputs: Vec::new(),
             }
         }
     }
+}
+
+/// #240: copy each stage directory's declared `output/` artifacts out of
+/// `binding.worktree_path` before it is removed, into
+/// `<stage-dir>.output/<stage-dir>/` sibling to the worktree — the same
+/// retained-evidence area [`capture_dirty_patch`] writes its patch into.
+/// A stage directory is any top-level entry of the worktree that has an
+/// `output/` subdirectory; nothing here consults the workflow catalog
+/// (Rule 4, `docs/icm/convention.md`: "no engine collection, no artifact
+/// manifest machinery" — the worktree's own filesystem shape is ground
+/// truth, exactly as [`capture_dirty_patch`] already treats it). Returns
+/// one [`RetainedStageOutput`] per stage directory that actually had a
+/// real (non-`README.md`) file to copy; a stage whose `output/` is empty
+/// or holds only its own declaration is not reported.
+fn retain_stage_outputs(binding: &RepositoryBinding) -> Vec<RetainedStageOutput> {
+    let Some(surface_root) = binding.worktree_path.parent() else {
+        return Vec::new();
+    };
+    let Ok(top_level) = std::fs::read_dir(&binding.worktree_path) else {
+        return Vec::new();
+    };
+    let dest_root = surface_root.join(format!("{}.output", binding.repository));
+    let mut outputs = Vec::new();
+    for entry in top_level.flatten() {
+        let stage_dir = entry.path();
+        if !stage_dir.is_dir() {
+            continue;
+        }
+        let output_dir = stage_dir.join("output");
+        if !output_dir.is_dir() {
+            continue;
+        }
+        let Some(stage_name) = stage_dir.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let dest = dest_root.join(stage_name);
+        let bytes = copy_declared_output_artifacts(&output_dir, &dest);
+        if bytes > 0 {
+            outputs.push(RetainedStageOutput {
+                stage: stage_name.to_string(),
+                path: dest,
+                bytes,
+            });
+        } else {
+            // Nothing real was copied (empty dir, or only README.md) —
+            // remove the now-empty destination so it never reads as
+            // retained evidence.
+            let _ = std::fs::remove_dir_all(&dest);
+        }
+    }
+    outputs
+}
+
+/// Copy every file directly under `src` except `README.md` (the
+/// declaration, not an artifact — Rule 4) into `dest`, creating `dest` on
+/// demand. Best-effort per file: a file this cannot read or write is
+/// skipped rather than aborting the whole stage's copy, matching
+/// [`capture_dirty_patch`]'s own best-effort posture toward anything past
+/// the point where failure can no longer lose already-durable evidence.
+/// Returns the total bytes actually copied.
+fn copy_declared_output_artifacts(src: &Path, dest: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(src) else {
+        return 0;
+    };
+    let mut bytes = 0u64;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.file_name().and_then(|n| n.to_str()) == Some("README.md") {
+            continue;
+        }
+        let Ok(contents) = std::fs::read(&path) else {
+            continue;
+        };
+        if std::fs::create_dir_all(dest).is_err() {
+            continue;
+        }
+        let Some(file_name) = path.file_name() else {
+            continue;
+        };
+        if crate::runtime::fsutil::write_atomic(&dest.join(file_name), &contents).is_ok() {
+            bytes += contents.len() as u64;
+        }
+    }
+    bytes
 }
 
 /// Stage everything `.gitignore` does not exclude (`git add -A`), diff it
@@ -4733,6 +4912,92 @@ mod tests {
         );
         let new_file = std::fs::read(target.join("new.rs")).expect("applied untracked file");
         assert_eq!(new_file, b"fn wanted() {}\n".to_vec());
+    }
+
+    /// #240: a stage's declared `output/` artifacts (Rule 4,
+    /// `docs/icm/convention.md`) must survive a dirty teardown as their own
+    /// retrievable, per-stage-labeled copy — not just bundled, undiscoverably,
+    /// inside the flat `.dirty.patch` alongside every other change. Two
+    /// stage directories, one with a real artifact plus its `README.md`
+    /// declaration, one with only the declaration — the second must not
+    /// produce a retained-output entry at all (nothing real was written).
+    #[test]
+    fn dirty_teardown_retains_each_stages_declared_output_artifacts() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01OUTPUTS",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        // `20-panel`: a declaration plus a real artifact the run actually
+        // wrote — this one must be retained.
+        let panel_output = worktree.join("20-panel").join("output");
+        std::fs::create_dir_all(&panel_output).expect("panel output dir");
+        std::fs::write(panel_output.join("README.md"), "declares findings.md")
+            .expect("panel README");
+        std::fs::write(panel_output.join("findings.md"), "four-axis findings")
+            .expect("panel artifact");
+
+        // `10-hypothesize`: only the declaration, nothing real ever written —
+        // this one must not show up as retained output.
+        let hyp_output = worktree.join("10-hypothesize").join("output");
+        std::fs::create_dir_all(&hyp_output).expect("hypothesize output dir");
+        std::fs::write(hyp_output.join("README.md"), "declares hypotheses.md")
+            .expect("hypothesize README");
+
+        // Also touch a tracked file so the worktree is dirty and teardown
+        // takes the `RetainedDirty` path at all.
+        std::fs::write(worktree.join("wip.rs"), "// still working\n").expect("dirty edit");
+
+        let report = teardown_of(&surface);
+        let BindingDisposition::RetainedDirty { patch, outputs, .. } =
+            &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected RetainedDirty: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        assert!(patch.is_some(), "the flat patch must still be captured too");
+
+        assert_eq!(
+            outputs.len(),
+            1,
+            "only the stage with a real artifact should be retained: {outputs:?}"
+        );
+        let panel = &outputs[0];
+        assert_eq!(panel.stage, "20-panel");
+
+        // The worktree is gone — the copy is the only place this is left.
+        assert!(!worktree.exists());
+        let retained_findings = std::fs::read_to_string(panel.path.join("findings.md"))
+            .expect("retained findings.md must be readable after teardown");
+        assert_eq!(retained_findings, "four-axis findings");
+        assert!(
+            !panel.path.join("README.md").exists(),
+            "the declaration itself is not an artifact and must not be copied"
+        );
+
+        // `retained_bindings` (the `sgt work retained` read side) must
+        // surface it too, tagged distinctly from the flat patch.
+        let bindings = retained_bindings(&report);
+        assert!(
+            bindings
+                .iter()
+                .any(|b| b.reason == "retained_output" && b.path == panel.path),
+            "retained_bindings must report the stage-output copy: {bindings:?}"
+        );
+        assert!(
+            bindings.iter().any(|b| b.reason == "retained_dirty"),
+            "the flat patch must still be reported alongside it: {bindings:?}"
+        );
     }
 
     /// #234 follow-up (`60-re-verify-and-postmortem`, F-SF-04/F-TH-01): the

--- a/tests/f_doctrine_skew.rs
+++ b/tests/f_doctrine_skew.rs
@@ -249,6 +249,32 @@ fn embedded_skills_carry_the_real_root_and_preflight_remedies() {
     );
 }
 
+/// #232: a literal-reading actor that finished a correct fix retired
+/// `completed_dirty` because no shared closing-stage context ever told it
+/// to commit — the `BindingSummary` names `work_branch`, but nothing said
+/// to land the work there. `@@fix-confirmed` is the stage context that
+/// instructs an actor to *do* fix work (as opposed to `@@close` /
+/// `@@evidence-requirements`, which only report on fixes already made),
+/// so it is the one this test pins the commit imperative in.
+#[test]
+fn fix_confirmed_context_states_the_commit_imperative() {
+    let fix_confirmed =
+        std::fs::read_to_string(repo_root().join(".sergeant/common/contexts/fix-confirmed.md"))
+            .expect("read fix-confirmed.md");
+    assert!(
+        fix_confirmed.contains("git commit") && fix_confirmed.contains("git add"),
+        "fix-confirmed.md must literally instruct the actor to `git add`/`git commit` its \
+         fix — the gap #232 found, where a literal-reading actor finishes a correct fix and \
+         retires it uncommitted because nothing ever said to commit"
+    );
+    assert!(
+        fix_confirmed.contains("work_branch"),
+        "fix-confirmed.md's commit imperative must name `work_branch` — the field the \
+         BindingSummary already hands every actor — so the instruction says *where* to commit, \
+         not just that a commit must happen"
+    );
+}
+
 // -------------------------------------------------- 2. embedded distro skew
 
 /// No `CONTEXT.md` under the embedded `.sergeant/workflows/` distro source

--- a/tests/m7_docker_executor.rs
+++ b/tests/m7_docker_executor.rs
@@ -1503,6 +1503,26 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
          materialized surface for {work_id}"
     );
 
+    // W4-carried minor (#234's own "every patch" claim, commit 56927a14):
+    // the marker check above may stop at the first satisfying entry, but
+    // *every* retained `.dirty.patch` under the surface — not just
+    // whichever one `walk_for_marker` happened to reach first — must
+    // actually be `git apply`-able. Collected separately so a second
+    // binding's corrupt patch cannot hide behind the first binding's good
+    // one.
+    let mut patches = Vec::new();
+    for entry in &branch_worktrees {
+        collect_dirty_patches(&entry.path(), &mut patches);
+    }
+    assert!(
+        !patches.is_empty(),
+        "expected at least one retained .dirty.patch under {:?} for {work_id}",
+        data.path().join("surfaces")
+    );
+    for patch in &patches {
+        assert_patch_is_git_applyable(patch);
+    }
+
     handle.shutdown().await;
     assert_no_containers_for_work(&work_id);
 }
@@ -1515,6 +1535,14 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
 /// evidence this test is proving survives teardown now travels in that
 /// form. Either way the evidence handed to the following actor was not
 /// lost, which is the actual N4/§21.5 claim this test pins.
+///
+/// Only decides *whether the marker exists somewhere* — `.any()`'s short-
+/// circuit here is fine, since finding it in one binding's patch says
+/// nothing about whether a *different* binding's patch is well-formed.
+/// That question belongs to [`collect_dirty_patches`]/
+/// [`assert_patch_is_git_applyable`] below, which do not stop at the first
+/// one (the W4-carried minor this pair fixes: #234's "every patch" claim
+/// was not actually checked against every patch).
 fn walk_for_marker(dir: &Path) -> bool {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return false;
@@ -1530,46 +1558,71 @@ fn walk_for_marker(dir: &Path) -> bool {
             && content.trim() == "container-produced-evidence"
         {
             return true;
-        } else if path.extension().and_then(|e| e.to_str()) == Some("patch")
+        } else if is_dirty_patch(&path)
             && let Ok(content) = std::fs::read_to_string(&path)
             && content.contains("validated.txt")
             && content.contains("container-produced-evidence")
         {
-            // #234: a retained `.dirty.patch` that merely *contains* the
-            // right text is not enough — the whole point of the bug was a
-            // patch that looked right but `git apply` rejected as corrupt
-            // at end-of-file. Pin the acceptance criteria directly: `git
-            // apply --stat` proves the patch parses at all, and `--check`
-            // (applied into a fresh empty scratch dir, since `validated.txt`
-            // is captured here as a brand-new untracked file) proves it is
-            // actually applicable, not just textually plausible.
-            let scratch = TempDir::new().expect("scratch dir for git apply --check");
-            let stat = Command::new("git")
-                .args(["apply", "--stat", path.to_str().expect("utf8 path")])
-                .current_dir(scratch.path())
-                .output()
-                .expect("git apply --stat");
-            assert!(
-                stat.status.success(),
-                "git apply --stat rejected {}: {}",
-                path.display(),
-                String::from_utf8_lossy(&stat.stderr)
-            );
-            let check = Command::new("git")
-                .args(["apply", "--check", path.to_str().expect("utf8 path")])
-                .current_dir(scratch.path())
-                .output()
-                .expect("git apply --check");
-            assert!(
-                check.status.success(),
-                "git apply --check rejected {}: {}",
-                path.display(),
-                String::from_utf8_lossy(&check.stderr)
-            );
             return true;
         }
     }
     false
+}
+
+fn is_dirty_patch(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.ends_with(".dirty.patch"))
+}
+
+/// Every `*.dirty.patch` file anywhere under `dir`, recursively — the full
+/// set `walk_for_marker`'s short-circuiting `.any()` caller used to leave
+/// unexamined past the first one that satisfied it.
+fn collect_dirty_patches(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_dirty_patches(&path, out);
+        } else if is_dirty_patch(&path) {
+            out.push(path);
+        }
+    }
+}
+
+/// #234: a retained `.dirty.patch` that merely *contains* the right text is
+/// not enough — the whole point of the bug was a patch that looked right
+/// but `git apply` rejected as corrupt at end-of-file. Pin the acceptance
+/// criteria directly: `git apply --stat` proves the patch parses at all,
+/// and `--check` (applied into a fresh empty scratch dir, since
+/// `validated.txt` is captured here as a brand-new untracked file) proves
+/// it is actually applicable, not just textually plausible.
+fn assert_patch_is_git_applyable(path: &Path) {
+    let scratch = TempDir::new().expect("scratch dir for git apply --check");
+    let stat = Command::new("git")
+        .args(["apply", "--stat", path.to_str().expect("utf8 path")])
+        .current_dir(scratch.path())
+        .output()
+        .expect("git apply --stat");
+    assert!(
+        stat.status.success(),
+        "git apply --stat rejected {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&stat.stderr)
+    );
+    let check = Command::new("git")
+        .args(["apply", "--check", path.to_str().expect("utf8 path")])
+        .current_dir(scratch.path())
+        .output()
+        .expect("git apply --check");
+    assert!(
+        check.status.success(),
+        "git apply --check rejected {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&check.stderr)
+    );
 }
 
 /// Poll OBSERVE until the container has exited, panicking on timeout.


### PR DESCRIPTION
Split-hardening wave W6. Fixes #232 and #240 (auto-close via head PR #263), plus W4's carried review minor (walk_for_marker now validates every retained patch).

Executed as Sergeant Work 01M0V28XG090FSHN2Z67QEYQBP (implement-change, sonnet). Retired completed_dirty by design: the dirty state is solely uncommitted stage-evidence files per captain instruction (landed in the workspace series); all product commits clean on the branch. Internal panel ran; confirmed invariants findings fixed in-Work (12ce0c4f).

- #232: explicit commit imperative in @@fix-confirmed (+ audited closing contexts), with a content-assertion test in f_doctrine_skew so dropping it fails CI.
- #240: declared per-stage output/ artifacts retained at teardown alongside the dirty patch; tool_use events surfaced in sgt work transcript --json; regression tests for both.
- m7 e2e walk now collects and git-apply-checks every .dirty.patch (makes 56927a14's commit-message claim true).

Rungs: R2 throughout (existing retention/transcript machinery extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4