### PR TITLE
S1/W1a: estate coordinate goes live — workspace_id stamped at Engine::commit; analytics estate_root column

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1669,6 +1669,15 @@ async fn submit_work(
     let work_id = work.id.clone();
     let mut draft = EventDraft::new(api_source(), KIND_WORK_SUBMITTED, json!({"work": work}))
         .with_work_id(&work_id);
+    // H1 touch point #4: `work.submitted` is the other emission point
+    // outside `Engine::commit` (`begin_start`'s later events go through
+    // that chokepoint and pick it up there). `plan` carries the estate this
+    // submission actually resolved against — `None` (no repository
+    // context offered) leaves the field absent, same as a Work that never
+    // reaches an estate at all.
+    if let Some(plan) = &plan {
+        draft = draft.with_workspace_id(plan.estate.root.to_string_lossy().into_owned());
+    }
     draft.correlation_id = Some(req.command_id.clone());
     if let Err(e) = core.commit(draft) {
         return internal_error(e);
@@ -5651,6 +5660,10 @@ mod tests {
             id: format!("evt-{seq}"),
             timestamp: rfc3339_utc_now(),
             source: EventSource::new("backend", "test"),
+            // Audited (H1 touch point #4): this fixture exercises
+            // `transcript_turns`, which reads only `work_id`/`kind`/
+            // `payload` — never estate-bound, so there is nothing to
+            // populate here.
             workspace_id: None,
             work_id: Some(work_id.to_string()),
             execution_id: execution_id.map(str::to_string),
@@ -6071,6 +6084,12 @@ mod tests {
                     id: format!("evt-{seq}"),
                     timestamp: rfc3339_utc_now(),
                     source: draft.source,
+                    // Audited (H1 touch point #4): mirrors whatever the
+                    // backend's own draft carried rather than hardcoding
+                    // `None` — backend-emitted conversation events are
+                    // outside this chokepoint's scope (`Engine::commit`),
+                    // so nothing here should invent a value the adapter
+                    // never set.
                     workspace_id: draft.workspace_id,
                     work_id: draft.work_id,
                     execution_id: draft.execution_id,

--- a/src/domain/event.rs
+++ b/src/domain/event.rs
@@ -124,6 +124,13 @@ impl EventDraft {
         self
     }
 
+    /// Set the estate scope: the canonical estate root, not its display
+    /// name (H1 touch point #5 — two estates can share a `[estate] name`).
+    pub fn with_workspace_id(mut self, workspace_id: impl Into<String>) -> Self {
+        self.workspace_id = Some(workspace_id.into());
+        self
+    }
+
     /// Finalize into a full envelope at the given sequence number, stamping a
     /// fresh ULID id and the current UTC time.
     pub fn into_event(self, seq: u64) -> Event {

--- a/src/runtime/analytics.rs
+++ b/src/runtime/analytics.rs
@@ -128,6 +128,7 @@ CREATE TABLE work (
     work_id       VARCHAR PRIMARY KEY,
     intent        VARCHAR,
     estate        VARCHAR,
+    estate_root   VARCHAR,
     workflow      VARCHAR,
     backend       VARCHAR,
     route_source  VARCHAR,
@@ -465,6 +466,13 @@ struct WorkRow {
     /// Work that never reached `workflow.bound` is an honest "not yet
     /// resolved to an estate", not a lost fact.
     estate: Option<String>,
+    /// H1 touch point #6: the canonical estate root, folded once from the
+    /// envelope's `workspace_id` at `work.submitted` — unlike `estate`
+    /// above, never overwritten at `workflow.bound`, since the coordinate
+    /// is already known (and immutable for a Work's life) at submission.
+    /// `None` for a pre-Phase-C-shaped legacy line, whose envelope never
+    /// carried the field at all — an honest "not recorded", not an error.
+    estate_root: Option<String>,
     workflow: Option<String>,
     backend: Option<String>,
     route_source: Option<String>,
@@ -576,6 +584,7 @@ impl WorkRow {
             Duck::Text(self.work_id.clone()),
             text(self.intent.as_deref()),
             text(self.estate.as_deref()),
+            text(self.estate_root.as_deref()),
             text(self.workflow.as_deref()),
             text(self.backend.as_deref()),
             text(self.route_source.as_deref()),
@@ -986,6 +995,11 @@ impl Analytics {
                             work_id: work_id.to_string(),
                             intent: string(&work["intent"]),
                             estate: string(&work["workspace"]),
+                            // H1 touch point #6: the envelope's own field,
+                            // not a payload key — real for every new Work
+                            // from `work.submitted` onward, `None` for a
+                            // legacy line whose envelope never carried it.
+                            estate_root: event.workspace_id.clone(),
                             workflow: string(&work["workflow"]),
                             backend: string(&work["backend"]),
                             route_source: None,
@@ -1602,6 +1616,40 @@ mod tests {
         let counts = analytics.table_counts().expect("counts");
         assert_eq!(counts[0], ("events".to_string(), 2));
         assert_eq!(counts[1], ("work".to_string(), 2));
+    }
+
+    /// H1 touch point #6: `estate_root` folds from the envelope at
+    /// `work.submitted` for a Work that never reaches `workflow.bound`
+    /// (today's documented `estate: None`-forever gap, now answered), and
+    /// stays `NULL` — never an error — for a pre-Phase-C-shaped legacy line
+    /// whose envelope never carried `workspace_id` at all (`Compatibility`
+    /// deliverable: old journal lines replay unchanged).
+    #[test]
+    fn work_estate_root_folds_from_the_submitted_envelope_and_stays_null_for_a_legacy_line() {
+        let root = "/estates/payments";
+        let mut current = submitted(1, "current");
+        current.workspace_id = Some(root.to_string());
+        // No `workspace_id` at all — exactly what a stored pre-Phase-C
+        // journal line deserializes to (`Event`'s `#[serde(default)]`).
+        let legacy = submitted(2, "legacy");
+
+        let mut analytics =
+            Analytics::in_memory(events(vec![current, legacy])).expect("projection");
+        analytics.materialize().expect("materialize");
+        let (columns, rows) = analytics
+            .select(
+                "SELECT work_id, estate_root FROM work ORDER BY work_id",
+                duckdb::params![],
+            )
+            .expect("select");
+        assert_eq!(columns, vec!["work_id", "estate_root"]);
+        assert_eq!(
+            rows,
+            vec![
+                vec![json!("current"), json!(root)],
+                vec![json!("legacy"), Value::Null],
+            ]
+        );
     }
 
     /// W2 §9.1 step 3: a failed `push` (surfaced through `finish`, since the

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -4551,10 +4551,17 @@ impl Engine {
         kind: &str,
         payload: Value,
     ) -> Result<(), EngineError> {
-        core.commit(
-            EventDraft::new(EventSource::new("daemon", "engine"), kind, payload)
-                .with_work_id(work_id),
-        )?;
+        let mut draft = EventDraft::new(EventSource::new("daemon", "engine"), kind, payload)
+            .with_work_id(work_id);
+        // H1 touch point #4: the one chokepoint every engine-emitted event
+        // goes through, so this is the one place that stamps the pinned
+        // estate root — never the display name (`self.estate_root` is
+        // already canonicalized, `Estate::admit`'s doc). `None` (a daemon
+        // bound to no estate) leaves the field absent, exactly as before.
+        if let Some(root) = &self.estate_root {
+            draft = draft.with_workspace_id(root.to_string_lossy().into_owned());
+        }
+        core.commit(draft)?;
         Ok(())
     }
 
@@ -4684,6 +4691,62 @@ mod tests {
             WorkState::Blocked,
             "and the work is still exactly where it was"
         );
+    }
+
+    /// H1 touch point #4: `Engine::commit` is the one chokepoint every
+    /// engine-emitted event goes through, so the pinned estate root must
+    /// land in the envelope from there, not from each individual caller.
+    #[test]
+    fn engine_committed_events_carry_the_pinned_estate_root() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+        let estate_root = dir.path().join("estate");
+        let engine = engine(dir.path()).with_estate_root(estate_root.clone());
+        let work_id = "01WORKSPACEID";
+        testing::submit(&mut core, work_id, "carry the estate root");
+
+        engine
+            .block(&mut core, work_id, "prove workspace_id travels", None)
+            .expect("block");
+
+        let blocked = core
+            .journal
+            .replay()
+            .expect("replay")
+            .map(|e| e.expect("event"))
+            .find(|e| e.kind == KIND_WORK_BLOCKED)
+            .expect("work.blocked journaled");
+        assert_eq!(
+            blocked.workspace_id.as_deref(),
+            Some(estate_root.to_string_lossy().as_ref()),
+            "an engine-committed event must carry the daemon's pinned estate root"
+        );
+    }
+
+    /// The companion case: a daemon started with no estate at all (test
+    /// rigs, the intent-capture path) commits events with `workspace_id`
+    /// still absent — there is no coordinate to stamp, and the field must
+    /// not invent one.
+    #[test]
+    fn engine_committed_events_carry_no_workspace_id_when_the_engine_has_no_estate() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = testing::core(dir.path());
+        let engine = engine(dir.path()); // no `.with_estate_root(..)`
+        let work_id = "01NOESTATE";
+        testing::submit(&mut core, work_id, "no estate here");
+
+        engine
+            .block(&mut core, work_id, "no estate pinned", None)
+            .expect("block");
+
+        let blocked = core
+            .journal
+            .replay()
+            .expect("replay")
+            .map(|e| e.expect("event"))
+            .find(|e| e.kind == KIND_WORK_BLOCKED)
+            .expect("work.blocked journaled");
+        assert_eq!(blocked.workspace_id, None);
     }
 
     // ------------------------- estate-root Phase C: Engine::resolve_scope

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -4695,58 +4695,47 @@ mod tests {
 
     /// H1 touch point #4: `Engine::commit` is the one chokepoint every
     /// engine-emitted event goes through, so the pinned estate root must
-    /// land in the envelope from there, not from each individual caller.
+    /// land in the envelope from there, not from each individual caller —
+    /// and an engine with no estate (test rigs, the intent-capture path)
+    /// must leave the field absent rather than invent a coordinate. Both
+    /// branches live in one test so the `None` half is pinned by a test
+    /// that still fails when the stamping is reverted.
     #[test]
-    fn engine_committed_events_carry_the_pinned_estate_root() {
+    fn engine_committed_events_stamp_workspace_id_only_when_an_estate_is_pinned() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let mut core = testing::core(dir.path());
         let estate_root = dir.path().join("estate");
-        let engine = engine(dir.path()).with_estate_root(estate_root.clone());
-        let work_id = "01WORKSPACEID";
-        testing::submit(&mut core, work_id, "carry the estate root");
+        let pinned = engine(dir.path()).with_estate_root(estate_root.clone());
+        let unpinned = engine(dir.path()); // no `.with_estate_root(..)`
 
-        engine
-            .block(&mut core, work_id, "prove workspace_id travels", None)
-            .expect("block");
+        testing::submit(&mut core, "01PINNED", "carry the estate root");
+        testing::submit(&mut core, "01NOESTATE", "no estate here");
+        pinned
+            .block(&mut core, "01PINNED", "prove workspace_id travels", None)
+            .expect("block pinned");
+        unpinned
+            .block(&mut core, "01NOESTATE", "no estate pinned", None)
+            .expect("block unpinned");
 
-        let blocked = core
+        let blocked: Vec<_> = core
             .journal
             .replay()
             .expect("replay")
             .map(|e| e.expect("event"))
-            .find(|e| e.kind == KIND_WORK_BLOCKED)
-            .expect("work.blocked journaled");
+            .filter(|e| e.kind == KIND_WORK_BLOCKED)
+            .collect();
+        let by_work = |id: &str| {
+            blocked
+                .iter()
+                .find(|e| e.work_id.as_deref() == Some(id))
+                .expect("work.blocked journaled")
+        };
         assert_eq!(
-            blocked.workspace_id.as_deref(),
+            by_work("01PINNED").workspace_id.as_deref(),
             Some(estate_root.to_string_lossy().as_ref()),
             "an engine-committed event must carry the daemon's pinned estate root"
         );
-    }
-
-    /// The companion case: a daemon started with no estate at all (test
-    /// rigs, the intent-capture path) commits events with `workspace_id`
-    /// still absent — there is no coordinate to stamp, and the field must
-    /// not invent one.
-    #[test]
-    fn engine_committed_events_carry_no_workspace_id_when_the_engine_has_no_estate() {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        let mut core = testing::core(dir.path());
-        let engine = engine(dir.path()); // no `.with_estate_root(..)`
-        let work_id = "01NOESTATE";
-        testing::submit(&mut core, work_id, "no estate here");
-
-        engine
-            .block(&mut core, work_id, "no estate pinned", None)
-            .expect("block");
-
-        let blocked = core
-            .journal
-            .replay()
-            .expect("replay")
-            .map(|e| e.expect("event"))
-            .find(|e| e.kind == KIND_WORK_BLOCKED)
-            .expect("work.blocked journaled");
-        assert_eq!(blocked.workspace_id, None);
+        assert_eq!(by_work("01NOESTATE").workspace_id, None);
     }
 
     // ------------------------- estate-root Phase C: Engine::resolve_scope

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -48,7 +48,7 @@ use sergeant_rs::runtime::journal::Journal;
 use sergeant_rs::runtime::surface::KIND_SURFACE_MATERIALIZED;
 
 mod support;
-use support::{DataDir, ReapSignal, daemon_pids};
+use support::{DataDir, ReapSignal, daemon_pids, scaffold_solo_estate};
 
 const SGT: &str = env!("CARGO_BIN_EXE_sgt");
 
@@ -588,6 +588,45 @@ async fn t3_submit_lists_pending_journals_and_survives_restart() {
     assert_eq!(list["works"][0]["id"], work_id.as_str());
     assert_eq!(list["works"][0]["state"], "pending");
     handle.shutdown().await;
+}
+
+/// H1 touch point #4/#5: `work.submitted` carries the daemon's bound
+/// estate — its canonical root, not the `[estate] name` — end to end
+/// through a real submission, not a hand-fabricated `Event`.
+#[tokio::test]
+async fn work_submitted_carries_the_bound_estate_root() {
+    let estate_dir = TempDir::new().expect("estate tempdir");
+    scaffold_solo_estate(estate_dir.path(), "target");
+    let data_dir = TempDir::new().expect("data dir tempdir");
+    let handle = daemon::start_with(
+        data_dir.path(),
+        DaemonConfig {
+            estate_root: Some(estate_dir.path().to_path_buf()),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start");
+    let http = client();
+
+    let (status, _, body) = submit(&http, &handle, &ulid(), "carry the estate root").await;
+    assert_eq!(status, 201, "submit must accept: {body}");
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+
+    handle.shutdown().await;
+
+    let canonical_root =
+        std::fs::canonicalize(estate_dir.path()).expect("canonicalize estate root");
+    let submitted = Journal::replay_data_dir(data_dir.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .find(|e| e.kind == KIND_WORK_SUBMITTED && e.work_id.as_deref() == Some(&work_id))
+        .expect("work.submitted journaled");
+    assert_eq!(
+        submitted.workspace_id.as_deref(),
+        Some(canonical_root.to_string_lossy().as_ref()),
+        "work.submitted must carry the daemon's bound estate root"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Wave W1a of sprint S1 (Host runtime), per the workspace sprint plan
(`knowledge/evidence/resources/host-atlas-s1-series/sprint-plan-2026-08-25.md`, decision **D1**).

- `EventDraft::with_workspace_id`; `Engine::commit` (the one chokepoint) stamps the pinned canonical estate root into every engine-committed event's envelope; absent when no estate is pinned.
- `work.submitted`'s API draft carries the resolved plan's estate root; the two `#[cfg(test)]` fixture sites stay `None` with comments naming why.
- Analytics `work` table gains `estate_root` folded once at `work.submitted` — a forever-`pending` Work now has an estate coordinate. The display-name `estate` column and its `workflow.bound` fold are untouched (D1: name stays display-only).
- Compatibility: legacy journal lines (no `workspace_id`; pre-Phase-C literal `estate` strings) replay unchanged; `estate_root_phase_c_scope_replay_tests` green untouched.

Gates: fmt/clippy `-D warnings` clean; targeted suites green; blind 4-axis panel + refuters run — one confirmed finding (non-revert-sensitive negative test) fixed in the follow-up commit.

Known-environmental: `m2_daemon_api` fails the same 9 real-daemon-spawn/e2e tests on the **unmodified 062b59e5 baseline** on the dev host (verified three ways incl. `git stash`); CI by SHA here is the decisive check.

Rungs: J3 (sprint plan D1, panel adjudication), R2 (field, chokepoint, and fold pattern all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4