### PR TITLE
W5b+W5c: codex grants that actually work — exec-resume regrant + app-server sandbox policy (#259)

### DIFF
--- a/.sergeant/workflows/fix-defect/00-build-feedback-loop/output/EVIDENCE.txt
+++ b/.sergeant/workflows/fix-defect/00-build-feedback-loop/output/EVIDENCE.txt
@@ -1,0 +1,90 @@
+W5b feedback loop — evidence of construction and a red run
+=============================================================
+
+Bug under investigation: split-hardening #259 fix (merged with W5) does not
+work under a real estate layout. A live codex-terra Work on a fresh scratch
+estate (/var/tmp/codex-proof-estate, Work 01M0VBVCXEGGDF3ZCRNBKVWWWR) retired
+completed_dirty with the stage detail:
+
+  "Blocked: the requested changes are present, but Git cannot create its
+   worktree `index.lock` because the linked repository's `.git/worktrees/...`
+   path is read-only. No commit was created."
+
+That Work's own binding record showed:
+  canonical_common_dir: /var/tmp/codex-proof-estate/repos/target-repo/.git
+  worktree_path:        /var/tmp/codex-proof-estate/.sergeant/data/surfaces/<id>/target-repo
+  stage_id: "30-close" (the 4th and final workflow stage, turns_spawned: 4)
+
+Construction path (ladder order, per skill instructions):
+1. Read tests/codex_backend.rs's existing stub-driven --add-dir test
+   (the_first_turn_grants_the_works_own_git_common_dir_as_an_add_dir_root)
+   and the existing live test (live_codex_actor_commits_to_the_works_own_
+   branch). Both build `source`/`worktree` as siblings under one shared
+   TempDir, and both exercise only a single turn (turn 1's own launch).
+   Neither reaches a resumed turn at all — a real gap regardless of the
+   nesting question the sprint brief raised.
+2. Inspected src/backend/codex.rs's own resume_turn_argv and its unit test
+   (resume_turn_argv_omits_cd_and_places_the_thread_id_right_after_resume,
+   ~line 5198): confirmed by the code itself that --sandbox/--add-dir/-C are
+   deliberately NOT recomposed on `exec resume` — the comment at line 5159
+   ("--output-schema DOES re-apply on resume, unlike --sandbox/--add-dir")
+   states this is a known, deliberate design choice, resting on an assumption
+   that codex-cli's own session state persists turn-1's sandbox grant across
+   `exec resume`.
+3. Tested that assumption directly against a live codex-cli 0.149.0 binary,
+   completely bypassing sergeant's own daemon/dispatch machinery for speed:
+     - turn 1: `codex exec --json --skip-git-repo-check -C <worktree>
+       --sandbox workspace-write --add-dir <common-dir> -m gpt-5.6-luna
+       "<edit only, no git>"` — exactly resume_turn_argv's sibling,
+       first_turn_argv's own composed shape.
+     - turn 2: `codex exec resume <thread> --json --skip-git-repo-check
+       -m gpt-5.6-luna "<git add && git commit>"`, run with the shell's cwd
+       set to the worktree (so no argv-vs-cwd confound).
+   Result: turn 2 fails with
+     fatal: Unable to create '<common-dir>/worktrees/<name>/index.lock':
+     Read-only file system
+   — the identical symptom class as the real production failure (same path
+   shape, same "Read-only file system" text), reproduced with a genuinely
+   separate estate/repos vs data/surfaces layout, matching production, not
+   the unit test's nested-tempdir shape.
+4. Packaged the two-turn repro as a standalone, deterministic script:
+   codex_resume_add_dir_repro.sh (this directory). Ran it fresh (no reuse of
+   the above scratch dirs) and it reproduced red on the first try:
+
+   $ bash codex_resume_add_dir_repro.sh
+   == turn 1 (first_turn_argv shape) ==
+   == turn 2 (resume_turn_argv shape) ==
+   RED: resumed turn did not commit. Turn 2 transcript:
+   {"type":"thread.started","thread_id":"01a036cb-45fb-76e1-ac63-fab857623818"}
+   {"type":"turn.started"}
+   {"type":"item.completed","item":{"id":"item_0","type":"agent_message",
+     "text":"fatal: Unable to create
+     '/tmp/codex-resume-repro.6fxmrv/estate/repos/solo/.git/worktrees/solo/
+     index.lock': Read-only file system"}}
+   {"type":"turn.completed", ...}
+
+   worktree status:
+    M README.md
+   EXIT_CODE=1
+
+Named feedback loop: codex_resume_add_dir_repro.sh (this directory).
+  - Red-capable: fails today (exit 1), against real codex-cli, with the
+    production symptom text.
+  - Deterministic: pinned model (gpt-5.6-luna), fixed one-word-bounded
+    prompts, fresh scratch dirs each run, no reliance on wall-clock/RNG.
+  - Fast: two short turns (~30-60s total), no sgt daemon, no full Work
+    dispatch, no build step.
+  - Agent-runnable: `bash codex_resume_add_dir_repro.sh`, exit 0 = fixed,
+    exit 1 = red, exit 2 = harness-level failure (turn 1 never started).
+
+Reframing vs. the sprint brief's own hypotheses: this loop shows the failure
+is NOT (or not only) about the unit test's nested-tempdir shape (hypothesis
+1) or a canonicalization gap in worktree_git_common_dir (hypothesis 2) — it
+reproduces even with a fully correct, canonical, production-shaped
+--add-dir grant on turn 1, because turn 2 (and every later workflow stage,
+since the codex thread is resumed across stages, not relaunched) never
+resends that grant at all. This loop's next consumer (10-form-hypothesis /
+implementation) should treat "codex exec resume must re-carry --sandbox/
+--add-dir" as the primary hypothesis, verify it doesn't contradict the
+codebase's own doc comment reasoning, and correct resume_turn_argv (and its
+regression test) accordingly.

--- a/.sergeant/workflows/fix-defect/00-build-feedback-loop/output/codex_resume_add_dir_repro.sh
+++ b/.sergeant/workflows/fix-defect/00-build-feedback-loop/output/codex_resume_add_dir_repro.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Red-capable, deterministic, fast repro for the W5b defect: a codex actor's
+# SECOND turn (an `exec resume`, exactly what `resume_turn_argv` in
+# src/backend/codex.rs composes for every stage after the first) never
+# re-sends `--sandbox workspace-write --add-dir <common-dir>`. The code
+# assumes codex-cli's session state persists the turn-1 sandbox grant across
+# `exec resume` — that assumption is false, empirically, on codex-cli
+# 0.149.0: the resumed turn's OS sandbox reverts to a narrower scope, and any
+# git operation that touches the worktree's git-common-dir (loose objects,
+# refs, and critically `<common>/worktrees/<name>/index.lock`) fails with
+# exactly the symptom the real fresh-estate proof recorded:
+#   fatal: Unable to create '.../.git/worktrees/<name>/index.lock': Read-only file system
+#
+# Mirrors the real production surface shape exactly: worktree under
+# <estate>/data/surfaces/<work>/<repo>, git-common-dir under
+# <estate>/repos/<repo>/.git — two genuinely separate top-level trees, NOT
+# nested under one shared temp root the way the existing unit test
+# (`real_worktree` in tests/codex_backend.rs) builds its fixture. That
+# nesting is why the existing stub-driven --add-dir test and the existing
+# live test (which also nests source/worktree under one `data_dir`) never
+# caught this: they assert on turn-1's argv/behavior only, and never
+# exercise a second (resumed) turn at all.
+#
+# Usage: bash /tmp/codex_resume_add_dir_repro.sh
+# Requires: a working `codex` CLI, logged in, network access (spends a few
+# cents of real tokens: two short turns, gpt-5.6-luna, one-word-bounded).
+# Deterministic: fixed prompts, pinned model, fresh scratch dirs each run.
+# Exit 0 = the commit landed (bug fixed / not present). Exit 1 = red — the
+# resumed turn could not commit, matching the production symptom.
+set -euo pipefail
+
+SCRATCH="$(mktemp -d /tmp/codex-resume-repro.XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+SOURCE="$SCRATCH/estate/repos/solo"
+WORKTREE="$SCRATCH/data/surfaces/W1/solo"
+mkdir -p "$SOURCE" "$(dirname "$WORKTREE")"
+
+git init -q -b main "$SOURCE"
+git -C "$SOURCE" config user.email a@b.c
+git -C "$SOURCE" config user.name test
+echo hi > "$SOURCE/README.md"
+git -C "$SOURCE" add README.md
+git -C "$SOURCE" commit -q -m init
+git -C "$SOURCE" worktree add -q -b sergeant/w1 "$WORKTREE"
+
+COMMON="$SOURCE/.git"
+
+echo "== turn 1 (first_turn_argv shape: -C \$WORKTREE --sandbox workspace-write --add-dir \$COMMON) ==" >&2
+TURN1_LOG="$SCRATCH/turn1.jsonl"
+timeout 90 codex exec --json --skip-git-repo-check -C "$WORKTREE" \
+  --sandbox workspace-write --add-dir "$COMMON" -m gpt-5.6-luna \
+  "Append the line 'edit1' to README.md using a shell command. Do not run git commands. Report only the word done." \
+  > "$TURN1_LOG" 2>&1
+THREAD="$(grep -o '"thread_id":"[^"]*"' "$TURN1_LOG" | head -1 | cut -d'"' -f4)"
+if [ -z "$THREAD" ]; then
+  echo "FAIL(harness): turn 1 never announced thread.started — see $TURN1_LOG" >&2
+  exit 2
+fi
+
+echo "== turn 2 (resume_turn_argv shape: exec resume \$THREAD, NO -C, NO --sandbox, NO --add-dir) ==" >&2
+TURN2_LOG="$SCRATCH/turn2.jsonl"
+( cd "$WORKTREE" && timeout 90 codex exec resume "$THREAD" --json --skip-git-repo-check -m gpt-5.6-luna \
+    "Run \`git add README.md\` then \`git commit -m repro\`. Report only the word done when finished, or the exact error text if it fails." \
+    > "$TURN2_LOG" 2>&1 )
+
+AFTER="$(git -C "$WORKTREE" rev-parse HEAD)"
+BEFORE_COUNT="$(git -C "$SOURCE" log --oneline sergeant/w1 | wc -l)"
+
+if git -C "$WORKTREE" log -1 --format=%s | grep -q '^repro$'; then
+  echo "PASS: resumed turn committed successfully (HEAD=$AFTER)" >&2
+  exit 0
+else
+  echo "RED: resumed turn did not commit. Turn 2 transcript:" >&2
+  cat "$TURN2_LOG" >&2
+  echo >&2
+  echo "worktree status:" >&2
+  git -C "$WORKTREE" status --short >&2
+  exit 1
+fi

--- a/.sergeant/workflows/fix-defect/30-instrument/output/probe_h3_writable_roots.sh
+++ b/.sergeant/workflows/fix-defect/30-instrument/output/probe_h3_writable_roots.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# [W5B-H3] Probe for 20-hypothesize's H3: does resume's `-c` override
+# mechanism reach the sandbox layer the way turn 1's `--add-dir` does?
+#
+# One variable changed vs. the baseline repro
+# (00-build-feedback-loop/output/codex_resume_add_dir_repro.sh): turn 2
+# (the resumed turn) additionally carries
+#   -c sandbox_workspace_write.writable_roots=["<common-dir>"]
+# — the `writable_roots` field name is not guessed; it was confirmed
+# present in the installed codex-cli 0.149.1 binary's own struct field
+# strings (`strings ~/.local/bin/codex | grep writable_roots`), adjacent
+# to `network_access`/`exclude_tmpdir_env_var`/`exclude_slash_tmp` under
+# `sandbox_workspace_write`, matching the config table name `-c` already
+# uses for #262's `network_access` override at codex.rs:1112.
+#
+# If turn 2 now commits, H3 is confirmed (narrowest fix: one function,
+# resume_turn_argv). If codex-cli rejects/ignores the key or the commit
+# still fails identically, H3 is falsified.
+#
+# Exit 0 = resumed turn committed (H3 confirmed). Exit 1 = still red (H3
+# falsified). Exit 2 = harness failure.
+set -euo pipefail
+
+SCRATCH="$(mktemp -d /tmp/codex-h3-probe.XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+SOURCE="$SCRATCH/estate/repos/solo"
+WORKTREE="$SCRATCH/data/surfaces/W1/solo"
+mkdir -p "$SOURCE" "$(dirname "$WORKTREE")"
+
+git init -q -b main "$SOURCE"
+git -C "$SOURCE" config user.email a@b.c
+git -C "$SOURCE" config user.name test
+echo hi > "$SOURCE/README.md"
+git -C "$SOURCE" add README.md
+git -C "$SOURCE" commit -q -m init
+git -C "$SOURCE" worktree add -q -b sergeant/w1 "$WORKTREE"
+
+COMMON="$SOURCE/.git"
+
+echo "[W5B-H3] turn 1 (first_turn_argv shape, unchanged) ==" >&2
+TURN1_LOG="$SCRATCH/turn1.jsonl"
+timeout 90 codex exec --json --skip-git-repo-check -C "$WORKTREE" \
+  --sandbox workspace-write --add-dir "$COMMON" -m gpt-5.6-luna \
+  "Append the line 'edit1' to README.md using a shell command. Do not run git commands. Report only the word done." \
+  > "$TURN1_LOG" 2>&1
+THREAD="$(grep -o '"thread_id":"[^"]*"' "$TURN1_LOG" | head -1 | cut -d'"' -f4)"
+if [ -z "$THREAD" ]; then
+  echo "[W5B-H3] FAIL(harness): turn 1 never announced thread.started — see $TURN1_LOG" >&2
+  exit 2
+fi
+
+echo "[W5B-H3] turn 2 (resume_turn_argv shape PLUS -c sandbox_workspace_write.writable_roots=[\"$COMMON\"]) ==" >&2
+TURN2_LOG="$SCRATCH/turn2.jsonl"
+( cd "$WORKTREE" && timeout 90 codex exec resume "$THREAD" --json --skip-git-repo-check \
+    -c "sandbox_workspace_write.writable_roots=[\"$COMMON\"]" \
+    -m gpt-5.6-luna \
+    "Run \`git add README.md\` then \`git commit -m repro\`. Report only the word done when finished, or the exact error text if it fails." \
+    > "$TURN2_LOG" 2>&1 )
+
+if git -C "$WORKTREE" log -1 --format=%s 2>/dev/null | grep -q '^repro$'; then
+  echo "[W5B-H3] RESULT: resumed turn COMMITTED successfully with the -c override (H3 confirmed)" >&2
+  exit 0
+else
+  echo "[W5B-H3] RESULT: resumed turn did NOT commit even with the -c override (H3 falsified). Transcript:" >&2
+  cat "$TURN2_LOG" >&2
+  echo "[W5B-H3] worktree status:" >&2
+  git -C "$WORKTREE" status --short >&2
+  exit 1
+fi

--- a/.sergeant/workflows/fix-defect/30-instrument/output/probe_h4_turn1_only.sh
+++ b/.sergeant/workflows/fix-defect/30-instrument/output/probe_h4_turn1_only.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# [W5B-H4] Probe for 20-hypothesize's H4 (rule-out): is turn 1 itself
+# under-granted, independent of resume at all?
+#
+# One variable changed vs. the baseline repro
+# (00-build-feedback-loop/output/codex_resume_add_dir_repro.sh): the SAME
+# turn 1 launch (first_turn_argv shape: -C $WORKTREE --sandbox
+# workspace-write --add-dir $COMMON) is asked to edit AND git add/commit,
+# in one turn — no resume at all. If this succeeds, H4 is falsified (turn
+# 1's grant is correct; the failure is specific to resume, as H1-H3
+# assume). If it fails identically, H4 is confirmed.
+#
+# Exit 0 = turn 1 alone can commit (H4 falsified). Exit 1 = turn 1 alone
+# cannot commit either (H4 confirmed). Exit 2 = harness failure.
+set -euo pipefail
+
+SCRATCH="$(mktemp -d /tmp/codex-h4-probe.XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+SOURCE="$SCRATCH/estate/repos/solo"
+WORKTREE="$SCRATCH/data/surfaces/W1/solo"
+mkdir -p "$SOURCE" "$(dirname "$WORKTREE")"
+
+git init -q -b main "$SOURCE"
+git -C "$SOURCE" config user.email a@b.c
+git -C "$SOURCE" config user.name test
+echo hi > "$SOURCE/README.md"
+git -C "$SOURCE" add README.md
+git -C "$SOURCE" commit -q -m init
+git -C "$SOURCE" worktree add -q -b sergeant/w1 "$WORKTREE"
+
+COMMON="$SOURCE/.git"
+
+echo "[W5B-H4] turn 1 only: -C \$WORKTREE --sandbox workspace-write --add-dir \$COMMON, edit+add+commit in one turn" >&2
+TURN1_LOG="$SCRATCH/turn1.jsonl"
+timeout 90 codex exec --json --skip-git-repo-check -C "$WORKTREE" \
+  --sandbox workspace-write --add-dir "$COMMON" -m gpt-5.6-luna \
+  "Append the line 'edit1' to README.md using a shell command, then run \`git add README.md\` then \`git commit -m repro\`. Report only the word done when finished, or the exact error text if it fails." \
+  > "$TURN1_LOG" 2>&1
+THREAD="$(grep -o '"thread_id":"[^"]*"' "$TURN1_LOG" | head -1 | cut -d'"' -f4)"
+if [ -z "$THREAD" ]; then
+  echo "[W5B-H4] FAIL(harness): turn 1 never announced thread.started — see $TURN1_LOG" >&2
+  exit 2
+fi
+
+if git -C "$WORKTREE" log -1 --format=%s 2>/dev/null | grep -q '^repro$'; then
+  echo "[W5B-H4] RESULT: turn 1 alone COMMITTED successfully (H4 falsified — turn 1's grant is correct)" >&2
+  exit 0
+else
+  echo "[W5B-H4] RESULT: turn 1 alone did NOT commit (H4 confirmed). Transcript:" >&2
+  cat "$TURN1_LOG" >&2
+  echo "[W5B-H4] worktree status:" >&2
+  git -C "$WORKTREE" status --short >&2
+  exit 1
+fi

--- a/src/backend/codex.rs
+++ b/src/backend/codex.rs
@@ -1346,15 +1346,22 @@ fn worktree_git_common_dir(worktree_path: &Path) -> Result<PathBuf, String> {
     Ok(lexically_normalize(&admin_dir.join(relative)))
 }
 
-/// [`worktree_git_common_dir`] over every binding this request carries.
-/// `Err` on the first binding whose common directory cannot be resolved —
-/// the caller (`prepare`/`launch`) turns that into a refusal rather than
-/// launching an actor that can edit files but cannot commit them.
-fn git_worktree_common_dirs(bindings: &[BindingSummary]) -> Result<Vec<PathBuf>, String> {
+/// Shared shape behind [`git_worktree_common_dirs`] and
+/// [`git_worktree_admin_dirs`]: run `resolve_one` over every binding this
+/// request carries, `Err` on the first binding whose directory cannot be
+/// resolved — the caller (`prepare`/`launch`) turns that into a refusal
+/// rather than launching an actor that can edit files but cannot commit
+/// them. (Collapses what were two structurally identical free functions —
+/// `50-panel` F-SI-01, fixed at `60-re-verify-and-postmortem`, split-
+/// hardening W5c.)
+fn git_worktree_dirs(
+    bindings: &[BindingSummary],
+    resolve_one: fn(&Path) -> Result<PathBuf, String>,
+) -> Result<Vec<PathBuf>, String> {
     bindings
         .iter()
         .map(|binding| {
-            worktree_git_common_dir(&binding.worktree_path).map_err(|reason| {
+            resolve_one(&binding.worktree_path).map_err(|reason| {
                 format!(
                     "{} ({}): {reason}",
                     binding.repository,
@@ -1363,50 +1370,58 @@ fn git_worktree_common_dirs(bindings: &[BindingSummary]) -> Result<Vec<PathBuf>,
             })
         })
         .collect()
+}
+
+/// [`worktree_git_common_dir`] over every binding this request carries.
+fn git_worktree_common_dirs(bindings: &[BindingSummary]) -> Result<Vec<PathBuf>, String> {
+    git_worktree_dirs(bindings, worktree_git_common_dir)
 }
 
 /// [`worktree_git_admin_dir`] over every binding this request carries —
 /// the app-server-only companion to [`git_worktree_common_dirs`].
 ///
-/// **Measured 2026-08-25 against codex-cli 0.149.1's `app-server`**: unlike
-/// `exec`'s `--add-dir` (whose grant of the common dir alone already covers
-/// `git add`/`git commit`, confirmed live via `codex exec --add-dir
-/// <common-dir>` against a real linked worktree — issue #259's exec-side fix
-/// stands unchanged), `thread/start.runtimeWorkspaceRoots` resolves into a
-/// `sandbox.writableRoots` grant that treats each linked worktree's private
-/// admin subdirectory (`<common-dir>/worktrees/<name>`) as protected in its
-/// own right, not merely inherited from a parent directory's grant. Driven
-/// by hand over the real JSON-RPC wire (`initialize` with
-/// `capabilities.experimentalApi: true`, then `command/exec` with
-/// `sandboxPolicy.writableRoots` set to the common dir alone): `git add`
-/// then fails with `Read-only file system` on this exact admin
-/// subdirectory's `index.lock`, even though the common dir that contains it
-/// was granted. Reproduced end-to-end through a real Work (`sgt run` against
-/// a scratch estate on the `codex-terra` profile, app-server transport):
-/// stage `30-close` blocked on the identical `index.lock` failure. Granting
-/// this directory *in addition to* the common dir — both, not either —
-/// resolves it; that combination is what this function adds to
-/// `launch_appserver`'s `runtimeWorkspaceRoots`, on top of (never instead
-/// of) [`git_worktree_common_dirs`].
+/// **Provenance, and an unresolved discrepancy recorded honestly
+/// (`60-re-verify-and-postmortem`, split-hardening W5c, 2026-08-25).** This
+/// grant was added in `d2acce1c` on the strength of a manual probe driven
+/// over `command/exec` — a JSON-RPC method `launch_appserver`/
+/// `appserver_send_turn` never call; the production path is `thread/start`
+/// then `turn/start` — plus an end-to-end `sgt run` against a scratch
+/// estate that blocked on the admin dir's `index.lock` without this grant.
+/// A later, more targeted probe (`30-instrument`, same date, probe 1b)
+/// drove the *exact* production call shape (`thread/start` with
+/// `runtimeWorkspaceRoots`, then a `turn/start` carrying no
+/// `sandboxPolicy` at all — today's literal code) against a real linked
+/// worktree and found `git add`/`git commit` succeed with the common dir
+/// alone, no admin dir, no denial at any step — contradicting the claim
+/// above. Neither measurement was reconciled against the other before
+/// `d2acce1c` merged.
+///
+/// This grant is kept regardless, on narrower grounds than the original
+/// claim: it is measured harmless (it does not break anything, and it
+/// makes `thread/start`'s echoed policy more complete), and a full live
+/// `sgt run` Work on today's code — carrying this grant — independently
+/// retired `completed` end to end (Work `01M0VK7FKCM9V210MXSNQ1V2QD`,
+/// 2026-08-25), which is this wave's actual acceptance criterion.
+/// Whether the grant is *necessary* on the `thread/start`/`turn/start`
+/// path is still open — removing it on this evidence alone would be a
+/// scope change this stage does not make. Reconciling the `command/exec`-
+/// vs-`turn/start` discrepancy, and removing this grant if it proves
+/// redundant with the common dir, is recommended to Captain as a follow-up
+/// investigation, not undertaken here.
 fn git_worktree_admin_dirs(bindings: &[BindingSummary]) -> Result<Vec<PathBuf>, String> {
-    bindings
-        .iter()
-        .map(|binding| {
-            worktree_git_admin_dir(&binding.worktree_path).map_err(|reason| {
-                format!(
-                    "{} ({}): {reason}",
-                    binding.repository,
-                    binding.worktree_path.display()
-                )
-            })
-        })
-        .collect()
+    git_worktree_dirs(bindings, worktree_git_admin_dir)
 }
 
 /// The named, actionable refusal text for #259's fail-closed rule: a
-/// mutation-shaped launch (one or more bindings) whose git common-dir grant
+/// mutation-shaped launch (one or more bindings) whose git directory grant
 /// cannot be resolved is refused rather than admitted to run and later
 /// retire `completed_dirty` with no durable commit.
+///
+/// `kind` names which grant failed (`"common"` or `"admin"`) so the
+/// message identifies the actual resolver that errored rather than always
+/// attributing it to the common-dir grant — before `60-re-verify-and-
+/// postmortem` (split-hardening W5c) this text was hardcoded to "common
+/// directory" and misreported admin-dir failures (`50-panel` F-IN-01).
 ///
 /// Ends in a remedy sentence naming what the operator should actually do
 /// about it — `src/runtime/preflight.rs`'s `PreflightCheck::remedy` and
@@ -1417,9 +1432,9 @@ fn git_worktree_admin_dirs(bindings: &[BindingSummary]) -> Result<Vec<PathBuf>, 
 /// `runtime::surface` actually created (its `.git` file is missing, or does
 /// not name a `gitdir`) — so one remedy sentence covers every case, rather
 /// than inventing a different one per parse failure.
-fn git_admin_dir_refusal(reason: &str) -> String {
+fn git_dir_refusal(kind: &str, reason: &str) -> String {
     format!(
-        "cannot grant this Work's git common directory ({reason}); a codex actor needs write \
+        "cannot grant this Work's git {kind} directory ({reason}); a codex actor needs write \
          access to its own worktree's shared git directory to `git add`/`git commit` (sergeant \
          issue #259) — refusing rather than admitting a Work that can edit files but can never \
          commit them. Remedy: this worktree path was not created by a real `git worktree add` \
@@ -3312,18 +3327,33 @@ impl CodexBackend {
         }
     }
 
-    /// #259: resolve each binding's git common dir, or refuse with the named,
-    /// actionable error. Shared by every call site that needs the grant for
-    /// real (PREPARE's own preflight, and each transport's LAUNCH) — RESUME
-    /// does not call this (see its own comment): the grant is provably inert
-    /// there, so resolving it would add a fail-closed check with no
-    /// corresponding capability it protects.
+    /// Shared shape behind [`Self::resolve_git_worktree_common_dirs`] and
+    /// [`Self::resolve_git_worktree_admin_dirs`]: resolve every binding's
+    /// git directory via `resolver`, or refuse with the named, actionable
+    /// error naming which grant (`kind`) failed. Shared by every call site
+    /// that needs a grant for real (PREPARE's own preflight, and each
+    /// transport's LAUNCH) — RESUME does not call either (see their own
+    /// comments): the grant is provably inert there, so resolving it would
+    /// add a fail-closed check with no corresponding capability it
+    /// protects. (Collapses two structurally identical methods — `50-panel`
+    /// F-SI-02, fixed at `60-re-verify-and-postmortem`, split-hardening
+    /// W5c.)
+    fn resolve_git_dirs(
+        &self,
+        bindings: &[BindingSummary],
+        kind: &str,
+        resolver: fn(&[BindingSummary]) -> Result<Vec<PathBuf>, String>,
+    ) -> Result<Vec<PathBuf>, BackendError> {
+        resolver(bindings).map_err(|reason| self.err_failed(git_dir_refusal(kind, &reason)))
+    }
+
+    /// #259: resolve each binding's git common dir, or refuse with the
+    /// named, actionable error.
     fn resolve_git_worktree_common_dirs(
         &self,
         bindings: &[BindingSummary],
     ) -> Result<Vec<PathBuf>, BackendError> {
-        git_worktree_common_dirs(bindings)
-            .map_err(|reason| self.err_failed(git_admin_dir_refusal(&reason)))
+        self.resolve_git_dirs(bindings, "common", git_worktree_common_dirs)
     }
 
     /// The app-server-only companion to [`Self::resolve_git_worktree_common_dirs`]
@@ -3333,8 +3363,7 @@ impl CodexBackend {
         &self,
         bindings: &[BindingSummary],
     ) -> Result<Vec<PathBuf>, BackendError> {
-        git_worktree_admin_dirs(bindings)
-            .map_err(|reason| self.err_failed(git_admin_dir_refusal(&reason)))
+        self.resolve_git_dirs(bindings, "admin", git_worktree_admin_dirs)
     }
 
     fn err_unknown(&self, execution_id: &str) -> BackendError {

--- a/src/backend/codex.rs
+++ b/src/backend/codex.rs
@@ -1365,6 +1365,44 @@ fn git_worktree_common_dirs(bindings: &[BindingSummary]) -> Result<Vec<PathBuf>,
         .collect()
 }
 
+/// [`worktree_git_admin_dir`] over every binding this request carries —
+/// the app-server-only companion to [`git_worktree_common_dirs`].
+///
+/// **Measured 2026-08-25 against codex-cli 0.149.1's `app-server`**: unlike
+/// `exec`'s `--add-dir` (whose grant of the common dir alone already covers
+/// `git add`/`git commit`, confirmed live via `codex exec --add-dir
+/// <common-dir>` against a real linked worktree — issue #259's exec-side fix
+/// stands unchanged), `thread/start.runtimeWorkspaceRoots` resolves into a
+/// `sandbox.writableRoots` grant that treats each linked worktree's private
+/// admin subdirectory (`<common-dir>/worktrees/<name>`) as protected in its
+/// own right, not merely inherited from a parent directory's grant. Driven
+/// by hand over the real JSON-RPC wire (`initialize` with
+/// `capabilities.experimentalApi: true`, then `command/exec` with
+/// `sandboxPolicy.writableRoots` set to the common dir alone): `git add`
+/// then fails with `Read-only file system` on this exact admin
+/// subdirectory's `index.lock`, even though the common dir that contains it
+/// was granted. Reproduced end-to-end through a real Work (`sgt run` against
+/// a scratch estate on the `codex-terra` profile, app-server transport):
+/// stage `30-close` blocked on the identical `index.lock` failure. Granting
+/// this directory *in addition to* the common dir — both, not either —
+/// resolves it; that combination is what this function adds to
+/// `launch_appserver`'s `runtimeWorkspaceRoots`, on top of (never instead
+/// of) [`git_worktree_common_dirs`].
+fn git_worktree_admin_dirs(bindings: &[BindingSummary]) -> Result<Vec<PathBuf>, String> {
+    bindings
+        .iter()
+        .map(|binding| {
+            worktree_git_admin_dir(&binding.worktree_path).map_err(|reason| {
+                format!(
+                    "{} ({}): {reason}",
+                    binding.repository,
+                    binding.worktree_path.display()
+                )
+            })
+        })
+        .collect()
+}
+
 /// The named, actionable refusal text for #259's fail-closed rule: a
 /// mutation-shaped launch (one or more bindings) whose git common-dir grant
 /// cannot be resolved is refused rather than admitted to run and later
@@ -3288,6 +3326,17 @@ impl CodexBackend {
             .map_err(|reason| self.err_failed(git_admin_dir_refusal(&reason)))
     }
 
+    /// The app-server-only companion to [`Self::resolve_git_worktree_common_dirs`]
+    /// — see [`git_worktree_admin_dirs`] for why `launch_appserver` needs
+    /// this grant in addition to (never instead of) the common dir.
+    fn resolve_git_worktree_admin_dirs(
+        &self,
+        bindings: &[BindingSummary],
+    ) -> Result<Vec<PathBuf>, BackendError> {
+        git_worktree_admin_dirs(bindings)
+            .map_err(|reason| self.err_failed(git_admin_dir_refusal(&reason)))
+    }
+
     fn err_unknown(&self, execution_id: &str) -> BackendError {
         BackendError::UnknownExecution {
             backend: CODEX_BACKEND_NAME.to_string(),
@@ -3719,6 +3768,10 @@ impl CodexBackend {
         // #259, mirrored from `launch_exec` — resolved fresh here rather
         // than trusted from PREPARE.
         let git_worktree_common_dirs = self.resolve_git_worktree_common_dirs(&request.bindings)?;
+        // #259 (W5c fix): app-server-only, on top of the common dir above —
+        // see `git_worktree_admin_dirs` for the measurement that shows the
+        // common dir alone is not enough on this transport.
+        let git_worktree_admin_dirs = self.resolve_git_worktree_admin_dirs(&request.bindings)?;
         let budgets = self.config.appserver_budgets.unwrap_or_default();
         let (handshake_budget, thread_start_budget, turn_start_budget) =
             (budgets.handshake, budgets.thread_start, budgets.turn_start);
@@ -3765,9 +3818,18 @@ impl CodexBackend {
         let mut roots = vec![request.cwd.to_string_lossy().into_owned()];
         roots.extend(extra_roots.iter().map(|p| p.to_string_lossy().into_owned()));
         // #259: the app-server's own writable-roots mechanism, granted the
-        // same one directory per binding that exec's `--add-dir` is.
+        // same common-dir-per-binding that exec's `--add-dir` is...
         roots.extend(
             git_worktree_common_dirs
+                .iter()
+                .map(|p| p.to_string_lossy().into_owned()),
+        );
+        // ...plus, app-server-only, each binding's own admin subdirectory —
+        // see `git_worktree_admin_dirs`'s doc comment for the live
+        // measurement showing the common dir alone leaves this transport's
+        // `sandbox.writableRoots` denying `index.lock` under it.
+        roots.extend(
+            git_worktree_admin_dirs
                 .iter()
                 .map(|p| p.to_string_lossy().into_owned()),
         );

--- a/src/backend/codex.rs
+++ b/src/backend/codex.rs
@@ -1059,13 +1059,15 @@ struct LaunchConfig {
 /// <value>] [--add-dir <path> ...]`. Prompt travels on stdin, no positional
 /// argument — see the module docs for why.
 ///
-/// `sandbox`/`extra_dirs`/`network_access` are **turn-1-only** — `exec
-/// resume` has neither `-s`/`--add-dir` nor `-c` on this build
-/// (`resume_turn_argv` below), so enforcement lapses on turn 2 of an
-/// exec-transport conversation. That asymmetry is recorded, not routed
-/// around (W3 spec §3.2): a first turn is where a Work does most of its
-/// damage, and it is itself an argument for app-server as the resolved
-/// transport, where the policy is thread-scoped and holds for every turn.
+/// `sandbox`/`network_access` are **turn-1-only** — `exec resume` has
+/// neither `-s`/`--sandbox` nor `-C`/`--add-dir` on this build
+/// (`resume_turn_argv` below), so those two lapse on turn 2 of an
+/// exec-transport conversation. `extra_dirs` is different: #259/W5b
+/// found `resume` *does* accept `-c key=value` (measured live against
+/// codex-cli 0.149.1's own `--help`, correcting an earlier "nor `-c`"
+/// claim here), and `sandbox_workspace_write.writable_roots` mirrors what
+/// `--add-dir` grants on turn 1 — so `resume_turn_argv` recomposes the
+/// same directories via that override instead of dropping them.
 fn first_turn_argv(
     cwd: &Path,
     model: Option<&str>,
@@ -1115,22 +1117,35 @@ fn first_turn_argv(
 }
 
 /// Turn N >= 2's argv, after `<executable>` (spec §3.2): `exec resume
-/// <thread_id> --json --skip-git-repo-check [-m <model>]`. The thread id sits
+/// <thread_id> --json --skip-git-repo-check [-m <model>] [-c
+/// sandbox_workspace_write.writable_roots=[...]]`. The thread id sits
 /// immediately after `resume`, before any flag — what makes §5.4's liveness
 /// rule an adjacency check rather than a substring search. `-C` is never
 /// passed here: `exec resume` has no such flag on this build
 /// [measured-negative]; `Command::current_dir` is the only mechanism left,
 /// and is set on every spawn regardless of turn number.
 ///
-/// `output_schema_path` **does** re-apply here, unlike `sandbox`/`extra_dirs`
-/// above: `exec resume --help` on 0.149.0 lists `--output-schema` (and
+/// `output_schema_path` **does** re-apply here, unlike `sandbox`/`-C` above:
+/// `exec resume --help` on 0.149.0 lists `--output-schema` (and
 /// `-o`/`--output-last-message`) — re-measured while implementing W3, and a
 /// correction to W1's own "verify at implementation time" placeholder
 /// (spec §4.2). So `structured_output`'s exec row is **not** turn-1-only.
+///
+/// `extra_dirs` (#259/W5b): the same paths `first_turn_argv` grants via
+/// `--add-dir` — `bindings_outside_cwd` plus each binding's
+/// `worktree_git_common_dir` — re-granted here as a single `-c
+/// sandbox_workspace_write.writable_roots=["<dir>", ...]` override, since
+/// `resume` has no `--add-dir` of its own. Measured live (W5b `30-instrument`
+/// probe, codex-cli 0.149.1, 2/2 runs): a resumed turn's `git commit`, which
+/// fails identically to the unmodified baseline's "Read-only file system" on
+/// the worktree's git common dir, succeeds once this override carries that
+/// directory. Omitted entirely when `extra_dirs` is empty, so a
+/// non-mutation-shaped resume (no bindings) composes no `-c` at all.
 fn resume_turn_argv(
     thread_id: &str,
     model: Option<&str>,
     output_schema_path: Option<&Path>,
+    extra_dirs: &[PathBuf],
 ) -> Vec<String> {
     let mut argv = vec![
         "exec".to_string(),
@@ -1146,6 +1161,15 @@ fn resume_turn_argv(
     if let Some(path) = output_schema_path {
         argv.push("--output-schema".to_string());
         argv.push(path.to_string_lossy().into_owned());
+    }
+    if !extra_dirs.is_empty() {
+        let roots = extra_dirs
+            .iter()
+            .map(|dir| format!("\"{}\"", dir.to_string_lossy()))
+            .collect::<Vec<_>>()
+            .join(",");
+        argv.push("-c".to_string());
+        argv.push(format!("sandbox_workspace_write.writable_roots=[{roots}]"));
     }
     argv
 }
@@ -3466,10 +3490,13 @@ impl CodexBackend {
             let thread_id = thread_id.clone().ok_or_else(|| {
                 self.err_failed("cannot send: no thread id recorded for this execution")
             })?;
+            let mut extra_dirs = bindings_outside_cwd.clone();
+            extra_dirs.extend(git_worktree_common_dirs.iter().cloned());
             command.args(resume_turn_argv(
                 &thread_id,
                 model.as_deref(),
                 output_schema_path,
+                &extra_dirs,
             ));
         }
         command
@@ -5162,6 +5189,7 @@ mod tests {
             "thread-y",
             None,
             Some(Path::new("/data/codex-output-schema.json")),
+            &[],
         );
         assert_eq!(
             resume_with_schema.last().unwrap(),
@@ -5196,7 +5224,7 @@ mod tests {
 
     #[test]
     fn resume_turn_argv_omits_cd_and_places_the_thread_id_right_after_resume() {
-        let argv = resume_turn_argv("01a02508-5880-7980-95b7-1d8bc22d5139", None, None);
+        let argv = resume_turn_argv("01a02508-5880-7980-95b7-1d8bc22d5139", None, None, &[]);
         assert_eq!(
             argv,
             vec![
@@ -5214,7 +5242,7 @@ mod tests {
         let resume_idx = argv.iter().position(|a| a == "resume").unwrap();
         assert_eq!(argv[resume_idx + 1], "01a02508-5880-7980-95b7-1d8bc22d5139");
 
-        let pinned = resume_turn_argv("thread-x", Some("gpt-5.6-luna"), None);
+        let pinned = resume_turn_argv("thread-x", Some("gpt-5.6-luna"), None, &[]);
         assert!(pinned.contains(&"-m".to_string()));
         assert_eq!(pinned.last().unwrap(), "gpt-5.6-luna");
 
@@ -5234,6 +5262,37 @@ mod tests {
                 "{absent} must never appear on resume"
             );
         }
+        assert!(
+            !argv.contains(&"-c".to_string()),
+            "no -c override when extra_dirs is empty"
+        );
+    }
+
+    /// #259/W5b: `resume` has no `--add-dir`, but it does accept `-c
+    /// key=value` (measured live, `30-instrument`'s H3 probe) — the same
+    /// git-common-dir grant `first_turn_argv` sends via `--add-dir` must
+    /// reappear here as `sandbox_workspace_write.writable_roots`, or a
+    /// resumed turn's `git commit` hits the exact "Read-only file system"
+    /// symptom #259 was filed about.
+    #[test]
+    fn resume_turn_argv_regrants_extra_dirs_via_writable_roots() {
+        let argv = resume_turn_argv(
+            "thread-z",
+            None,
+            None,
+            &[
+                PathBuf::from("/estate/repos/solo/.git"),
+                PathBuf::from("/other/outside"),
+            ],
+        );
+        let c_idx = argv
+            .iter()
+            .position(|a| a == "-c")
+            .expect("-c must be present when extra_dirs is non-empty");
+        assert_eq!(
+            argv[c_idx + 1],
+            "sandbox_workspace_write.writable_roots=[\"/estate/repos/solo/.git\",\"/other/outside\"]"
+        );
     }
 
     // ------------------------------------------------------------ §3.4 prompt

--- a/src/backend/codex.rs
+++ b/src/backend/codex.rs
@@ -853,9 +853,12 @@ const ADMISSION_ROWS: &[AdmissionRow] = &[
         // second function under the spec's literal name. Naming the real
         // function here keeps this citation resolvable.
         admission_test: "first_turn_argv_carries_the_measured_shape",
-        note: "turn-1-only: exec resume has neither -s nor --add-dir on this build -- the \
-               composed-flags handshake is proven, enforcement itself is not (bwrap cannot \
-               initialize a network namespace on Cerberus, H0 §C.3 finding 4)",
+        note: "turn-1 grants --add-dir directly; exec resume has neither -s nor --add-dir on \
+               this build, but #259/W5b re-composes --add-dir's writable-roots effect via \
+               `-c sandbox_workspace_write.writable_roots` on resume, so only -s/network_access \
+               remains turn-1-only -- the composed-flags handshake is proven, enforcement itself \
+               is not (bwrap cannot initialize a network namespace on Cerberus, H0 §C.3 finding \
+               4)",
     },
     AdmissionRow {
         capability: "sandbox_enforcement",
@@ -3474,10 +3477,10 @@ impl CodexBackend {
         };
 
         let output_schema_path = self.output_schema_path();
+        let mut extra_dirs = bindings_outside_cwd.clone();
+        extra_dirs.extend(git_worktree_common_dirs.iter().cloned());
         let mut command = Command::new(&executable);
         if first_turn {
-            let mut extra_dirs = bindings_outside_cwd.clone();
-            extra_dirs.extend(git_worktree_common_dirs.iter().cloned());
             command.args(first_turn_argv(
                 &cwd,
                 model.as_deref(),
@@ -3490,8 +3493,6 @@ impl CodexBackend {
             let thread_id = thread_id.clone().ok_or_else(|| {
                 self.err_failed("cannot send: no thread id recorded for this execution")
             })?;
-            let mut extra_dirs = bindings_outside_cwd.clone();
-            extra_dirs.extend(git_worktree_common_dirs.iter().cloned());
             command.args(resume_turn_argv(
                 &thread_id,
                 model.as_deref(),

--- a/tests/codex_backend.rs
+++ b/tests/codex_backend.rs
@@ -2252,9 +2252,11 @@ fn wait_for_event(
 }
 
 /// §3.6 test 4: the captured `thread/start` params carry exactly `cwd`,
-/// `sandbox`, `approvalPolicy`, and `runtimeWorkspaceRoots` naming cwd plus
-/// the one binding outside it — never the inside-cwd binding (already
-/// covered by cwd), never anything fabricated.
+/// `sandbox`, `approvalPolicy`, and `runtimeWorkspaceRoots` naming cwd, the
+/// one binding outside it, every binding's git common dir (#259), and —
+/// app-server-only, #259 W5c's own fix — every binding's git admin dir
+/// (`<common-dir>/worktrees/<name>`) — never the estate root, never
+/// anything fabricated.
 #[test]
 fn appserver_thread_start_names_exactly_the_works_surfaces() {
     let dir = TempDir::new().expect("tempdir");
@@ -2326,9 +2328,24 @@ fn appserver_thread_start_names_exactly_the_works_surfaces() {
                 .join(".git")
                 .to_string_lossy()
                 .to_string(),
+            inside_source
+                .path()
+                .join(".git")
+                .join("worktrees")
+                .join("inside-binding")
+                .to_string_lossy()
+                .to_string(),
+            outside_source
+                .path()
+                .join(".git")
+                .join("worktrees")
+                .join("outside-binding")
+                .to_string_lossy()
+                .to_string(),
         ],
-        "cwd, the one outside binding, then #259's git common-dir grants for every binding \
-         in order -- never the estate root, never anything fabricated"
+        "cwd, the one outside binding, then #259's git common-dir grants for every binding in \
+         order, then #259 W5c's own app-server-only git admin-dir grants for every binding in \
+         order -- never the estate root, never anything fabricated"
     );
 
     backend.stop(&handle).expect("stop").wait();
@@ -4539,7 +4556,29 @@ fn live_appserver_thread_start_echoes_the_requested_policy() {
     // during PROBE (G4's handshake uses `initialize` only, not
     // `thread/start` — so this LAUNCH is the first `thread/start` this test
     // sends).
-    let outside = live_workdir("appserver-policy-outside");
+    //
+    // A **real** linked worktree, not a bare directory: a bare directory has
+    // no `.git` file, so `prepare`'s own `resolve_git_worktree_common_dirs`
+    // would refuse it outright (§259's fail-closed rule) — it could never
+    // exercise what this test is actually for. Using a real linked worktree
+    // is also what makes the admin-dir assertion below possible at all: #259
+    // W5c's own fix (`git_worktree_admin_dirs`) is scoped to exactly this
+    // shape, and the shape this test used before (a bindings-outside-cwd
+    // directory with no git structure) could not have caught its absence —
+    // "the echo test asserts the model pin, not the roots" was true of a
+    // *plain-directory* binding by construction, since a plain directory has
+    // neither a common dir nor an admin dir to assert on.
+    let outside_source = live_workdir("appserver-policy-outside-source");
+    let outside_worktree = live_workdir("appserver-policy-outside-worktree");
+    // `live_workdir` itself makes the directory; `worktree add` requires the
+    // target not to already exist.
+    std::fs::remove_dir(outside_worktree.path()).expect("clear the pre-made worktree dir");
+    let admin_dir = real_worktree(
+        outside_source.path(),
+        outside_worktree.path(),
+        "sergeant/appserver-policy-outside",
+    );
+    let common_dir = outside_source.path().join(".git");
     let backend = CodexBackend::new(live_appserver_config(data_dir.path()));
     let mut request = start_request(data_dir.path());
     request.model = Some("gpt-5.6-luna".to_string());
@@ -4547,10 +4586,10 @@ fn live_appserver_thread_start_echoes_the_requested_policy() {
     // discriminate on beyond cwd alone (§3.6's own test 4 shape).
     request.bindings = vec![BindingSummary {
         repository: "outside".to_string(),
-        worktree_path: outside.path().to_path_buf(),
-        work_branch: "b".to_string(),
-        base_branch: None,
-        base_sha: "0".repeat(40),
+        worktree_path: outside_worktree.path().to_path_buf(),
+        work_branch: "sergeant/appserver-policy-outside".to_string(),
+        base_branch: Some("main".to_string()),
+        base_sha: support::git(outside_worktree.path(), &["rev-parse", "HEAD"]),
     }];
     let prepared = backend.prepare(&request).expect("prepare");
     let handle = backend.launch(&prepared).expect("launch");
@@ -4573,12 +4612,104 @@ fn live_appserver_thread_start_echoes_the_requested_policy() {
         .map(|v| v.as_str().unwrap_or(""))
         .collect();
     assert!(
-        writable_roots.contains(&outside.path().to_string_lossy().as_ref()),
+        writable_roots.contains(&outside_worktree.path().to_string_lossy().as_ref()),
         "sandbox.writableRoots must name the out-of-cwd binding: {writable_roots:?}"
+    );
+    // The regression this stage exists to close: #259's app-server grant
+    // shipped naming only the worktree path and the shared common dir —
+    // `git commit` still failed with `Read-only file system` on
+    // `<common-dir>/worktrees/<name>/index.lock`, because codex-cli's
+    // `sandbox.writableRoots` on this transport treats a linked worktree's
+    // own admin subdirectory as protected in its own right, not merely
+    // inherited from the common dir that contains it (measured live against
+    // codex-cli 0.149.1, see `git_worktree_admin_dirs`'s doc comment). A
+    // model-pin-only echo assertion, or a roots assertion against a bare
+    // directory with no admin dir to omit, could not have caught this ship.
+    assert!(
+        writable_roots.contains(&common_dir.to_string_lossy().as_ref()),
+        "sandbox.writableRoots must name the binding's git common dir: {writable_roots:?}"
+    );
+    assert!(
+        writable_roots.contains(&admin_dir.to_string_lossy().as_ref()),
+        "sandbox.writableRoots must name the binding's own git admin dir \
+         (<common-dir>/worktrees/<name>) in addition to the common dir — the app-server-only \
+         gap #259 W5c closed: {writable_roots:?}"
     );
     assert_eq!(echo["cwd"], data_dir.path().to_string_lossy().as_ref());
     assert_eq!(echo["approvalPolicy"], "never");
     assert_eq!(echo["model"], "gpt-5.6-luna");
+    backend.stop(&handle).expect("stop").wait();
+}
+
+/// The app-server-transport counterpart of
+/// `live_codex_actor_commits_to_the_works_own_branch`: the same acceptance
+/// criterion ("a real Codex contract test edits, stages, and commits in an
+/// assigned linked worktree; the commit advances the assigned
+/// `sergeant/<work-id>` branch"), driven over the app-server transport
+/// rather than exec. Where the echo test above proves the *wire policy*
+/// names the right roots, this proves the roots actually work end to end —
+/// an echoed grant the server does not in fact honor would still fail here.
+/// #259 W5c's own regression: before `git_worktree_admin_dirs`, this exact
+/// scenario failed `git commit` with `Read-only file system` on
+/// `<common-dir>/worktrees/<name>/index.lock`.
+#[test]
+#[ignore = "opt-in, spends real tokens: SERGEANT_CODEX_TESTS=1 cargo test --test codex_backend -- --ignored"]
+fn live_appserver_actor_commits_to_the_works_own_branch() {
+    let data_dir = live_workdir("appserver-commit");
+    if !codex_appserver_live_enabled(
+        "live_appserver_actor_commits_to_the_works_own_branch",
+        data_dir.path(),
+    ) {
+        return;
+    }
+    let source = data_dir.path().join("source");
+    let worktree = data_dir.path().join("worktree");
+    let branch = "sergeant/live-259-appserver";
+    real_worktree(&source, &worktree, branch);
+    let before = support::git(&worktree, &["rev-parse", "HEAD"]);
+
+    let backend = CodexBackend::new(live_appserver_config(data_dir.path()));
+    let (sink_fn, events) = sink();
+    backend.set_event_sink(sink_fn);
+    let mut request = start_request(&worktree);
+    request.model = Some("gpt-5.6-luna".to_string());
+    request.intent = "Append the single line \"ok\" to README.md, then run `git add \
+                       README.md` and `git commit -m \"live appserver #259 test\"`. Do nothing \
+                       else, and report only the word done when finished."
+        .to_string();
+    request.bindings = vec![BindingSummary {
+        repository: "solo".to_string(),
+        worktree_path: worktree.clone(),
+        work_branch: branch.to_string(),
+        base_branch: Some("main".to_string()),
+        base_sha: before.clone(),
+    }];
+    let prepared = backend.prepare(&request).expect("prepare");
+    let handle = backend.launch(&prepared).expect("launch");
+    let _user = wait_for_kind(&events, "conversation.user");
+    wait_for_appserver_settled(&backend, &handle, &events, 0);
+
+    let after = support::git(&worktree, &["rev-parse", "HEAD"]);
+    assert_ne!(
+        before, after,
+        "the actor must have committed in its own worktree"
+    );
+    let parent = support::git(&worktree, &["rev-parse", "HEAD^"]);
+    assert_eq!(
+        parent, before,
+        "the new commit must be built directly on the Work's own starting point"
+    );
+    let branch_tip = support::git(&source, &["rev-parse", branch]);
+    assert_eq!(
+        branch_tip, after,
+        "the commit must advance the assigned sergeant/<work-id> branch, not just the \
+         worktree's detached view of it"
+    );
+    let head_is_branch = support::git(&worktree, &["symbolic-ref", "--quiet", "--short", "HEAD"]);
+    assert_eq!(
+        head_is_branch, branch,
+        "HEAD must still be the work branch, not detached"
+    );
     backend.stop(&handle).expect("stop").wait();
 }
 

--- a/tests/codex_backend.rs
+++ b/tests/codex_backend.rs
@@ -2257,6 +2257,15 @@ fn wait_for_event(
 /// app-server-only, #259 W5c's own fix — every binding's git admin dir
 /// (`<common-dir>/worktrees/<name>`) — never the estate root, never
 /// anything fabricated.
+///
+/// **Scope, stated honestly** (`50-panel` F-TH-04, `60-re-verify-and-
+/// postmortem`, split-hardening W5c): this is a wire-composition test
+/// against a stub, using the same string construction the production code
+/// uses to build the expected paths — it proves `launch_appserver`
+/// composes the roots array it means to, in order, nothing more or less.
+/// It cannot show the admin dir is needed or that the sandbox honors it;
+/// that behavioral question belongs to the `live_appserver_*` tests, and
+/// per their own doc comments it remains open there too.
 #[test]
 fn appserver_thread_start_names_exactly_the_works_surfaces() {
     let dir = TempDir::new().expect("tempdir");
@@ -4615,16 +4624,22 @@ fn live_appserver_thread_start_echoes_the_requested_policy() {
         writable_roots.contains(&outside_worktree.path().to_string_lossy().as_ref()),
         "sandbox.writableRoots must name the out-of-cwd binding: {writable_roots:?}"
     );
-    // The regression this stage exists to close: #259's app-server grant
-    // shipped naming only the worktree path and the shared common dir —
-    // `git commit` still failed with `Read-only file system` on
-    // `<common-dir>/worktrees/<name>/index.lock`, because codex-cli's
-    // `sandbox.writableRoots` on this transport treats a linked worktree's
-    // own admin subdirectory as protected in its own right, not merely
-    // inherited from the common dir that contains it (measured live against
-    // codex-cli 0.149.1, see `git_worktree_admin_dirs`'s doc comment). A
-    // model-pin-only echo assertion, or a roots assertion against a bare
-    // directory with no admin dir to omit, could not have caught this ship.
+    // This asserts the wire *echo* only — that `sandbox.writableRoots`
+    // names the admin dir, not that write access under it actually differs
+    // from the common dir alone. A later, more targeted probe
+    // (`30-instrument`, split-hardening W5c, probe 1b) found that on this
+    // measured codex-cli 0.149.1 build a granted parent directory's write
+    // access already covers writes under its own subdirectories via the
+    // production `thread/start`/`turn/start` call shape — so the admin dir
+    // being *named* here may change only what the wire response echoes, not
+    // what the sandbox enforces (`50-panel` F-TH-02; see
+    // `git_worktree_admin_dirs`'s doc comment for the full, unresolved
+    // discrepancy). `live_appserver_actor_commits_to_the_works_own_branch`
+    // below is the test that would show a real enforcement difference, and
+    // per its own doc comment it does not discriminate this either. Kept
+    // regardless because a model-pin-only echo assertion, or a roots
+    // assertion against a bare directory with no admin dir to omit, could
+    // not even prove the wire echo is complete.
     assert!(
         writable_roots.contains(&common_dir.to_string_lossy().as_ref()),
         "sandbox.writableRoots must name the binding's git common dir: {writable_roots:?}"
@@ -4646,12 +4661,20 @@ fn live_appserver_thread_start_echoes_the_requested_policy() {
 /// criterion ("a real Codex contract test edits, stages, and commits in an
 /// assigned linked worktree; the commit advances the assigned
 /// `sergeant/<work-id>` branch"), driven over the app-server transport
-/// rather than exec. Where the echo test above proves the *wire policy*
-/// names the right roots, this proves the roots actually work end to end —
-/// an echoed grant the server does not in fact honor would still fail here.
-/// #259 W5c's own regression: before `git_worktree_admin_dirs`, this exact
-/// scenario failed `git commit` with `Read-only file system` on
-/// `<common-dir>/worktrees/<name>/index.lock`.
+/// rather than exec.
+///
+/// **Does not discriminate the admin-dir grant** (`50-panel` F-TH-01,
+/// fixed at `60-re-verify-and-postmortem`, split-hardening W5c): despite an
+/// earlier version of this doc comment claiming this scenario failed
+/// before `git_worktree_admin_dirs`, `40-fix-with-regression-test` directly
+/// measured this exact test passing on both pre-fix (`d2acce1c^`) and
+/// post-fix code — that claim was false. What this test does prove: the
+/// wave's actual end-to-end acceptance criterion (a real commit landing on
+/// the Work's own branch over the app-server transport) holds with the
+/// admin-dir grant present, matching an independent full `sgt run` (Work
+/// `01M0VK7FKCM9V210MXSNQ1V2QD`). It does not show the grant is load-
+/// bearing; `live_appserver_thread_start_echoes_the_requested_policy`
+/// above is the one place that gap is recorded honestly.
 #[test]
 #[ignore = "opt-in, spends real tokens: SERGEANT_CODEX_TESTS=1 cargo test --test codex_backend -- --ignored"]
 fn live_appserver_actor_commits_to_the_works_own_branch() {

--- a/tests/codex_backend.rs
+++ b/tests/codex_backend.rs
@@ -1404,6 +1404,67 @@ fn the_resume_turn_launches_the_recorded_grammar() {
     assert!(resume.stdin.contains("turn two"));
 }
 
+/// #259/W5b: the exact seam the production bug lives at — a *resumed* turn
+/// (SEND, via `resume_turn_argv`) must re-grant the Work's own git common
+/// dir, the same one directory `the_first_turn_grants_the_works_own_git_
+/// common_dir_as_an_add_dir_root` proves turn 1 gets via `--add-dir`.
+/// `resume` has no `--add-dir` (proven above), so this grant must reappear
+/// as `-c sandbox_workspace_write.writable_roots=[...]` instead — the fix
+/// `30-instrument`'s H3 probe confirmed live (2/2) against real codex-cli.
+/// Before the fix, `resume_turn_argv` composed no `-c` at all here and a
+/// resumed `git commit` failed with "Read-only file system" on exactly this
+/// directory (`00-build-feedback-loop`/`10-reproduce-and-minimize`).
+#[test]
+fn the_resume_turn_regrants_the_git_common_dir_via_writable_roots() {
+    let dir = TempDir::new().expect("tempdir");
+    let source = dir.path().join("source");
+    let worktree = dir.path().join("worktree");
+    real_worktree(&source, &worktree, "sergeant/w-codex");
+    let common_dir = source.join(".git");
+
+    let stub = StubCodex::passing(dir.path());
+    stub.replays(AGENT_MESSAGE_TURN);
+    let backend = CodexBackend::new(config_for(
+        &stub,
+        dir.path(),
+        &dir.path().join("codex-home"),
+    ));
+    let mut request = start_request(&worktree);
+    request.bindings = vec![BindingSummary {
+        repository: "solo".to_string(),
+        worktree_path: worktree.clone(),
+        work_branch: "sergeant/w-codex".to_string(),
+        base_branch: Some("main".to_string()),
+        base_sha: "0".repeat(40),
+    }];
+    let prepared = backend.prepare(&request).expect("prepare");
+    let handle = backend.launch(&prepared).expect("launch");
+    let thread_id = handle.native_id.clone().unwrap();
+    wait_for_settled(&backend, &handle);
+
+    stub.replays(&plain_turn_naming(&thread_id));
+    backend
+        .send(&handle, "git add && git commit")
+        .expect("send");
+    let launches = stub.wait_for_launches(2);
+    let resume = &launches[1];
+    assert_eq!(resume.argv[1], "resume");
+    assert!(
+        !resume.has("--add-dir"),
+        "resume has no --add-dir on this build; the grant must travel via -c"
+    );
+    assert_eq!(
+        resume.value_after("-c"),
+        Some(
+            format!(
+                "sandbox_workspace_write.writable_roots=[\"{}\"]",
+                common_dir.to_str().unwrap()
+            )
+            .as_str()
+        )
+    );
+}
+
 #[test]
 fn the_raw_stream_is_archived_before_any_conclusion_is_drawn() {
     let dir = TempDir::new().expect("tempdir");
@@ -4905,10 +4966,23 @@ async fn daemon_start_registers_codex_and_journals_its_own_probe() {
 /// The commit advances the assigned `sergeant/<work-id>` branch." A real
 /// one-commit repo plus a real `git worktree add`-created linked worktree
 /// (`real_worktree`, same fixture the stub-driven `--add-dir` test above
-/// uses), a turn instructed to append a line and commit it, then the
-/// assigned branch's tip in the *source* checkout is asserted to have moved
-/// to a new commit whose parent is the worktree's pre-turn `HEAD` — proving
-/// the commit is real, on-branch, and not merely a detached-HEAD or
+/// uses).
+///
+/// #259/W5b (`20-hypothesize` H5): the edit and the `git add`/`git commit`
+/// are split across **two turns** — LAUNCH edits `README.md` only, then SEND
+/// resumes the same thread to add and commit — rather than one turn asked to
+/// do both. A single-turn version of this test is structurally blind to the
+/// production bug: turn 1's own `--add-dir` grant is always sufficient
+/// (`30-instrument`'s H4 probe measured this directly), so a same-turn
+/// edit+commit passes whether or not `resume_turn_argv` ever re-grants
+/// anything. The real failure (`10-reproduce-and-minimize`'s repro,
+/// `.git/worktrees/<name>/index.lock` "Read-only file system") only shows up
+/// when the commit happens on a *resumed* turn, which is also the shape a
+/// real Work uses (edit across earlier stages, commit on a later one).
+///
+/// The assigned branch's tip in the *source* checkout is asserted to have
+/// moved to a new commit whose parent is the worktree's pre-turn `HEAD` —
+/// proving the commit is real, on-branch, and not merely a detached-HEAD or
 /// working-tree-only edit.
 #[test]
 #[ignore = "opt-in, spends real tokens: SERGEANT_CODEX_TESTS=1 cargo test --test codex_backend -- --ignored"]
@@ -4929,8 +5003,8 @@ fn live_codex_actor_commits_to_the_works_own_branch() {
     let backend = CodexBackend::new(live_exec_config(data_dir.path()));
     let mut request = start_request(&worktree);
     request.model = Some("gpt-5.6-luna".to_string());
-    request.intent = "Append the single line \"ok\" to README.md, then run `git add \
-                       README.md` and `git commit -m \"live #259 test\"`. Do nothing else, \
+    request.intent = "Append the single line \"ok\" to README.md using a shell command. Do \
+                       not run any git commands. Do nothing else, \
                        and report only the word done when finished."
         .to_string();
     request.bindings = vec![BindingSummary {
@@ -4942,6 +5016,17 @@ fn live_codex_actor_commits_to_the_works_own_branch() {
     }];
     let prepared = backend.prepare(&request).expect("prepare");
     let handle = backend.launch(&prepared).expect("launch");
+    wait_for_settled(&backend, &handle);
+
+    // The commit happens on a *resumed* turn (SEND), the seam #259/W5b's
+    // fix and its regression test target — see the doc comment above.
+    backend
+        .send(
+            &handle,
+            "Run `git add README.md` then `git commit -m \"live #259 test\"`. Report only \
+             the word done when finished, or the exact error text if it fails.",
+        )
+        .expect("send");
     wait_for_settled(&backend, &handle);
 
     let after = support::git(&worktree, &["rev-parse", "HEAD"]);


### PR DESCRIPTION
Split-hardening waves W5b/W5c — the real #259 completion after the merged W5 fix proved insufficient on the daemon's actual (app-server) transport.

- W5b (fix-defect, Work QXJ05P): exec-resume turns re-grant the git common dir via -c writable_roots (the turn-1-only lapse); honest escalation that app-server remained broken.
- W5c (fix-defect, Work D3S3B3): app-server grant composed into the real thread/start schema (captain-measured: runtimeWorkspaceRoots does not exist in codex-cli 0.149.1; sandbox is a policy object — see workspace knowledge/evidence/resources/split-hardening-series/codex-appserver-schema-2026-08-25.md); 14 refuter-confirmed findings fixed incl. reconciling overclaimed measurement docs.
- **Live acceptance passed**: fresh scratch estate on the fixed tree, codex-terra Work 01M0VPGV01QAMS5WWKK7JCD93P retired `completed` with commit 457a9a7d on its Work branch over app-server — the retro's 0/21 scenario closed empirically.

Head: 654a26b6fa54b40ee53a4e77512fa13562c2da94. CI is the merge gate; focused review Work dispatched against the schema evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4