### PR TITLE
S1/W4c: service packaging, host doctor rows, spawn-failure diagnostics (#275, #276; stretch #282)

### DIFF
--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -138,3 +138,15 @@ cov_stage_end 1 "the coverage_stage_membership test binary must write its own pr
 cov_stage_begin c2-docs_contract
 cov_run cargo llvm-cov --no-report --test docs_contract --locked || cov_fail "docs_contract failed under instrumentation"
 cov_stage_end 1 "the docs_contract test binary must write its own profile"
+
+# W4c fixer sweep (#231(b)): wired at recovery time — the suite's own
+# authorship commit (e01a53fb) left it invoked by neither stage script, the
+# exact #231 gap coverage_stage_membership.rs exists to catch. Sits in C2,
+# not C3, for codex_backend's/opencode_backend's/agy_backend's exact reasons:
+# every `daemon install-service` case exercised here uses an injected fake
+# `systemctl`/`launchctl` shell-script stand-in (`write_fake_binary`, this
+# suite's own SGT_SYSTEMCTL_BIN precedent) or no external process at all
+# (`doctor`, `init`); no case spawns a real `sgt daemon`. Floor 1.
+cov_stage_begin c2-w4c_service_doctor
+cov_run cargo llvm-cov --no-report --test w4c_service_doctor --locked || cov_fail "w4c_service_doctor failed under instrumentation"
+cov_stage_end 1 "the w4c_service_doctor test binary must write its own profile (its fake systemctl/launchctl binaries are shell-script stand-ins, uninstrumented and no loss, per codex_backend's precedent)"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2501,20 +2501,37 @@ fn spawn_daemon(data_dir: &Path, estate_root: &Path) -> Result<(), CliError> {
 /// `spawn_daemon` already opened, so the reason survives even when nothing
 /// interactive is watching stderr (a systemd-launched daemon has no such
 /// terminal at all — the exact gap this deliverable closes).
-fn spawn_daemon_error(e: std::io::Error, mut log: std::fs::File) -> CliError {
+fn spawn_daemon_error(e: std::io::Error, log: std::fs::File) -> CliError {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let path = std::env::var_os("PATH");
+    spawn_daemon_error_with(e, log, home.as_deref(), path.as_ref(), |d| d.exists())
+}
+
+/// The injectable core of [`spawn_daemon_error`] — real `HOME`/`PATH` and a
+/// real filesystem `exists` check in production, a controlled `home`/`path`/
+/// `exists` in tests, the same injection shape as
+/// [`crate::harness::dirs_missing_from_path`] itself. Both halves of #275's
+/// deliverable live here together — the diagnostic appended to the returned
+/// message, and the identical reason written to `log` — so a test calling
+/// this once and reading `log` back afterward can assert the two stayed in
+/// sync, exactly the gap that used to let a spawn failure vanish for a
+/// systemd-launched daemon with no terminal to print to.
+fn spawn_daemon_error_with(
+    e: std::io::Error,
+    mut log: std::fs::File,
+    home: Option<&Path>,
+    path: Option<&OsString>,
+    exists: impl Fn(&Path) -> bool,
+) -> CliError {
     use std::io::Write;
 
     let path_diagnostic = if matches!(
         e.kind(),
         std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
     ) {
-        std::env::var_os("HOME").and_then(|home| {
-            let dirs = crate::harness::toolchain_path_dirs(Path::new(&home));
-            let missing = crate::harness::dirs_missing_from_path(
-                std::env::var_os("PATH").as_ref(),
-                &dirs,
-                |d| d.exists(),
-            );
+        home.and_then(|home| {
+            let dirs = crate::harness::toolchain_path_dirs(home);
+            let missing = crate::harness::dirs_missing_from_path(path, &dirs, exists);
             if missing.is_empty() {
                 None
             } else {
@@ -5898,5 +5915,78 @@ mod tests {
         let (dir, source) = resolve_host_runtime_dir(None, probe).unwrap();
         assert_eq!(source, DataDirSource::PlatformFallback);
         assert_eq!(dir, crate::platform::data_dir::fallback_dir(probe).unwrap());
+    }
+
+    /// W4c panel finding: `spawn_daemon_error` used to have no test proving
+    /// either half of #275's own deliverable actually happens. This drives
+    /// [`spawn_daemon_error_with`] — the injectable core — with a `NotFound`
+    /// error and a `home` whose `.cargo/bin` exists but is absent from
+    /// `path`, then checks *both* halves against the one call: the returned
+    /// message names the missing dir (the diagnostic half), and the exact
+    /// same reason is what landed in the log file (the logging half).
+    /// Deleting the `path_diagnostic` computation (reverting it to always
+    /// `None`) fails the first assertion; deleting the `writeln!` in
+    /// `spawn_daemon_error_with` (reverting the logging half) fails the
+    /// second — each half is independently revert-sensitive.
+    #[test]
+    fn spawn_daemon_error_names_missing_path_dirs_in_both_message_and_log() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(home.join(".cargo").join("bin")).expect("mk .cargo/bin");
+        let log_path = tmp.path().join("daemon.log");
+        let log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .expect("open log");
+
+        let e = std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory");
+        let err = spawn_daemon_error_with(
+            e,
+            log,
+            Some(&home),
+            None, // PATH carries none of the toolchain dirs
+            |d| d.exists(),
+        );
+
+        let message = err.to_string();
+        assert!(
+            message.contains(".cargo/bin") && message.contains("not on PATH"),
+            "message must name the missing PATH dir: {message}"
+        );
+
+        let logged = std::fs::read_to_string(&log_path).expect("read log");
+        assert!(
+            logged.contains("spawn failed:") && logged.contains(".cargo/bin"),
+            "log must carry the same named reason: {logged}"
+        );
+        assert!(
+            logged.contains(&message),
+            "log's reason must match the returned message exactly: log={logged} message={message}"
+        );
+    }
+
+    /// The counterpart to the test above: when none of the toolchain dirs
+    /// exist on disk, `spawn_daemon_error_with` must not fabricate a
+    /// diagnostic — the plain `io::Error` text is the whole message, and
+    /// that same plain text is still what reaches the log.
+    #[test]
+    fn spawn_daemon_error_adds_no_diagnostic_when_no_toolchain_dirs_exist() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let home = tmp.path().join("home-without-toolchain-dirs");
+        let log_path = tmp.path().join("daemon.log");
+        let log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .expect("open log");
+
+        let e = std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory");
+        let err = spawn_daemon_error_with(e, log, Some(&home), None, |d| d.exists());
+
+        let message = err.to_string();
+        assert_eq!(message, "cannot spawn daemon: No such file or directory");
+        let logged = std::fs::read_to_string(&log_path).expect("read log");
+        assert!(logged.contains(&message), "log must match: {logged}");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3744,8 +3744,17 @@ pub(crate) mod doctor {
     ///
     /// Two unconditional severities:
     /// - The literal substring `sergeant-rs-workspace` anywhere in the
-    ///   installed corpus is always a `Fail` — a route into a private,
-    ///   unshipped repository is wrong in principle for a consumer estate.
+    ///   sgt-owned corpus is a `Fail` — a route into a private, unshipped
+    ///   repository is wrong in principle for a consumer estate. #282: for
+    ///   `AGENTS.md` this is scoped to the `sgt:managed` block only — the
+    ///   rest of the file is user-authored content
+    ///   (`domain::distro::write_agents_md`'s own contract), and a consumer
+    ///   estate's own constitution citing its own paths is not this
+    ///   binary's mistake to fail on (found live on the dev workspace's own
+    ///   estate, whose `AGENTS.md` legitimately cites
+    ///   `sergeant-rs-workspace` paths because that estate IS that
+    ///   repository). A malformed `AGENTS.md` with no markers falls back to
+    ///   the whole file — fail closed, never a silent skip.
     /// - A dead `AGENTS.md ... step N` anchor cited anywhere when
     ///   `AGENTS.md` itself has no matching `step N` text.
     ///
@@ -3786,12 +3795,42 @@ pub(crate) mod doctor {
                 continue;
             };
             let rel = path.strip_prefix(estate_root).unwrap_or(path);
+            let is_agents_md = *path == estate_root.join("AGENTS.md");
 
-            if text.contains("sergeant-rs-workspace") {
+            // #282: `AGENTS.md` outside the `sgt:managed` block is
+            // user-authored (`domain::distro::write_agents_md`'s own
+            // contract) — a consumer estate's own constitution citing its
+            // own paths (including, on this very repo's dev estate, a path
+            // that happens to spell `sergeant-rs-workspace` because that IS
+            // this estate) is not sgt's mistake to fail on. Every other
+            // source here (`skills/`, `.sergeant/workflows/`,
+            // `.sergeant/common/contexts/`) is entirely sgt-owned, so the
+            // unconditional rule still applies to the whole file there.
+            // A malformed `AGENTS.md` with no markers at all falls back to
+            // checking the whole file — fail closed, never silently skip.
+            let workspace_check_text: &str = if is_agents_md {
+                match (
+                    text.find(crate::domain::distro::MANAGED_BEGIN),
+                    text.find(crate::domain::distro::MANAGED_END),
+                ) {
+                    (Some(begin), Some(end)) if begin <= end => {
+                        &text[begin..end + crate::domain::distro::MANAGED_END.len()]
+                    }
+                    _ => &text,
+                }
+            } else {
+                &text
+            };
+            if workspace_check_text.contains("sergeant-rs-workspace") {
                 fails.push(format!(
                     "{} cites `sergeant-rs-workspace` — a private, unshipped repository \
-                     path",
-                    rel.display()
+                     path{}",
+                    rel.display(),
+                    if is_agents_md {
+                        " (inside the sgt:managed block)"
+                    } else {
+                        ""
+                    }
                 ));
             }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -355,6 +355,28 @@ enum DaemonCommand {
     /// Idempotent: stopping a daemon that is not running, or one already
     /// mid-drain from an earlier `sgt daemon stop`, is not an error.
     Stop,
+    /// Generate the native per-user service unit for the host daemon (H1
+    /// §2, #275/#276): a systemd user unit on Linux, a macOS LaunchAgent
+    /// elsewhere — pointed at [`resolve_host_runtime_dir`]'s host runtime
+    /// root, with `harness::toolchain_path_dirs`' PATH enrichment baked
+    /// into the unit's own `Environment=`/`EnvironmentVariables` at
+    /// generation time (#275's fix — never an inline prefix on the start
+    /// command, `scripts/gate.sh`'s own measured Cerberus hazard).
+    ///
+    /// Without `--print`: writes the unit/plist to its native per-user
+    /// location and, when a service manager is reachable, enables it
+    /// (`systemctl --user daemon-reload && enable`,
+    /// `launchctl bootstrap`). A manager that is not reachable is not an
+    /// error — the files are still written, and the check names the
+    /// remedy (H1-05: no silent linger enabling). Idempotent: re-running
+    /// against an unchanged binary/PATH writes nothing and does not
+    /// restart an already-enabled unit.
+    InstallService {
+        /// Write the generated unit/plist to stdout instead of the native
+        /// per-user location. Never attempts enablement.
+        #[arg(long)]
+        print: bool,
+    },
 }
 
 /// `sgt repo ...` subcommands (MVP-3).
@@ -775,14 +797,12 @@ fn resolve_data_dir(
 /// (`Manifest`/`EstateDefault` simply never occur here — there is no
 /// estate rung on this ladder at all).
 ///
-/// `#[allow(dead_code)]`: not yet a caller's problem. This wave (W1b) lands
-/// the resolver and its own unit tests only — no `cli.rs` caller is
-/// rewired onto it, by design (see the doc comment above and the brief's
-/// "zero behavior change"). W2/W3 are the waves that call this from
-/// `dispatch`/`ensure_daemon`'s host-scoped paths; the same
-/// production-dead-until-wired shape [`crate::platform::data_dir`]'s own
-/// `FREEDESKTOP`/`MACOS` constants already use.
-#[allow(dead_code)]
+/// W1b landed this resolver with no caller (`#[allow(dead_code)]`,
+/// "zero behavior change" by design). **W4c is this seat's first caller**:
+/// [`install_service`] resolves the host runtime root a generated unit
+/// points at through this exact function, not a second copy of the ladder
+/// — W2/W3 remain the waves that rewire `dispatch`/`ensure_daemon`'s own
+/// host-scoped paths onto it.
 fn resolve_host_runtime_dir(
     flag: Option<PathBuf>,
     env: impl Fn(&str) -> Option<OsString>,
@@ -884,6 +904,18 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                 ));
             }
             daemon_stop(&data_dir, &estate_root(&estate), sgt.json).await
+        }
+        Command::Daemon {
+            command: Some(DaemonCommand::InstallService { print }),
+            rebuild_cache,
+        } => {
+            if rebuild_cache {
+                return Err(CliError::new(
+                    "--rebuild-cache applies only to `sgt daemon` (foreground start); \
+                     `sgt daemon install-service` does not start a daemon",
+                ));
+            }
+            install_service(data_dir_flag, print, sgt.json)
         }
         Command::Status => {
             let client = observe_connect(&data_dir, &estate_root(&estate)).await?;
@@ -1369,6 +1401,35 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // rather than left behind (#241). It writes only within `cwd`,
             // and never inside `.sergeant/local/`.
             let distro_outcome = crate::domain::distro::write_distro(&cwd)?;
+            // H1 recon risk 2: `sgt init` had zero concept of a host-level,
+            // cross-estate bootstrap step — no service-unit generation, no
+            // host data-dir creation, no "is this the first estate on this
+            // host" branch anywhere in this path. This is that branch, kept
+            // to exactly what the risk note asks for and no more: create
+            // the host runtime root the *first* time it is missing, and
+            // point at `sgt daemon install-service` — never install a
+            // service, never touch a live daemon, so a second/Nth estate's
+            // `sgt init` on an already-bootstrapped host is a true no-op
+            // here (idempotent: `host_runtime_dir.exists()` is the whole
+            // guard).
+            // Resolution failure (no flag/env and `$HOME` unset — the same
+            // last rung `resolve_data_dir`'s own pre-estate fallback can
+            // hit) must not turn into an `sgt init` regression on a host
+            // with no host-runtime concept available: this step degrades
+            // to "nothing to bootstrap" rather than failing the whole
+            // command, the same advisory posture `claude`/`docker`'s rows
+            // already take at init time.
+            let host_bootstrap: Option<(PathBuf, bool)> =
+                resolve_host_runtime_dir(data_dir_flag.clone(), |name| std::env::var_os(name))
+                    .ok()
+                    .map(|(host_runtime_dir, _source)| {
+                        let created = if host_runtime_dir.exists() {
+                            false
+                        } else {
+                            std::fs::create_dir_all(&host_runtime_dir).is_ok()
+                        };
+                        (host_runtime_dir, created)
+                    });
             // Re-resolve now that `sergeant.toml` exists: the `data_dir`
             // computed above ran before `init_estate` created it, so on a
             // fresh estate estate discovery had nothing to find yet and
@@ -1396,6 +1457,10 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                         "distro_symlink_unavailable": distro_outcome.symlink_unavailable,
                         "changed": outcome.changed() || distro_outcome.changed(),
                     },
+                    "host_bootstrap": host_bootstrap.as_ref().map(|(dir, created)| json!({
+                        "host_runtime_dir": dir,
+                        "created": created,
+                    })),
                     "doctor": report.to_json(),
                 }));
             } else {
@@ -1449,6 +1514,17 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                     println!(
                         "estate at {} is already initialized — nothing to do",
                         cwd.display()
+                    );
+                }
+                if let Some((host_runtime_dir, true)) = &host_bootstrap {
+                    println!();
+                    println!(
+                        "host runtime root created at {}",
+                        host_runtime_dir.display()
+                    );
+                    println!(
+                        "  run `sgt daemon install-service` to install the native per-user \
+                         service unit for the host daemon (H1 §2) — not done automatically"
                     );
                 }
                 println!();
@@ -2389,7 +2465,7 @@ fn spawn_daemon(data_dir: &Path, estate_root: &Path) -> Result<(), CliError> {
         .arg("daemon")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::from(log.try_clone()?))
-        .stderr(std::process::Stdio::from(log));
+        .stderr(std::process::Stdio::from(log.try_clone()?));
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -2397,8 +2473,73 @@ fn spawn_daemon(data_dir: &Path, estate_root: &Path) -> Result<(), CliError> {
         // and not receive the client's signals.
         command.process_group(0);
     }
-    command.spawn()?;
+    // #275's cli-side share: a bare `e?` here used to vanish the spawn
+    // failure into a generic message with no PATH diagnostic and nothing
+    // logged for a caller with no terminal (systemd) to ever see it.
+    // `spawn_daemon_error` prints *and* logs a named reason instead.
+    //
+    // W2 seam: the daemon-side half of #275 — journaling a `NotFound`/
+    // PATH-shaped backend-spawn failure (`Command::new(claude_cli).spawn()`
+    // and friends inside `src/daemon.rs`) as a Work-visible reason at the
+    // actual call site — is W2's file to change, not this one. It can reuse
+    // this same `harness::dirs_missing_from_path` diagnostic.
+    if let Err(e) = command.spawn() {
+        return Err(spawn_daemon_error(e, log));
+    }
     Ok(())
+}
+
+/// #275's cli-side share: a spawn failure that used to vanish into a bare
+/// `io::Error` message now prints *and* logs a named reason. `NotFound`/
+/// `PermissionDenied` are exactly #60's failure shape — the same fact
+/// `doctor::environment_check` already surfaces (a toolchain dir exists on
+/// disk but is not on `PATH`, so an exec that depends on it reads as a
+/// permissions fault) — so this reuses that check's exact underlying
+/// diagnostic ([`crate::harness::dirs_missing_from_path`], the identical
+/// list `doctor` prints) rather than inventing a second copy that could
+/// silently disagree with it. `log` is the same `daemon.log` handle
+/// `spawn_daemon` already opened, so the reason survives even when nothing
+/// interactive is watching stderr (a systemd-launched daemon has no such
+/// terminal at all — the exact gap this deliverable closes).
+fn spawn_daemon_error(e: std::io::Error, mut log: std::fs::File) -> CliError {
+    use std::io::Write;
+
+    let path_diagnostic = if matches!(
+        e.kind(),
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+    ) {
+        std::env::var_os("HOME").and_then(|home| {
+            let dirs = crate::harness::toolchain_path_dirs(Path::new(&home));
+            let missing = crate::harness::dirs_missing_from_path(
+                std::env::var_os("PATH").as_ref(),
+                &dirs,
+                |d| d.exists(),
+            );
+            if missing.is_empty() {
+                None
+            } else {
+                Some(format!(
+                    "; {} exist{} on disk but {} not on PATH (#60/#275's failure shape) — \
+                     this is likely why the exec failed",
+                    missing
+                        .iter()
+                        .map(|d| d.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    if missing.len() == 1 { "s" } else { "" },
+                    if missing.len() == 1 { "is" } else { "are" },
+                ))
+            }
+        })
+    } else {
+        None
+    };
+    let message = format!(
+        "cannot spawn daemon: {e}{}",
+        path_diagnostic.as_deref().unwrap_or("")
+    );
+    let _ = writeln!(log, "spawn failed: {message}");
+    CliError::new(message)
 }
 
 /// How long `sgt daemon stop` waits for `active` work to settle before
@@ -2539,6 +2680,236 @@ fn report_daemon_stop(json: bool, status: &str, message: &str) {
         print_json(&json!({"status": status, "message": message}));
     } else {
         println!("{message}");
+    }
+}
+
+/// `sgt daemon install-service` (H1 §2, #275/#276): generate the native
+/// per-user service unit for the host daemon and, unless `--print`, write
+/// it and attempt enablement.
+///
+/// `--print` is a pure dry run: generate, print to stdout, touch nothing on
+/// disk, attempt no enablement — the golden-file content a test or an
+/// operator inspecting before installing sees is exactly what this
+/// function would otherwise write. Otherwise: the unit/plist is written to
+/// its native per-user location via [`crate::runtime::fsutil::write_atomic`]
+/// (the same idempotent-write discipline `domain::distro::write_distro`
+/// already uses — unchanged content is not rewritten), and enablement is
+/// attempted only when [`enable_service`]'s manager probe says one is
+/// reachable (the `docker_check` degradation pattern: an absent/unreachable
+/// manager is a named, non-fatal fact). Exit 0 whenever the unit/plist is
+/// written; nonzero only on an actual write failure — a skipped enablement
+/// is reported, never turned into a command failure (H1-05: no silent
+/// linger enabling means the *absence* must stay visible, not that this
+/// command must fail because of it).
+fn install_service(
+    data_dir_flag: Option<PathBuf>,
+    print: bool,
+    json: bool,
+) -> Result<(), CliError> {
+    // The host runtime root, not the estate-scoped `data_dir` — H1 §3's
+    // whole point is that the daemon a unit supervises is decoupled from
+    // any one estate (W1b's seam; see `resolve_host_runtime_dir`'s own doc
+    // comment).
+    let (host_runtime_dir, _source) =
+        resolve_host_runtime_dir(data_dir_flag, |name| std::env::var_os(name))?;
+    let binary_path = std::env::current_exe()?;
+    let home = std::env::var_os("HOME").ok_or_else(|| {
+        CliError::new(
+            "cannot compose the service unit's PATH enrichment: $HOME is not set — set HOME \
+             and retry",
+        )
+    })?;
+    let home = PathBuf::from(home);
+    let dirs = crate::harness::toolchain_path_dirs(&home);
+    // #275's fix, baked in here rather than left to the manager's own
+    // inherited environment (`scripts/gate.sh`'s measured Cerberus hazard,
+    // see `platform::service`'s module doc): the composed PATH becomes part
+    // of the generated content itself.
+    let path =
+        crate::harness::compose_path(std::env::var_os("PATH").as_ref(), &dirs, |d| d.exists())
+            .to_string_lossy()
+            .into_owned();
+    let spec = crate::platform::service::ServiceSpec {
+        binary_path,
+        host_runtime_dir,
+        path,
+    };
+
+    #[cfg(target_os = "macos")]
+    let (content, install_path) = (
+        crate::platform::service::launchd_plist(&spec),
+        crate::platform::service::launchd_plist_path(&home),
+    );
+    #[cfg(not(target_os = "macos"))]
+    let (content, install_path) = (
+        crate::platform::service::systemd_unit(&spec),
+        crate::platform::service::systemd_unit_path(&home),
+    );
+
+    if print {
+        print!("{content}");
+        return Ok(());
+    }
+
+    if let Some(parent) = install_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    crate::runtime::fsutil::write_atomic(&install_path, content.as_bytes())?;
+
+    let enable = enable_service(&install_path);
+    report_install_service(json, &install_path, &enable);
+    Ok(())
+}
+
+/// What happened when [`install_service`] tried to enable the just-written
+/// unit/plist.
+enum EnableOutcome {
+    /// The manager was reachable and both the reload/bootstrap and the
+    /// enable step succeeded.
+    Enabled,
+    /// No attempt was made — the manager is not reachable from this
+    /// session. Never a command failure (H1-05): the files are already
+    /// written, and `remedy` names what to do next.
+    Skipped { remedy: String },
+    /// The manager was reachable but the enable attempt itself failed.
+    /// Also never a command failure by itself — the files are already
+    /// written and stand on their own; `detail` is the evidence.
+    Failed { detail: String },
+}
+
+/// Linux arm: probe `systemctl --user`, and only on [`ManagerStatus::
+/// Reachable`] run `daemon-reload` then `enable --now` against the unit
+/// just written. `unit_path`'s file name (not the whole path — `systemctl
+/// --user enable` resolves unit names against its own search path, which
+/// already includes [`crate::platform::service::systemd_user_unit_dir`])
+/// is what gets enabled.
+#[cfg(not(target_os = "macos"))]
+fn enable_service(unit_path: &Path) -> EnableOutcome {
+    use crate::platform::service::ManagerStatus;
+
+    match crate::platform::service::detect_systemd_status() {
+        ManagerStatus::Reachable => {
+            let unit_name = unit_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(crate::platform::service::SYSTEMD_UNIT_NAME);
+            let reload = std::process::Command::new("systemctl")
+                .args(["--user", "daemon-reload"])
+                .status();
+            let enable = std::process::Command::new("systemctl")
+                .args(["--user", "enable", "--now", unit_name])
+                .status();
+            match (reload, enable) {
+                (Ok(r), Ok(e)) if r.success() && e.success() => EnableOutcome::Enabled,
+                (reload, enable) => EnableOutcome::Failed {
+                    detail: format!(
+                        "systemctl --user daemon-reload/enable --now {unit_name} did not both \
+                         succeed: daemon-reload={reload:?}, enable={enable:?}"
+                    ),
+                },
+            }
+        }
+        ManagerStatus::PresentNoUserSession { detail } => EnableOutcome::Skipped {
+            remedy: format!(
+                "a systemd user manager is installed but not reachable from this session \
+                 ({detail}) — this is the common bare SSH/cron shape (no user D-Bus session); \
+                 run `loginctl enable-linger $USER` and start a session with one (a desktop \
+                 login, or `machinectl shell`/`systemd-run --user` from an already-lingering \
+                 session), then re-run `sgt daemon install-service`"
+            ),
+        },
+        ManagerStatus::Absent => EnableOutcome::Skipped {
+            remedy: "no systemd user manager was found on PATH — the unit file has been \
+                      written at the path above; install one and re-run `sgt daemon \
+                      install-service`, or continue running `sgt daemon` in the foreground as \
+                      the development/diagnostic path (H1 §2)"
+                .to_string(),
+        },
+    }
+}
+
+/// macOS arm: probe `launchctl print gui/$UID`, and only on
+/// [`ManagerStatus::Reachable`] run `launchctl bootstrap`. `$UID` is read
+/// via `id -u` rather than a new libc/nix dependency for one syscall's
+/// worth of value (R2/R6: `daemon_stop`'s SIGTERM path already shells out
+/// to `kill` for the identical reason).
+#[cfg(target_os = "macos")]
+fn enable_service(plist_path: &Path) -> EnableOutcome {
+    use crate::platform::service::ManagerStatus;
+
+    let Some(uid) = macos_uid() else {
+        return EnableOutcome::Skipped {
+            remedy: "could not determine this user's UID (`id -u` failed) — the plist has \
+                      been written at the path above; run `launchctl bootstrap gui/$(id -u) \
+                      <path>` yourself, or continue running `sgt daemon` in the foreground as \
+                      the development/diagnostic path (H1 §2)"
+                .to_string(),
+        };
+    };
+    match crate::platform::service::detect_launchd_status(uid) {
+        ManagerStatus::Reachable => {
+            let bootstrap = std::process::Command::new("launchctl")
+                .args(["bootstrap", &format!("gui/{uid}")])
+                .arg(plist_path)
+                .status();
+            match bootstrap {
+                Ok(status) if status.success() => EnableOutcome::Enabled,
+                other => EnableOutcome::Failed {
+                    detail: format!(
+                        "launchctl bootstrap gui/{uid} {}: {other:?}",
+                        plist_path.display()
+                    ),
+                },
+            }
+        }
+        ManagerStatus::PresentNoUserSession { detail } => EnableOutcome::Skipped {
+            remedy: format!(
+                "launchd is present but this session's GUI/user domain is not reachable \
+                 ({detail}) — this typically means no GUI session (bare SSH); log in \
+                 interactively, then re-run `sgt daemon install-service`"
+            ),
+        },
+        ManagerStatus::Absent => EnableOutcome::Skipped {
+            remedy: "launchctl was not found on PATH — the plist file has been written at the \
+                      path above; install one and re-run `sgt daemon install-service`, or \
+                      continue running `sgt daemon` in the foreground as the \
+                      development/diagnostic path (H1 §2)"
+                .to_string(),
+        },
+    }
+}
+
+/// `id -u`, the one-syscall value `enable_service`'s macOS arm needs
+/// without a new dependency.
+#[cfg(target_os = "macos")]
+fn macos_uid() -> Option<u32> {
+    let output = std::process::Command::new("id").arg("-u").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
+/// `sgt daemon install-service`'s one report shape, human or `--json`.
+fn report_install_service(json: bool, install_path: &Path, enable: &EnableOutcome) {
+    let (enabled, remedy_or_detail) = match enable {
+        EnableOutcome::Enabled => (true, None),
+        EnableOutcome::Skipped { remedy } => (false, Some(remedy.clone())),
+        EnableOutcome::Failed { detail } => (false, Some(detail.clone())),
+    };
+    if json {
+        print_json(&json!({
+            "written": install_path,
+            "enabled": enabled,
+            "remedy": remedy_or_detail,
+        }));
+    } else {
+        println!("wrote {}", install_path.display());
+        match enable {
+            EnableOutcome::Enabled => println!("enabled and started"),
+            EnableOutcome::Skipped { remedy } => println!("not enabled: {remedy}"),
+            EnableOutcome::Failed { detail } => println!("enable attempt failed: {detail}"),
+        }
     }
 }
 
@@ -2780,6 +3151,12 @@ pub(crate) mod doctor {
         checks.push(journal_check);
         checks.push(projection_check(journal_ok, journal_events.as_deref()));
         checks.push(daemon_check(data_dir).await);
+        // H1 §2/#276: "is a native per-user service manager reachable at
+        // all" — a distinct question from `daemon_check`'s per-data-dir
+        // descriptor health above, and the prerequisite `sgt daemon
+        // install-service`'s enablement step probes identically (never a
+        // second, disagreeing probe).
+        checks.push(host_service_manager_check());
         // §4.2: `sgt doctor` is usable outside an estate and never searches
         // upward. The estate-root row is the one that says out loud whether
         // this directory is an estate root at all — a failing row with the
@@ -2789,6 +3166,11 @@ pub(crate) mod doctor {
         // by name instead of each re-deriving the same answer.
         let (estate_root_check, admitted) = estate_root_check(root);
         checks.push(estate_root_check);
+        // H1 §6's cutover gate: is this estate still carrying daemon state
+        // under its own `.sergeant/data` from before a host runtime root
+        // existed. Threaded off `admitted` the same way the rows below it
+        // are — never a second, independent estate-root search.
+        checks.push(legacy_estate_runtime_check(admitted.as_deref()));
         checks.push(permission_mode_check(admitted.as_deref()));
         checks.push(network_access_check(admitted.as_deref()));
         checks.push(estate_check(admitted.as_deref()));
@@ -4637,6 +5019,135 @@ pub(crate) mod doctor {
                 "harmless: a mutating verb (`run`, `respond`, `retry`, `extend`, `cancel`) or \
                  `sgt daemon` spawns a fresh daemon, which republishes it — observation verbs \
                  refuse instead rather than spawning one just to observe it (ADR 0009)",
+            )
+        }
+    }
+
+    /// H1 §2/#276: "if a supported Linux environment has no usable native
+    /// user service manager, `sgt doctor` names that missing host
+    /// prerequisite" — and macOS's `launchctl` gets the equivalent probe.
+    /// Reuses [`crate::platform::service::detect_systemd_status`]/
+    /// [`detect_launchd_status`] — the identical probe `sgt daemon
+    /// install-service`'s own enablement step runs, so the two can never
+    /// disagree about whether a manager is reachable. `Warn`, never `Fail`,
+    /// in every non-`Reachable` case: a dev host with no service manager is
+    /// legal (§17.5's degraded-daemon doctrine, the same posture `docker`'s
+    /// row already takes for a missing capability).
+    fn host_service_manager_check() -> Check {
+        #[cfg(target_os = "macos")]
+        {
+            let Some(uid) = super::macos_uid() else {
+                return Check::warn(
+                    "host_service_manager",
+                    "could not determine this user's UID (`id -u` failed)",
+                    "run `id -u` manually to see why the probe cannot run; without it launchd \
+                     reachability cannot be checked",
+                );
+            };
+            host_service_manager_report(
+                crate::platform::service::detect_launchd_status(uid),
+                "launchd",
+            )
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            host_service_manager_report(
+                crate::platform::service::detect_systemd_status(),
+                "a systemd user manager",
+            )
+        }
+    }
+
+    /// The three-way report shape [`host_service_manager_check`]'s two
+    /// platform arms share — so the wording (and the "dev hosts are legal"
+    /// posture) can never drift between them.
+    fn host_service_manager_report(
+        status: crate::platform::service::ManagerStatus,
+        name: &str,
+    ) -> Check {
+        use crate::platform::service::ManagerStatus;
+
+        match status {
+            ManagerStatus::Reachable => Check::ok(
+                "host_service_manager",
+                format!(
+                    "{name} is reachable — `sgt daemon install-service` can enable the \
+                     generated unit"
+                ),
+            ),
+            ManagerStatus::PresentNoUserSession { detail } => Check::warn(
+                "host_service_manager",
+                format!("{name} is present but not reachable from this session: {detail}"),
+                "the common bare SSH/cron shape (no user D-Bus/GUI session) — dev hosts are \
+                 legal without one; `sgt daemon install-service` still writes the unit/plist, \
+                 it just cannot enable it until a reachable session exists",
+            ),
+            ManagerStatus::Absent => Check::warn(
+                "host_service_manager",
+                format!("no {name} was found on PATH"),
+                "dev hosts are legal without one — `sgt daemon` in the foreground remains the \
+                 development/diagnostic path (H1 §2); `sgt daemon install-service` still writes \
+                 the unit/plist for later",
+            ),
+        }
+    }
+
+    /// H1 §6's cutover gate: does this estate still carry daemon state
+    /// under its own `.sergeant/data` from before a host runtime root
+    /// existed — `daemon.lock`/`runtime.json`/`journal/`, the exact three
+    /// markers [`daemon`]'s own module owns the names of. `Warn`, not
+    /// `Fail`, in this wave: cutover is not flipped until W2/W3 land (this
+    /// row exists and is tested ahead of that, per the brief).
+    fn legacy_estate_runtime_check(estate_root: Option<&Path>) -> Check {
+        let Some(estate_root) = estate_root else {
+            return Check::ok(
+                "legacy_estate_runtime",
+                "not an estate root — nothing to check",
+            );
+        };
+        // The cutover gate only makes sense once a host runtime root
+        // concept resolves at all on this host — reuses the exact same
+        // ladder `sgt daemon install-service` resolves against, never a
+        // second copy.
+        if super::resolve_host_runtime_dir(None, |name| std::env::var_os(name)).is_err() {
+            return Check::ok(
+                "legacy_estate_runtime",
+                "host runtime root does not resolve on this host (see the `environment` check \
+                 above) — nothing to compare against",
+            );
+        }
+        let legacy_dir = estate_root.join(crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR);
+        let mut found = Vec::new();
+        if legacy_dir.join(daemon::DAEMON_LOCK_FILE).exists() {
+            found.push(daemon::DAEMON_LOCK_FILE.to_string());
+        }
+        if legacy_dir.join(daemon::DESCRIPTOR_FILE).exists() {
+            found.push(daemon::DESCRIPTOR_FILE.to_string());
+        }
+        if legacy_dir.join("journal").is_dir() {
+            found.push("journal/".to_string());
+        }
+        if found.is_empty() {
+            Check::ok(
+                "legacy_estate_runtime",
+                format!(
+                    "no estate-local daemon state found at {}",
+                    legacy_dir.display()
+                ),
+            )
+        } else {
+            Check::warn(
+                "legacy_estate_runtime",
+                format!(
+                    "estate-local daemon state still present at {}: {}",
+                    legacy_dir.display(),
+                    found.join(", "),
+                ),
+                "H1 §6's cutover gate — reconcile or abandon before relying on host mode: stop \
+                 any daemon still running against this estate-local data dir (`sgt daemon stop \
+                 --data-dir <that dir>`), let non-terminal Work drain or explicitly abandon it, \
+                 then re-submit under host mode once it is available; this row stays a warning, \
+                 not a failure, until cutover itself is flipped (W2/W3)",
             )
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2793,10 +2793,16 @@ fn enable_service(unit_path: &Path) -> EnableOutcome {
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or(crate::platform::service::SYSTEMD_UNIT_NAME);
-            let reload = std::process::Command::new("systemctl")
+            // Same binary the probe above just used (`SGT_SYSTEMCTL_BIN`,
+            // default `systemctl`) — a test pointing the probe at a fake
+            // must see these calls go to the identical fake, not a real
+            // `systemctl` this host may not even have.
+            let bin = std::env::var(crate::platform::service::SYSTEMCTL_BIN_ENV)
+                .unwrap_or_else(|_| "systemctl".to_string());
+            let reload = std::process::Command::new(&bin)
                 .args(["--user", "daemon-reload"])
                 .status();
-            let enable = std::process::Command::new("systemctl")
+            let enable = std::process::Command::new(&bin)
                 .args(["--user", "enable", "--now", unit_name])
                 .status();
             match (reload, enable) {
@@ -2848,7 +2854,11 @@ fn enable_service(plist_path: &Path) -> EnableOutcome {
     };
     match crate::platform::service::detect_launchd_status(uid) {
         ManagerStatus::Reachable => {
-            let bootstrap = std::process::Command::new("launchctl")
+            // Same binary the probe above just used — see the systemd
+            // arm's identical note.
+            let bin = std::env::var(crate::platform::service::LAUNCHCTL_BIN_ENV)
+                .unwrap_or_else(|_| "launchctl".to_string());
+            let bootstrap = std::process::Command::new(&bin)
                 .args(["bootstrap", &format!("gui/{uid}")])
                 .arg(plist_path)
                 .status();

--- a/src/domain/distro.rs
+++ b/src/domain/distro.rs
@@ -59,9 +59,12 @@ static CONTEXTS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/.sergeant/comm
 static WORKFLOWS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/.sergeant/workflows");
 
 /// The comment markers delimiting `AGENTS.md`'s sgt-owned managed section.
-/// See [`write_agents_md`].
-const MANAGED_BEGIN: &str = "<!-- sgt:managed:begin -->";
-const MANAGED_END: &str = "<!-- sgt:managed:end -->";
+/// See [`write_agents_md`]. `pub(crate)`: `cli::doctor::doc_routes_check`
+/// (#282) needs the exact same markers to scope its own sgt-owned-content
+/// rule to the managed span, never a second, independently-typed copy of
+/// the marker strings.
+pub(crate) const MANAGED_BEGIN: &str = "<!-- sgt:managed:begin -->";
+pub(crate) const MANAGED_END: &str = "<!-- sgt:managed:end -->";
 
 /// What went wrong writing the distro. Distinct from a bare [`io::Error`]
 /// because the managed-`AGENTS.md` case (below) is not an I/O fault at all

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -27,3 +27,4 @@ pub mod data_dir;
 pub mod disk;
 pub mod fs_locking;
 pub mod process;
+pub mod service;

--- a/src/platform/service.rs
+++ b/src/platform/service.rs
@@ -1,0 +1,473 @@
+//! Native per-user service unit generation and reachability probing (H1
+//! §2, #275/#276).
+//!
+//! Two things live here, kept apart the same way [`super::process`] keeps
+//! `running_processes`/`process_alive` apart — different questions, tested
+//! differently:
+//!
+//! - **Generation** ([`systemd_unit`], [`launchd_plist`]) is pure text
+//!   assembly over a [`ServiceSpec`] — no service manager, no filesystem, no
+//!   subprocess. It is exercised by golden-file tests from any host, always
+//!   (ADR 0002 D3): the systemd arm and the macOS arm are both compiled and
+//!   both tested unconditionally, the same discipline `platform::data_dir`
+//!   already uses for its `FREEDESKTOP`/`MACOS` constants.
+//! - **Reachability** ([`ManagerStatus`], [`detect_status`]) shells out to
+//!   `systemctl --user`/`launchctl`, following the `docker_check` degradation
+//!   pattern: a missing or unreachable manager is a named, warn-not-fail
+//!   fact, never a broken build. The classification logic
+//!   ([`classify_systemctl_output`]) is a plain function over already-
+//!   captured process output, unit-tested directly without a real systemd
+//!   user session — the `SGT_GIT_BIN`-style injectable-binary precedent
+//!   (`runtime::git::GIT_BIN_ENV`) covers the subprocess-integration half via
+//!   [`SYSTEMCTL_BIN_ENV`]/[`LAUNCHCTL_BIN_ENV`], a PATH-shimmed fake binary
+//!   a test can point at.
+//!
+//! **The env-stripping hazard this generator exists to close (#275):**
+//! `scripts/gate.sh`'s own measured incident (Cerberus, 2026-08-11) found
+//! that a systemd-user-managed unit only bakes `HOME`/`PATH` in from the
+//! *manager's* own environment, and silently discards anything set as an
+//! inline prefix on the start command. [`ServiceSpec::path`] is therefore
+//! computed once, at generation time, by the caller (never read from the
+//! environment inside this module) and baked into the unit's own
+//! `Environment=`/the plist's own `EnvironmentVariables` — never assumed to
+//! flow through from whatever shell ran `sgt daemon install-service`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// The generated systemd user unit's file name, unqualified — joined under
+/// [`systemd_user_unit_dir`] to get the full install path.
+pub const SYSTEMD_UNIT_NAME: &str = "sergeant-daemon.service";
+
+/// The generated LaunchAgent's `Label`, and (with `.plist` appended) its
+/// file name under [`launchd_agents_dir`].
+pub const LAUNCHD_LABEL: &str = "com.sergeant.host-daemon";
+
+/// Every input the two generators need — deliberately plain data, not a
+/// struct that reaches into the environment itself, so [`systemd_unit`] and
+/// [`launchd_plist`] stay pure functions of their arguments and golden-file
+/// tests can pin their output byte for byte with substituted paths.
+#[derive(Debug, Clone)]
+pub struct ServiceSpec {
+    /// The current `sgt` binary's own path (`std::env::current_exe()`),
+    /// exec'd with a fixed `--data-dir <host_runtime_dir> daemon` tail — the
+    /// unit does not go through a shell, so no quoting is needed.
+    pub binary_path: PathBuf,
+    /// The host runtime root ([`crate::cli::resolve_host_runtime_dir`]'s
+    /// result — W1b's seam): named explicitly with `--data-dir` rather than
+    /// relying on any inherited environment, the same "name it explicitly,
+    /// never infer it from an environment a detached child does not
+    /// reliably keep" discipline `spawn_daemon` already applies to
+    /// `estate_root`.
+    pub host_runtime_dir: PathBuf,
+    /// PATH, already composed with [`crate::harness::toolchain_path_dirs`]
+    /// baked in by the caller at generation time (#275's fix) — never
+    /// recomputed or read from the environment inside this module. See the
+    /// module doc's env-stripping hazard note.
+    pub path: String,
+}
+
+/// The systemd user unit's full text — `[Unit]`/`[Service]`/`[Install]`,
+/// `ExecStart` pointing at [`ServiceSpec::binary_path`] with
+/// `--data-dir <host_runtime_dir> daemon`, and `Environment=` carrying
+/// [`ServiceSpec::path`] (#275: never an inline prefix on `ExecStart`
+/// itself — see the module doc). Deterministic: the same `spec` always
+/// produces the same bytes, which is what makes [`crate::runtime::fsutil::
+/// write_atomic`]'s idempotent-write pattern ("write only when content
+/// differs") a correct fit for installing it.
+pub fn systemd_unit(spec: &ServiceSpec) -> String {
+    format!(
+        "[Unit]\n\
+         Description=Sergeant host daemon\n\
+         After=network.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={} --data-dir {} daemon\n\
+         Environment=\"PATH={}\"\n\
+         Restart=on-failure\n\
+         RestartSec=5\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+        spec.binary_path.display(),
+        spec.host_runtime_dir.display(),
+        spec.path,
+    )
+}
+
+/// The macOS LaunchAgent plist's full text — `ProgramArguments` carrying
+/// the binary and its argv as separate array entries (no shell, no
+/// quoting-by-string-concatenation), `EnvironmentVariables` carrying
+/// [`ServiceSpec::path`] under the `PATH` key. Risk 5 from this seat's own
+/// recon (`recon-doctor-init-service.md`): a LaunchAgent's
+/// `EnvironmentVariables` has not been measured on real macOS hardware the
+/// way `gate.sh`'s systemd finding has — this generator follows the
+/// documented Apple-side contract (a plain string-keyed dict, no special
+/// expansion), but the "never an inline prefix" fix is applied identically
+/// to both arms on the same reasoning until a macOS measurement pass says
+/// otherwise.
+pub fn launchd_plist(spec: &ServiceSpec) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+         <plist version=\"1.0\">\n\
+         <dict>\n\
+         \t<key>Label</key>\n\
+         \t<string>{label}</string>\n\
+         \t<key>ProgramArguments</key>\n\
+         \t<array>\n\
+         \t\t<string>{binary}</string>\n\
+         \t\t<string>--data-dir</string>\n\
+         \t\t<string>{host_runtime_dir}</string>\n\
+         \t\t<string>daemon</string>\n\
+         \t</array>\n\
+         \t<key>EnvironmentVariables</key>\n\
+         \t<dict>\n\
+         \t\t<key>PATH</key>\n\
+         \t\t<string>{path}</string>\n\
+         \t</dict>\n\
+         \t<key>RunAtLoad</key>\n\
+         \t<true/>\n\
+         \t<key>KeepAlive</key>\n\
+         \t<true/>\n\
+         \t<key>ProcessType</key>\n\
+         \t<string>Background</string>\n\
+         </dict>\n\
+         </plist>\n",
+        label = LAUNCHD_LABEL,
+        binary = spec.binary_path.display(),
+        host_runtime_dir = spec.host_runtime_dir.display(),
+        path = spec.path,
+    )
+}
+
+/// `~/.config/systemd/user/` — the native per-user unit directory
+/// (freedesktop convention; not `$XDG_CONFIG_HOME`-overridable here because
+/// `systemctl --user` itself does not honor that override for unit search
+/// either, only for its own config).
+pub fn systemd_user_unit_dir(home: &Path) -> PathBuf {
+    home.join(".config").join("systemd").join("user")
+}
+
+/// `~/Library/LaunchAgents/` — the native per-user LaunchAgent directory.
+pub fn launchd_agents_dir(home: &Path) -> PathBuf {
+    home.join("Library").join("LaunchAgents")
+}
+
+/// [`launchd_agents_dir`] joined with `{LAUNCHD_LABEL}.plist` — the exact
+/// install path `launchctl bootstrap` expects to find.
+pub fn launchd_plist_path(home: &Path) -> PathBuf {
+    launchd_agents_dir(home).join(format!("{LAUNCHD_LABEL}.plist"))
+}
+
+/// [`systemd_user_unit_dir`] joined with [`SYSTEMD_UNIT_NAME`].
+pub fn systemd_unit_path(home: &Path) -> PathBuf {
+    systemd_user_unit_dir(home).join(SYSTEMD_UNIT_NAME)
+}
+
+/// Overrides the `systemctl` binary [`detect_systemd_status`] shells out to
+/// — mirrors `runtime::git::GIT_BIN_ENV` (a scripted fake stands in for a
+/// real user D-Bus session, which CI does not have). Read fresh on every
+/// call for the same reason `GIT_BIN_ENV` is: a cached value would leak one
+/// test's override into another's in a parallel run.
+pub const SYSTEMCTL_BIN_ENV: &str = "SGT_SYSTEMCTL_BIN";
+
+/// Overrides the `launchctl` binary [`detect_launchd_status`] shells out to.
+pub const LAUNCHCTL_BIN_ENV: &str = "SGT_LAUNCHCTL_BIN";
+
+/// The three-way answer `sgt doctor`'s `host_service_manager` row (#276)
+/// needs: a supported manager reachable and usable right now, present but
+/// unusable from this session, or genuinely absent. Each has its own
+/// remedy — collapsing `PresentNoUserSession` into `Absent` would tell an
+/// SSH/cron operator to install something that is already installed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManagerStatus {
+    /// The manager answered a reachability probe successfully.
+    Reachable,
+    /// The manager binary exists and ran, but reported it cannot reach a
+    /// user session (e.g. `systemctl --user` with no D-Bus session — common
+    /// in bare SSH/cron contexts per this seat's recon, risk 6).
+    PresentNoUserSession {
+        /// The manager's own stderr, trimmed — the most useful evidence to
+        /// surface verbatim.
+        detail: String,
+    },
+    /// The manager binary could not be found or executed at all.
+    Absent,
+}
+
+/// The classification logic proper, over already-captured process output —
+/// unit-tested directly (no real systemd user session needed) per this
+/// seat's recon's stated preference for whichever of the two test shapes
+/// fits; this one needs no PATH shim at all. Shared by both
+/// [`detect_systemd_status`]'s real-subprocess arm and its tests: they can
+/// never silently disagree about what a given `systemctl --user` outcome
+/// means.
+fn classify_systemctl_output(result: std::io::Result<Output>) -> ManagerStatus {
+    match result {
+        Ok(output) if output.status.success() => ManagerStatus::Reachable,
+        Ok(output) => {
+            // The binary exists and ran (this arm is only reached when
+            // spawning succeeded) but reported failure — on a
+            // `systemctl --user`/`launchctl print gui/$UID` probe that
+            // means the manager is present but this session cannot reach
+            // it (no user D-Bus/GUI session, the common bare SSH/cron
+            // shape per this seat's recon risk 6), not "absent". The
+            // stderr — typically a bus-connection failure — is carried
+            // verbatim as the most useful evidence.
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            ManagerStatus::PresentNoUserSession { detail: stderr }
+        }
+        Err(_) => ManagerStatus::Absent,
+    }
+}
+
+/// `systemctl --user list-units` (a read-only reachability probe — nothing
+/// here is enabled or started), via the binary named by
+/// [`SYSTEMCTL_BIN_ENV`] (default `systemctl`, the same "read fresh, no
+/// caching" discipline `runtime::git`'s injection point uses).
+#[cfg(target_os = "linux")]
+pub fn detect_systemd_status() -> ManagerStatus {
+    let bin = std::env::var(SYSTEMCTL_BIN_ENV).unwrap_or_else(|_| "systemctl".to_string());
+    classify_systemctl_output(Command::new(bin).args(["--user", "list-units"]).output())
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(dead_code)]
+pub fn detect_systemd_status() -> ManagerStatus {
+    ManagerStatus::Absent
+}
+
+/// `launchctl print gui/$UID` — the recon's own stated macOS equivalent of
+/// the systemd probe above: a zero exit means launchd is reachable for this
+/// user's GUI session, a nonzero exit with `launchctl` itself runnable means
+/// present-but-unreachable (no GUI session — the same shape SSH/cron gives
+/// systemd), and a failed spawn means absent.
+#[cfg(target_os = "macos")]
+pub fn detect_launchd_status(uid: u32) -> ManagerStatus {
+    let bin = std::env::var(LAUNCHCTL_BIN_ENV).unwrap_or_else(|_| "launchctl".to_string());
+    classify_systemctl_output(
+        Command::new(bin)
+            .args(["print", &format!("gui/{uid}")])
+            .output(),
+    )
+}
+
+#[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
+pub fn detect_launchd_status(_uid: u32) -> ManagerStatus {
+    ManagerStatus::Absent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> ServiceSpec {
+        ServiceSpec {
+            binary_path: PathBuf::from("/home/x/.cargo/bin/sgt"),
+            host_runtime_dir: PathBuf::from("/home/x/.local/share/sergeant"),
+            path: "/home/x/.cargo/bin:/home/x/.local/bin:/usr/bin:/bin".to_string(),
+        }
+    }
+
+    /// Golden-file: the exact generated systemd unit, paths substituted.
+    /// Reverting `systemd_unit`'s format string in any way that changes
+    /// this content fails this test immediately — no service manager
+    /// needed.
+    #[test]
+    fn systemd_unit_golden() {
+        let unit = systemd_unit(&spec());
+        assert_eq!(
+            unit,
+            "[Unit]\n\
+             Description=Sergeant host daemon\n\
+             After=network.target\n\
+             \n\
+             [Service]\n\
+             Type=simple\n\
+             ExecStart=/home/x/.cargo/bin/sgt --data-dir /home/x/.local/share/sergeant daemon\n\
+             Environment=\"PATH=/home/x/.cargo/bin:/home/x/.local/bin:/usr/bin:/bin\"\n\
+             Restart=on-failure\n\
+             RestartSec=5\n\
+             \n\
+             [Install]\n\
+             WantedBy=default.target\n"
+        );
+    }
+
+    /// Golden-file: the exact generated LaunchAgent plist, paths
+    /// substituted.
+    #[test]
+    fn launchd_plist_golden() {
+        let plist = launchd_plist(&spec());
+        assert_eq!(
+            plist,
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+             <plist version=\"1.0\">\n\
+             <dict>\n\
+             \t<key>Label</key>\n\
+             \t<string>com.sergeant.host-daemon</string>\n\
+             \t<key>ProgramArguments</key>\n\
+             \t<array>\n\
+             \t\t<string>/home/x/.cargo/bin/sgt</string>\n\
+             \t\t<string>--data-dir</string>\n\
+             \t\t<string>/home/x/.local/share/sergeant</string>\n\
+             \t\t<string>daemon</string>\n\
+             \t</array>\n\
+             \t<key>EnvironmentVariables</key>\n\
+             \t<dict>\n\
+             \t\t<key>PATH</key>\n\
+             \t\t<string>/home/x/.cargo/bin:/home/x/.local/bin:/usr/bin:/bin</string>\n\
+             \t</dict>\n\
+             \t<key>RunAtLoad</key>\n\
+             \t<true/>\n\
+             \t<key>KeepAlive</key>\n\
+             \t<true/>\n\
+             \t<key>ProcessType</key>\n\
+             \t<string>Background</string>\n\
+             </dict>\n\
+             </plist>\n"
+        );
+    }
+
+    /// #275's negative test, named explicitly in the brief: the generated
+    /// unit's `Environment=` PATH must contain every entry
+    /// `harness::toolchain_path_dirs` names, not just whatever happened to
+    /// already be on the composing shell's PATH — this is what makes the
+    /// env-stripping hazard structurally unable to recur inside a generated
+    /// unit.
+    #[test]
+    fn systemd_unit_environment_path_contains_every_toolchain_dir() {
+        let home = PathBuf::from("/home/x");
+        let dirs = crate::harness::toolchain_path_dirs(&home);
+        let path = crate::harness::compose_path(
+            Some(&std::ffi::OsString::from("/usr/bin:/bin")),
+            &dirs,
+            |_| true, // pretend every toolchain dir exists on disk
+        )
+        .to_string_lossy()
+        .into_owned();
+        let unit = systemd_unit(&ServiceSpec {
+            binary_path: PathBuf::from("/home/x/.cargo/bin/sgt"),
+            host_runtime_dir: PathBuf::from("/home/x/.local/share/sergeant"),
+            path: path.clone(),
+        });
+        for dir in &dirs {
+            assert!(
+                unit.contains(&dir.display().to_string()),
+                "generated unit's Environment= is missing toolchain dir {} — \
+                 got:\n{unit}",
+                dir.display()
+            );
+        }
+        // And it must be inside `Environment=`, not merely present anywhere
+        // (e.g. leaking into `ExecStart` some other way) — pin the exact
+        // line.
+        assert!(unit.contains(&format!("Environment=\"PATH={path}\"")));
+    }
+
+    /// Same negative test, plist arm.
+    #[test]
+    fn launchd_plist_environment_variables_path_contains_every_toolchain_dir() {
+        let home = PathBuf::from("/home/x");
+        let dirs = crate::harness::toolchain_path_dirs(&home);
+        let path = crate::harness::compose_path(
+            Some(&std::ffi::OsString::from("/usr/bin:/bin")),
+            &dirs,
+            |_| true,
+        )
+        .to_string_lossy()
+        .into_owned();
+        let plist = launchd_plist(&ServiceSpec {
+            binary_path: PathBuf::from("/home/x/.cargo/bin/sgt"),
+            host_runtime_dir: PathBuf::from("/home/x/.local/share/sergeant"),
+            path: path.clone(),
+        });
+        for dir in &dirs {
+            assert!(
+                plist.contains(&dir.display().to_string()),
+                "generated plist's EnvironmentVariables is missing toolchain dir {} — \
+                 got:\n{plist}",
+                dir.display()
+            );
+        }
+    }
+
+    #[test]
+    fn generation_is_deterministic_across_calls() {
+        assert_eq!(systemd_unit(&spec()), systemd_unit(&spec()));
+        assert_eq!(launchd_plist(&spec()), launchd_plist(&spec()));
+    }
+
+    #[test]
+    fn install_paths_are_under_the_native_per_user_locations() {
+        let home = Path::new("/home/x");
+        assert_eq!(
+            systemd_unit_path(home),
+            PathBuf::from("/home/x/.config/systemd/user/sergeant-daemon.service")
+        );
+        let home = Path::new("/Users/x");
+        assert_eq!(
+            launchd_plist_path(home),
+            PathBuf::from("/Users/x/Library/LaunchAgents/com.sergeant.host-daemon.plist")
+        );
+    }
+
+    #[test]
+    fn classify_success_is_reachable() {
+        let output = Command::new("true").output();
+        assert_eq!(classify_systemctl_output(output), ManagerStatus::Reachable);
+    }
+
+    #[test]
+    fn classify_spawn_failure_is_absent() {
+        let result = Command::new("sgt-w4c-nonexistent-binary-xyz").output();
+        assert_eq!(classify_systemctl_output(result), ManagerStatus::Absent);
+    }
+
+    #[test]
+    fn classify_no_bus_session_is_present_no_user_session() {
+        // A scripted `sh -c` stand-in for `systemctl --user list-units`
+        // against a stub that fails the way a real bus-less session does —
+        // the fake-binary shape this seat's brief flags as the fitting
+        // precedent for exercising a real subprocess boundary.
+        let output = Command::new("sh")
+            .args([
+                "-c",
+                "echo 'Failed to connect to bus: No such file or directory' >&2; exit 1",
+            ])
+            .output();
+        assert_eq!(
+            classify_systemctl_output(output),
+            ManagerStatus::PresentNoUserSession {
+                detail: "Failed to connect to bus: No such file or directory".to_string()
+            }
+        );
+    }
+
+    /// [`detect_systemd_status`]'s real-subprocess arm, exercised through
+    /// [`SYSTEMCTL_BIN_ENV`] pointed at a scripted fake — the PATH-shimmed
+    /// injection precedent (`runtime::git::GIT_BIN_ENV`) applied here.
+    /// Process-global env var: this test owns its own value (set then
+    /// immediately restored) rather than running in a shared parallel
+    /// fixture, mirroring `runtime::git`'s own caveat about
+    /// `tests/c11_injectable_git.rs` needing its own process.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn detect_systemd_status_uses_the_injected_binary() {
+        // SAFETY: this test only mutates an env var it reads back inside
+        // the same synchronous call below, restoring it before returning —
+        // no other code observes the mutation in between.
+        unsafe {
+            std::env::set_var(SYSTEMCTL_BIN_ENV, "true");
+        }
+        let status = detect_systemd_status();
+        unsafe {
+            std::env::remove_var(SYSTEMCTL_BIN_ENV);
+        }
+        assert_eq!(status, ManagerStatus::Reachable);
+    }
+}

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -1403,6 +1403,10 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
     // have a reachable Docker Engine (N4.md's own probe-gating rule for
     // Docker facts on the GH runner / cloud container).
     let docker = stub_docker(bin.path());
+    // W4c: same treatment for `host_service_manager` — this test's "every
+    // check must be ok" assertion must not depend on whether *this host*
+    // happens to have a reachable native service manager either.
+    let service_manager = stub_service_manager(bin.path());
     // Same treatment for the `environment` check's own `$HOME`: a fixture
     // dir with neither `.cargo/bin` nor `.local/bin` on disk, so it reads a
     // deterministic "ok" regardless of what toolchain directories the
@@ -1435,6 +1439,8 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
         &[
             ("SGT_CLAUDE_BIN", &claude),
             ("SGT_DOCKER_BIN", &docker),
+            ("SGT_SYSTEMCTL_BIN", &service_manager),
+            ("SGT_LAUNCHCTL_BIN", &service_manager),
             ("HOME", &home),
         ],
         false,
@@ -1446,6 +1452,8 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
         &[
             ("SGT_CLAUDE_BIN", &claude),
             ("SGT_DOCKER_BIN", &docker),
+            ("SGT_SYSTEMCTL_BIN", &service_manager),
+            ("SGT_LAUNCHCTL_BIN", &service_manager),
             ("HOME", &home),
         ],
         true,
@@ -1481,6 +1489,10 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
             "journal",
             "projection",
             "daemon",
+            // H1 §2/#276, W4c: is a native per-user service manager
+            // reachable at all — a distinct question from `daemon`'s own
+            // per-data-dir descriptor health above.
+            "host_service_manager",
             // Estate-root §4.2/§4.4: is the directory this `sgt doctor` was
             // run from an estate root at all? It is the row the three
             // beneath it read their answer from — a single admission,
@@ -1488,6 +1500,12 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
             // three independent searches — which is also why it sits
             // immediately above them rather than beside `estate`.
             "estate_root",
+            // H1 §6, W4c: the cutover gate — daemon.lock/runtime.json/
+            // journal/ still present under this estate's own
+            // `.sergeant/data` from before a host runtime root existed.
+            // Threaded off `estate_root` the same way `permission_mode`
+            // below it is.
+            "legacy_estate_runtime",
             "permission_mode",
             // #262: the per-profile `network_access` override, right beside
             // `permission_mode` — same estate-root threading, same
@@ -4911,6 +4929,17 @@ fn stub_claude(dir: &Path) -> String {
              --help) echo '{flags}';;\n  *) cat >/dev/null;;\nesac\n"
         ),
     )
+}
+
+/// A stand-in `systemctl`/`launchctl` that always reports success — same
+/// reasoning as `stub_docker`/`stub_claude`: `host_service_manager`'s
+/// "every check must be green on a healthy install" assertion below must
+/// not depend on whether *this host* happens to have a reachable native
+/// service manager (W4c, following TH-02's own probe-gating precedent).
+/// Wired in through `SGT_SYSTEMCTL_BIN`/`SGT_LAUNCHCTL_BIN`
+/// (`platform::service`'s injection points, the `SGT_GIT_BIN` precedent).
+fn stub_service_manager(dir: &Path) -> String {
+    write_script(dir, "service-manager-stub", "#!/bin/sh\nexit 0\n")
 }
 
 /// A stand-in `docker` that passes both `DockerBackend::probe`'s cheap

--- a/tests/m8_estate_cli.rs
+++ b/tests/m8_estate_cli.rs
@@ -1194,9 +1194,26 @@ fn init_reports_and_creates_the_estate_local_data_dir_not_the_pre_estate_fallbac
         "init must leave the estate-local data dir created on disk, matching the \
          .gitignore rule it scaffolds for .sergeant/data"
     );
+    // W4c re-audit (recon-doctor-init-service.md's own warning: a host
+    // runtime root as a fourth resolution target needs every one of these
+    // precedence tests re-examined, not just left passing): `sgt init`'s
+    // *estate* data dir resolution above still never touches `$XDG_DATA_HOME`
+    // — the assertion above already pins that. But `sgt init` now also runs
+    // a *separate*, deliberate host-bootstrap step (H1 §3/recon risk 2) that
+    // creates the host runtime root when absent, and with no `--data-dir`/
+    // `SGT_DATA_DIR` override that root resolves to this exact
+    // `$XDG_DATA_HOME/sergeant` path by design — the same pre-estate
+    // fallback tail, now serving a second, legitimate purpose (one host
+    // daemon's root, decoupled from any one estate) rather than being a
+    // wrong answer for *this* estate's own data. So this directory existing
+    // now is correct, not the #164 regression this test was written to
+    // catch; only the doctor-report identity assertion above is that
+    // regression's guard.
     assert!(
-        !xdg.exists(),
-        "init must not touch the pre-estate XDG fallback once an estate is being created"
+        xdg.is_dir(),
+        "sgt init's host-bootstrap step (H1 §3) must create the host runtime root — with no \
+         override it resolves to the same $XDG_DATA_HOME/sergeant path this test's HOME/XDG \
+         env points at"
     );
 }
 

--- a/tests/w4c_service_doctor.rs
+++ b/tests/w4c_service_doctor.rs
@@ -1,0 +1,585 @@
+//! W4c acceptance: service packaging + doctor host rows (#275/#276).
+//!
+//! `sgt daemon install-service [--print]` (generation, idempotent write,
+//! capability-probe-gated enablement) · the `host_service_manager` and
+//! `legacy_estate_runtime` doctor rows · `sgt init`'s host-bootstrap branch.
+//! Mirrors `m8_estate_cli.rs`'s own shape: every verb here is either
+//! non-daemon-spawning plumbing (`install-service`, `doctor`, `init` — no
+//! `support::DataDir` guard needed) or reuses `tests/support`'s injectable
+//! fake-binary precedent (`runtime::git::GIT_BIN_ENV`'s sibling,
+//! `SGT_SYSTEMCTL_BIN`) to exercise the capability probe without a real
+//! systemd user session.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+const SGT: &str = env!("CARGO_BIN_EXE_sgt");
+
+// ---------------------------------------------------------------- helpers
+
+/// Run `sgt` with `cwd`, an optional `--data-dir`, extra env, and `args` —
+/// mirrors `m8_estate_cli.rs`'s own `run` helper exactly (no daemon is ever
+/// spawned by any verb this suite exercises).
+fn run(cwd: &Path, data_dir: Option<&Path>, env: &[(&str, &str)], args: &[&str]) -> Output {
+    let mut command = Command::new(SGT);
+    command.current_dir(cwd);
+    if let Some(data_dir) = data_dir {
+        command.arg("--data-dir").arg(data_dir);
+    }
+    command.args(args);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let output = command.output().expect("run sgt");
+    Output {
+        code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    }
+}
+
+struct Output {
+    code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+impl Output {
+    fn json(&self) -> Value {
+        serde_json::from_str(&self.stdout)
+            .unwrap_or_else(|e| panic!("stdout is not JSON ({e}): {}", self.stdout))
+    }
+
+    fn assert_ok(&self, what: &str) -> &Self {
+        assert_eq!(
+            self.code,
+            Some(0),
+            "{what} must succeed, got {:?}\nstdout: {}\nstderr: {}",
+            self.code,
+            self.stdout,
+            self.stderr
+        );
+        self
+    }
+}
+
+/// A minimal valid estate — `Estate::admit`'s own requirement (`[estate]`
+/// declared) is all `install-service`/`doctor`/`init` need here; no repo
+/// mounts, matching `m6_surfaces.rs`'s own `doctor(...)` fixture shape.
+fn scaffold_bare_estate(root: &Path, name: &str) {
+    std::fs::create_dir_all(root).expect("estate root");
+    std::fs::write(
+        root.join("sergeant.toml"),
+        format!("[estate]\nname = {name:?}\n"),
+    )
+    .expect("write sergeant.toml");
+}
+
+/// A scripted binary on `PATH` a test can point `SGT_SYSTEMCTL_BIN` at —
+/// the `SGT_GIT_BIN`/`runtime::git`-style injection precedent, applied to
+/// `platform::service`'s manager probe. `body` is the shell script's own
+/// body (already has `#!/bin/sh` prepended).
+fn write_fake_binary(path: &Path, body: &str) {
+    std::fs::write(path, format!("#!/bin/sh\n{body}\n")).expect("write fake binary");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake binary");
+    }
+}
+
+// --------------------------------------------------------- install-service
+
+/// guard-map: `--print` writes nothing to disk and prints a unit whose
+/// `ExecStart` names the host runtime root and whose `Environment=` carries
+/// a composed PATH — the golden-file content this seat's brief calls for,
+/// exercised end to end through the real binary rather than only through
+/// `platform::service`'s own inline tests. Mutation this kills: `--print`
+/// writing to the native location anyway, or `ExecStart`/`Environment=`
+/// losing the host runtime root / PATH.
+#[test]
+fn install_service_print_is_a_pure_dry_run() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "print-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let host_root = root.path().join("host-runtime-root");
+
+    let out = run(
+        root.path(),
+        Some(&host_root),
+        &[("HOME", home.path().to_str().expect("utf8"))],
+        &["daemon", "install-service", "--print"],
+    );
+    out.assert_ok("install-service --print");
+
+    assert!(
+        out.stdout.contains(&host_root.display().to_string()),
+        "printed unit must name the host runtime root, got:\n{}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.contains("Environment=") || out.stdout.contains("EnvironmentVariables"),
+        "printed unit must carry PATH enrichment in its own Environment= (or plist \
+         EnvironmentVariables), never left to an inline prefix (#275): got:\n{}",
+        out.stdout
+    );
+
+    // Never writes the native per-user location.
+    assert!(
+        !home.path().join(".config/systemd/user").exists(),
+        "--print must never write the native systemd unit dir"
+    );
+    assert!(
+        !home.path().join("Library/LaunchAgents").exists(),
+        "--print must never write the native LaunchAgent dir"
+    );
+}
+
+/// guard-map: without `--print`, the unit/plist is actually written to the
+/// native per-user location under the fake `$HOME`, and — with no real
+/// service manager reachable in this test's `PATH` — enablement is skipped
+/// with a named remedy rather than failing the command (H1-05, the
+/// `docker_check` degradation pattern). Mutation this kills: a write
+/// failure being swallowed, or a missing manager turning into a nonzero
+/// exit instead of a skip.
+#[test]
+fn install_service_writes_and_skips_enablement_with_no_manager_reachable() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "write-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let host_root = root.path().join("host-runtime-root");
+
+    // A `systemctl`/`launchctl` that always fails to spawn — the "Absent"
+    // arm, exercised end to end (not just `platform::service`'s own
+    // `classify_systemctl_output` unit test).
+    let out = run(
+        root.path(),
+        Some(&host_root),
+        &[
+            ("HOME", home.path().to_str().expect("utf8")),
+            ("SGT_SYSTEMCTL_BIN", "sgt-w4c-nonexistent-systemctl-xyz"),
+            ("SGT_LAUNCHCTL_BIN", "sgt-w4c-nonexistent-launchctl-xyz"),
+        ],
+        &["--json", "daemon", "install-service"],
+    );
+    out.assert_ok("install-service without --print, no manager reachable");
+    let json = out.json();
+    assert_eq!(
+        json["enabled"].as_bool(),
+        Some(false),
+        "no manager reachable — enabled must be false, got {json}"
+    );
+    assert!(
+        json["remedy"].as_str().is_some(),
+        "a skipped enablement must name a remedy, got {json}"
+    );
+
+    #[cfg(target_os = "macos")]
+    let written = home
+        .path()
+        .join("Library/LaunchAgents/com.sergeant.host-daemon.plist");
+    #[cfg(not(target_os = "macos"))]
+    let written = home
+        .path()
+        .join(".config/systemd/user/sergeant-daemon.service");
+
+    assert!(
+        written.is_file(),
+        "the unit/plist must still be written even though enablement was skipped, expected {}",
+        written.display()
+    );
+    let content = std::fs::read_to_string(&written).expect("read written unit");
+    assert!(content.contains(&host_root.display().to_string()));
+}
+
+/// guard-map: a second `install-service` run over unchanged inputs writes
+/// the identical bytes — `write_atomic`'s idempotent-write discipline
+/// applied here, pinned by mtime/inode not moving on a byte-identical
+/// rewrite would be the stronger version, but content equality alone
+/// already kills the mutation class this seat's brief calls out
+/// (non-deterministic generation, e.g. an embedded timestamp).
+#[test]
+fn install_service_generation_is_idempotent_across_repeated_runs() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "idempotent-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let host_root = root.path().join("host-runtime-root");
+    let env: &[(&str, &str)] = &[
+        ("HOME", home.path().to_str().expect("utf8")),
+        ("SGT_SYSTEMCTL_BIN", "sgt-w4c-nonexistent-systemctl-xyz"),
+        ("SGT_LAUNCHCTL_BIN", "sgt-w4c-nonexistent-launchctl-xyz"),
+    ];
+
+    run(
+        root.path(),
+        Some(&host_root),
+        env,
+        &["daemon", "install-service"],
+    )
+    .assert_ok("first");
+
+    #[cfg(target_os = "macos")]
+    let written = home
+        .path()
+        .join("Library/LaunchAgents/com.sergeant.host-daemon.plist");
+    #[cfg(not(target_os = "macos"))]
+    let written = home
+        .path()
+        .join(".config/systemd/user/sergeant-daemon.service");
+
+    let first_content = std::fs::read_to_string(&written).expect("first content");
+
+    run(
+        root.path(),
+        Some(&host_root),
+        env,
+        &["daemon", "install-service"],
+    )
+    .assert_ok("second");
+    let second_content = std::fs::read_to_string(&written).expect("second content");
+
+    assert_eq!(
+        first_content, second_content,
+        "unchanged inputs must generate byte-identical content across runs"
+    );
+}
+
+/// guard-map: a scripted `systemctl` on `PATH` (the `SGT_SYSTEMCTL_BIN`
+/// injection precedent, Linux-only — this exercises `enable_service`'s
+/// `Reachable` arm end to end) reports success, and `install-service`
+/// reports `enabled: true`. Skipped on non-Linux since the systemd arm is
+/// production-dead there.
+#[test]
+#[cfg(target_os = "linux")]
+fn install_service_enables_when_a_scripted_systemctl_reports_reachable() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "reachable-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let host_root = root.path().join("host-runtime-root");
+    let bin_dir = tempfile::TempDir::new().expect("bin dir");
+    let fake_systemctl = bin_dir.path().join("fake-systemctl");
+    // Every invocation succeeds — `list-units` (the probe), `daemon-reload`,
+    // and `enable --now` alike.
+    write_fake_binary(&fake_systemctl, "exit 0");
+
+    let out = run(
+        root.path(),
+        Some(&host_root),
+        &[
+            ("HOME", home.path().to_str().expect("utf8")),
+            ("SGT_SYSTEMCTL_BIN", fake_systemctl.to_str().expect("utf8")),
+        ],
+        &["--json", "daemon", "install-service"],
+    );
+    out.assert_ok("install-service with a reachable scripted systemctl");
+    let json = out.json();
+    assert_eq!(
+        json["enabled"].as_bool(),
+        Some(true),
+        "a reachable manager must be reported as enabled, got {json}"
+    );
+}
+
+/// guard-map: a scripted `systemctl` that fails the way a bus-less session
+/// does (per this seat's recon and `scripts/gate.sh`'s own measured
+/// evidence) is reported as skipped, distinctly from "absent" — the remedy
+/// text differs (no linger/desktop session vs. install a manager).
+#[test]
+#[cfg(target_os = "linux")]
+fn install_service_skips_with_a_no_session_remedy_when_systemctl_reports_no_bus() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "no-session-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let host_root = root.path().join("host-runtime-root");
+    let bin_dir = tempfile::TempDir::new().expect("bin dir");
+    let fake_systemctl = bin_dir.path().join("fake-systemctl");
+    write_fake_binary(
+        &fake_systemctl,
+        "echo 'Failed to connect to bus: No such file or directory' >&2; exit 1",
+    );
+
+    let out = run(
+        root.path(),
+        Some(&host_root),
+        &[
+            ("HOME", home.path().to_str().expect("utf8")),
+            ("SGT_SYSTEMCTL_BIN", fake_systemctl.to_str().expect("utf8")),
+        ],
+        &["--json", "daemon", "install-service"],
+    );
+    out.assert_ok("install-service with a present-but-unreachable scripted systemctl");
+    let json = out.json();
+    assert_eq!(json["enabled"].as_bool(), Some(false));
+    let remedy = json["remedy"].as_str().expect("remedy present");
+    assert!(
+        remedy.contains("session") || remedy.contains("bus"),
+        "the no-user-session remedy must name the actual cause, got: {remedy}"
+    );
+}
+
+// --------------------------------------------------------------- doctor
+
+/// guard-map: `sgt doctor --json` carries both new rows by name, in every
+/// run — a caller that only ever sees `host_service_manager`/
+/// `legacy_estate_runtime` missing from the checks array has silently lost
+/// the row entirely (not merely "reports a different verdict").
+#[test]
+fn doctor_reports_both_new_rows_by_name() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "doctor-rows-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let data_dir = root.path().join("data-dir");
+
+    let out = run(
+        root.path(),
+        Some(&data_dir),
+        &[
+            ("HOME", home.path().to_str().expect("utf8")),
+            ("SGT_SYSTEMCTL_BIN", "sgt-w4c-nonexistent-systemctl-xyz"),
+            ("SGT_LAUNCHCTL_BIN", "sgt-w4c-nonexistent-launchctl-xyz"),
+        ],
+        &["--json", "doctor"],
+    );
+    let json = out.json();
+    let names: Vec<&str> = json["checks"]
+        .as_array()
+        .expect("checks array")
+        .iter()
+        .map(|c| c["name"].as_str().expect("name"))
+        .collect();
+    assert!(
+        names.contains(&"host_service_manager"),
+        "doctor must report host_service_manager, got {names:?}"
+    );
+    assert!(
+        names.contains(&"legacy_estate_runtime"),
+        "doctor must report legacy_estate_runtime, got {names:?}"
+    );
+}
+
+/// guard-map: with no manager reachable, `host_service_manager` warns
+/// (never fails — dev hosts are legal without one) and names a remedy.
+/// Mutation this kills: the row reporting `fail` for an absent manager, or
+/// reporting `ok` with no remedy.
+#[test]
+fn host_service_manager_warns_not_fails_when_absent() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "manager-absent-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let data_dir = root.path().join("data-dir");
+
+    let out = run(
+        root.path(),
+        Some(&data_dir),
+        &[
+            ("HOME", home.path().to_str().expect("utf8")),
+            ("SGT_SYSTEMCTL_BIN", "sgt-w4c-nonexistent-systemctl-xyz"),
+            ("SGT_LAUNCHCTL_BIN", "sgt-w4c-nonexistent-launchctl-xyz"),
+        ],
+        &["--json", "doctor"],
+    );
+    let json = out.json();
+    let row = json["checks"]
+        .as_array()
+        .expect("checks")
+        .iter()
+        .find(|c| c["name"] == "host_service_manager")
+        .expect("host_service_manager row present");
+    assert_eq!(row["status"].as_str(), Some("warn"));
+    assert!(row["remedy"].as_str().is_some());
+}
+
+/// guard-map (Linux): a scripted reachable `systemctl` makes the row `ok`.
+#[test]
+#[cfg(target_os = "linux")]
+fn host_service_manager_is_ok_when_reachable() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "manager-reachable-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let data_dir = root.path().join("data-dir");
+    let bin_dir = tempfile::TempDir::new().expect("bin dir");
+    let fake_systemctl = bin_dir.path().join("fake-systemctl");
+    write_fake_binary(&fake_systemctl, "exit 0");
+
+    let out = run(
+        root.path(),
+        Some(&data_dir),
+        &[
+            ("HOME", home.path().to_str().expect("utf8")),
+            ("SGT_SYSTEMCTL_BIN", fake_systemctl.to_str().expect("utf8")),
+        ],
+        &["--json", "doctor"],
+    );
+    let json = out.json();
+    let row = json["checks"]
+        .as_array()
+        .expect("checks")
+        .iter()
+        .find(|c| c["name"] == "host_service_manager")
+        .expect("host_service_manager row present");
+    assert_eq!(row["status"].as_str(), Some("ok"), "row: {row}");
+}
+
+/// guard-map: `legacy_estate_runtime` warns (never fails, this wave) and
+/// names the H1 §6 reconcile-or-abandon remedy once `daemon.lock`/
+/// `runtime.json`/`journal/` exist under the estate's own
+/// `.sergeant/data` — the exact pre-cutover shape a not-yet-migrated
+/// estate leaves behind. Mutation this kills: the row staying `ok` with
+/// legacy state actually present, or firing on an estate that has none.
+#[test]
+fn legacy_estate_runtime_warns_when_estate_local_daemon_state_is_present() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "legacy-runtime-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    // Estate-local `.sergeant/data` (the pre-cutover default location) with
+    // a stale daemon.lock left in it, simulating an un-migrated estate.
+    let legacy_dir = root.path().join(".sergeant/data");
+    std::fs::create_dir_all(&legacy_dir).expect("legacy dir");
+    std::fs::write(legacy_dir.join("daemon.lock"), b"").expect("legacy lock");
+
+    // No --data-dir flag: resolution falls to the estate default
+    // (`.sergeant/data`), which is exactly the directory just seeded —
+    // matching how a real un-migrated estate would look.
+    let out = run(
+        root.path(),
+        None,
+        &[
+            ("HOME", home.path().to_str().expect("utf8")),
+            ("SGT_SYSTEMCTL_BIN", "sgt-w4c-nonexistent-systemctl-xyz"),
+            ("SGT_LAUNCHCTL_BIN", "sgt-w4c-nonexistent-launchctl-xyz"),
+        ],
+        &["--json", "doctor"],
+    );
+    let json = out.json();
+    let row = json["checks"]
+        .as_array()
+        .expect("checks")
+        .iter()
+        .find(|c| c["name"] == "legacy_estate_runtime")
+        .expect("legacy_estate_runtime row present");
+    assert_eq!(row["status"].as_str(), Some("warn"), "row: {row}");
+    let remedy = row["remedy"].as_str().expect("remedy present");
+    assert!(
+        remedy.to_lowercase().contains("stop") && remedy.to_lowercase().contains("drain"),
+        "remedy must name the stop-and-drain reconcile path, got: {remedy}"
+    );
+}
+
+/// guard-map: a fresh estate with none of the three markers reports `ok`.
+#[test]
+fn legacy_estate_runtime_is_ok_with_no_markers_present() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "legacy-runtime-clean-test");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let data_dir = root.path().join("data-dir");
+
+    let out = run(
+        root.path(),
+        Some(&data_dir),
+        &[("HOME", home.path().to_str().expect("utf8"))],
+        &["--json", "doctor"],
+    );
+    let json = out.json();
+    let row = json["checks"]
+        .as_array()
+        .expect("checks")
+        .iter()
+        .find(|c| c["name"] == "legacy_estate_runtime")
+        .expect("legacy_estate_runtime row present");
+    assert_eq!(row["status"].as_str(), Some("ok"), "row: {row}");
+}
+
+// ----------------------------------------------------------------- init
+
+/// guard-map: a fresh `sgt init` creates the host runtime root and reports
+/// it in `--json` output; a second `init` (same `HOME`) finds it already
+/// there and reports `created: false` — `m8_estate_cli.rs`'s own
+/// `init_scaffolds_and_is_idempotent` idempotence style, applied to the
+/// host-bootstrap branch. Mutation this kills: the host runtime root not
+/// being created at all, or a second `init` recreating/re-reporting it as
+/// newly created.
+#[test]
+fn init_creates_the_host_runtime_root_once_and_is_idempotent() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let scratch_data_dir = root.path().join("scratch-data-dir");
+    let env: &[(&str, &str)] = &[("HOME", home.path().to_str().expect("utf8"))];
+
+    let first = run(
+        root.path(),
+        Some(&scratch_data_dir),
+        env,
+        &["--json", "init", "--name", "host-bootstrap-test"],
+    );
+    first.assert_ok("first init");
+    let first_json = first.json();
+    let bootstrap = &first_json["host_bootstrap"];
+    assert!(
+        !bootstrap.is_null(),
+        "a resolvable host runtime root must produce a host_bootstrap object, got {first_json}"
+    );
+    assert_eq!(
+        bootstrap["created"].as_bool(),
+        Some(true),
+        "first init must create the host runtime root, got {bootstrap}"
+    );
+    let host_runtime_dir = bootstrap["host_runtime_dir"]
+        .as_str()
+        .expect("host_runtime_dir string");
+    assert!(
+        PathBuf::from(host_runtime_dir).is_dir(),
+        "the reported host runtime root must actually exist on disk: {host_runtime_dir}"
+    );
+
+    let second = run(
+        root.path(),
+        Some(&scratch_data_dir),
+        env,
+        &["--json", "init", "--name", "host-bootstrap-test"],
+    );
+    second.assert_ok("second init");
+    let second_json = second.json();
+    assert_eq!(
+        second_json["host_bootstrap"]["created"].as_bool(),
+        Some(false),
+        "a second init must find the host runtime root already there, got {second_json}"
+    );
+}
+
+/// guard-map: `sgt init` never touches a live daemon and never installs a
+/// service — the host-bootstrap branch's own stated boundary (recon risk
+/// 2). A daemon descriptor dropped into the just-created host runtime root
+/// beforehand must survive `sgt init` untouched, and no service unit
+/// appears under the fake `$HOME` as a side effect of `init` alone.
+#[test]
+fn init_host_bootstrap_never_installs_a_service_or_touches_daemon_state() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let scratch_data_dir = root.path().join("scratch-data-dir");
+
+    run(
+        root.path(),
+        Some(&scratch_data_dir),
+        &[("HOME", home.path().to_str().expect("utf8"))],
+        &["--json", "init", "--name", "no-side-effects-test"],
+    )
+    .assert_ok("init");
+
+    assert!(
+        !home
+            .path()
+            .join(".config/systemd/user/sergeant-daemon.service")
+            .exists(),
+        "`sgt init` must never install the systemd unit on its own"
+    );
+    assert!(
+        !home
+            .path()
+            .join("Library/LaunchAgents/com.sergeant.host-daemon.plist")
+            .exists(),
+        "`sgt init` must never install the LaunchAgent on its own"
+    );
+}

--- a/tests/w4c_service_doctor.rs
+++ b/tests/w4c_service_doctor.rs
@@ -1,14 +1,16 @@
-//! W4c acceptance: service packaging + doctor host rows (#275/#276).
+//! W4c acceptance: service packaging + doctor host rows (#275/#276), plus
+//! the #282 stretch.
 //!
 //! `sgt daemon install-service [--print]` (generation, idempotent write,
 //! capability-probe-gated enablement) · the `host_service_manager` and
-//! `legacy_estate_runtime` doctor rows · `sgt init`'s host-bootstrap branch.
-//! Mirrors `m8_estate_cli.rs`'s own shape: every verb here is either
-//! non-daemon-spawning plumbing (`install-service`, `doctor`, `init` — no
-//! `support::DataDir` guard needed) or reuses `tests/support`'s injectable
-//! fake-binary precedent (`runtime::git::GIT_BIN_ENV`'s sibling,
-//! `SGT_SYSTEMCTL_BIN`) to exercise the capability probe without a real
-//! systemd user session.
+//! `legacy_estate_runtime` doctor rows · `sgt init`'s host-bootstrap branch
+//! · `doc_routes`' managed-block scoping of the `sergeant-rs-workspace`
+//! rule (#282). Mirrors `m8_estate_cli.rs`'s own shape: every verb here is
+//! either non-daemon-spawning plumbing (`install-service`, `doctor`,
+//! `init` — no `support::DataDir` guard needed) or reuses `tests/
+//! support`'s injectable fake-binary precedent (`runtime::git::
+//! GIT_BIN_ENV`'s sibling, `SGT_SYSTEMCTL_BIN`) to exercise the capability
+//! probe without a real systemd user session.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -582,4 +584,93 @@ fn init_host_bootstrap_never_installs_a_service_or_touches_daemon_state() {
             .exists(),
         "`sgt init` must never install the LaunchAgent on its own"
     );
+}
+
+// ------------------------------------------------------- doc_routes (#282)
+
+/// guard-map (#282): a private, unshipped `sergeant-rs-workspace` path
+/// cited in `AGENTS.md`'s *user-authored* content (outside the
+/// `sgt:managed` block) must not fail `doc_routes` — the exact false
+/// positive this issue names, found live on the dev workspace's own
+/// estate, whose constitution legitimately cites its own repo name.
+/// Mutation this kills: reverting the managed-block scoping back to a
+/// whole-file substring check.
+#[test]
+fn doc_routes_ignores_a_workspace_citation_outside_the_managed_block() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "doc-routes-user-content-test");
+    std::fs::write(
+        root.path().join("AGENTS.md"),
+        "# my constitution\n\n\
+         see sergeant-rs-workspace's development record for context.\n\n\
+         <!-- sgt:managed:begin -->\n\
+         managed body, no workspace citation here\n\
+         <!-- sgt:managed:end -->\n",
+    )
+    .expect("write AGENTS.md");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let data_dir = root.path().join("data-dir");
+
+    let out = run(
+        root.path(),
+        Some(&data_dir),
+        &[("HOME", home.path().to_str().expect("utf8"))],
+        &["--json", "doctor"],
+    );
+    let json = out.json();
+    let row = json["checks"]
+        .as_array()
+        .expect("checks")
+        .iter()
+        .find(|c| c["name"] == "doc_routes")
+        .expect("doc_routes row present");
+    assert_eq!(
+        row["status"].as_str(),
+        Some("ok"),
+        "a workspace citation outside the managed block must not fail: {row}"
+    );
+}
+
+/// guard-map (#282): the same substring *inside* the `sgt:managed` block —
+/// sgt-owned content — still fails, exactly as before. This is what proves
+/// the fix scoped the rule rather than disabling it.
+#[test]
+fn doc_routes_still_fails_when_the_managed_block_itself_cites_the_workspace() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    scaffold_bare_estate(root.path(), "doc-routes-managed-content-test");
+    std::fs::write(
+        root.path().join("AGENTS.md"),
+        "# my constitution\n\n\
+         <!-- sgt:managed:begin -->\n\
+         this managed body cites sergeant-rs-workspace directly\n\
+         <!-- sgt:managed:end -->\n",
+    )
+    .expect("write AGENTS.md");
+    let home = tempfile::TempDir::new().expect("fake home");
+    let data_dir = root.path().join("data-dir");
+
+    let out = run(
+        root.path(),
+        Some(&data_dir),
+        &[("HOME", home.path().to_str().expect("utf8"))],
+        &["--json", "doctor"],
+    );
+    let json = out.json();
+    let row = json["checks"]
+        .as_array()
+        .expect("checks")
+        .iter()
+        .find(|c| c["name"] == "doc_routes")
+        .expect("doc_routes row present");
+    assert_eq!(
+        row["status"].as_str(),
+        Some("fail"),
+        "a workspace citation inside the managed block must still fail: {row}"
+    );
+    let detail = row["detail"].as_str().expect("detail present");
+    assert!(
+        detail.contains("sergeant-rs-workspace"),
+        "the detail must still name the offending citation, got: {detail}"
+    );
+    assert!(row["remedy"].as_str().is_some());
 }


### PR DESCRIPTION
Wave W4c of sprint S1 (Host runtime), per the workspace sprint plan.

- `src/platform/service.rs`: pure systemd user-unit + LaunchAgent plist generators, golden-file tested, with toolchain PATH baked into `Environment=`/`EnvironmentVariables` at generation time (the measured gate.sh env-stripping hazard; closes #275's class inside the unit). Never enables linger (H1-05).
- `sgt daemon install-service [--print]`: writes to the native per-user location; enablement gated behind a three-way manager probe (systemd reachable / present-but-no-user-session / absent), degrading with a named remedy, never a hard failure — the `docker_check` pattern. First consumer of W1b's `resolve_host_runtime_dir` seam.
- Two doctor rows: `host_service_manager` and `legacy_estate_runtime` (the H1 §6 cutover gate, Warn until cutover flips in W2/W3).
- #275 cli-side share: `spawn_daemon` failures print AND log a named missing-PATH-dirs reason (revert-sensitive tests for both halves, added at panel direction); daemon-side half is a marked `// W2 seam:`.
- `sgt init` host-bootstrap branch: creates the host runtime root once, points at install-service, never touches a live daemon.
- Stretch #282: `doc_routes` workspace-path fail scoped to the sgt-managed AGENTS.md block — fixes the false positive on the dev workspace's own estate.
- New `w4c_service_doctor` suite wired into coverage stage C2 (#231(b) guard green).

Gates: fmt/clippy clean; blind 4-axis panel + refuters — one confirmed HIGH (missing L7 coverage for the spawn diagnostic) fixed with hand-verified revert-sensitivity; full suite green except the 9 pre-existing #293 host-latency spawn failures (baseline-verified; CI is decisive).

Rungs: J3 (sprint plan, #275/#276/#282 traced to code), R2 throughout (write_distro idempotence, docker_check degradation, SGT_GIT_BIN-style injection).

Fixes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4