### PR TITLE
S1/W2: daemon core — host runtime root, descriptor v3, lazy multi-estate admission, per-call engine estate

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1527,8 +1527,34 @@ async fn submit_work(
             Err(e) => {
                 let result = error_body(e.code(), e.to_string());
                 let mut core = CoreGuard::acquire(&state.core).await;
+                // §26 first, exactly as the accepting path does it below: a
+                // `command_id` whose outcome is already recorded replays
+                // that outcome, and one caught in the `work.submitted`/
+                // `command.accepted` crash window re-records its real
+                // outcome from the replayed state. An estate that broke
+                // *after* a submission was accepted must not turn a retry
+                // of that submission into a refusal — the Work exists, and
+                // §26's promise is about what already happened, not about
+                // whether it could happen again now.
                 if let Some(resp) = replay_command(&core, &req.command_id) {
                     return resp;
+                }
+                if let Some(work_id) = core
+                    .registry
+                    .state()
+                    .command_works
+                    .get(&req.command_id)
+                    .cloned()
+                {
+                    let replayed = work_view(&core, &state.engine, &work_id);
+                    return record_and_respond(
+                        &mut core,
+                        &req.command_id,
+                        "work.submit",
+                        Some(&work_id),
+                        StatusCode::CREATED,
+                        replayed,
+                    );
                 }
                 return record_and_respond(
                     &mut core,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1120,6 +1120,14 @@ async fn healthz() -> Json<Value> {
 /// every live client needs it and none of them may read the journal to find
 /// it: it is the resume point an SSE subscriber passes as `from` so that
 /// attaching to the tail does not replay all of history first.
+///
+/// **H1 keeps it a single number, deliberately** (brief deliverable 5): a
+/// host daemon owns exactly one journal, shared by every admitted estate,
+/// so there is one head and one resume point — the estate coordinate lives
+/// on each event (D1), not on the stream. `data_dir` likewise still names
+/// one directory; what changed is *which* — the host runtime root (D2),
+/// no longer any estate's. Which estates this daemon serves is a different
+/// question, and it has its own route: `GET /v1/estates`.
 fn system_body(state: &ApiState, journal_head: u64, admission_paused: bool) -> Value {
     json!({
         "version": env!("CARGO_PKG_VERSION"),
@@ -4065,6 +4073,21 @@ struct EventsQuery {
     /// Keep only the newest `limit` matching events. Absent = all of them.
     #[serde(default)]
     limit: Option<usize>,
+    /// D4/D6: restrict to one estate's events, by canonical exact root,
+    /// matched against each event's own `workspace_id` coordinate (D1).
+    ///
+    /// Optional, and **server-side on purpose**: without it, "estate-wide
+    /// watch" would silently become "host-wide watch" for every existing
+    /// `sgt watch` invocation the moment a daemon starts serving a second
+    /// estate — a behavior change nobody asked for. The filter is not
+    /// validated by admission: this is a read, it creates nothing, and a
+    /// root that matches no event is an empty answer rather than a refusal.
+    ///
+    /// This wave lands the wire field and the filter. Routing the *client*
+    /// onto it — what `sgt watch` inside an estate defaults to, and how a
+    /// host-wide watch is asked for — is W3's, per this wave's brief.
+    #[serde(default)]
+    estate_root: Option<String>,
 }
 
 /// The `GET /v1/events` body for an already-fetched slice.
@@ -4078,13 +4101,10 @@ struct EventsQuery {
 /// asked for is gone under retention policy" — without it those two cases
 /// are wire-identical.
 fn events_body(events: Vec<Event>, query: &EventsQuery, floor_seq: u64) -> Value {
-    let mut events: Vec<Event> = match &query.work_id {
-        Some(work_id) => events
-            .into_iter()
-            .filter(|e| e.work_id.as_deref() == Some(work_id.as_str()))
-            .collect(),
-        None => events,
-    };
+    let mut events: Vec<Event> = events
+        .into_iter()
+        .filter(|e| matches_query(e, query))
+        .collect();
     if let Some(limit) = query.limit
         && events.len() > limit
     {
@@ -4093,7 +4113,33 @@ fn events_body(events: Vec<Event>, query: &EventsQuery, floor_seq: u64) -> Value
     json!({"events": events, "floor_seq": floor_seq})
 }
 
-/// `GET /v1/events?from=N&work_id=X&limit=K` — journaled history after seq N.
+/// Does this event pass the query's filters?
+///
+/// One predicate, shared by the history route and the SSE pump, so a client
+/// that asks the same question of both cannot get two different answers —
+/// which is the whole point of `watch`'s attach-then-replay ordering.
+///
+/// D4/D6: `estate_root` matches the envelope's own coordinate (D1). An event
+/// with no coordinate — every pre-envelope journal line, and everything not
+/// bound to an estate at all — is filtered *out* when an estate is asked
+/// for, because "I do not know which estate this belongs to" is not
+/// evidence that it belongs to the one asked about.
+fn matches_query(event: &Event, query: &EventsQuery) -> bool {
+    if let Some(work_id) = &query.work_id
+        && event.work_id.as_deref() != Some(work_id.as_str())
+    {
+        return false;
+    }
+    if let Some(estate_root) = &query.estate_root
+        && event.workspace_id.as_deref() != Some(estate_root.as_str())
+    {
+        return false;
+    }
+    true
+}
+
+/// `GET /v1/events?from=N&work_id=X&limit=K&estate_root=R` — journaled
+/// history after seq N.
 ///
 /// `from` is the only bound on how much journal is read; `work_id` and `limit`
 /// shape the answer, not the scan. A client that wants a cheap tail should
@@ -4147,7 +4193,7 @@ async fn event_stream(
         None => query.from,
     };
     let (tx, rx) = mpsc::channel::<Result<SseEvent, std::convert::Infallible>>(64);
-    tokio::spawn(pump_until_closing(state, from, tx));
+    tokio::spawn(pump_until_closing(state, from, query, tx));
     Sse::new(ReceiverStream::new(rx))
         .keep_alive(KeepAlive::new().interval(SSE_KEEP_ALIVE))
         .into_response()
@@ -4165,11 +4211,12 @@ async fn event_stream(
 async fn pump_until_closing(
     state: ApiState,
     from: u64,
+    query: EventsQuery,
     tx: mpsc::Sender<Result<SseEvent, std::convert::Infallible>>,
 ) {
     let mut closing = state.closing.clone();
     tokio::select! {
-        () = forward_events(state, from, tx) => {}
+        () = forward_events(state, from, query, tx) => {}
         () = daemon_closing(&mut closing) => {}
     }
 }
@@ -4190,6 +4237,7 @@ async fn daemon_closing(closing: &mut watch::Receiver<bool>) {
 async fn forward_events(
     state: ApiState,
     from: u64,
+    query: EventsQuery,
     tx: mpsc::Sender<Result<SseEvent, std::convert::Infallible>>,
 ) {
     // Subscribe before reading history so nothing can fall in the gap.
@@ -4209,7 +4257,10 @@ async fn forward_events(
     match history {
         Ok(events) => {
             for event in events {
-                if send_sse(&tx, &event).await.is_err() {
+                // `last_sent` advances past a filtered-out event too: it is
+                // the resume point, not a delivery count, and a client that
+                // reconnects must not be handed the same skipped seqs again.
+                if matches_query(&event, &query) && send_sse(&tx, &event).await.is_err() {
                     return;
                 }
                 last_sent = event.seq;
@@ -4227,7 +4278,7 @@ async fn forward_events(
                 if event.seq <= last_sent {
                     continue; // already delivered from history
                 }
-                if send_sse(&tx, &event).await.is_err() {
+                if matches_query(&event, &query) && send_sse(&tx, &event).await.is_err() {
                     return;
                 }
                 last_sent = event.seq;
@@ -5616,7 +5667,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::channel(1);
-        let pump = tokio::spawn(forward_events(state.clone(), 0, tx));
+        let pump = tokio::spawn(forward_events(state.clone(), 0, EventsQuery::default(), tx));
 
         // W4 §1.1.2: the very first frame on any connection is the floor
         // control frame, sent before history — consumed here, separately,
@@ -5705,7 +5756,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::channel(1);
-        let pump = tokio::spawn(forward_events(state.clone(), 0, tx));
+        let pump = tokio::spawn(forward_events(state.clone(), 0, EventsQuery::default(), tx));
 
         let floor = rx
             .recv()

--- a/src/api.rs
+++ b/src/api.rs
@@ -443,7 +443,16 @@ pub struct ApiState {
     /// and finish, because graceful shutdown waits for in-flight responses.
     pub closing: watch::Receiver<bool>,
     /// The workflow engine: backends, routing defaults, and the surfaces dir.
+    ///
+    /// D10: it carries **no** estate. Every handler that needs topology
+    /// admits the estate its request addressed (below) and hands the root to
+    /// `Engine::plan` per call.
     pub engine: Arc<Engine>,
+    /// H1 §4: the admitted-estate registry — this daemon's observational
+    /// record of every estate it has validated, keyed by canonical root and
+    /// rebuilt from requests. Nothing is served for an estate that is not in
+    /// here, and nothing gets in here without passing admission.
+    pub estates: Arc<crate::runtime::estates::EstateRegistry>,
     /// The disposable DuckDB analytical + graph projection (§21–§23).
     ///
     /// Behind its own lock, not the core's: an analytics query is a read of a
@@ -484,6 +493,7 @@ pub fn router(state: ApiState) -> Router {
             get(estate_list_groups).post(estate_add_group),
         )
         .route("/estate/groups/{name}", delete(estate_remove_group))
+        .route("/estates", get(list_estates))
         .route("/doctor", get(doctor_report))
         .route("/admission/pause", post(pause_admission))
         .route("/graph/work/{id}", get(work_graph))
@@ -1311,6 +1321,24 @@ fn internal_error(e: impl std::fmt::Display) -> Response {
 struct SubmitRequest {
     command_id: String,
     intent: String,
+    /// D4: the estate this submission addresses — the canonical exact root
+    /// (D1/H1-06: no UUID), validated by admission and never by trust.
+    ///
+    /// §7.4 removed `workspace` because the daemon was bound to exactly one
+    /// estate and a wire field would have been a second, conflicting
+    /// authority. A host daemon is bound to none, so the field is back — but
+    /// as an *address*, not a binding: what it names is re-admitted per
+    /// submission ([`crate::runtime::estates::EstateRegistry::admit`]), and
+    /// a root that does not validate is refused rather than served.
+    ///
+    /// Absent keeps the meaning "no repository context offered": the Work is
+    /// accepted and stays `pending`, exactly as a submission to an
+    /// estate-less daemon always did. That is not a hole in H1 §11.3 — the
+    /// client-side gate is what refuses `sgt run` outside an estate, before
+    /// a request is ever built — it is the existing, journaled,
+    /// non-error meaning of "I have no estate to offer".
+    #[serde(default)]
+    estate_root: Option<PathBuf>,
     /// estate-root proposal §7/§13.3's structured scope request
     /// (`--repo`/`--group`/`--all`). §7.4: `estate` no longer exists as
     /// a wire field at all — the daemon is bound to exactly one estate, and
@@ -1479,10 +1507,37 @@ async fn submit_work(
     // does not reach that append (a preflight refusal, a replayed
     // `command_id`, an empty intent) simply discards it.
     let work_id_candidate = ulid::Ulid::generate().to_string();
+    // D4: admit the addressed estate **before** planning. A root that does
+    // not validate is this submission's refusal (journaled under its
+    // `command_id` like every other semantic rejection, so a retry replays
+    // it), never a plan against topology nobody checked — and never a reason
+    // to refuse some *other* estate's request.
+    let addressed = match req.estate_root.as_deref() {
+        None => None,
+        Some(root) => match state.estates.admit(root) {
+            Ok(estate) => Some(estate.root),
+            Err(e) => {
+                let result = error_body(e.code(), e.to_string());
+                let mut core = CoreGuard::acquire(&state.core).await;
+                if let Some(resp) = replay_command(&core, &req.command_id) {
+                    return resp;
+                }
+                return record_and_respond(
+                    &mut core,
+                    &req.command_id,
+                    "work.submit",
+                    None,
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    result,
+                );
+            }
+        },
+    };
     let planned = if req.intent.trim().is_empty() {
         None
     } else {
         let engine = state.engine.clone();
+        let estate_root = addressed.clone();
         let backend = req.backend.clone();
         let workflow = req.workflow.clone();
         let profile = req.profile.clone();
@@ -1493,18 +1548,21 @@ async fn submit_work(
         let override_git_preflight = req.override_git_preflight;
         Some(
             blocking(move || {
-                engine.plan(&SubmitContext {
-                    cwd: origin_cwd.as_deref(),
-                    origin_client: origin_client.as_deref(),
-                    backend: backend.as_deref(),
-                    workflow: workflow.as_deref(),
-                    profile: profile.as_deref(),
-                    repos: &scope.repos,
-                    group: scope.group.as_deref(),
-                    all: scope.all,
-                    work_id: Some(&candidate),
-                    override_git_preflight,
-                })
+                engine.plan(
+                    estate_root.as_deref(),
+                    &SubmitContext {
+                        cwd: origin_cwd.as_deref(),
+                        origin_client: origin_client.as_deref(),
+                        backend: backend.as_deref(),
+                        workflow: workflow.as_deref(),
+                        profile: profile.as_deref(),
+                        repos: &scope.repos,
+                        group: scope.group.as_deref(),
+                        all: scope.all,
+                        work_id: Some(&candidate),
+                        override_git_preflight,
+                    },
+                )
             })
             .await,
         )
@@ -2264,11 +2322,13 @@ async fn list_work(State(state): State<ApiState>) -> Response {
 
 #[derive(Debug, Deserialize)]
 struct WorkflowsQuery {
-    /// The client's working directory — estate discovery (§9) starts
-    /// here, exactly as [`Origin::cwd`] does for `POST /v1/work`, so what
-    /// this route shows as available matches what submission would actually
-    /// resolve (§19.4's "cwd discovery matches submission").
+    /// The client's working directory — evidence only since §5.2 removed
+    /// its authority over topology; still validated so an obviously-broken
+    /// client hears about it.
     cwd: String,
+    /// D4: the estate whose local catalog half this request addresses.
+    #[serde(default)]
+    estate_root: Option<PathBuf>,
 }
 
 /// One `CatalogEntry.stages[]` element (§11.2's StageEntry): order, kind,
@@ -2367,7 +2427,15 @@ async fn list_workflows(
             "cwd must be an absolute path",
         );
     }
-    let estate_root = state.engine.estate_root.clone();
+    // D4: the catalog's estate-local half is the *addressed* estate's, and
+    // only once admitted. Unaddressed (or unadmitted) answers the embedded
+    // catalog alone — an honest "no estate in play here", never another
+    // estate's forks.
+    let estate_root = req
+        .estate_root
+        .as_deref()
+        .and_then(|root| state.estates.admit(root).ok())
+        .map(|estate| estate.root);
     let workflows = blocking(move || workflow_catalog_entries(estate_root.as_deref())).await;
     Json(json!({"workflows": workflows})).into_response()
 }
@@ -3216,8 +3284,11 @@ async fn list_retained(State(state): State<ApiState>) -> Response {
 /// estate's own ordinary checkout — §6.1's derived mount, no symlink, no
 /// linked worktree, no other estate's clone. A declared-but-unresolvable
 /// repository fails the whole pass by name rather than being swept past.
-fn sweep_topology(state: &ApiState) -> Result<Estate, (StatusCode, Value)> {
-    let root = estate_root_or_error(state)?;
+fn sweep_topology(
+    state: &ApiState,
+    requested: Option<&std::path::Path>,
+) -> Result<Estate, (StatusCode, Value)> {
+    let root = estate_root_or_error(state, requested, "sweeping")?;
     Estate::resolve(&root).map_err(|e| {
         (
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -3261,8 +3332,8 @@ fn journaled_work_states(core: &Core) -> std::collections::BTreeMap<String, Work
 /// mid-walk is therefore classified against the snapshot; that is safe
 /// because nothing here acts on the answer, and the deletion half re-derives
 /// its own classification from scratch anyway.
-async fn sweep_estate(State(state): State<ApiState>) -> Response {
-    let estate = match sweep_topology(&state) {
+async fn sweep_estate(State(state): State<ApiState>, Query(query): Query<EstateQuery>) -> Response {
+    let estate = match sweep_topology(&state, query.estate_root.as_deref()) {
         Ok(estate) => estate,
         Err((status, body)) => return (status, Json(body)).into_response(),
     };
@@ -3277,6 +3348,9 @@ async fn sweep_estate(State(state): State<ApiState>) -> Response {
 #[derive(Debug, Deserialize)]
 struct SweepRequest {
     command_id: String,
+    /// D4: the estate whose `sergeant/*` refs this sweep addresses.
+    #[serde(default)]
+    estate_root: Option<PathBuf>,
     /// Must be `true`, or the request is refused — sweep deletes branches
     /// and git's reflog is the only undo.
     #[serde(default)]
@@ -3338,7 +3412,7 @@ async fn sweep_delete(
             result,
         );
     }
-    let estate = match sweep_topology(&state) {
+    let estate = match sweep_topology(&state, req.estate_root.as_deref()) {
         Ok(estate) => estate,
         Err((status, body)) => {
             return record_and_respond(
@@ -3374,20 +3448,30 @@ async fn sweep_delete(
 // state (R-NS-4, `src/domain/manifest.rs`'s own module doc), so unlike every
 // other mutation in this file there is no `command_id`/replay pair.
 
-/// The estate root these routes edit: an upward walk from this daemon's own
-/// `data_dir`, unscoped — correct for the default `<estate_root>/.sergeant/
-/// data` layout `sgt init` always produces, deterministic, and dependent on
-/// nothing but the one fact [`ApiState`] already carries.
+/// D4: the estate root these routes operate on comes from the **request**,
+/// and is served only after this daemon's registry admits it.
 ///
-/// The process's own working directory is deliberately **not** consulted —
-/// a long-running daemon's cwd is not reliably the estate root in every real
-/// deployment, and unlike a walk that simply finds nothing, a cwd that
-/// happens to sit inside a *different* estate (an unrelated git checkout
-/// that is itself one, `sgt`'s own self-hosting shape among them) would
-/// silently resolve to the wrong manifest rather than failing closed — the
-/// one outcome R-NS-4's discipline exists to prevent.
-fn resolve_estate_root(state: &ApiState) -> Result<PathBuf, Box<Response>> {
-    estate_root_or_error(state)
+/// It used to come from `state.engine.estate_root` — the one estate the
+/// process was bound to. A host daemon has none, so every estate-scoped
+/// route now carries an explicit `estate_root` (a canonical exact root per
+/// D1/H1-06: no UUID), and the daemon validates it *by admission*, never by
+/// trust. The refusal taxonomy is
+/// [`crate::runtime::estates::EstateAdmissionError`]'s, unchanged between
+/// this and the client-side gate.
+///
+/// The process's own working directory is still deliberately **not**
+/// consulted, for exactly the reason it never was: a long-running daemon's
+/// cwd is not reliably anything, and a cwd that happens to sit inside a
+/// *different* estate would silently resolve to the wrong manifest rather
+/// than failing closed — the one outcome R-NS-4's discipline exists to
+/// prevent. H1 removes the daemon's binding; it does not give the daemon a
+/// new way to guess.
+fn resolve_estate_root(
+    state: &ApiState,
+    requested: Option<&std::path::Path>,
+    operation: &str,
+) -> Result<PathBuf, Box<Response>> {
+    estate_root_or_error(state, requested, operation)
         .map_err(|(status, body)| Box::new((status, Json(body)).into_response()))
 }
 
@@ -3395,18 +3479,75 @@ fn resolve_estate_root(state: &ApiState) -> Result<PathBuf, Box<Response>> {
 /// finished response — the shape a *command* handler needs, because its
 /// refusal has to be journaled under a `command_id` before it is answered
 /// with, and `record_and_respond` takes the body.
-fn estate_root_or_error(state: &ApiState) -> Result<PathBuf, (StatusCode, Value)> {
-    match state.engine.estate_root.clone() {
-        Some(root) => Ok(root),
-        None => Err((
+fn estate_root_or_error(
+    state: &ApiState,
+    requested: Option<&std::path::Path>,
+    operation: &str,
+) -> Result<PathBuf, (StatusCode, Value)> {
+    admit_addressed_estate(state, requested, operation).map(|estate| estate.root)
+}
+
+/// Admit the estate a request addressed, or turn the refusal into this
+/// file's one `{"error": {"code", "message"}}` shape.
+///
+/// `NOT_FOUND` for "no estate addressed" (the operation has no object) and
+/// `UNPROCESSABLE_ENTITY` for a root that will not admit (the request named
+/// something, and it is wrong) — the same split every other refusal in this
+/// file already draws between an absent thing and an invalid one.
+fn admit_addressed_estate(
+    state: &ApiState,
+    requested: Option<&std::path::Path>,
+    operation: &str,
+) -> Result<crate::runtime::estates::AdmittedEstate, (StatusCode, Value)> {
+    let Some(requested) = requested else {
+        return Err((
             StatusCode::NOT_FOUND,
             error_body(
                 "no_estate",
-                "this daemon is bound to no estate — start it from an estate root (`sgt daemon` \
-                 from the root, or `sgt -C <estate-root> daemon`)",
+                format!(
+                    "{operation} is estate-scoped, but this request addressed no estate — send \
+                     `estate_root` (the exact estate root, canonical)"
+                ),
             ),
-        )),
-    }
+        ));
+    };
+    state.estates.admit(requested).map_err(|e| {
+        (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            error_body(e.code(), e.to_string()),
+        )
+    })
+}
+
+/// `GET /v1/estates` (H1 §4, brief deliverable 6) — the admitted-estate
+/// registry as this process holds it right now.
+///
+/// Observational, and says so: a row exists because some request addressed
+/// that root and admission succeeded, never because the daemon went looking.
+/// `available` is the last re-validation's verdict, so an estate whose
+/// manifest has since been deleted is still *listed* — its Work is still in
+/// the journal — and reported unavailable with the reason, rather than
+/// vanishing as though it had never been served.
+async fn list_estates(State(state): State<ApiState>) -> Response {
+    let estates: Vec<Value> = state
+        .estates
+        .entries()
+        .into_iter()
+        .map(|entry| {
+            json!({
+                "root": entry.estate.root,
+                "name": entry.estate.name,
+                "manifest_path": entry.estate.manifest_path,
+                "admitted_at": entry.estate.admitted_at,
+                "available": entry.available,
+                "unavailable_reason": entry.unavailable_reason,
+                "last_touched_at": entry.last_touched_at,
+                "retention": entry.estate.retention,
+                "surfaces_dir": entry.estate.surfaces_dir,
+            })
+        })
+        .collect();
+    Json(json!({"estates": estates})).into_response()
 }
 
 /// Stable per-variant code for a [`ManifestError`], for the same
@@ -3472,6 +3613,18 @@ fn manifest_error_response(e: &ManifestError) -> Response {
     )
 }
 
+/// D4: how an estate-addressed **query** names its estate.
+///
+/// `GET`/`DELETE` routes have no body to carry `estate_root` in, so it rides
+/// the query string — the canonical exact root, percent-encoded by the
+/// client. Absent is refusal (c): the operation has no object, and the
+/// daemon does not pick one.
+#[derive(Debug, Deserialize, Default)]
+struct EstateQuery {
+    #[serde(default)]
+    estate_root: Option<PathBuf>,
+}
+
 /// The declared repositories, read the same way `sgt repo list --json` does.
 fn workspace_read(estate_root: &std::path::Path) -> Result<Estate, Box<Response>> {
     Estate::from_config_allow_empty(&estate_root.join(crate::domain::estate::MANIFEST_FILE))
@@ -3486,11 +3639,15 @@ fn workspace_read(estate_root: &std::path::Path) -> Result<Estate, Box<Response>
 
 /// `GET /v1/estate/repos` (§16.2) — the same read `sgt repo list --json`
 /// already performs, over the daemon's own estate.
-async fn estate_list_repos(State(state): State<ApiState>) -> Response {
-    let estate_root = match resolve_estate_root(&state) {
-        Ok(root) => root,
-        Err(resp) => return *resp,
-    };
+async fn estate_list_repos(
+    State(state): State<ApiState>,
+    Query(query): Query<EstateQuery>,
+) -> Response {
+    let estate_root =
+        match resolve_estate_root(&state, query.estate_root.as_deref(), "listing repositories") {
+            Ok(root) => root,
+            Err(resp) => return *resp,
+        };
     let estate = match workspace_read(&estate_root) {
         Ok(w) => w,
         Err(resp) => return *resp,
@@ -3512,6 +3669,9 @@ async fn estate_list_repos(State(state): State<ApiState>) -> Response {
 
 #[derive(Debug, Deserialize)]
 struct AddRepoRequest {
+    /// D4: the estate this edit addresses (canonical exact root).
+    #[serde(default)]
+    estate_root: Option<PathBuf>,
     name: String,
     #[serde(default)]
     origin: Option<String>,
@@ -3550,10 +3710,11 @@ async fn estate_add_repo(
             );
         }
     };
-    let estate_root = match resolve_estate_root(&state) {
-        Ok(root) => root,
-        Err(resp) => return *resp,
-    };
+    let estate_root =
+        match resolve_estate_root(&state, req.estate_root.as_deref(), "adding a repository") {
+            Ok(root) => root,
+            Err(resp) => return *resp,
+        };
     let name = req.name.clone();
     let origin = req.origin.clone();
     let upstream = req.upstream.clone();
@@ -3585,8 +3746,16 @@ async fn estate_add_repo(
 /// `DELETE /v1/estate/repos/{name}` (§16.2) — `manifest::remove_repo`
 /// exactly; the group-reference refusal it returns reaches the caller
 /// structured, not reworded.
-async fn estate_remove_repo(State(state): State<ApiState>, Path(name): Path<String>) -> Response {
-    let estate_root = match resolve_estate_root(&state) {
+async fn estate_remove_repo(
+    State(state): State<ApiState>,
+    Path(name): Path<String>,
+    Query(query): Query<EstateQuery>,
+) -> Response {
+    let estate_root = match resolve_estate_root(
+        &state,
+        query.estate_root.as_deref(),
+        "removing a repository",
+    ) {
         Ok(root) => root,
         Err(resp) => return *resp,
     };
@@ -3598,11 +3767,15 @@ async fn estate_remove_repo(State(state): State<ApiState>, Path(name): Path<Stri
 
 /// `GET /v1/estate/groups` (§16.2) — the same read `sgt group list --json`
 /// already performs.
-async fn estate_list_groups(State(state): State<ApiState>) -> Response {
-    let estate_root = match resolve_estate_root(&state) {
-        Ok(root) => root,
-        Err(resp) => return *resp,
-    };
+async fn estate_list_groups(
+    State(state): State<ApiState>,
+    Query(query): Query<EstateQuery>,
+) -> Response {
+    let estate_root =
+        match resolve_estate_root(&state, query.estate_root.as_deref(), "listing groups") {
+            Ok(root) => root,
+            Err(resp) => return *resp,
+        };
     let estate = match workspace_read(&estate_root) {
         Ok(w) => w,
         Err(resp) => return *resp,
@@ -3617,6 +3790,9 @@ async fn estate_list_groups(State(state): State<ApiState>) -> Response {
 
 #[derive(Debug, Deserialize)]
 struct AddGroupRequest {
+    /// D4: the estate this edit addresses (canonical exact root).
+    #[serde(default)]
+    estate_root: Option<PathBuf>,
     name: String,
     #[serde(default)]
     repos: Vec<String>,
@@ -3635,10 +3811,11 @@ async fn estate_add_group(
         Ok(r) => r,
         Err(resp) => return *resp,
     };
-    let estate_root = match resolve_estate_root(&state) {
-        Ok(root) => root,
-        Err(resp) => return *resp,
-    };
+    let estate_root =
+        match resolve_estate_root(&state, req.estate_root.as_deref(), "adding a group") {
+            Ok(root) => root,
+            Err(resp) => return *resp,
+        };
     let name = req.name.clone();
     let repos = req.repos.clone();
     let brief = req.brief.clone();
@@ -3672,6 +3849,7 @@ struct RemoveGroupRequest {
 async fn estate_remove_group(
     State(state): State<ApiState>,
     Path(name): Path<String>,
+    Query(query): Query<EstateQuery>,
     body: axum::body::Bytes,
 ) -> Response {
     let repos = if body.is_empty() {
@@ -3688,27 +3866,31 @@ async fn estate_remove_group(
             }
         }
     };
-    let estate_root = match resolve_estate_root(&state) {
-        Ok(root) => root,
-        Err(resp) => return *resp,
-    };
+    let estate_root =
+        match resolve_estate_root(&state, query.estate_root.as_deref(), "removing a group") {
+            Ok(root) => root,
+            Err(resp) => return *resp,
+        };
     match blocking_sync(|| manifest::remove_group(&estate_root, &name, &repos)) {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => manifest_error_response(&e),
     }
 }
 
-/// The directory `GET /v1/doctor` reports the estate rows against: this
-/// daemon's own bound estate root (§5.1), never the daemon process's cwd —
-/// a long-running daemon's cwd is not reliably anything. With no bound
-/// estate the data dir stands in, and the estate-root row correctly fails
-/// there, which is exactly what a daemon started outside an estate should
-/// report.
-fn doctor_root(state: &ApiState) -> PathBuf {
-    state
-        .engine
-        .estate_root
-        .clone()
+/// The directory `GET /v1/doctor` reports the estate rows against: the
+/// estate **this request addressed** (D4), never the daemon process's cwd —
+/// a long-running daemon's cwd is not reliably anything, and a host daemon
+/// no longer has a bound root to fall back on either.
+///
+/// An unaddressed or unadmitted estate falls back to the host runtime root,
+/// where the estate-root row correctly fails — which is exactly what
+/// `sgt doctor` asking a host daemon about no estate in particular should
+/// report, and is the same answer a daemon started outside an estate has
+/// always given.
+fn doctor_root(state: &ApiState, requested: Option<&std::path::Path>) -> PathBuf {
+    requested
+        .and_then(|root| state.estates.admit(root).ok())
+        .map(|estate| estate.root)
         .unwrap_or_else(|| state.data_dir.clone())
 }
 
@@ -3720,8 +3902,12 @@ fn doctor_root(state: &ApiState) -> PathBuf {
 /// CLI invocation resolved `state.data_dir` before spawning or attaching to
 /// this daemon — that resolution, and its winning rung, do not survive
 /// across the process boundary to this handler.
-async fn doctor_report(State(state): State<ApiState>) -> Response {
-    let report = doctor::run(&state.data_dir, &doctor_root(&state), false).await;
+async fn doctor_report(
+    State(state): State<ApiState>,
+    Query(query): Query<EstateQuery>,
+) -> Response {
+    let root = doctor_root(&state, query.estate_root.as_deref());
+    let report = doctor::run(&state.data_dir, &root, false).await;
     Json(report.to_json()).into_response()
 }
 
@@ -4355,10 +4541,17 @@ pub struct ApiClient {
     http: reqwest::Client,
     endpoint: String,
     token: String,
+    estate_root: Option<PathBuf>,
 }
 
 impl ApiClient {
     /// Build a client for a daemon endpoint and its bearer token.
+    ///
+    /// D4: the client addresses **no** estate until one is named with
+    /// [`Self::with_estate_root`]. That is the honest default under H1 — the
+    /// daemon is host-scoped, so a client that has not said which estate it
+    /// means has not said it — and it is what lets the host-scoped verb
+    /// bucket W3 lands connect with no estate at all.
     pub fn new(endpoint: &str, token: &str) -> Result<Self, ClientError> {
         Ok(Self {
             http: reqwest::Client::builder()
@@ -4366,7 +4559,39 @@ impl ApiClient {
                 .build()?,
             endpoint: endpoint.trim_end_matches('/').to_string(),
             token: token.to_string(),
+            estate_root: None,
         })
+    }
+
+    /// Address every estate-scoped request from this client at `root` — the
+    /// exact estate root the caller already admitted (§4.3 admits before a
+    /// descriptor is even read, so this is never a fresh guess).
+    pub fn with_estate_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.estate_root = Some(root.into());
+        self
+    }
+
+    /// The estate this client addresses, if any.
+    pub fn estate_root(&self) -> Option<&std::path::Path> {
+        self.estate_root.as_deref()
+    }
+
+    /// `?estate_root=<root>` for the GET/DELETE routes that have no body to
+    /// carry it in. Empty when this client addresses no estate, so the
+    /// daemon answers with refusal (c) rather than being handed a blank.
+    fn estate_query(&self) -> String {
+        match &self.estate_root {
+            Some(root) => format!("?estate_root={}", urlencode(&root.to_string_lossy())),
+            None => String::new(),
+        }
+    }
+
+    /// Add this client's estate address to a request body, if it has one.
+    fn addressed(&self, mut body: Value) -> Value {
+        if let (Some(root), Some(map)) = (&self.estate_root, body.as_object_mut()) {
+            map.insert("estate_root".to_string(), json!(root));
+        }
+        body
     }
 
     /// The daemon endpoint this client talks to.
@@ -4493,8 +4718,12 @@ impl ApiClient {
     /// bind now.
     pub async fn workflows(&self, cwd: &std::path::Path) -> Result<Value, ClientError> {
         self.get(&format!(
-            "/v1/workflows?cwd={}",
-            urlencode(&cwd.display().to_string())
+            "/v1/workflows?cwd={}{}",
+            urlencode(&cwd.display().to_string()),
+            match &self.estate_root {
+                Some(root) => format!("&estate_root={}", urlencode(&root.to_string_lossy())),
+                None => String::new(),
+            }
         ))
         .await
     }
@@ -4516,7 +4745,7 @@ impl ApiClient {
     /// `GET /v1/sweep` — §12.3's deliberate sweep, classification half
     /// (#159). Mutates nothing.
     pub async fn sweep(&self) -> Result<Value, ClientError> {
-        self.get("/v1/sweep").await
+        self.get(&format!("/v1/sweep{}", self.estate_query())).await
     }
 
     /// `POST /v1/sweep` with a fresh command id (§26) — the deletion half.
@@ -4529,18 +4758,19 @@ impl ApiClient {
     ) -> Result<Value, ClientError> {
         self.post(
             "/v1/sweep",
-            &json!({
+            &self.addressed(json!({
                 "command_id": ulid::Ulid::generate().to_string(),
                 "confirm": confirm,
                 "branches": branches,
-            }),
+            })),
         )
         .await
     }
 
     /// `GET /v1/estate/repos` (§16.2/§20.4) — declared repositories.
     pub async fn repos(&self) -> Result<Value, ClientError> {
-        self.get("/v1/estate/repos").await
+        self.get(&format!("/v1/estate/repos{}", self.estate_query()))
+            .await
     }
 
     /// `POST /v1/estate/repos` (§16.2/§20.4) — `manifest::add_repo`.
@@ -4553,25 +4783,33 @@ impl ApiClient {
     ) -> Result<Value, ClientError> {
         self.post(
             "/v1/estate/repos",
-            &json!({
+            &self.addressed(json!({
                 "name": name,
                 "origin": origin,
                 "upstream": upstream,
                 "instructions": instructions,
-            }),
+            })),
         )
         .await
     }
 
     /// `DELETE /v1/estate/repos/{name}` (§16.2/§20.4) — `manifest::remove_repo`.
     pub async fn remove_repo(&self, name: &str) -> Result<Value, ClientError> {
-        self.delete(&format!("/v1/estate/repos/{}", urlencode(name)), &json!({}))
-            .await
+        self.delete(
+            &format!(
+                "/v1/estate/repos/{}{}",
+                urlencode(name),
+                self.estate_query()
+            ),
+            &json!({}),
+        )
+        .await
     }
 
     /// `GET /v1/estate/groups` (§16.2/§20.4) — declared groups.
     pub async fn groups(&self) -> Result<Value, ClientError> {
-        self.get("/v1/estate/groups").await
+        self.get(&format!("/v1/estate/groups{}", self.estate_query()))
+            .await
     }
 
     /// `POST /v1/estate/groups` (§16.2/§20.4) — `manifest::add_group`'s
@@ -4584,7 +4822,7 @@ impl ApiClient {
     ) -> Result<Value, ClientError> {
         self.post(
             "/v1/estate/groups",
-            &json!({"name": name, "repos": repos, "brief": brief}),
+            &self.addressed(json!({"name": name, "repos": repos, "brief": brief})),
         )
         .await
     }
@@ -4593,7 +4831,11 @@ impl ApiClient {
     /// empty `repos` removes the whole group, otherwise just those members.
     pub async fn remove_group(&self, name: &str, repos: &[String]) -> Result<Value, ClientError> {
         self.delete(
-            &format!("/v1/estate/groups/{}", urlencode(name)),
+            &format!(
+                "/v1/estate/groups/{}{}",
+                urlencode(name),
+                self.estate_query()
+            ),
             &json!({"repos": repos}),
         )
         .await
@@ -4602,7 +4844,14 @@ impl ApiClient {
     /// `GET /v1/doctor` (§16.3/§20.4) — the same `doctor::Report` `sgt doctor
     /// --json` prints.
     pub async fn doctor(&self) -> Result<Value, ClientError> {
-        self.get("/v1/doctor").await
+        self.get(&format!("/v1/doctor{}", self.estate_query()))
+            .await
+    }
+
+    /// `GET /v1/estates` (H1 §4) — every estate this daemon has admitted.
+    /// Host-scoped: it addresses no estate, because the answer *is* the set.
+    pub async fn estates(&self) -> Result<Value, ClientError> {
+        self.get("/v1/estates").await
     }
 
     /// Open the SSE live tail at `GET /v1/events/stream?from=N`.
@@ -5189,6 +5438,7 @@ mod tests {
                 None,
                 data_dir,
             )),
+            estates: Arc::new(crate::runtime::estates::EstateRegistry::new()),
             analytics: Arc::new(tokio::sync::Mutex::new(analytics)),
             prune_policy: crate::runtime::prune::PrunePolicy {
                 retention: crate::domain::estate::DEFAULT_RETENTION,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -797,12 +797,15 @@ fn resolve_data_dir(
 /// (`Manifest`/`EstateDefault` simply never occur here — there is no
 /// estate rung on this ladder at all).
 ///
-/// W1b landed this resolver with no caller (`#[allow(dead_code)]`,
-/// "zero behavior change" by design). **W4c is this seat's first caller**:
-/// [`install_service`] resolves the host runtime root a generated unit
-/// points at through this exact function, not a second copy of the ladder
-/// — W2/W3 remain the waves that rewire `dispatch`/`ensure_daemon`'s own
-/// host-scoped paths onto it.
+/// W1b landed this resolver caller-less ("zero behavior change" by
+/// design). Two callers own it now: W4c's [`install_service`] resolves
+/// the host runtime root a generated unit points at, and W2 wires the
+/// foreground `sgt daemon` verb (the one that creates the runtime root)
+/// onto it. W3 rewires the remaining client paths
+/// (`ensure_daemon`/`observe_connect`/`spawn_daemon`) — until then those
+/// still resolve per-estate, which stays consistent because
+/// `spawn_daemon` passes `--data-dir` explicitly (the flag rung wins on
+/// both ladders).
 fn resolve_host_runtime_dir(
     flag: Option<PathBuf>,
     env: impl Fn(&str) -> Option<OsString>,
@@ -851,42 +854,41 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
         None
     };
     let (data_dir, data_dir_source) = resolve_data_dir(
-        sgt.data_dir,
+        sgt.data_dir.clone(),
         estate.as_ref().map(|e| e.path.as_path()).unwrap_or(&root),
     )?;
-    // W1b caller classification (this wave tags, does not rewire — W2/W3
-    // consume it): every downstream use of this one `data_dir` below, by
-    // where it actually gets used rather than by `Command` variant (several
-    // variants reach more than one):
-    //   HOST   — daemon discovery/spawn/stop: `ensure_daemon`/
-    //            `observe_connect`/`daemon_stop`/`spawn_daemon` (every
-    //            match arm that constructs a client or calls `daemon::
-    //            run_until_signal`), plus `exec_harness`'s adapter-state
-    //            directory (`DaemonConfig`'s per-adapter config already
-    //            documents "`None` = system binary + adapter state under
-    //            `data_dir`" — daemon-owned state, not estate-owned).
-    //   ESTATE — `doctor::run`'s journal-replay-derived checks specifically
-    //            (`journal_check`, `projection_check`, `git_surfaces_check`,
-    //            `journal_growth_check` — all read *this estate's* journal
-    //            events); everything else `doctor::run` checks about the
-    //            directory itself (existence/writability/locking/disk
-    //            pressure/adapter probes) is HOST today because `data_dir`
-    //            *is* the one directory in play, but is slated to move
-    //            under `resolve_host_runtime_dir` once W2 splits journal
-    //            ownership from estate-local state (see `resolve_data_dir`'s
-    //            doc comment above).
+    // W1b's caller classification, W2 consuming the first of it. The HOST
+    // bucket — daemon discovery/spawn/stop and `exec_harness`'s adapter
+    // state — is what `resolve_host_runtime_dir` is for; the ESTATE bucket
+    // (`doctor::run`'s journal-replay-derived checks) keeps
+    // `resolve_data_dir`.
+    //
+    // **This wave wires exactly one caller: the foreground daemon**, which
+    // is the one that actually *creates* the runtime root and therefore the
+    // one that has to name it correctly for `daemon.lock`, the journal, the
+    // blob store and the descriptor to live where D2 says. The client-side
+    // discovery/spawn callers (`ensure_daemon`/`observe_connect`/
+    // `daemon_stop`/`spawn_daemon`) are W3's, per this wave's brief, and
+    // still resolve as they did — which stays consistent because
+    // `spawn_daemon` passes `--data-dir` explicitly, so the child it starts
+    // takes the flag rung and lands in the same directory its parent looked
+    // in. The two ladders only diverge for a `sgt daemon` typed by hand with
+    // no flag and no `SGT_DATA_DIR`, which is exactly the case that *should*
+    // now be the host root.
     match command {
         Command::Daemon {
             command: None,
             rebuild_cache,
         } => {
             tracing_subscriber::fmt().init();
-            daemon::run_until_signal(
-                &data_dir,
-                estate.as_ref().map(|e| e.path.as_path()),
-                rebuild_cache,
-            )
-            .await?;
+            // D2 (J3): `--data-dir` -> `SGT_DATA_DIR` -> the platform
+            // convention, with no estate rung at all. `-C` on this verb
+            // named the estate this invocation addresses; it does not bind
+            // the process (deliverable 8), and the daemon it starts serves
+            // every estate admitted to it later.
+            let (host_root, _) =
+                resolve_host_runtime_dir(sgt.data_dir.clone(), |name| std::env::var_os(name))?;
+            daemon::run_until_signal(&host_root, rebuild_cache).await?;
             Ok(())
         }
         Command::Daemon {
@@ -1026,6 +1028,10 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             let body = json!({
                 "command_id": ulid::Ulid::generate().to_string(),
                 "intent": intent,
+                // D4: the submission *addresses* this estate — the exact
+                // root §4.3 already admitted above, sent explicitly rather
+                // than left to a daemon binding that no longer exists.
+                "estate_root": estate_root(&estate),
                 "workflow": workflow,
                 "backend": backend,
                 "profile": profile,
@@ -2284,7 +2290,7 @@ async fn ensure_daemon(data_dir: &Path, estate_root: &Path) -> Result<ApiClient,
         // failed"), never about which estate some descriptor was bound to.
         check_binding(estate_root, "this command")?;
         if healthz_ok(&http, &descriptor.endpoint).await {
-            return client_for(&descriptor);
+            return client_for(&descriptor, Some(estate_root));
         }
         if daemon::pid_alive(descriptor.pid) {
             // Ambiguous: something with that PID is alive but the endpoint
@@ -2332,7 +2338,7 @@ async fn ensure_daemon(data_dir: &Path, estate_root: &Path) -> Result<ApiClient,
             // because a manifest can break inside the spawn window.
             check_binding(estate_root, "this command")?;
             if healthz_ok(&http, &descriptor.endpoint).await {
-                return client_for(&descriptor);
+                return client_for(&descriptor, Some(estate_root));
             }
         }
         tokio::time::sleep(SPAWN_POLL).await;
@@ -2345,8 +2351,22 @@ async fn ensure_daemon(data_dir: &Path, estate_root: &Path) -> Result<ApiClient,
     )))
 }
 
-fn client_for(descriptor: &RuntimeDescriptor) -> Result<ApiClient, CliError> {
-    ApiClient::new(&descriptor.endpoint, &descriptor.token).map_err(CliError::from)
+/// Build the API client for a descriptor, addressed at the estate this
+/// invocation already admitted (D4).
+///
+/// `None` is the host-scoped shape: a client that names no estate, whose
+/// estate-scoped requests the daemon refuses by name rather than guessing
+/// for. W3 is what actually routes verbs into that bucket; the client can
+/// already express it.
+fn client_for(
+    descriptor: &RuntimeDescriptor,
+    estate_root: Option<&Path>,
+) -> Result<ApiClient, CliError> {
+    let client = ApiClient::new(&descriptor.endpoint, &descriptor.token)?;
+    Ok(match estate_root {
+        Some(root) => client.with_estate_root(root),
+        None => client,
+    })
 }
 
 /// The client gate, rewritten for H1 (sprint-plan D4, brief deliverable 4).
@@ -2409,7 +2429,7 @@ async fn observe_connect(data_dir: &Path, estate_root: &Path) -> Result<ApiClien
         .timeout(REQUEST_TIMEOUT)
         .build()?;
     if healthz_ok(&http, &descriptor.endpoint).await {
-        return client_for(&descriptor);
+        return client_for(&descriptor, Some(estate_root));
     }
     if daemon::pid_alive(descriptor.pid) {
         return Err(CliError::new(format!(
@@ -2641,7 +2661,7 @@ async fn daemon_stop(data_dir: &Path, estate_root: &Path, json: bool) -> Result<
         );
         return Ok(());
     }
-    let client = client_for(&descriptor)?;
+    let client = client_for(&descriptor, Some(estate_root))?;
 
     // 1. Pause admission — MVP-3's drain flag, scoped exactly to this verb.
     // Idempotent: a retry against a still-live, already-paused daemon

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2663,6 +2663,22 @@ async fn daemon_stop(data_dir: &Path, estate_root: &Path, json: bool) -> Result<
     }
     let client = client_for(&descriptor, Some(estate_root))?;
 
+    // 0. D5: **say what is about to stop.** `sgt daemon stop` stops the
+    // *host* daemon — every admitted estate's, not just the one this
+    // invocation happens to stand in. Before H1 those were the same
+    // sentence; now they are not, and a stop whose blast radius the operator
+    // has to infer is exactly the kind of silent behavior carryover the
+    // recon flagged. The count is read live from `GET /v1/estates` rather
+    // than assumed, and a daemon that cannot answer is reported as an
+    // unknown count rather than a comfortable zero.
+    let affected = match client.estates().await {
+        Ok(body) => body["estates"].as_array().map(Vec::len),
+        Err(e) => {
+            tracing::debug!(error = %e, "could not read the admitted-estate registry");
+            None
+        }
+    };
+
     // 1. Pause admission — MVP-3's drain flag, scoped exactly to this verb.
     // Idempotent: a retry against a still-live, already-paused daemon
     // journals nothing new (`pause_admission`'s own doc).
@@ -2719,8 +2735,23 @@ async fn daemon_stop(data_dir: &Path, estate_root: &Path, json: bool) -> Result<
             descriptor.pid,
         )));
     }
-    report_daemon_stop(json, "stopped", "daemon stopped");
+    report_daemon_stop(json, "stopped", &stopped_message(affected));
     Ok(())
+}
+
+/// D5's blast-radius sentence: what was stopped, and how much it covered.
+///
+/// `None` is an honest "the registry could not be read", never a silent 0 —
+/// telling an operator that no estates were affected when nobody actually
+/// asked is worse than telling them the count is unknown.
+fn stopped_message(affected: Option<usize>) -> String {
+    match affected {
+        Some(1) => "stopped the host daemon; 1 admitted estate affected".to_string(),
+        Some(n) => format!("stopped the host daemon; {n} admitted estates affected"),
+        None => {
+            "stopped the host daemon; the number of admitted estates could not be read".to_string()
+        }
+    }
 }
 
 /// `sgt daemon stop`'s one report shape, human or `--json`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2278,11 +2278,11 @@ async fn ensure_daemon(data_dir: &Path, estate_root: &Path) -> Result<ApiClient,
         .build()?;
 
     let stale = if let Some(descriptor) = daemon::read_descriptor(data_dir)? {
-        // §5.1: verify the binding **before** the endpoint is used for
-        // anything, and before any decision that could spawn. A daemon bound
-        // to another estate is a named refusal — never a connection, and
-        // never a second daemon over the same data dir.
-        check_binding(&descriptor, data_dir, estate_root)?;
+        // D4: validate the addressed estate **before** the endpoint is used
+        // for anything, and before any decision that could spawn. The
+        // refusal is now about the estate ("not an estate", "admission
+        // failed"), never about which estate some descriptor was bound to.
+        check_binding(estate_root, "this command")?;
         if healthz_ok(&http, &descriptor.endpoint).await {
             return client_for(&descriptor);
         }
@@ -2326,10 +2326,11 @@ async fn ensure_daemon(data_dir: &Path, estate_root: &Path) -> Result<ApiClient,
         if let Ok(Some(descriptor)) = daemon::read_descriptor(data_dir)
             && !is_stale_descriptor(stale.as_ref(), &descriptor)
         {
-            // The winner of the spawn race may be another client's child,
-            // and §5.1 applies to it exactly as it did above: a daemon bound
-            // elsewhere is refused, not adopted.
-            check_binding(&descriptor, data_dir, estate_root)?;
+            // The winner of the spawn race may be another client's child.
+            // Under H1 that is fine — it is the *host* daemon either way —
+            // but the addressed estate is re-validated exactly as above,
+            // because a manifest can break inside the spawn window.
+            check_binding(estate_root, "this command")?;
             if healthz_ok(&http, &descriptor.endpoint).await {
                 return client_for(&descriptor);
             }
@@ -2348,17 +2349,27 @@ fn client_for(descriptor: &RuntimeDescriptor) -> Result<ApiClient, CliError> {
     ApiClient::new(&descriptor.endpoint, &descriptor.token).map_err(CliError::from)
 }
 
-/// §5.1/§15: refuse a descriptor bound to a different estate, naming both
-/// roots. Runs before the endpoint is probed, connected to, or used to
-/// decide whether to spawn — "never connect, never a second daemon on the
-/// same data dir" is only true if the check comes first.
-fn check_binding(
-    descriptor: &RuntimeDescriptor,
-    data_dir: &Path,
-    estate_root: &Path,
-) -> Result<(), CliError> {
-    descriptor
-        .check_estate_root(data_dir, Some(estate_root))
+/// The client gate, rewritten for H1 (sprint-plan D4, brief deliverable 4).
+///
+/// **What it used to be.** `check_binding` compared the client's exact root
+/// against the one root the v2 descriptor published, refusing in both
+/// directions — "this daemon is bound to a different estate", "this daemon
+/// is bound to no estate". That class is retired, not silently deleted: a
+/// host daemon serving an estate it was never started from is H1's whole
+/// point, so the comparison has no object left to make.
+///
+/// **What it is now.** The one thing that was ever load-bearing: does the
+/// estate this command addresses actually validate, right now, as an estate
+/// (§4.1's exact-root check, plus this root's own filesystem reliability)?
+/// The taxonomy is [`crate::runtime::estates::EstateAdmissionError`]'s —
+/// (a) not an estate, (b) admission failed, (c) no estate addressed at all.
+///
+/// It still runs *before* the endpoint is probed, connected to, or used to
+/// decide whether to spawn, for the same reason it always did: a directory
+/// mistake must not be able to reach a daemon at all.
+fn check_binding(estate_root: &Path, operation: &str) -> Result<(), CliError> {
+    crate::runtime::estates::check_estate_root(Some(estate_root), operation)
+        .map(|_| ())
         .map_err(|e| CliError::new(e.to_string()))
 }
 
@@ -2391,9 +2402,9 @@ async fn observe_connect(data_dir: &Path, estate_root: &Path) -> Result<ApiClien
             data_dir.display(),
         )));
     };
-    // §5.1, before the endpoint is touched at all — the same gate
+    // D4, before the endpoint is touched at all — the same gate
     // `ensure_daemon` applies, for the same reason.
-    check_binding(&descriptor, data_dir, estate_root)?;
+    check_binding(estate_root, "this command")?;
     let http = reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
         .build()?;
@@ -2601,10 +2612,11 @@ async fn daemon_stop(data_dir: &Path, estate_root: &Path, json: bool) -> Result<
         );
         return Ok(());
     };
-    // §5.1, before the endpoint is touched: stopping is *using* a daemon,
-    // and a daemon bound to another estate is no more this estate's to stop
-    // than it is this estate's to submit to.
-    check_binding(&descriptor, data_dir, estate_root)?;
+    // D4/D5, before the endpoint is touched: `sgt daemon stop` stops the
+    // *host* daemon — every admitted estate's — so the estate this
+    // invocation stands in is validated for the ordinary reason (a directory
+    // mistake must not reach a daemon), not because it owns the daemon.
+    check_binding(estate_root, "sgt daemon stop")?;
     let http = reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
         .build()?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -42,7 +42,6 @@ use crate::backend::docker::{DOCKER_BACKEND_NAME, DockerBackend, DockerConfig};
 use crate::backend::fake::FAKE_BACKEND_NAME;
 use crate::backend::opencode::{OPENCODE_BACKEND_NAME, OpencodeBackend, OpencodeConfig};
 use crate::backend::{BackendRegistry, EventSink};
-use crate::domain::estate::Estate;
 use crate::domain::event::{EventDraft, EventSource};
 use crate::platform::fs_locking::{self, Reliability};
 use crate::runtime::analytics::{Analytics, AnalyticsError};
@@ -354,23 +353,19 @@ pub struct DaemonConfig {
     /// alternative — shrinking the window instead — would mean the tests
     /// prove a window nothing ships.
     pub segment_max_bytes: Option<u64>,
-    /// §5.1: the estate root this daemon is bound to, for its whole life.
-    ///
-    /// [`start_with`] admits it (§4.1's exact-root check —
-    /// [`Estate::admit`]) before the data dir is created, the journal
-    /// opened, or the descriptor published, so a daemon can never come up
-    /// bound to something that is not an estate. The canonical form is
-    /// pinned into the engine and published in the runtime descriptor, where
-    /// every client verifies it against its own root before use.
-    ///
-    /// `None` is a daemon bound to no estate: `Engine::plan` answers "no
-    /// repository context" and every submission stays `pending`. That is the
-    /// test rigs' shape — never a silent fallback to discovery, of which
-    /// there is none left.
-    pub estate_root: Option<PathBuf>,
     /// W3: retention cap for this daemon's journal, overriding `[estate]
-    /// retention`. `None` — production, always — takes the manifest's value
-    /// or [`crate::domain::estate::DEFAULT_RETENTION`].
+    /// retention`. `None` — production, always — takes
+    /// [`crate::domain::estate::DEFAULT_RETENTION`].
+    ///
+    /// **H1:** a host daemon has no one estate whose manifest could supply
+    /// this, so the `Manifest` rung is gone from the *process-wide* policy.
+    /// Each admitted estate's own `[estate] retention` is read at admission
+    /// ([`crate::runtime::estates::AdmittedEstate::retention`]); partitioning
+    /// the retention *decision* by estate is W4a's deliverable (D7 keeps the
+    /// blob-reference scan journal-wide either way). Until then the
+    /// process-wide policy is the explicit override or the built-in default,
+    /// which is a widening — never a silent narrowing — of what any one
+    /// estate declared.
     ///
     /// Configurable for the same reason `segment_max_bytes`/`completion_poll`
     /// are: a prune test has to stand on the far side of the cap, and
@@ -399,7 +394,6 @@ impl Default for DaemonConfig {
             turn_cap: None,
             rebuild_cache: false,
             segment_max_bytes: None,
-            estate_root: None,
             retention: None,
         }
     }
@@ -433,15 +427,18 @@ pub async fn start_with(
     data_dir: &Path,
     config: DaemonConfig,
 ) -> Result<DaemonHandle, DaemonError> {
-    // 0a. §4.1/§5.1: admit the estate root **first**, before the data dir is
-    // even created. A daemon that cannot name its estate must not come up at
-    // all — §4.3's ordering applies to the daemon's own startup exactly as
-    // it does to a client's dispatch, and the canonical root admitted here
-    // is what the descriptor publishes and every client verifies against.
-    let estate = match &config.estate_root {
-        Some(root) => Some(Estate::admit(root)?),
-        None => None,
-    };
+    // 0a. **Estate admission is no longer a startup step.** It used to be the
+    // first thing this function did — `Estate::admit(config.estate_root)`,
+    // before the data dir was even created, refusing the whole start when it
+    // failed. H1 moves it out: a host daemon starts bound to **zero** estates
+    // (the normal state, not a rig edge case) and admits each one lazily on
+    // the first request that addresses it
+    // ([`crate::runtime::estates::EstateRegistry`]). Keeping the old step
+    // would mean one estate's broken `sergeant.toml` refusing to start the
+    // daemon every *other* estate's Work depends on — which is precisely why
+    // admission failure is now an estate-specific refusal to the caller that
+    // asked for it, and never process death.
+    let estates = Arc::new(crate::runtime::estates::EstateRegistry::new());
 
     create_dir_all_durable(data_dir)?;
 
@@ -451,6 +448,12 @@ pub async fn start_with(
     // two daemons are racing the same data dir. An inconclusive probe (e.g.
     // today's always-Unknown macOS arm) does not refuse — see
     // `refuse_if_unreliable`.
+    //
+    // H1: `data_dir` is now the **host runtime root**, so this is the host
+    // half of a check that has become two. The estate half runs per estate
+    // root at admission (`estates::admit_root`), because an estate on a
+    // network share and a host root on local disk is a real shape, and one
+    // probe at one path can no longer answer for both.
     refuse_if_unreliable(data_dir, fs_locking::detect_for_path(data_dir))?;
 
     // 1. Exclusive daemon lock: a second daemon on the same data dir fails
@@ -578,46 +581,31 @@ pub async fn start_with(
         .with_floor_ledger(Arc::new(floor_ledger))
         .with_first_seq_index(first_seq_by_work);
 
-    // W3 §1.2: resolve the retention policy once, for this process's whole
-    // life — `config.retention` (test rigs only) -> `[estate] retention` ->
-    // the built-in default. Journaled on every prune event so the record
-    // names the authorization, not just the number (A1).
+    // W3 §1.2, as H1 leaves it: resolve the *process-wide* retention policy
+    // once — `config.retention` (test rigs only) -> the built-in default.
+    // Journaled on every prune event so the record names the authorization,
+    // not just the number (A1).
     //
-    // `estate` above is only an `EstateRoot` (path + manifest_path admitted
-    // by §4.1's exact-root check) — it never parsed `[estate] retention`, so
-    // it is re-read here through the *structural* parser: schema-level
-    // checks in full, no per-repository git validation (`Estate::admit`
-    // never did that either, so this cannot newly refuse a daemon start that
-    // used to succeed). A failure here — unreachable in practice, since
-    // `admit` already parsed the same file successfully — falls back to the
-    // default rather than turning a policy-resolution nicety into a new
-    // startup failure mode.
-    let estate_retention = estate.as_ref().and_then(|estate_root| {
-        match Estate::from_config_structural(&estate_root.manifest_path) {
-            Ok(full) => full.retention,
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "could not re-read the estate manifest for [estate] retention; using the default"
-                );
-                None
-            }
-        }
-    });
+    // The `[estate] retention` rung is gone from **this** resolution, and
+    // that is a deliberate, named change rather than an omission. It used to
+    // re-read the one bound estate's manifest here; a host journal holds
+    // many estates' Works, so "the manifest" has no referent at startup.
+    // Each admitted estate's own declaration is read at admission
+    // (`estates::admit_root` -> `AdmittedEstate::retention`) and W4a owns
+    // partitioning the retention *decision* by estate — D7 keeps the
+    // blob-reference scan journal-wide regardless, precisely so a per-estate
+    // decision can never condemn another estate's live blobs. Until W4a
+    // lands, the process-wide number is the explicit override or the
+    // default: a widening of what any one estate declared, never a silent
+    // narrowing.
     let prune_policy = match config.retention {
         Some(retention) => crate::runtime::prune::PrunePolicy {
             retention,
             source: crate::runtime::prune::PolicySource::Config,
         },
-        None => match estate_retention {
-            Some(retention) => crate::runtime::prune::PrunePolicy {
-                retention,
-                source: crate::runtime::prune::PolicySource::Manifest,
-            },
-            None => crate::runtime::prune::PrunePolicy {
-                retention: crate::domain::estate::DEFAULT_RETENTION,
-                source: crate::runtime::prune::PolicySource::Default,
-            },
+        None => crate::runtime::prune::PrunePolicy {
+            retention: crate::domain::estate::DEFAULT_RETENTION,
+            source: crate::runtime::prune::PolicySource::Default,
         },
     };
 
@@ -862,11 +850,9 @@ pub async fn start_with(
     // harness) are never left unsynced while unbounded — see its doc.
     let mut engine = Engine::new(backends, config.default_backend.clone(), data_dir)
         .with_turn_ceiling(config.turn_ceiling);
-    // §5.2: the engine's one topology authority for the life of this
-    // process. Nothing downstream ever re-derives it from a request cwd.
-    if let Some(estate) = &estate {
-        engine = engine.with_estate_root(estate.path.clone());
-    }
+    // D10: no `with_estate_root` here any more. The engine holds no estate;
+    // each `plan` call is handed the one its request addressed, after the
+    // registry admitted it.
     if let Some(surfaces_root) = config.surfaces_root.clone() {
         engine = engine.with_surfaces_root(surfaces_root);
     }
@@ -874,7 +860,7 @@ pub async fn start_with(
         engine = engine.with_turn_cap(turn_cap);
     }
     let engine = Arc::new(engine);
-    let reconciled = recovery::reconcile(&engine, &mut core)?;
+    let reconciled = recovery::reconcile(&engine, &estates, &mut core)?;
     // Backstop, not load-bearing: `reconcile` already leaves nothing open on
     // its own account, but a future edit there that forgets a flush must not
     // be able to publish the descriptor over an unsynced group. Free when
@@ -935,6 +921,7 @@ pub async fn start_with(
         data_dir: data_dir.to_path_buf(),
         closing: closing_rx,
         engine,
+        estates,
         analytics: Arc::new(tokio::sync::Mutex::new(analytics)),
         prune_policy,
     };
@@ -1196,13 +1183,16 @@ async fn export_events(
 /// Run the daemon in the foreground until SIGINT/SIGTERM, then shut down
 /// cleanly. This is what `sgt daemon` (and therefore auto-spawn) executes.
 ///
+/// `data_dir` is the **host runtime root** (D2): journal, projections, blob
+/// store, `daemon.lock` and the descriptor all live beneath it, and it is
+/// resolved from `--data-dir` / `SGT_DATA_DIR` / the platform convention —
+/// never from an estate. There is deliberately no estate parameter any more
+/// (deliverable 8): `-C` on a `daemon` verb names the estate the invocation
+/// is *addressing*, not one this process binds itself to for life.
+///
 /// This is the one place §28 export is configured from the environment, and
 /// [`TelemetryConfig::from_env`] answers "off" unless explicitly switched on.
-pub async fn run_until_signal(
-    data_dir: &Path,
-    estate_root: Option<&Path>,
-    rebuild_cache: bool,
-) -> Result<(), DaemonError> {
+pub async fn run_until_signal(data_dir: &Path, rebuild_cache: bool) -> Result<(), DaemonError> {
     // **Handlers first, before anything makes this daemon reachable.**
     //
     // Publishing the runtime descriptor is what tells the world "there is a
@@ -1268,10 +1258,6 @@ pub async fn run_until_signal(
             telemetry: telemetry.clone(),
             surfaces_root,
             turn_cap,
-            // §5.1: the estate this daemon is bound to for its whole life,
-            // handed down from the invocation that already admitted it
-            // (`sgt -C <root> daemon`, or `sgt daemon` from the root).
-            estate_root: estate_root.map(Path::to_path_buf),
             rebuild_cache,
             ..DaemonConfig::default()
         },

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -59,7 +59,18 @@ pub const DESCRIPTOR_FILE: &str = "runtime.json";
 /// Exclusive daemon lock file name inside the data dir.
 pub const DAEMON_LOCK_FILE: &str = "daemon.lock";
 /// Schema identifier for the runtime descriptor.
-pub const DESCRIPTOR_SCHEMA: &str = "sergeant.runtime/v2";
+///
+/// **v3 (H1, sprint-plan D3):** no estate fields. v2 published the one
+/// estate root the process was bound to, because that binding *was* the
+/// client-side safety check; a host daemon has no such binding, and the
+/// admitted-estate set is dynamic state served live by `GET /v1/estates`
+/// rather than something a file written once, atomically, at startup could
+/// honestly describe. A v2 descriptor therefore fails closed through
+/// [`DaemonError::UnknownDescriptorSchema`] like any other unknown schema —
+/// no shim, deliberately: "the daemon you are talking to is from another
+/// build" is exactly the fact a client must not paper over, and here it also
+/// means "that daemon believes it owns one estate."
+pub const DESCRIPTOR_SCHEMA: &str = "sergeant.runtime/v3";
 
 /// Event kind: the daemon came up and owns the journal.
 pub const KIND_DAEMON_STARTED: &str = "daemon.started";
@@ -97,17 +108,23 @@ pub const KIND_ADMISSION_PAUSED: &str = "admission.paused";
 /// recovery (§25), there is no ambiguous case here to fail closed on.
 pub const KIND_ADMISSION_RESUMED: &str = "admission.resumed";
 
-/// The runtime descriptor published for clients (proposal §6, estate-root
-/// §5.1): endpoint, PID, API revision, the bearer token, and — since
-/// `sergeant.runtime/v2` — **the estate this daemon is bound to**, protected
-/// by owner-only file permissions.
+/// The runtime descriptor published for clients (proposal §6, H1 §3):
+/// endpoint, PID, API revision, and the bearer token, protected by
+/// owner-only file permissions. Five fields, and — since
+/// [`DESCRIPTOR_SCHEMA`]'s v3 bump — **nothing about estates** (D3).
 ///
-/// §5.1: "A client validates that the descriptor's root matches its exact
-/// current root before using the endpoint. A live daemon bound to another
-/// estate is a named refusal, never a reusable global service." That check
-/// is [`RuntimeDescriptor::check_estate_root`], and every client path
-/// (`ensure_daemon`, `observe_connect`) runs it before the endpoint is used
-/// for anything.
+/// **What the retired v2 fields did, and what replaced them.** v2 carried
+/// `estate_root`/`manifest_path`, and §5.1's client gate compared the
+/// caller's exact root against them: "a live daemon bound to another estate
+/// is a named refusal, never a reusable global service." H1 makes one daemon
+/// serving many estates the normal case, so that comparison has no object.
+/// The property it protected — nothing is ever served for an estate nobody
+/// validated — is now kept where the validation actually happens: the
+/// admitted-estate registry ([`crate::runtime::estates::EstateRegistry`]),
+/// re-checked per request, with
+/// [`crate::runtime::estates::check_estate_root`] as its client-side half.
+/// The set is dynamic, so it is answered live by `GET /v1/estates` rather
+/// than frozen into a file written once at startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimeDescriptor {
     /// Descriptor schema identifier.
@@ -119,76 +136,11 @@ pub struct RuntimeDescriptor {
     /// API revision the daemon serves.
     pub api_revision: String,
     /// Random bearer token required on all `/v1/*` routes.
-    pub token: String,
-    /// §5.1: the canonical estate root this daemon was started against.
-    /// `None` only for a daemon bound to no estate at all — a test rig, or
-    /// `sgt daemon` run somewhere that is not an estate root.
-    #[serde(default)]
-    pub estate_root: Option<PathBuf>,
-    /// §5.1: `<estate_root>/sergeant.toml`, recorded alongside the root so a
-    /// reader never has to reconstruct it.
-    #[serde(default)]
-    pub manifest_path: Option<PathBuf>,
-}
-
-/// A live daemon bound to a different estate than the client's own exact
-/// root (§5.1, §15): named refusal, never a connection, and never a second
-/// daemon over the same data dir.
-#[derive(Debug, thiserror::Error)]
-#[error(
-    "the daemon running for {data_dir} is bound to a different estate\n\n\
-     This estate root:\n  {wanted}\n\n\
-     Daemon's estate root:\n  {found}\n\n\
-     Refusing to connect, and refusing to start a second daemon over the same data dir.\n\
-     Stop the running daemon and retry, or point this estate at its own data dir:\n  \
-     sgt -C {found} daemon stop\n  \
-     sgt --data-dir <dir> <command>"
-)]
-pub struct EstateBindingMismatch {
-    /// Data dir both would own.
-    pub data_dir: String,
-    /// The root the client resolved.
-    pub wanted: String,
-    /// The root the running daemon is bound to, or the fact that it has
-    /// none.
-    pub found: String,
-}
-
-impl RuntimeDescriptor {
-    /// §5.1's client-side gate: does this descriptor's estate root match the
-    /// caller's own exact root?
     ///
-    /// Both directions are refusals, deliberately: a daemon bound to estate
-    /// A cannot serve a client standing in estate B, **and** a daemon bound
-    /// to no estate cannot serve a client that has one (its engine would
-    /// plan against nothing, so every submission would silently land
-    /// `pending`). A client with no estate root of its own — no such client
-    /// exists on the estate-scoped paths, since §4.3 admits the root first —
-    /// is the only case that passes without comparison.
-    pub fn check_estate_root(
-        &self,
-        data_dir: &Path,
-        wanted: Option<&Path>,
-    ) -> Result<(), EstateBindingMismatch> {
-        let Some(wanted) = wanted else {
-            return Ok(());
-        };
-        let matches = self
-            .estate_root
-            .as_deref()
-            .is_some_and(|bound| bound == wanted);
-        if matches {
-            return Ok(());
-        }
-        Err(EstateBindingMismatch {
-            data_dir: data_dir.display().to_string(),
-            wanted: wanted.display().to_string(),
-            found: match &self.estate_root {
-                Some(root) => root.display().to_string(),
-                None => "(none — this daemon was started outside any estate)".to_string(),
-            },
-        })
-    }
+    /// D8: one token spans every admitted estate — the ratified single-user
+    /// trust model. The widened blast radius of a leaked token is stated,
+    /// not silently inherited.
+    pub token: String,
 }
 
 /// Errors from daemon startup and shutdown.
@@ -257,13 +209,17 @@ pub enum DaemonError {
     /// mean something else entirely, and acting on them could mean talking
     /// to the wrong process — or spawning a second daemon.
     ///
-    /// **0.1.0, estate-root Phase D:** `sergeant.runtime/v1` descriptors are
-    /// exactly this case. A v1 descriptor carries no `estate_root`, so a
-    /// client could not verify §5.1's binding against it at all — it fails
-    /// closed here rather than being read half-way, and the remedy is to
-    /// stop the old daemon and let a v2 one publish. There is deliberately no
-    /// compatibility shim: at 0.1.0, "the daemon you are talking to is from
-    /// another build" is exactly the fact a client must not paper over.
+    /// **Every superseded schema is exactly this case, in both directions.**
+    /// A `sergeant.runtime/v1` descriptor carried no estate binding at all;
+    /// a `sergeant.runtime/v2` one carried a binding to exactly one estate,
+    /// which a host daemon does not have (D3). Neither can be read half-way
+    /// — the v2 case is the sharper of the two, because its fields still
+    /// *parse*, and acting on them would mean addressing a daemon that
+    /// believes it owns one estate as though it served many. There is
+    /// deliberately no compatibility shim in either direction; the remedy is
+    /// H1 §6's cutover, and this refusal is its backstop: stop the old
+    /// daemon and let a restarted one republish in the schema this build
+    /// reads.
     #[error(
         "runtime descriptor {path} declares unknown schema {found:?} (this build understands {expected:?}); \
          refusing to use it. If a daemon from an older build is still running, stop it \
@@ -965,8 +921,6 @@ pub async fn start_with(
         pid: std::process::id(),
         api_revision: API_REVISION.to_string(),
         token: token.clone(),
-        estate_root: estate.as_ref().map(|e| e.path.clone()),
-        manifest_path: estate.as_ref().map(|e| e.manifest_path.clone()),
     };
     let descriptor_path = data_dir.join(DESCRIPTOR_FILE);
     write_atomic_secret(&descriptor_path, &serde_json::to_vec_pretty(&descriptor)?)?;
@@ -1470,97 +1424,103 @@ mod tests {
     use opentelemetry_sdk::trace::InMemorySpanExporter;
     use std::time::Duration;
 
-    /// A `sergeant.runtime/v2` descriptor bound to `estate_root`.
-    fn descriptor_bound_to(estate_root: Option<&str>) -> RuntimeDescriptor {
-        RuntimeDescriptor {
+    /// **Re-scoped, not deleted** (brief deliverable 4): this test used to be
+    /// `a_descriptor_is_usable_only_from_the_estate_it_is_bound_to`, proving
+    /// the strict-equality binding gate in both directions. That refusal
+    /// class is retired with H1, so the negative it protected is re-pointed
+    /// rather than dropped: a descriptor no longer *says* anything about
+    /// estates, and what refuses an unvalidated estate is the admission
+    /// check that replaced it.
+    #[test]
+    fn a_v3_descriptor_says_nothing_about_estates_and_admission_is_what_refuses() {
+        let descriptor = RuntimeDescriptor {
             schema: DESCRIPTOR_SCHEMA.to_string(),
             endpoint: "http://127.0.0.1:1".to_string(),
             pid: 1,
             api_revision: API_REVISION.to_string(),
             token: "t".to_string(),
-            estate_root: estate_root.map(PathBuf::from),
-            manifest_path: estate_root.map(|r| PathBuf::from(r).join("sergeant.toml")),
-        }
-    }
-
-    /// §5.1: a descriptor whose estate root matches the client's own exact
-    /// root is usable; one bound elsewhere is a refusal naming **both**
-    /// roots, in both directions.
-    #[test]
-    fn a_descriptor_is_usable_only_from_the_estate_it_is_bound_to() {
-        let data_dir = Path::new("/data");
-        let here = descriptor_bound_to(Some("/estates/payments"));
-
-        here.check_estate_root(data_dir, Some(Path::new("/estates/payments")))
-            .expect("the daemon's own estate may use it");
-
-        let err = here
-            .check_estate_root(data_dir, Some(Path::new("/estates/billing")))
-            .expect_err("another estate must be refused");
-        let message = err.to_string();
-        assert!(
-            message.contains("/estates/billing") && message.contains("/estates/payments"),
-            "§15: the refusal names both roots: {message}"
-        );
-        assert!(
-            message.contains("refusing to start a second daemon"),
-            "§5.1: never a second daemon over the same data dir: {message}"
+        };
+        let serialized = serde_json::to_value(&descriptor).expect("descriptor json");
+        let mut keys: Vec<&str> = serialized
+            .as_object()
+            .expect("object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["api_revision", "endpoint", "pid", "schema", "token"],
+            "D3: a v3 descriptor carries no estate binding to compare against"
         );
 
-        // The other direction: a daemon bound to nothing cannot serve a
-        // client that has an estate — its engine would plan against nothing.
-        let unbound = descriptor_bound_to(None);
-        let err = unbound
-            .check_estate_root(data_dir, Some(Path::new("/estates/payments")))
-            .expect_err("an unbound daemon must be refused too");
-        assert!(
-            err.to_string().contains("started outside any estate"),
-            "got {err}"
-        );
+        // What refuses instead: the admission check, per estate, on its own
+        // evidence rather than on what some file said at startup.
+        let err = crate::runtime::estates::check_estate_root(
+            Some(Path::new("/estates/definitely-not-one")),
+            "sgt run",
+        )
+        .expect_err("an unvalidated root must still be refused");
+        assert_eq!(err.code(), "invalid_estate", "got {err}");
     }
 
     /// The v1→v2 bump has no compatibility shim: a descriptor written by an
     /// older build fails closed as an unknown schema, and the diagnostic
     /// names the stop/restart remedy rather than leaving an operator staring
     /// at a schema string.
+    ///
+    /// **v2 joins v1 here at the D3 bump** — and it is the case that actually
+    /// happens at cutover, since a v2 daemon is what every developer has
+    /// running the moment before they install a host-mode build. Its fields
+    /// still parse, which is precisely why it must be refused rather than
+    /// read: they describe a process that believes it owns exactly one
+    /// estate.
     #[test]
-    fn a_v1_descriptor_fails_closed_with_a_restart_remedy() {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        std::fs::write(
-            dir.path().join(DESCRIPTOR_FILE),
-            serde_json::json!({
-                "schema": "sergeant.runtime/v1",
-                "endpoint": "http://127.0.0.1:1",
-                "pid": 1,
-                "api_revision": API_REVISION,
-                "token": "t",
-            })
-            .to_string(),
-        )
-        .expect("write v1 descriptor");
+    fn a_superseded_descriptor_fails_closed_with_a_restart_remedy() {
+        for superseded in ["sergeant.runtime/v1", "sergeant.runtime/v2"] {
+            let dir = tempfile::TempDir::new().expect("tempdir");
+            std::fs::write(
+                dir.path().join(DESCRIPTOR_FILE),
+                serde_json::json!({
+                    "schema": superseded,
+                    "endpoint": "http://127.0.0.1:1",
+                    "pid": 1,
+                    "api_revision": API_REVISION,
+                    "token": "t",
+                    "estate_root": "/estates/payments",
+                })
+                .to_string(),
+            )
+            .expect("write superseded descriptor");
 
-        let err = read_descriptor(dir.path()).expect_err("v1 must fail closed");
-        let message = err.to_string();
-        assert!(
-            matches!(err, DaemonError::UnknownDescriptorSchema { .. }),
-            "got {message}"
-        );
-        assert!(
-            message.contains("sergeant.runtime/v1") && message.contains("sergeant.runtime/v2"),
-            "both schemas must be named: {message}"
-        );
-        assert!(
-            message.contains("sgt daemon stop"),
-            "the remedy must tell the operator to restart the daemon: {message}"
-        );
+            let err =
+                read_descriptor(dir.path()).expect_err("a superseded schema must fail closed");
+            let message = err.to_string();
+            assert!(
+                matches!(err, DaemonError::UnknownDescriptorSchema { .. }),
+                "got {message}"
+            );
+            assert!(
+                message.contains(superseded) && message.contains(DESCRIPTOR_SCHEMA),
+                "both schemas must be named: {message}"
+            );
+            assert!(
+                message.contains("sgt daemon stop"),
+                "the remedy must tell the operator to restart the daemon: {message}"
+            );
+        }
     }
 
-    /// Complements `a_v1_descriptor_fails_closed_with_a_restart_remedy` above:
+    /// Complements `a_superseded_descriptor_fails_closed_with_a_restart_remedy`:
     /// the positive case for the *current* schema, going through the same
-    /// on-disk file-write → `read_descriptor` path (not the in-memory
-    /// `descriptor_bound_to()` helper, which never touches disk).
+    /// on-disk file-write → `read_descriptor` path.
+    ///
+    /// It also pins the half of D3 a struct definition cannot: a v3
+    /// descriptor that someone has *added* estate fields to still reads back
+    /// as the five fields this build knows, so no code path can start
+    /// depending on an out-of-band estate binding smuggled through the file.
     #[test]
-    fn a_v2_descriptor_round_trips_through_read_descriptor() {
+    fn a_v3_descriptor_round_trips_through_read_descriptor_ignoring_estate_fields() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         std::fs::write(
             dir.path().join(DESCRIPTOR_FILE),
@@ -1575,7 +1535,7 @@ mod tests {
             })
             .to_string(),
         )
-        .expect("write v2 descriptor");
+        .expect("write v3 descriptor");
 
         let descriptor = read_descriptor(dir.path())
             .expect("read must succeed")
@@ -1585,13 +1545,11 @@ mod tests {
         assert_eq!(descriptor.pid, 1);
         assert_eq!(descriptor.api_revision, API_REVISION);
         assert_eq!(descriptor.token, "t");
-        assert_eq!(
-            descriptor.estate_root.as_deref(),
-            Some(Path::new("/estates/payments"))
-        );
-        assert_eq!(
-            descriptor.manifest_path.as_deref(),
-            Some(Path::new("/estates/payments/sergeant.toml"))
+        let round_tripped = serde_json::to_value(&descriptor).expect("descriptor json");
+        assert!(
+            round_tripped.get("estate_root").is_none()
+                && round_tripped.get("manifest_path").is_none(),
+            "D3: nothing in this build carries an estate on the descriptor, got {round_tripped}"
         );
     }
 

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -1150,20 +1150,6 @@ pub struct Engine {
     /// completion driver alongside [`Self::due_observations`] (see
     /// [`Self::due_interrupts`]).
     pub turn_ceiling: Duration,
-    /// §5.1/§5.2: the one estate this daemon is bound to, admitted at
-    /// startup ([`crate::domain::estate::Estate::admit`]) and pinned
-    /// here for the process's whole life.
-    ///
-    /// **This is the only topology authority.** [`Self::plan`] reads the
-    /// manifest at *this* root; a submission's `origin.cwd` is recorded
-    /// evidence only (§13.3) and can never move it. That is what removes the
-    /// recursion hazard §5.2 names — a child command launched from a Work
-    /// surface rediscovering that linked worktree as a new estate.
-    ///
-    /// `None` only for a daemon started with no estate at all (test rigs and
-    /// the intent-capture path): [`Self::plan`] answers `Ok(None)` there,
-    /// exactly as "no repository context" always has.
-    pub estate_root: Option<PathBuf>,
     /// When each Work's current turn was last (re-)spawned, for the ceiling
     /// sweep. Deliberately **not** journaled or durable: a restart forgets
     /// it, which is acceptable for a soak-test hang bound (never an
@@ -1190,17 +1176,8 @@ impl Engine {
             data_dir: data_dir.to_path_buf(),
             turn_cap: DEFAULT_TURN_CAP,
             turn_ceiling: DEFAULT_TURN_CEILING,
-            estate_root: None,
             turn_started: Arc::new(Mutex::new(BTreeMap::new())),
         }
-    }
-
-    /// Bind this engine to one estate root (§5.1). The daemon calls this
-    /// once at startup with the canonical root it was started against; every
-    /// later [`Self::plan`] reads that estate and no other.
-    pub fn with_estate_root(mut self, estate_root: PathBuf) -> Self {
-        self.estate_root = Some(estate_root);
-        self
     }
 
     /// Override the daemon-wide turn cap (R-MVP1-7). Wired from
@@ -1263,16 +1240,31 @@ impl Engine {
 
     /// Resolve everything a run needs, without touching anything.
     ///
-    /// **§5.2: the request's cwd has no authority here.** Topology comes from
-    /// [`Self::estate_root`] — the one estate this daemon was started
-    /// against — and from nowhere else. `context.cwd` survives only as
-    /// `origin.cwd`, recorded evidence for diagnostics (§13.3).
+    /// **D10: the estate is a per-call parameter, not a field.** The engine
+    /// held one `estate_root` pinned for the process's whole life while a
+    /// daemon served exactly one estate. A host daemon serves many, so the
+    /// estate this submission resolved against is handed in per call — by
+    /// the handler, from the *request*, after the admitted-estate registry
+    /// validated it ([`crate::runtime::estates::EstateRegistry::admit`]).
+    /// The field and `with_estate_root` are removed rather than left
+    /// vestigially in place: a second, stale topology authority sitting
+    /// beside the real one is exactly how estate B's Work gets planned
+    /// against estate A's manifest.
     ///
-    /// `Ok(None)` means "this daemon is bound to no estate": the intent is
-    /// accepted and stays `pending` rather than being rejected, exactly as
-    /// "no repository context" always has. Every *other* failure (a
-    /// `sergeant.toml` that no longer resolves, an unroutable backend, a
-    /// missing workflow) is a real error and is returned as one.
+    /// **§5.2 still holds, and is now the caller's to keep.** The request's
+    /// cwd has no authority here: `context.cwd` survives only as
+    /// `origin.cwd`, recorded evidence for diagnostics (§13.3). What may
+    /// name `estate_root` is an *addressed* root the daemon then validates
+    /// by admission — never a cwd it infers one from, and never a parent
+    /// search. That is what keeps §5.2's recursion hazard closed (a child
+    /// command launched from a Work surface rediscovering that linked
+    /// worktree as a new estate).
+    ///
+    /// `None` means the submission offered no repository context at all: the
+    /// intent is accepted and stays `pending` rather than being rejected,
+    /// exactly as it always has. Every *other* failure (a `sergeant.toml`
+    /// that no longer resolves, an unroutable backend, a missing workflow)
+    /// is a real error and is returned as one.
     ///
     /// "No surface" does not mean "no §13". A submission that *names* a
     /// backend has asked for something, and §13's terminal state for a
@@ -1282,11 +1274,16 @@ impl Engine {
     /// tolerated here, because a captured intent with no repository has
     /// nothing to route yet and no default to disappoint.
     ///
-    /// The manifest is re-read from the pinned root on every plan rather
-    /// than cached from startup, so `sgt repo add` reaches a running daemon
-    /// — the *root* is what startup fixes, and the root is what §5 binds.
-    pub fn plan(&self, context: &SubmitContext<'_>) -> Result<Option<StartPlan>, EngineError> {
-        let estate = match &self.estate_root {
+    /// The manifest is re-read from the addressed root on every plan rather
+    /// than cached, so `sgt repo add` reaches a running daemon — that
+    /// discipline is untouched by D10; only *which* root is re-read changes,
+    /// and it changes per call rather than never.
+    pub fn plan(
+        &self,
+        estate_root: Option<&Path>,
+        context: &SubmitContext<'_>,
+    ) -> Result<Option<StartPlan>, EngineError> {
+        let estate = match estate_root {
             None => None,
             Some(root) => Some(Estate::resolve(root)?),
         };

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -4553,13 +4553,28 @@ impl Engine {
     ) -> Result<(), EngineError> {
         let mut draft = EventDraft::new(EventSource::new("daemon", "engine"), kind, payload)
             .with_work_id(work_id);
-        // H1 touch point #4: the one chokepoint every engine-emitted event
-        // goes through, so this is the one place that stamps the pinned
-        // estate root — never the display name (`self.estate_root` is
-        // already canonicalized, `Estate::admit`'s doc). `None` (a daemon
-        // bound to no estate) leaves the field absent, exactly as before.
-        if let Some(root) = &self.estate_root {
-            draft = draft.with_workspace_id(root.to_string_lossy().into_owned());
+        // H1 touch point #4, now per Work rather than per process (D10).
+        //
+        // W1a stamped this from the engine's own pinned `estate_root`, which
+        // was correct while a daemon had exactly one. A host daemon has
+        // none, and reading "the engine's estate" for a Work belonging to
+        // some *other* estate is precisely the silent mis-stamping D10
+        // exists to remove — so the coordinate comes from the Work itself:
+        // the canonical root its `work.submitted` envelope recorded
+        // (`WorkIndexRow::estate_root`), folded from the journal and
+        // therefore identical across a restart and a replay.
+        //
+        // Absent (a Work submitted with no repository context, or a journal
+        // line older than the envelope field) leaves the field absent,
+        // exactly as before — never a guess, and never the display name.
+        if let Some(root) = core
+            .registry
+            .state()
+            .work_index
+            .get(work_id)
+            .and_then(|row| row.estate_root.clone())
+        {
+            draft = draft.with_workspace_id(root);
         }
         core.commit(draft)?;
         Ok(())
@@ -4693,29 +4708,45 @@ mod tests {
         );
     }
 
-    /// H1 touch point #4: `Engine::commit` is the one chokepoint every
-    /// engine-emitted event goes through, so the pinned estate root must
-    /// land in the envelope from there, not from each individual caller —
-    /// and an engine with no estate (test rigs, the intent-capture path)
-    /// must leave the field absent rather than invent a coordinate. Both
-    /// branches live in one test so the `None` half is pinned by a test
-    /// that still fails when the stamping is reverted.
+    /// H1 touch point #4 as D10 leaves it: `Engine::commit` is still the one
+    /// chokepoint every engine-emitted event goes through, but the
+    /// coordinate it stamps is now the **Work's own**, not the engine's.
+    ///
+    /// This is W1a's test evolved, not reverted. W1a proved the stamping
+    /// happens at the chokepoint against an engine pinned to one estate;
+    /// there is no pinned estate any more, and the fact that matters is
+    /// sharper: **one engine, two Works, two different estates, each event
+    /// stamped with its own Work's root.** Under the pinned field this could
+    /// not even be expressed — every event would have carried the same root,
+    /// which is exactly the silent mis-stamping D10 removes. The `None` half
+    /// is kept in the same test, so a revert of the stamping still fails.
     #[test]
-    fn engine_committed_events_stamp_workspace_id_only_when_an_estate_is_pinned() {
+    fn engine_committed_events_stamp_each_works_own_estate_root() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let mut core = testing::core(dir.path());
-        let estate_root = dir.path().join("estate");
-        let pinned = engine(dir.path()).with_estate_root(estate_root.clone());
-        let unpinned = engine(dir.path()); // no `.with_estate_root(..)`
+        let payments = dir.path().join("estates/payments");
+        let billing = dir.path().join("estates/billing");
+        // One engine — a host daemon has exactly one, serving every estate.
+        let engine = engine(dir.path());
 
-        testing::submit(&mut core, "01PINNED", "carry the estate root");
-        testing::submit(&mut core, "01NOESTATE", "no estate here");
-        pinned
-            .block(&mut core, "01PINNED", "prove workspace_id travels", None)
-            .expect("block pinned");
-        unpinned
-            .block(&mut core, "01NOESTATE", "no estate pinned", None)
-            .expect("block unpinned");
+        testing::submit_in(
+            &mut core,
+            "01PAYMENTS",
+            "carry payments' root",
+            Some(payments.to_string_lossy().as_ref()),
+        );
+        testing::submit_in(
+            &mut core,
+            "01BILLING",
+            "carry billing's root",
+            Some(billing.to_string_lossy().as_ref()),
+        );
+        testing::submit(&mut core, "01NOESTATE", "no repository context at all");
+        for work_id in ["01PAYMENTS", "01BILLING", "01NOESTATE"] {
+            engine
+                .block(&mut core, work_id, "prove workspace_id travels", None)
+                .expect("block");
+        }
 
         let blocked: Vec<_> = core
             .journal
@@ -4731,9 +4762,14 @@ mod tests {
                 .expect("work.blocked journaled")
         };
         assert_eq!(
-            by_work("01PINNED").workspace_id.as_deref(),
-            Some(estate_root.to_string_lossy().as_ref()),
-            "an engine-committed event must carry the daemon's pinned estate root"
+            by_work("01PAYMENTS").workspace_id.as_deref(),
+            Some(payments.to_string_lossy().as_ref()),
+            "each event carries its own Work's estate, not the engine's"
+        );
+        assert_eq!(
+            by_work("01BILLING").workspace_id.as_deref(),
+            Some(billing.to_string_lossy().as_ref()),
+            "the second estate is not the first estate"
         );
         assert_eq!(by_work("01NOESTATE").workspace_id, None);
     }
@@ -6066,6 +6102,7 @@ mod tests {
                     created_at: "2026-01-01T00:00:00Z".to_string(),
                     updated_at: "2026-01-01T00:00:00Z".to_string(),
                     last_seq: 1,
+                    estate_root: None,
                 },
             );
             registry.terminal_runs.insert(

--- a/src/runtime/estates.rs
+++ b/src/runtime/estates.rs
@@ -1,0 +1,479 @@
+//! The admitted-estate registry (H1 §4, sprint-plan D3/D4/D10).
+//!
+//! One host daemon serves many estates. Nothing about that set is baked into
+//! the process at startup: a daemon comes up bound to **zero** estates — the
+//! normal state, not a test-rig edge case — and learns each one the first
+//! time a request addresses it. That is what "observational" means in H1 §4:
+//! the registry records estates that were *validated*, never estates that
+//! were inferred, discovered by search, or trusted from the wire.
+//!
+//! Three rules the whole module exists to keep:
+//!
+//! 1. **Admission is the validation.** An estate enters this map only by
+//!    passing [`Estate::admit`]'s exact-root check (§4.1: the exact
+//!    directory, no parent search, no Git inference) *and*
+//!    `refuse_if_unreliable` for that root's own filesystem — different
+//!    estates on different filesystems are real, so the check that used to
+//!    run once for the one data dir now runs per root.
+//! 2. **A failed admission is a named, estate-specific refusal, never
+//!    process death.** The pre-H1 daemon refused to *start* when its one
+//!    estate did not admit ([`crate::daemon::start_with`]'s old step 0a).
+//!    With N estates that would let one broken `sergeant.toml` take down
+//!    every other estate's Work, so admission failure is answered to the
+//!    caller that asked for it and nothing else.
+//! 3. **No persistence, and no estate UUID (H1-06).** The registry rebuilds
+//!    itself from requests; what makes Work↔estate durable is the journal's
+//!    own `workspace_id` coordinate (D1), which is a canonical root, not an
+//!    identifier this process mints.
+//!
+//! **The retired refusal class.** Before H1 the client-side gate was
+//! `RuntimeDescriptor::check_estate_root`: strict equality against the one
+//! root the descriptor published, refusing in both directions ("this daemon
+//! is bound to a different estate", "this daemon is bound to no estate").
+//! That class is retired here, deliberately and with the reasoning recorded
+//! for the W5 ADR: under H1 a daemon serving an estate it was not started
+//! from is the *point*, not the bug. What replaces it is
+//! [`EstateAdmissionError`]'s taxonomy — "not an estate", "admission
+//! failed", "no estate addressed" — which keeps the property the old check
+//! actually protected (a request is never served for an estate nobody
+//! validated) without the property H1 removes (one process, one estate).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use crate::domain::estate::{Estate, EstateRoot, EstateRootError};
+use crate::domain::event::rfc3339_utc_now;
+use crate::platform::fs_locking::{self, Reliability};
+
+/// Why a request addressed at an estate could not be served.
+///
+/// The taxonomy the client gate and the daemon-side registry share, because
+/// they are asking the same question from two sides (sprint-plan D4, brief
+/// deliverable 4):
+///
+/// - (a) the requested root is not a valid estate → [`Self::NotAnEstate`],
+///   carrying [`Estate::admit`]'s own §4.4 diagnostic verbatim;
+/// - (b) it is a plausible estate but admission failed for a reason of this
+///   registry's own → [`Self::UnreliableFilesystem`];
+/// - (c) an estate-scoped operation named no estate at all →
+///   [`Self::NoEstateAddressed`].
+#[derive(Debug, thiserror::Error)]
+pub enum EstateAdmissionError {
+    /// (c) — H1 §11 criterion 3 preserved: an estate-scoped operation with
+    /// no estate to operate on fails closed rather than picking one.
+    #[error(
+        "{operation} is estate-scoped, but no estate was addressed\n\n\
+         The daemon is host-scoped: it serves every estate that has been admitted to it, and \
+         therefore never assumes which one a request means.\n\
+         Name one:\n  \
+         sgt -C <estate-root> <command>\n  \
+         or run the command from the estate root itself."
+    )]
+    NoEstateAddressed {
+        /// What was being attempted, for the message.
+        operation: String,
+    },
+    /// (a) — the exact-root check refused. The inner error is §4.4's full
+    /// corrective block; it is never summarized, because the whole value of
+    /// exact-root admission is that the refusal teaches the operator where
+    /// they actually are.
+    #[error("cannot admit the estate at {root}\n\n{source}")]
+    NotAnEstate {
+        /// The directory that was addressed, as given.
+        root: PathBuf,
+        /// §4.4's own diagnostic.
+        #[source]
+        source: Box<EstateRootError>,
+    },
+    /// (b) — #85 / ADR 0003 D6, per estate root rather than once for the one
+    /// data dir. An estate on a filesystem where advisory locking is
+    /// unreliable cannot have its repository locks trusted, so it is refused
+    /// at admission rather than served and quietly raced.
+    #[error(
+        "the estate at {root} sits on a {filesystem} filesystem, where advisory locking is \
+         unreliable; refusing to admit it — {remedy}"
+    )]
+    UnreliableFilesystem {
+        /// The estate root that was refused.
+        root: PathBuf,
+        /// The offending filesystem type, as the mount table names it.
+        filesystem: String,
+        /// What to do about it.
+        remedy: String,
+    },
+}
+
+impl EstateAdmissionError {
+    /// Stable per-variant code, for the `{"error": {"code", "message"}}`
+    /// shape every API refusal answers with.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NoEstateAddressed { .. } => "no_estate",
+            Self::NotAnEstate { .. } => "invalid_estate",
+            Self::UnreliableFilesystem { .. } => "unreliable_filesystem",
+        }
+    }
+}
+
+/// One admitted estate, as the registry holds it.
+///
+/// Everything here is read **at admission time** from the manifest that made
+/// the root an estate — the same "re-read the manifest, do not cache it from
+/// process startup" discipline `Engine::plan` has always had, now applied per
+/// estate rather than once per daemon (brief deliverable 8).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdmittedEstate {
+    /// Canonical estate root — the coordinate (D1, H1-06: no UUID).
+    pub root: PathBuf,
+    /// `<root>/sergeant.toml`.
+    pub manifest_path: PathBuf,
+    /// `[estate] name`, display only (D1: never identity).
+    pub name: String,
+    /// `[estate] retention`, read per estate at admission. W4a owns
+    /// partitioning the retention *enforcement*; this wave owns the read.
+    pub retention: Option<u32>,
+    /// `[estate] surfaces_dir`, resolved absolute. Narrows the daemon-wide
+    /// surfaces root per estate (H1-07: Work surfaces stay estate-local).
+    pub surfaces_dir: Option<PathBuf>,
+    /// RFC3339 UTC time this root was first admitted to this process.
+    pub admitted_at: String,
+}
+
+/// A registry row as `GET /v1/estates` reports it: the admitted facts plus
+/// whether the estate still validated the last time anything touched it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EstateEntry {
+    /// The estate as admitted.
+    pub estate: AdmittedEstate,
+    /// `false` once a re-validation has failed — the estate is still in the
+    /// registry (its Work is still journaled against it), but nothing will
+    /// mutate through it until it validates again.
+    pub available: bool,
+    /// Why it is unavailable, when it is.
+    pub unavailable_reason: Option<String>,
+    /// RFC3339 UTC time of the last admission or re-validation attempt.
+    pub last_touched_at: String,
+}
+
+/// The daemon's admitted-estate registry: in-memory, keyed by canonical
+/// root, rebuilt from requests.
+#[derive(Debug, Default)]
+pub struct EstateRegistry {
+    entries: Mutex<BTreeMap<PathBuf, EstateEntry>>,
+}
+
+impl EstateRegistry {
+    /// An empty registry — a freshly started host daemon's normal state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Admit `root`, or refresh what is already admitted.
+    ///
+    /// Lazy by design: this is called on the first estate-addressed request
+    /// and on every one after it, so a manifest edited while the daemon runs
+    /// is picked up without a restart (the existing `plan()`-re-reads-the-
+    /// manifest discipline, now per estate). The canonical root is the map
+    /// key, so two spellings of the same directory are one entry, not two.
+    pub fn admit(&self, root: &Path) -> Result<AdmittedEstate, EstateAdmissionError> {
+        let outcome = admit_root(root);
+        let now = rfc3339_utc_now();
+        let mut entries = self.entries.lock().expect("estate registry lock");
+        match outcome {
+            Ok(admitted) => {
+                let entry = entries
+                    .entry(admitted.root.clone())
+                    .or_insert_with(|| EstateEntry {
+                        estate: admitted.clone(),
+                        available: true,
+                        unavailable_reason: None,
+                        last_touched_at: now.clone(),
+                    });
+                // An already-admitted estate keeps its original
+                // `admitted_at` — when this process first validated it is a
+                // fact, and a later refresh is not a new admission — but
+                // every other field is what the manifest says *now*.
+                let admitted_at = entry.estate.admitted_at.clone();
+                entry.estate = AdmittedEstate {
+                    admitted_at,
+                    ..admitted
+                };
+                entry.available = true;
+                entry.unavailable_reason = None;
+                entry.last_touched_at = now;
+                Ok(entry.estate.clone())
+            }
+            Err(e) => {
+                // Only *known* roots are marked unavailable. A request naming
+                // a directory that was never an estate must not create a
+                // registry row — the registry records what was admitted, and
+                // an admission that never happened is not an observation.
+                if let Some(entry) = canonical_key(root).and_then(|key| entries.get_mut(&key)) {
+                    entry.available = false;
+                    entry.unavailable_reason = Some(e.to_string());
+                    entry.last_touched_at = now;
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Re-validate an estate before a *resumed* mutation (recovery's path).
+    ///
+    /// Identical to [`Self::admit`] in mechanism and deliberately so: H1 §4's
+    /// "re-validated before resumed mutation" is exactly "admit it again,
+    /// now" — a Work resuming against an estate whose manifest has since been
+    /// deleted or broken must fail closed with a reason, not act on the
+    /// admission a previous process life recorded.
+    pub fn revalidate(&self, root: &Path) -> Result<AdmittedEstate, EstateAdmissionError> {
+        self.admit(root)
+    }
+
+    /// Every row, in canonical-root order.
+    pub fn entries(&self) -> Vec<EstateEntry> {
+        self.entries
+            .lock()
+            .expect("estate registry lock")
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    /// How many estates this daemon has admitted — `sgt daemon stop`'s blast
+    /// radius (D5).
+    pub fn len(&self) -> usize {
+        self.entries.lock().expect("estate registry lock").len()
+    }
+
+    /// Whether nothing has been admitted yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// The exact-root admission check, shared by the client gate and the
+/// registry: [`Estate::admit`] (§4.1), then this root's own filesystem
+/// reliability (#85 / ADR 0003 D6, per root), then the per-estate policy the
+/// manifest declares.
+pub fn admit_root(root: &Path) -> Result<AdmittedEstate, EstateAdmissionError> {
+    let EstateRoot {
+        path,
+        manifest_path,
+    } = Estate::admit(root).map_err(|source| EstateAdmissionError::NotAnEstate {
+        root: root.to_path_buf(),
+        source: Box::new(source),
+    })?;
+    if let Reliability::Unreliable { filesystem } = fs_locking::detect_for_path(&path) {
+        return Err(EstateAdmissionError::UnreliableFilesystem {
+            remedy: fs_locking::remedy(&filesystem),
+            root: path,
+            filesystem,
+        });
+    }
+    // `Estate::admit` proved the manifest parses structurally; this reads the
+    // policy fields out of the same file. A failure here is unreachable in
+    // practice (the parse just succeeded) and is treated as "no declared
+    // policy" rather than a new refusal, exactly as `start_with`'s old
+    // per-daemon retention read did.
+    let declared = Estate::from_config_structural(&manifest_path).ok();
+    Ok(AdmittedEstate {
+        name: declared
+            .as_ref()
+            .map(|e| e.name.clone())
+            .unwrap_or_default(),
+        retention: declared.as_ref().and_then(|e| e.retention),
+        surfaces_dir: declared.as_ref().and_then(|e| e.surfaces_dir.clone()),
+        admitted_at: rfc3339_utc_now(),
+        root: path,
+        manifest_path,
+    })
+}
+
+/// The client-side gate, replacing `RuntimeDescriptor::check_estate_root`.
+///
+/// The old gate compared the client's root against the one root the
+/// descriptor published. A v3 descriptor publishes no root at all (D3), so
+/// what is left to check is the only thing that was ever load-bearing: is the
+/// estate this command addresses actually an estate, admissible right now?
+/// `None` — an estate-scoped operation that named none — is refusal (c).
+pub fn check_estate_root(
+    wanted: Option<&Path>,
+    operation: &str,
+) -> Result<AdmittedEstate, EstateAdmissionError> {
+    let Some(wanted) = wanted else {
+        return Err(EstateAdmissionError::NoEstateAddressed {
+            operation: operation.to_string(),
+        });
+    };
+    admit_root(wanted)
+}
+
+/// Canonicalize for map lookup, matching [`Estate::admit`]'s own fallback
+/// (an unresolvable path is used as given rather than erroring here — the
+/// admission itself is what refuses it).
+fn canonical_key(root: &Path) -> Option<PathBuf> {
+    Some(std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scaffold(root: &Path, name: &str) {
+        std::fs::create_dir_all(root.join("repos").join("solo")).expect("mount dir");
+        std::fs::write(
+            root.join("sergeant.toml"),
+            format!("[estate]\nname = {name:?}\n"),
+        )
+        .expect("manifest");
+    }
+
+    /// H1 §4: a daemon starts bound to zero estates and learns each one on
+    /// first contact; the canonical root is the key, so admitting the same
+    /// estate twice is one row, not two, and the first admission's timestamp
+    /// survives the refresh.
+    #[test]
+    fn admission_is_lazy_keyed_by_canonical_root_and_idempotent() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path().join("estate");
+        scaffold(&root, "payments");
+        let registry = EstateRegistry::new();
+        assert!(registry.is_empty(), "a fresh daemon has admitted nothing");
+
+        let first = registry.admit(&root).expect("admit");
+        assert_eq!(first.name, "payments");
+        assert_eq!(
+            first.root,
+            std::fs::canonicalize(&root).expect("canonical"),
+            "the coordinate is the canonical root (D1), never the spelling asked for"
+        );
+        assert_eq!(registry.len(), 1);
+
+        // A second spelling of the same directory is the same estate.
+        let again = registry
+            .admit(&root.join(".").join("..").join("estate"))
+            .expect("re-admit");
+        assert_eq!(registry.len(), 1, "one canonical root, one row");
+        assert_eq!(
+            again.admitted_at, first.admitted_at,
+            "a refresh is not a new admission"
+        );
+    }
+
+    /// Refusal (a): a directory that is not an estate never becomes a
+    /// registry row, and the refusal carries §4.4's own diagnostic rather
+    /// than a summary of it.
+    #[test]
+    fn a_directory_that_is_not_an_estate_is_refused_and_never_recorded() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let registry = EstateRegistry::new();
+        let err = registry
+            .admit(dir.path())
+            .expect_err("a bare directory is not an estate");
+        assert_eq!(err.code(), "invalid_estate");
+        assert!(
+            err.to_string()
+                .contains("does not search parent directories"),
+            "§4.4's own block must survive verbatim, got: {err}"
+        );
+        assert!(
+            registry.is_empty(),
+            "a refused admission is not an observation"
+        );
+    }
+
+    /// Refusal (c): an estate-scoped operation that addressed no estate is
+    /// refused by name (H1 §11 criterion 3 preserved), and says how to name
+    /// one.
+    #[test]
+    fn an_estate_scoped_operation_with_no_estate_addressed_is_refused() {
+        let err = check_estate_root(None, "sgt run").expect_err("no estate addressed");
+        assert_eq!(err.code(), "no_estate");
+        let message = err.to_string();
+        assert!(
+            message.contains("sgt run") && message.contains("sgt -C <estate-root>"),
+            "the refusal names the operation and the remedy, got: {message}"
+        );
+    }
+
+    /// H1 §4: one estate going bad is that estate's refusal and nothing
+    /// else's — the registry marks the known row unavailable with the reason
+    /// and leaves every other admitted estate exactly where it was.
+    #[test]
+    fn a_broken_estate_goes_unavailable_without_touching_its_neighbour() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let payments = dir.path().join("payments");
+        let billing = dir.path().join("billing");
+        scaffold(&payments, "payments");
+        scaffold(&billing, "billing");
+        let registry = EstateRegistry::new();
+        registry.admit(&payments).expect("admit payments");
+        registry.admit(&billing).expect("admit billing");
+
+        std::fs::remove_file(payments.join("sergeant.toml")).expect("break payments");
+        let err = registry
+            .admit(&payments)
+            .expect_err("a vanished manifest must refuse");
+        assert_eq!(err.code(), "invalid_estate");
+
+        let rows = registry.entries();
+        assert_eq!(rows.len(), 2, "the broken estate stays in the registry");
+        let payments_row = rows
+            .iter()
+            .find(|r| r.estate.name == "payments")
+            .expect("payments row");
+        assert!(!payments_row.available);
+        assert!(
+            payments_row
+                .unavailable_reason
+                .as_deref()
+                .is_some_and(|r| r.contains("no estate found")),
+            "the row records why, got: {:?}",
+            payments_row.unavailable_reason
+        );
+        let billing_row = rows
+            .iter()
+            .find(|r| r.estate.name == "billing")
+            .expect("billing row");
+        assert!(
+            billing_row.available,
+            "one estate's failure is not another's"
+        );
+        registry.admit(&billing).expect("billing still admits");
+    }
+
+    /// Brief deliverable 8: per-estate policy is read at admission, from
+    /// that estate's own manifest — not once, daemon-wide, at startup.
+    #[test]
+    fn per_estate_policy_is_read_from_each_manifest_at_admission() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let tight = dir.path().join("tight");
+        let loose = dir.path().join("loose");
+        std::fs::create_dir_all(&tight).expect("dir");
+        std::fs::create_dir_all(&loose).expect("dir");
+        std::fs::write(
+            tight.join("sergeant.toml"),
+            "[estate]\nname = \"tight\"\nretention = 500\nsurfaces_dir = \"work-surfaces\"\n",
+        )
+        .expect("manifest");
+        std::fs::write(loose.join("sergeant.toml"), "[estate]\nname = \"loose\"\n")
+            .expect("manifest");
+
+        let registry = EstateRegistry::new();
+        let tight = registry.admit(&tight).expect("admit tight");
+        let loose = registry.admit(&loose).expect("admit loose");
+        assert_eq!(tight.retention, Some(500));
+        assert_eq!(
+            tight.surfaces_dir,
+            Some(
+                std::fs::canonicalize(dir.path())
+                    .expect("canonical")
+                    .join("tight")
+                    .join("work-surfaces")
+            )
+        );
+        assert_eq!(loose.retention, None, "each estate answers for itself");
+        assert_eq!(loose.surfaces_dir, None);
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 pub mod analytics;
 pub mod blob;
 pub mod engine;
+pub mod estates;
 pub(crate) mod fsutil;
 pub mod git;
 pub mod graph;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -56,11 +56,24 @@ pub(crate) mod testing {
         .expect("commit");
     }
 
-    /// Record a submitted (`pending`) work.
+    /// Record a submitted (`pending`) work with no estate coordinate — a
+    /// submission that offered no repository context, or a journal line
+    /// older than the envelope field.
     pub(crate) fn submit(core: &mut Core, work_id: &str, intent: &str) {
-        commit(
-            core,
-            work_id,
+        submit_in(core, work_id, intent, None);
+    }
+
+    /// [`submit`], but recording the canonical estate root the submission
+    /// resolved against — H1 D1's coordinate, on the envelope where the real
+    /// `work.submitted` draft puts it (never in the payload).
+    pub(crate) fn submit_in(
+        core: &mut Core,
+        work_id: &str,
+        intent: &str,
+        estate_root: Option<&str>,
+    ) {
+        let mut draft = EventDraft::new(
+            EventSource::new("daemon", "test"),
             KIND_WORK_SUBMITTED,
             json!({"work": {
                 "id": work_id,
@@ -69,6 +82,11 @@ pub(crate) mod testing {
                 "created_by": "test",
                 "created_at": "2026-01-01T00:00:00Z",
             }}),
-        );
+        )
+        .with_work_id(work_id);
+        if let Some(root) = estate_root {
+            draft = draft.with_workspace_id(root);
+        }
+        core.commit(draft).expect("commit");
     }
 }

--- a/src/runtime/projection.rs
+++ b/src/runtime/projection.rs
@@ -491,6 +491,27 @@ pub struct WorkIndexRow {
     /// wrote"), per §20's forward-compatibility stance.
     #[serde(default)]
     pub last_seq: u64,
+    /// H1 D1/D10: the canonical estate root this Work was submitted against,
+    /// folded once from the **envelope's** `workspace_id` at
+    /// `work.submitted` — never from a payload key, and never overwritten
+    /// later (a Work's estate is fixed at submission and immutable for its
+    /// life).
+    ///
+    /// This row is the per-Work estate coordinate the daemon reads back:
+    /// `Engine::commit` stamps every later event from it, and recovery
+    /// re-admits each resumed Work's estate from it — the recon-flagged
+    /// silent-failure trap (resuming estate B's Work against estate A's
+    /// pinned config) exists precisely because there was nowhere to read
+    /// this from before. It lives on the slim index row rather than on
+    /// [`Work`] because the index row is the one per-Work structure that is
+    /// never evicted (#4) and is not a journaled payload.
+    ///
+    /// `None` is an honest "not recorded": every journal line written before
+    /// the envelope carried the field, and every Work submitted with no
+    /// repository context at all. Never an error, and never a reason to
+    /// invent a coordinate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estate_root: Option<String>,
 }
 
 /// Everything the journal says about one work's run: the workflow it pinned,
@@ -927,6 +948,12 @@ fn apply_registry_event(state: &mut WorkRegistry, event: &Event, evict: bool) {
                         created_at: work.created_at.clone(),
                         updated_at: work.created_at.clone(),
                         last_seq: event.seq,
+                        // D1: the envelope's coordinate, folded once, here
+                        // and nowhere else. `workflow.bound`'s
+                        // `"workspace"` payload key stays what it always
+                        // was — a display name — and is deliberately not
+                        // consulted: two estates may share one.
+                        estate_root: event.workspace_id.clone(),
                     },
                 );
                 state.works.insert(work.id.clone(), work);

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -1416,6 +1416,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00.000Z".to_string(),
             updated_at: "2026-01-01T00:00:00.000Z".to_string(),
             last_seq,
+            estate_root: None,
         }
     }
 

--- a/src/runtime/recovery.rs
+++ b/src/runtime/recovery.rs
@@ -49,6 +49,7 @@ use crate::api::Core;
 use crate::domain::execution::ReconcileDisposition;
 use crate::domain::work::WorkState;
 use crate::runtime::engine::{Engine, EngineError};
+use crate::runtime::estates::EstateRegistry;
 
 /// What one restart's reconciliation did.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -76,7 +77,30 @@ pub struct ReconcileReport {
 /// from starting. §25's fail-closed contract is stated per-work — "ambiguous
 /// states fail closed to blocked with evidence" — not "one bad journal entry
 /// makes the whole daemon unavailable".
-pub fn reconcile(engine: &Engine, core: &mut Core) -> Result<ReconcileReport, EngineError> {
+///
+/// **H1 §4 / D10: each Work's estate is re-validated before it is resumed.**
+/// This pass was accidentally already host-shaped — it never filtered by
+/// estate, because there was only ever one — and that is exactly what hid
+/// the trap the recon flagged: every *action* it takes runs through the
+/// engine, which used to carry one pinned estate, so resuming estate B's
+/// Work would silently have used estate A's topology. With the engine's
+/// field gone (D10) the resolution has to come from the Work itself: its
+/// journaled `workspace_id` coordinate (D1), re-admitted here through the
+/// registry. A Work whose estate no longer validates goes `blocked` with the
+/// admission refusal as its reason — fail-closed and *named*, rather than
+/// mis-planned or refused later with a confusing diagnostic against the
+/// wrong root.
+///
+/// A Work with **no** recorded coordinate is untouched by this check and
+/// reconciles exactly as before: every journal line written before the
+/// envelope carried the field is that shape, and inventing an estate for it
+/// (or blocking it for not having one) would be the daemon deciding
+/// something the journal never recorded.
+pub fn reconcile(
+    engine: &Engine,
+    estates: &EstateRegistry,
+    core: &mut Core,
+) -> Result<ReconcileReport, EngineError> {
     let in_flight: Vec<String> = core
         .registry
         .state()
@@ -174,6 +198,12 @@ pub fn reconcile(engine: &Engine, core: &mut Core) -> Result<ReconcileReport, En
 
     let mut report = ReconcileReport::default();
     for work_id in in_flight {
+        if let Some(refusal) = estate_unavailable(estates, core, &work_id) {
+            block_on_unavailable_estate(engine, core, &work_id, &refusal);
+            flush_after_reconciling(core, &work_id);
+            report.blocked.push(work_id);
+            continue;
+        }
         let outcome = engine.reconcile_work(core, &work_id);
         flush_after_reconciling(core, &work_id);
         match outcome {
@@ -189,7 +219,13 @@ pub fn reconcile(engine: &Engine, core: &mut Core) -> Result<ReconcileReport, En
         }
     }
     for work_id in crashed_starts {
-        if let Err(e) = engine.reconcile_crashed_start(core, &work_id) {
+        // A crashed start is already headed for `blocked`; re-validating the
+        // estate first is what makes its *reason* honest when the estate is
+        // the thing that went away, and keeps `reconcile_crashed_start`'s own
+        // git teardown from running against a root that no longer validates.
+        if let Some(refusal) = estate_unavailable(estates, core, &work_id) {
+            block_on_unavailable_estate(engine, core, &work_id, &refusal);
+        } else if let Err(e) = engine.reconcile_crashed_start(core, &work_id) {
             block_on_reconcile_error(engine, core, &work_id, &e);
         }
         flush_after_reconciling(core, &work_id);
@@ -233,6 +269,44 @@ pub fn reconcile(engine: &Engine, core: &mut Core) -> Result<ReconcileReport, En
         }
     }
     Ok(report)
+}
+
+/// H1 §4's "re-validated before resumed mutation", per Work.
+///
+/// Returns the refusal when this Work names an estate that will not admit
+/// right now, and `None` both when it validates and when the Work names no
+/// estate at all (see [`reconcile`]'s doc for why the latter is not a
+/// refusal).
+fn estate_unavailable(estates: &EstateRegistry, core: &Core, work_id: &str) -> Option<String> {
+    let root = core
+        .registry
+        .state()
+        .work_index
+        .get(work_id)
+        .and_then(|row| row.estate_root.clone())?;
+    match estates.revalidate(std::path::Path::new(&root)) {
+        Ok(_) => None,
+        Err(e) => Some(e.to_string()),
+    }
+}
+
+/// Fail one Work closed because *its own* estate no longer validates,
+/// recording the admission refusal as the reason. Isolated exactly like
+/// [`block_on_reconcile_error`]: one estate going bad blocks that estate's
+/// Work and nothing else's.
+fn block_on_unavailable_estate(engine: &Engine, core: &mut Core, work_id: &str, refusal: &str) {
+    tracing::warn!(
+        work_id,
+        refusal,
+        "a Work's estate no longer admits; blocking it rather than resuming against \
+         topology nobody validated"
+    );
+    let _ = engine.block(
+        core,
+        work_id,
+        "this Work's estate could not be re-admitted at startup",
+        Some(refusal.to_string()),
+    );
 }
 
 /// Close the open group after one work's reconciliation, best-effort
@@ -353,7 +427,8 @@ mod tests {
         );
         testing::commit(&mut core, intact, KIND_WORK_STARTED, json!({}));
 
-        let report = reconcile(&engine, &mut core).expect("recovery must not abort");
+        let report =
+            reconcile(&engine, &EstateRegistry::new(), &mut core).expect("recovery must not abort");
         assert_eq!(report.resumed, Vec::<String>::new());
         assert_eq!(report.blocked, vec![broken.to_string(), intact.to_string()]);
 
@@ -430,7 +505,8 @@ mod tests {
         );
         testing::commit(&mut core, work_id, KIND_WORK_STARTED, json!({}));
 
-        let report = reconcile(&engine, &mut core).expect("recovery must not abort");
+        let report =
+            reconcile(&engine, &EstateRegistry::new(), &mut core).expect("recovery must not abort");
         assert_eq!(report.blocked, vec![work_id.to_string()]);
         assert_eq!(
             core.registry.state().works[work_id].state,
@@ -512,7 +588,8 @@ mod tests {
         // below (that reconcile's flushing is not a no-op it stumbled into).
         let fsyncs_before = core.journal.fsync_count();
 
-        let report = reconcile(&engine, &mut core).expect("recovery must not abort");
+        let report =
+            reconcile(&engine, &EstateRegistry::new(), &mut core).expect("recovery must not abort");
         assert_eq!(report.blocked, vec![broken.to_string(), intact.to_string()]);
 
         assert_eq!(
@@ -611,7 +688,7 @@ mod tests {
             .expect("git");
         assert!(output.status.success(), "checkout: {output:?}");
 
-        let report = reconcile(&engine, &mut core).expect("recovery");
+        let report = reconcile(&engine, &EstateRegistry::new(), &mut core).expect("recovery");
         assert_eq!(report.surfaces_retired, vec![work_id.to_string()]);
 
         let torn = events(&core, work_id, KIND_SURFACE_TORN_DOWN);

--- a/src/runtime/recovery.rs
+++ b/src/runtime/recovery.rs
@@ -371,6 +371,132 @@ mod tests {
     };
     use crate::runtime::testing;
 
+    /// Scaffold a minimal valid estate at `root`.
+    fn scaffold(root: &std::path::Path, name: &str) {
+        std::fs::create_dir_all(root).expect("estate dir");
+        std::fs::write(
+            root.join("sergeant.toml"),
+            format!("[estate]\nname = {name:?}\n"),
+        )
+        .expect("manifest");
+    }
+
+    /// **The D10 trap, named as an acceptance test rather than hoped for.**
+    ///
+    /// Recovery never filtered by estate — there was only ever one — so under
+    /// a host journal it will happily walk two estates' Work in one pass.
+    /// That is right for H1 §11 criterion 5 and wrong for everything after
+    /// it: every *action* recovery takes goes through the engine, which used
+    /// to carry one pinned estate, so estate B's Work would have been resumed
+    /// against estate A's topology. Silently — a mis-plan, or a confusing
+    /// `Estate::resolve` error against the wrong root, never a named refusal.
+    ///
+    /// With the engine's field gone (D10), each Work's estate is resolved
+    /// from its own journaled coordinate (D1) and **re-admitted** before it
+    /// is acted on. This proves both halves at once, which is the point: one
+    /// pass, two estates, one of them broken — the broken estate's Work
+    /// blocks with the admission refusal as its reason, and its neighbour is
+    /// reconciled exactly as it would have been alone.
+    #[test]
+    fn a_work_whose_estate_no_longer_admits_blocks_and_its_neighbour_still_reconciles() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let payments = dir.path().join("payments");
+        let billing = dir.path().join("billing");
+        scaffold(&payments, "payments");
+        scaffold(&billing, "billing");
+        let mut core = testing::core(dir.path());
+        let engine = Engine::new(Arc::new(BackendRegistry::new()), None, dir.path());
+        let estates = EstateRegistry::new();
+
+        // Reconciled in work-id order: the vanished estate's Work first, so a
+        // regression that let it abort the pass would take the survivor with
+        // it.
+        let vanished = "01AAAAAAAAAAAAAAAAAAAAAAAA";
+        let survivor = "01BBBBBBBBBBBBBBBBBBBBBBBB";
+        for (work_id, root) in [(vanished, &payments), (survivor, &billing)] {
+            testing::submit_in(
+                &mut core,
+                work_id,
+                "in flight across a restart",
+                Some(root.to_string_lossy().as_ref()),
+            );
+            testing::commit(
+                &mut core,
+                work_id,
+                KIND_WORKFLOW_BOUND,
+                json!({
+                    "workflow": {"name": "tiny", "version": "1", "source": "test",
+                                 "stages": [{"id": "00-first", "context": "c"}]},
+                    "backend": "vanished",
+                }),
+            );
+            testing::commit(
+                &mut core,
+                work_id,
+                KIND_STAGE_ENTERED,
+                json!({"stage_id": "00-first", "index": 0, "attempt": 1}),
+            );
+            testing::commit(
+                &mut core,
+                work_id,
+                KIND_EXECUTION_STARTED,
+                json!({"execution": {
+                    "execution_id": "e1",
+                    "backend": "vanished",
+                    "native_id": "n1",
+                    "stage_id": "00-first",
+                    "attempt": 1,
+                    "stop_requested": false,
+                }}),
+            );
+            testing::commit(&mut core, work_id, KIND_WORK_STARTED, json!({}));
+        }
+
+        // One estate's manifest is gone by the time the daemon restarts —
+        // deleted, renamed, an unmounted volume. Its coordinate is still in
+        // the journal, which is exactly the situation that must fail closed
+        // rather than be resolved against whatever else is lying around.
+        std::fs::remove_file(payments.join("sergeant.toml")).expect("break payments");
+
+        let report = reconcile(&engine, &estates, &mut core).expect("recovery must not abort");
+        assert_eq!(
+            report.blocked,
+            vec![vanished.to_string(), survivor.to_string()],
+            "both block here — but for different reasons, asserted below"
+        );
+
+        // The vanished estate's Work names *the estate* as the reason, with
+        // the admission diagnostic as its evidence — not a backend error, and
+        // not a mis-plan against some other estate.
+        let blocked = events(&core, vanished, KIND_WORK_BLOCKED);
+        assert_eq!(blocked.len(), 1);
+        assert_eq!(
+            blocked[0]["reason"], "this Work's estate could not be re-admitted at startup",
+            "the refusal must name the estate, not the symptom: {}",
+            blocked[0]
+        );
+        assert!(
+            blocked[0]["evidence"]
+                .as_str()
+                .is_some_and(|e| e.contains("no estate found") && e.contains("payments")),
+            "the admission refusal itself is the evidence: {}",
+            blocked[0]
+        );
+
+        // The survivor never touched the broken estate: it reconciled on its
+        // own terms and blocked for its own (its backend is not registered).
+        let blocked = events(&core, survivor, KIND_WORK_BLOCKED);
+        assert_eq!(blocked.len(), 1);
+        assert_ne!(
+            blocked[0]["reason"], "this Work's estate could not be re-admitted at startup",
+            "one estate's failure must not be charged to another's Work: {}",
+            blocked[0]
+        );
+        estates
+            .admit(&billing)
+            .expect("the surviving estate still admits");
+    }
+
     /// §25's fail-closed rule is stated per work: "ambiguous states fail
     /// closed to `blocked` with evidence". One work whose reconciliation
     /// *errors* — not "is ambiguous", but fails outright — must therefore

--- a/src/runtime/startup.rs
+++ b/src/runtime/startup.rs
@@ -530,6 +530,17 @@ pub struct FloorWorkRow {
     pub updated_at: String,
     /// Same as [`WorkIndexRow::last_seq`].
     pub last_seq: u64,
+    /// Same as [`WorkIndexRow::estate_root`] — H1 D1's per-Work estate
+    /// coordinate, carried across the window so a cache-hit start does not
+    /// forget which estate a below-window Work belongs to.
+    ///
+    /// `#[serde(default)]` rather than a schema bump: a v2 cache written
+    /// before this field existed reads back `None`, which is exactly what
+    /// the field already means everywhere else ("not recorded") — unlike
+    /// `first_seq`, whose absence would have made pruning permanently inert
+    /// and therefore had to be a named miss.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estate_root: Option<String>,
     /// W3 §3.1: first seq this process has ever seen for this Work — the
     /// field without which a cache-hit start cannot compute the prune
     /// horizon's no-straddle predicate at all (see
@@ -908,6 +919,7 @@ impl Plan {
                             created_at: row.created_at.clone(),
                             updated_at: row.updated_at.clone(),
                             last_seq: row.last_seq,
+                            estate_root: row.estate_root.clone(),
                         },
                     );
                 }
@@ -1105,6 +1117,7 @@ fn build_floor_state(
             updated_at: row.updated_at.clone(),
             last_seq: row.last_seq,
             first_seq: first_seq.get(&row.id).copied().unwrap_or(0),
+            estate_root: row.estate_root.clone(),
         })
         .collect();
     works.sort_unstable_by(|a, b| a.id.cmp(&b.id));
@@ -1281,6 +1294,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             updated_at: "2026-01-01T00:00:00Z".to_string(),
             last_seq,
+            estate_root: None,
         }
     }
 
@@ -1368,17 +1382,113 @@ mod tests {
     /// prefix `Plan::resolve` should accept.
     fn build_journal_and_cache(dir: &Path) -> (Journal, FloorState) {
         let mut journal = Journal::open_with(dir, 1).expect("open");
-        for n in 1..=20 {
+        for n in 1u32..=20 {
             journal
-                .append(draft(
-                    KIND_WORK_SUBMITTED,
-                    Some(&format!("w{n}")),
-                    submit_payload(&format!("w{n}"), "pending"),
-                ))
+                .append(
+                    draft(
+                        KIND_WORK_SUBMITTED,
+                        Some(&format!("w{n}")),
+                        submit_payload(&format!("w{n}"), "pending"),
+                    )
+                    // H1 D1: alternate the estate coordinate so any test
+                    // built on this fixture is standing on a *multi*-estate
+                    // journal, which is what a host journal actually is.
+                    .with_workspace_id(if n.is_multiple_of(2) {
+                        "/estates/billing"
+                    } else {
+                        "/estates/payments"
+                    }),
+                )
                 .expect("append");
         }
         let cache = cache_for(&journal);
         (journal, cache)
+    }
+
+    /// H1 D1/D10: a Work's estate coordinate must survive the startup
+    /// window. On a cache-hit start the below-window Works are seeded from
+    /// `FloorWorkRow`, never replayed — so without the coordinate on that
+    /// row, `Engine::commit` and recovery would both silently see "no
+    /// estate" for every Work older than the window, which is the exact
+    /// shape of the silent failure D10 exists to close.
+    #[test]
+    fn the_per_work_estate_coordinate_survives_the_startup_window() {
+        let expected = |id: &str| {
+            let n: u32 = id.trim_start_matches('w').parse().expect("w<n> id");
+            if n.is_multiple_of(2) {
+                "/estates/billing"
+            } else {
+                "/estates/payments"
+            }
+        };
+        let dir = TempDir::new().expect("tempdir");
+        let (journal, seed_cache) = build_journal_and_cache(dir.path());
+
+        // First start: full replay, every coordinate folded from the
+        // envelope, and the cache this start would leave behind.
+        let mut registry = crate::runtime::projection::work_registry_projection();
+        drive(
+            Plan::Full {
+                floor_seq: 1,
+                window_seq: 0,
+                miss: CacheMiss::Absent,
+            }
+            .replay(&journal)
+            .expect("replay"),
+            &mut [&mut RegistrySink(&mut registry)],
+        )
+        .expect("drive");
+        for (id, row) in &registry.state().work_index {
+            assert_eq!(row.estate_root.as_deref(), Some(expected(id)), "{id}");
+        }
+        let first_seq: BTreeMap<String, u64> = registry
+            .state()
+            .work_index
+            .keys()
+            .map(|id| (id.clone(), 1))
+            .collect();
+        // The cache this start would leave behind, built through the real
+        // mapping (`build_floor_state` is exactly what `next_cache` calls;
+        // the horizon is handed in directly, as the sibling
+        // `build_floor_state_*` tests do, because this fixture's Works are
+        // all still `pending` and therefore pin the computed one at 0).
+        let cache = build_floor_state(
+            &journal.segment_bounds().expect("bounds"),
+            seed_cache.binding.summarized_through_seq,
+            registry.state(),
+            &LedgerSink::default(),
+            &CapabilitySink::default(),
+            &first_seq,
+        )
+        .expect("build_floor_state")
+        .expect("H > 0 must produce a cache");
+        assert!(
+            !cache.works.is_empty(),
+            "the fixture must really summarize some Works below the window"
+        );
+
+        // Second start, cache hit: below-window Works are *seeded*, never
+        // replayed. Without the coordinate on `FloorWorkRow` every one of
+        // them would silently read back as "no estate".
+        write_cache(dir.path(), &cache);
+        let plan = Plan::resolve(dir.path(), &journal, false).expect("resolve");
+        assert!(matches!(plan, Plan::Windowed { .. }), "{plan:?}");
+        let mut registry = plan.seed_registry();
+        let seeded: Vec<String> = registry.state().work_index.keys().cloned().collect();
+        assert!(!seeded.is_empty(), "the cache must seed some index rows");
+        drive(
+            plan.replay(&journal).expect("replay"),
+            &mut [&mut RegistrySink(&mut registry)],
+        )
+        .expect("drive");
+        for (id, row) in &registry.state().work_index {
+            assert_eq!(
+                row.estate_root.as_deref(),
+                Some(expected(id)),
+                "{id} lost its estate coordinate across the window (seeded: {})",
+                seeded.contains(id)
+            );
+        }
     }
 
     /// The cache half of [`build_journal_and_cache`], on its own, so a test

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -960,6 +960,16 @@ impl App {
     pub async fn execute(&mut self, client: &ApiClient, action: Action) -> Action {
         match action {
             Action::Submit(body) => {
+                // D4: the composer builds the submission; the client is what
+                // knows which estate this session addresses, so the address
+                // is stamped here rather than threaded through every screen.
+                // A client addressing no estate sends none, and the daemon
+                // answers exactly as it does for any submission with no
+                // repository context.
+                let mut body = body;
+                if let (Some(root), Some(map)) = (client.estate_root(), body.as_object_mut()) {
+                    map.insert("estate_root".to_string(), serde_json::json!(root));
+                }
                 match client.post("/v1/work", &body).await {
                     Ok(result) => {
                         let id = result["work"]["id"].as_str().unwrap_or("?").to_string();

--- a/tests/agy_routing.rs
+++ b/tests/agy_routing.rs
@@ -77,7 +77,7 @@ fn estate_with_manifest(root: &Path, manifest: &str, repos: &[&str]) {
 
 /// Start a daemon with one scripted fake (the global default) and agy
 /// registered for real, but deterministically unavailable.
-async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
+async fn start(data_dir: &Path, _estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
     daemon::start_with(
         data_dir,
         DaemonConfig {
@@ -86,7 +86,6 @@ async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>
             ),
             default_backend: global_default.map(str::to_string),
             agy: Some(deterministic_agy_config(data_dir)),
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -136,6 +135,9 @@ async fn submit(
     let mut body = json!({
         "command_id": ulid(),
         "intent": "route me",
+        // D4: the estate this submission addresses (`extra` may override it,
+        // including to `null` for the no-topology cases).
+        "estate_root": cwd,
         "origin": {"client": "cli", "cwd": cwd},
     });
     if let Some(fields) = extra.as_object() {

--- a/tests/codex_routing.rs
+++ b/tests/codex_routing.rs
@@ -77,7 +77,7 @@ fn estate_with_manifest(root: &Path, manifest: &str, repos: &[&str]) {
 
 /// Start a daemon with one scripted fake (the global default) and codex
 /// registered for real, but deterministically unavailable.
-async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
+async fn start(data_dir: &Path, _estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
     daemon::start_with(
         data_dir,
         DaemonConfig {
@@ -86,7 +86,6 @@ async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>
             ),
             default_backend: global_default.map(str::to_string),
             codex: Some(deterministic_codex_config(data_dir)),
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -136,6 +135,9 @@ async fn submit(
     let mut body = json!({
         "command_id": ulid(),
         "intent": "route me",
+        // D4: the estate this submission addresses (`extra` may override it,
+        // including to `null` for the no-topology cases).
+        "estate_root": cwd,
         "origin": {"client": "cli", "cwd": cwd},
     });
     if let Some(fields) = extra.as_object() {

--- a/tests/e_admission_uses_no_network_git.rs
+++ b/tests/e_admission_uses_no_network_git.rs
@@ -98,7 +98,6 @@ async fn a_whole_admission_never_runs_a_network_or_branch_changing_git_command()
             backends: Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             claude: None,
-            estate_root: Some(estate.clone()),
             ..DaemonConfig::default()
         },
     )
@@ -116,6 +115,7 @@ async fn a_whole_admission_never_runs_a_network_or_branch_changing_git_command()
             "command_id": ulid::Ulid::generate().to_string(),
             "intent": "admit two clean mounts",
             "scope": {"all": true},
+            "estate_root": estate,
             "origin": {"client": "cli"},
         }))
         .send()

--- a/tests/e_git_admission.rs
+++ b/tests/e_git_admission.rs
@@ -47,7 +47,7 @@ fn http() -> reqwest::Client {
 /// A daemon bound to `estate`, backed by a fake that hangs — so an admitted
 /// submission stays in flight and its surface can be inspected while it
 /// exists.
-async fn start(data: &DataDir, estate: &Path) -> (DaemonHandle, FakeBackend) {
+async fn start(data: &DataDir, _estate: &Path) -> (DaemonHandle, FakeBackend) {
     let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, [FakeStep::hang()]);
     let handle = daemon::start_with(
         data.path(),
@@ -55,7 +55,6 @@ async fn start(data: &DataDir, estate: &Path) -> (DaemonHandle, FakeBackend) {
             backends: Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             claude: None,
-            estate_root: Some(estate.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -64,16 +63,19 @@ async fn start(data: &DataDir, estate: &Path) -> (DaemonHandle, FakeBackend) {
     (handle, fake)
 }
 
-/// Submit, merging `extra` into the request body.
+/// Submit against `estate_root`, merging `extra` into the request body.
 async fn submit(
     client: &reqwest::Client,
     handle: &DaemonHandle,
+    estate_root: &Path,
     intent: &str,
     extra: Value,
 ) -> (reqwest::StatusCode, Value) {
     let mut body = json!({
         "command_id": ulid::Ulid::generate().to_string(),
         "intent": intent,
+        // D4: the estate this submission addresses.
+        "estate_root": estate_root,
         "origin": {"client": "cli"},
     });
     if let Some(fields) = extra.as_object() {
@@ -151,7 +153,14 @@ async fn a_dirty_mount_is_refused_before_a_work_record_exists() {
 
     let (handle, fake) = start(&data, &estate).await;
     let client = http();
-    let (status, body) = submit(&client, &handle, "work on a dirty mount", json!({})).await;
+    let (status, body) = submit(
+        &client,
+        &handle,
+        &estate,
+        "work on a dirty mount",
+        json!({}),
+    )
+    .await;
 
     assert_eq!(status, 422, "a dirty mount is refused: {body}");
     assert_eq!(body["error"]["code"], "git_preflight_dirty_mount");
@@ -221,6 +230,7 @@ async fn an_unresolvable_head_is_refused_and_says_no_override_applies() {
         let (status, body) = submit(
             &client,
             &handle,
+            &estate,
             "no commit to be based on",
             json!({"override_git_preflight": override_flag}),
         )
@@ -264,6 +274,7 @@ async fn a_partial_plan_leaves_no_work_record_and_no_side_effects() {
     let (status, body) = submit(
         &client,
         &handle,
+        &estate,
         "half a scope",
         json!({"scope": {"all": true}}),
     )
@@ -323,6 +334,7 @@ async fn an_override_admits_a_dirty_mount_and_journals_what_it_excluded() {
     let (status, body) = submit(
         &client,
         &handle,
+        &estate,
         "based on the committed head",
         json!({"override_git_preflight": true}),
     )
@@ -411,7 +423,14 @@ async fn an_override_admits_a_detached_mount_with_no_named_base_branch() {
     let client = http();
 
     // Without the flag, §15's detached row refuses and offers the hatch.
-    let (status, refused) = submit(&client, &handle, "detached, no override", json!({})).await;
+    let (status, refused) = submit(
+        &client,
+        &handle,
+        &estate,
+        "detached, no override",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 422, "{refused}");
     assert_eq!(refused["error"]["code"], "git_preflight_detached_head");
     assert!(
@@ -424,6 +443,7 @@ async fn an_override_admits_a_detached_mount_with_no_named_base_branch() {
     let (status, body) = submit(
         &client,
         &handle,
+        &estate,
         "detached, overridden",
         json!({"override_git_preflight": true}),
     )
@@ -547,7 +567,7 @@ async fn the_never_bypass_list_is_never_bypassed() {
         // row has to submit under the id the branch was cut for. The daemon
         // mints its own, so the row instead relies on the branch it planted
         // colliding with nothing — see the dedicated assertion below.
-        let (status, body) = submit(&client, &handle, label, fields).await;
+        let (status, body) = submit(&client, &handle, &estate, label, fields).await;
         if expected == "git_preflight_work_branch_collision" {
             // The daemon mints a fresh ULID per submission, so a *planted*
             // branch cannot collide with it. What this row proves instead is
@@ -613,6 +633,7 @@ async fn the_never_bypass_list_is_never_bypassed() {
     let (status, body) = submit(
         &client,
         &aliased_handle,
+        &aliased_estate,
         "wrong/aliased repository path",
         json!({"override_git_preflight": true, "scope": {"repos": ["audit"]}}),
     )
@@ -656,6 +677,7 @@ async fn the_override_is_not_sticky_and_has_no_source_but_the_submission() {
     let (status, first) = submit(
         &client,
         &handle,
+        &estate,
         "overridden once",
         json!({"override_git_preflight": true}),
     )
@@ -666,7 +688,7 @@ async fn the_override_is_not_sticky_and_has_no_source_but_the_submission() {
         ("omitted entirely", json!({})),
         ("explicitly false", json!({"override_git_preflight": false})),
     ] {
-        let (status, body) = submit(&client, &handle, label, fields).await;
+        let (status, body) = submit(&client, &handle, &estate, label, fields).await;
         assert_eq!(
             status, 422,
             "{label}: the override applies to the submission that typed it and to no other: \
@@ -801,7 +823,7 @@ async fn admission_journals_nothing_before_the_plan_and_leaves_the_order_intact(
 ",
     )
     .expect("dirty it");
-    let (status, refused) = submit(&client, &handle, "refused", json!({})).await;
+    let (status, refused) = submit(&client, &handle, &estate, "refused", json!({})).await;
     assert_eq!(status, 422, "{refused}");
     let after_refusal: Vec<String> = events(&data)
         .into_iter()
@@ -815,7 +837,7 @@ async fn admission_journals_nothing_before_the_plan_and_leaves_the_order_intact(
 
     // Then an accepted one, and the order is unchanged.
     git(&mount, &["checkout", "--", "README.md"]);
-    let (status, body) = submit(&client, &handle, "admitted", json!({})).await;
+    let (status, body) = submit(&client, &handle, &estate, "admitted", json!({})).await;
     assert_eq!(status, 201, "{body}");
     let work_id = body["work"]["id"].as_str().expect("work id").to_string();
     let kinds: Vec<String> = events(&data)

--- a/tests/e_sweep_uses_only_local_git.rs
+++ b/tests/e_sweep_uses_only_local_git.rs
@@ -97,13 +97,15 @@ async fn a_whole_sweep_reads_refs_and_deletes_nothing_but_a_redundant_sergeant_b
         DaemonConfig {
             backends: Arc::new(BackendRegistry::new().with(Arc::new(fake))),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(estate.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
     .await
     .expect("daemon start");
-    let client = ApiClient::new(&handle.endpoint, &handle.token).expect("client");
+    // D4: the sweep addresses the estate whose `sergeant/*` refs it means.
+    let client = ApiClient::new(&handle.endpoint, &handle.token)
+        .expect("client")
+        .with_estate_root(estate.path());
 
     // A real Work, under the real git, so the branch the sweep classifies is
     // one a materialization actually left behind.
@@ -114,6 +116,7 @@ async fn a_whole_sweep_reads_refs_and_deletes_nothing_but_a_redundant_sergeant_b
                 "command_id": ulid::Ulid::generate().to_string(),
                 "intent": "leave a branch behind",
                 "workflow": "solo",
+                "estate_root": estate.path(),
                 "origin": {"client": "cli", "cwd": estate.path()},
             }),
         )

--- a/tests/e_work_sweep.rs
+++ b/tests/e_work_sweep.rs
@@ -64,7 +64,6 @@ async fn rig() -> (TempDir, PathBuf, TempDir, DaemonHandle) {
         DaemonConfig {
             backends: Arc::new(BackendRegistry::new().with(Arc::new(fake))),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(root.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -85,6 +84,7 @@ async fn completed_work(client: &ApiClient, cwd: &Path) -> String {
                 "command_id": ulid::Ulid::generate().to_string(),
                 "intent": "leave a branch behind",
                 "workflow": "solo",
+                "estate_root": cwd,
                 "origin": {"client": "cli", "cwd": cwd},
             }),
         )
@@ -138,7 +138,10 @@ fn refs_in(mount: &Path) -> String {
 #[tokio::test]
 async fn classification_reports_redundant_and_orphan_and_mutates_nothing() {
     let (root, mount, _data, handle) = rig().await;
-    let client = ApiClient::new(&handle.endpoint, &handle.token).expect("client");
+    // D4: the sweep addresses the estate whose `sergeant/*` refs it means.
+    let client = ApiClient::new(&handle.endpoint, &handle.token)
+        .expect("client")
+        .with_estate_root(root.path());
     let id = completed_work(&client, root.path()).await;
     git(&mount, &["branch", ORPHAN_BRANCH, "main"]);
 
@@ -184,7 +187,10 @@ async fn classification_reports_redundant_and_orphan_and_mutates_nothing() {
 #[tokio::test]
 async fn deletion_without_confirmation_refuses_and_deletes_nothing() {
     let (root, mount, _data, handle) = rig().await;
-    let client = ApiClient::new(&handle.endpoint, &handle.token).expect("client");
+    // D4: the sweep addresses the estate whose `sergeant/*` refs it means.
+    let client = ApiClient::new(&handle.endpoint, &handle.token)
+        .expect("client")
+        .with_estate_root(root.path());
     let id = completed_work(&client, root.path()).await;
 
     let before = refs_in(&mount);
@@ -218,7 +224,10 @@ async fn deletion_without_confirmation_refuses_and_deletes_nothing() {
 #[tokio::test]
 async fn a_confirmed_sweep_deletes_only_the_redundant_branch_and_journals_its_tip() {
     let (root, mount, _data, handle) = rig().await;
-    let client = ApiClient::new(&handle.endpoint, &handle.token).expect("client");
+    // D4: the sweep addresses the estate whose `sergeant/*` refs it means.
+    let client = ApiClient::new(&handle.endpoint, &handle.token)
+        .expect("client")
+        .with_estate_root(root.path());
     let id = completed_work(&client, root.path()).await;
     git(&mount, &["branch", ORPHAN_BRANCH, "main"]);
     let work_branch = format!("sergeant/{id}");

--- a/tests/estate_routes.rs
+++ b/tests/estate_routes.rs
@@ -560,3 +560,74 @@ async fn an_unaddressed_or_unadmitted_estate_is_refused_by_name() {
 
     handle.shutdown().await;
 }
+
+/// §26 survives an estate breaking underneath an accepted submission.
+///
+/// A `command_id` whose outcome is already recorded replays that outcome —
+/// even once its estate has stopped admitting. The alternative is that a
+/// client retrying an uncertain-but-accepted submission is told 422 and
+/// concludes nothing happened, while a real Work sits in the journal. §26's
+/// promise is about what already happened, not about whether it could
+/// happen again now, and D4's admission check is deliberately *behind* it.
+#[tokio::test]
+async fn an_accepted_submission_still_replays_after_its_estate_stops_admitting() {
+    let (root, data_dir) = estate();
+    // A submission has to be plannable, so this estate declares its one
+    // derived mount (§6.1) rather than being the bare post-`sgt init` shape
+    // the CRUD tests above use.
+    std::fs::write(
+        root.path().join("sergeant.toml"),
+        "[estate]\nname = \"t3-estate\"\n\n[[repo]]\nname = \"solo\"\n",
+    )
+    .expect("manifest");
+    init_repo(&root.path().join("repos").join("solo"));
+    let handle = start(&data_dir, root.path()).await;
+    let http = reqwest::Client::new();
+    let command_id = ulid::Ulid::generate().to_string();
+    let body = serde_json::json!({
+        "command_id": command_id,
+        "intent": "accepted before the estate broke",
+        "estate_root": root.path(),
+    });
+
+    let first = http
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("submit");
+    assert_eq!(first.status(), 201);
+    let first: Value = first.json().await.expect("json");
+
+    // The estate goes away — deleted, renamed, an unmounted volume.
+    std::fs::remove_file(root.path().join("sergeant.toml")).expect("break the estate");
+
+    // A brand-new submission is refused by name...
+    let fresh = http
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&serde_json::json!({
+            "command_id": ulid::Ulid::generate().to_string(),
+            "intent": "after the estate broke",
+            "estate_root": root.path(),
+        }))
+        .send()
+        .await
+        .expect("submit");
+    assert_eq!(fresh.status(), 422, "a new submission must be refused");
+
+    // ...but the retry of the accepted one replays, byte for byte.
+    let replayed = http
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("submit");
+    assert_eq!(replayed.status(), 201, "the accepted command must replay");
+    let replayed: Value = replayed.json().await.expect("json");
+    assert_eq!(replayed, first, "§26: a replay is the same answer");
+
+    handle.shutdown().await;
+}

--- a/tests/estate_routes.rs
+++ b/tests/estate_routes.rs
@@ -70,11 +70,10 @@ fn estate() -> (TempDir, std::path::PathBuf) {
 
 /// Start a daemon on `data_dir`, **bound** to `estate_root` (§5.1). Every
 /// `/v1/estate/*` route resolves the estate through that binding now.
-async fn start(data_dir: &Path, estate_root: &Path) -> DaemonHandle {
+async fn start(data_dir: &Path, _estate_root: &Path) -> DaemonHandle {
     daemon::start_with(
         data_dir,
         DaemonConfig {
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -82,8 +81,13 @@ async fn start(data_dir: &Path, estate_root: &Path) -> DaemonHandle {
     .expect("daemon start")
 }
 
-fn client_for(handle: &DaemonHandle) -> ApiClient {
-    ApiClient::new(&handle.endpoint, &handle.token).expect("client")
+/// D4: a client addresses the estate its estate-scoped requests mean. The
+/// daemon binds none, so a client that named none would be refused by name
+/// on every estate-scoped route — which is the contract, not a rig quirk.
+fn client_for(handle: &DaemonHandle, estate_root: &Path) -> ApiClient {
+    ApiClient::new(&handle.endpoint, &handle.token)
+        .expect("client")
+        .with_estate_root(estate_root)
 }
 
 // -------------------------------------------------------------- repos
@@ -92,7 +96,7 @@ fn client_for(handle: &DaemonHandle) -> ApiClient {
 async fn get_estate_repos_reflects_the_manifest_empty_then_populated() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let empty = client.repos().await.expect("get repos");
     assert_eq!(empty["repos"].as_array().expect("array").len(), 0);
@@ -122,7 +126,7 @@ async fn get_estate_repos_reflects_the_manifest_empty_then_populated() {
 async fn post_estate_repos_honors_the_instructions_choice() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -144,7 +148,7 @@ async fn post_estate_repos_honors_the_instructions_choice() {
 async fn post_estate_repos_refuses_a_duplicate_name_with_the_manifest_refusal() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -172,7 +176,7 @@ async fn post_estate_repos_refuses_a_duplicate_name_with_the_manifest_refusal() 
 async fn delete_estate_repos_removes_the_declaration_but_not_the_clone() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -198,7 +202,7 @@ async fn delete_estate_repos_removes_the_declaration_but_not_the_clone() {
 async fn delete_estate_repos_refuses_while_a_group_still_references_it() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -232,7 +236,7 @@ async fn delete_estate_repos_refuses_while_a_group_still_references_it() {
 async fn post_estate_groups_creates_then_extends_by_union() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -272,7 +276,7 @@ async fn post_estate_groups_creates_then_extends_by_union() {
 async fn post_estate_groups_refuses_an_undeclared_member() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let err = client
         .add_group("core", &["ghost".to_string()], None)
@@ -290,7 +294,7 @@ async fn post_estate_groups_refuses_an_undeclared_member() {
 async fn get_estate_groups_reflects_the_manifest() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -317,7 +321,7 @@ async fn get_estate_groups_reflects_the_manifest() {
 async fn delete_estate_groups_with_named_repos_removes_only_those_members() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -354,7 +358,7 @@ async fn delete_estate_groups_with_named_repos_removes_only_those_members() {
 async fn delete_estate_groups_with_no_repos_removes_the_whole_group() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -383,7 +387,7 @@ async fn delete_estate_groups_with_no_repos_removes_the_whole_group() {
 async fn delete_estate_groups_refuses_a_nonmember() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let source = TempDir::new().expect("source repo tempdir");
     init_repo(source.path());
@@ -414,7 +418,7 @@ async fn delete_estate_groups_refuses_a_nonmember() {
 async fn get_doctor_matches_the_shape_sgt_doctor_json_already_prints() {
     let (root, data_dir) = estate();
     let handle = start(&data_dir, root.path()).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, root.path());
 
     let report = client.doctor().await.expect("get doctor report");
     assert!(report["healthy"].is_boolean());

--- a/tests/estate_routes.rs
+++ b/tests/estate_routes.rs
@@ -8,13 +8,13 @@
 //! loopback endpoint), plus a real git fixture the same way `tests/
 //! m8_estate_cli.rs` builds one for `sgt repo add`'s populate-or-verify.
 //!
-//! Every estate here uses the default `<estate_root>/.sergeant/data` layout
-//! and starts its daemon **bound** to the estate root (estate-root §5.1):
-//! `src/api.rs`'s `resolve_estate_root` reads that binding off the engine
-//! rather than walking up from `data_dir`, so these routes depend on nothing
-//! but the root the daemon was started against — and, as before, not at all
-//! on the test process's own working directory (`current_dir` is global
-//! process state, and nothing here needs to touch it).
+//! Every estate here uses the default `<estate_root>/.sergeant/data` layout.
+//! Under H1 the daemon is bound to **no** estate: `src/api.rs`'s
+//! `resolve_estate_root` reads the estate off the *request* (D4) and admits
+//! it, so these routes depend on nothing but the root each request names —
+//! and, as before, not at all on the test process's own working directory
+//! (`current_dir` is global process state, and nothing here needs to touch
+//! it).
 
 use std::path::Path;
 use std::process::Command;
@@ -22,7 +22,7 @@ use std::process::Command;
 use serde_json::Value;
 use tempfile::TempDir;
 
-use sergeant_rs::api::ApiClient;
+use sergeant_rs::api::{ApiClient, ClientError};
 use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
 
 fn git(dir: &Path, args: &[&str]) -> String {
@@ -439,6 +439,124 @@ async fn get_doctor_matches_the_shape_sgt_doctor_json_already_prints() {
     let names: Vec<&str> = checks.iter().filter_map(|c| c["name"].as_str()).collect();
     assert!(names.contains(&"estate"), "{names:?}");
     assert!(names.contains(&"disk_pressure"), "{names:?}");
+
+    handle.shutdown().await;
+}
+
+// ------------------------------------------------- H1: the estate registry
+
+/// `GET /v1/estates` (H1 §4, brief deliverable 6): the registry is
+/// **observational**. It is empty on a daemon nobody has addressed, gains a
+/// row the moment one is, and never gains a row for a root that failed
+/// admission — a refused admission is not an observation.
+#[tokio::test]
+async fn get_estates_is_empty_until_a_request_addresses_one() {
+    let (root, data_dir) = estate();
+    let handle = start(&data_dir, root.path()).await;
+
+    let unaddressed = ApiClient::new(&handle.endpoint, &handle.token).expect("client");
+    let listed = unaddressed.estates().await.expect("GET /v1/estates");
+    assert_eq!(
+        listed["estates"].as_array().expect("estates").len(),
+        0,
+        "a host daemon starts bound to zero estates: {listed}"
+    );
+
+    // A root that is not an estate is refused *and leaves no row*.
+    let bogus = TempDir::new().expect("tempdir");
+    let refused = ApiClient::new(&handle.endpoint, &handle.token)
+        .expect("client")
+        .with_estate_root(bogus.path());
+    refused
+        .repos()
+        .await
+        .expect_err("a non-estate must be refused");
+    let listed = unaddressed.estates().await.expect("GET /v1/estates");
+    assert_eq!(
+        listed["estates"].as_array().expect("estates").len(),
+        0,
+        "a refused admission must not become a registry row: {listed}"
+    );
+
+    // A real one is admitted on first contact, and reported with its
+    // canonical root, its display name, and its availability.
+    let client = client_for(&handle, root.path());
+    client.repos().await.expect("GET /v1/estate/repos");
+    let listed = unaddressed.estates().await.expect("GET /v1/estates");
+    let rows = listed["estates"].as_array().expect("estates");
+    assert_eq!(rows.len(), 1, "{listed}");
+    assert_eq!(
+        rows[0]["root"],
+        Value::String(
+            std::fs::canonicalize(root.path())
+                .expect("canonical")
+                .to_string_lossy()
+                .into_owned()
+        ),
+        "the coordinate is the canonical root (D1), never the display name"
+    );
+    assert_eq!(rows[0]["name"], "t3-estate");
+    assert_eq!(rows[0]["available"], true);
+    assert!(rows[0]["admitted_at"].is_string(), "{listed}");
+
+    handle.shutdown().await;
+}
+
+/// D4's refusal taxonomy, over the wire, on a route that cannot proceed
+/// without an estate:
+///
+/// - (c) no estate addressed at all → `404 no_estate`, naming what to send;
+/// - (a) a root that is not an estate → `422 invalid_estate`, carrying
+///   §4.4's own corrective block rather than a summary of it.
+///
+/// This is the negative the retired "bound to a different estate" refusal
+/// used to carry, re-pointed rather than dropped: what must never happen is
+/// serving a request for an estate nobody validated, and that is still
+/// exactly what happens here.
+#[tokio::test]
+async fn an_unaddressed_or_unadmitted_estate_is_refused_by_name() {
+    let (root, data_dir) = estate();
+    let handle = start(&data_dir, root.path()).await;
+
+    let unaddressed = ApiClient::new(&handle.endpoint, &handle.token).expect("client");
+    let err = unaddressed
+        .repos()
+        .await
+        .expect_err("an estate-scoped route with no estate must refuse");
+    let ClientError::Api {
+        status,
+        code,
+        message,
+    } = &err
+    else {
+        panic!("expected a structured refusal, got {err}");
+    };
+    assert_eq!((*status, code.as_str()), (404, "no_estate"), "{err}");
+    assert!(
+        message.contains("estate_root"),
+        "the refusal must say what to send: {message}"
+    );
+
+    let bogus = TempDir::new().expect("tempdir");
+    let err = ApiClient::new(&handle.endpoint, &handle.token)
+        .expect("client")
+        .with_estate_root(bogus.path())
+        .repos()
+        .await
+        .expect_err("a root that is not an estate must refuse");
+    let ClientError::Api {
+        status,
+        code,
+        message,
+    } = &err
+    else {
+        panic!("expected a structured refusal, got {err}");
+    };
+    assert_eq!((*status, code.as_str()), (422, "invalid_estate"), "{err}");
+    assert!(
+        message.contains("does not search parent directories"),
+        "§4.4's own diagnostic must survive to the client verbatim: {message}"
+    );
 
     handle.shutdown().await;
 }

--- a/tests/i9_floor_pinning.rs
+++ b/tests/i9_floor_pinning.rs
@@ -512,7 +512,7 @@ fn plan_full_leaves_core_floor_ledger_empty() {
 
 async fn start_fake_tiny_segments(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     script: impl IntoIterator<Item = FakeStep>,
 ) -> (DaemonHandle, FakeBackend) {
     let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, script);
@@ -522,7 +522,6 @@ async fn start_fake_tiny_segments(
         DaemonConfig {
             backends: std::sync::Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(estate_root.to_path_buf()),
             // Tiny threshold (§5.4): reaching a >16-segment journal by
             // shrinking this, never by shrinking the window.
             segment_max_bytes: Some(256),
@@ -568,6 +567,7 @@ async fn the_real_daemon_journal_pins() {
             .json(&json!({
                 "command_id": ulid(),
                 "intent": "i9 acceptance work",
+                "estate_root": root.path(),
                 "origin": {"client": "cli", "cwd": root.path()},
             }))
             .send()
@@ -883,6 +883,7 @@ async fn a_below_window_command_id_is_refused_by_name_through_a_real_http_retry(
     let submit_body = json!({
         "command_id": early_command_id,
         "intent": "below-window refusal fixture",
+        "estate_root": root.path(),
         "origin": {"client": "cli", "cwd": root.path()},
     });
     let early_work_id;

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -1967,6 +1967,99 @@ fn t7_cli_end_to_end_a_second_estate_is_admitted_and_a_second_process_fails_clos
     stop_daemon(dir.path());
 }
 
+/// §26 outranks D4's admission check, and the crash window is where that
+/// actually bites.
+///
+/// A daemon that dies between `work.submitted` and `command.accepted` leaves
+/// a durable Work with no recorded outcome; `command_works` is the index that
+/// lets the retry answer for the command that already ran instead of running
+/// a second one (`crash_between_mutation_and_command_record_still_replays`
+/// pins that on its own). H1 adds a step *before* planning — admit the
+/// addressed estate — and if that step answered first, a retry landing in
+/// exactly this window after the estate broke would be told `422 the estate
+/// is invalid` while its Work sat in the journal. The client would conclude
+/// nothing happened. §26's promise is about what already happened, not about
+/// whether it could happen again now, so admission is deliberately behind
+/// both replay checks.
+#[tokio::test]
+async fn a_crash_window_retry_replays_even_after_its_estate_stops_admitting() {
+    let dir = TempDir::new().expect("tempdir");
+    let estate = second_estate("crash-window");
+    let handle = start(dir.path()).await;
+    let command_id = ulid();
+    let (status, _, body) = submit_addressed(
+        &client(),
+        &handle,
+        Some(estate.path()),
+        &command_id,
+        "accepted, then the estate vanished",
+    )
+    .await;
+    assert_eq!(status, 201, "{body}");
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    handle.shutdown().await;
+
+    // The exact crash image: the durable `work.submitted`, its
+    // `command.accepted` never written.
+    let events = journal_events(dir.path());
+    let submitted_at = events
+        .iter()
+        .position(|e| e.kind == KIND_WORK_SUBMITTED)
+        .expect("work.submitted journaled");
+    truncate_journal(dir.path(), submitted_at + 1);
+
+    // ...and by the time anyone retries, the estate is gone.
+    std::fs::remove_file(estate.path().join("sergeant.toml")).expect("break the estate");
+
+    let handle = start(dir.path()).await;
+    let http = client();
+    let (retry_status, _, retry_body) = submit_addressed(
+        &http,
+        &handle,
+        Some(estate.path()),
+        &command_id,
+        "accepted, then the estate vanished",
+    )
+    .await;
+    assert_eq!(
+        retry_status, status,
+        "the retry must answer for the command that already ran: {retry_body}"
+    );
+    assert_eq!(
+        retry_body["work"]["id"].as_str(),
+        Some(work_id.as_str()),
+        "and for the same Work: {retry_body}"
+    );
+    // Deliberately not byte-equality with the first response, unlike
+    // `crash_between_mutation_and_command_record_still_replays`: that rig's
+    // daemon plans nothing, so its Work never moves past `pending` and the
+    // two bodies are identical. Here the first submission really ran, and the
+    // truncation cut every event after `work.submitted` away — so the
+    // re-derived view honestly describes the journal as it now stands. What
+    // this test is about is *which* answer the retry gives (the recorded
+    // command's, not a refusal), not how much of the run survived surgery.
+    assert!(
+        retry_body["error"].is_null(),
+        "the retry must not be an error at all: {retry_body}"
+    );
+
+    // A genuinely new submission against the same broken estate is still
+    // refused — the exemption is for the command that already ran, not for
+    // the estate.
+    let (fresh_status, _, fresh_body) = submit_addressed(
+        &http,
+        &handle,
+        Some(estate.path()),
+        &ulid(),
+        "a new one, after the break",
+    )
+    .await;
+    assert_eq!(fresh_status, 422, "{fresh_body}");
+    assert_eq!(fresh_body["error"]["code"], "invalid_estate");
+
+    handle.shutdown().await;
+}
+
 /// The rest of the contracted CLI surface through the spawned binary:
 /// `sgt status`, `sgt work show <id>`, `sgt cancel <id>`, in both human and
 /// `--json` form. Everything here talks to a real daemon over the loopback

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -324,7 +324,7 @@ async fn t1_descriptor_lifecycle_and_healthz() {
     let path = daemon::descriptor_path(dir.path());
     let bytes = std::fs::read(&path).expect("descriptor readable");
     let descriptor: RuntimeDescriptor = serde_json::from_slice(&bytes).expect("descriptor json");
-    assert_eq!(descriptor.schema, "sergeant.runtime/v2");
+    assert_eq!(descriptor.schema, "sergeant.runtime/v3");
     assert!(
         descriptor.endpoint.starts_with("http://127.0.0.1:"),
         "loopback endpoint, got {}",
@@ -334,14 +334,25 @@ async fn t1_descriptor_lifecycle_and_healthz() {
     assert_eq!(descriptor.api_revision, "v1");
     assert_eq!(descriptor.token, handle.token);
     assert_token_plausible(&descriptor.token);
-    // estate-root §5.1: `v2` exists for these two fields. This daemon was
-    // started against no estate (`DaemonConfig::estate_root` is `None` — the
-    // shape most of this file's in-process rigs use), and the descriptor has
-    // to *say so* rather than omit the question: a client comparing its own
-    // exact root against `None` gets the mismatch refusal, which is the only
-    // safe answer when the daemon would plan against nothing.
-    assert_eq!(descriptor.estate_root, None);
-    assert_eq!(descriptor.manifest_path, None);
+    // D3: a v3 descriptor carries **no** estate fields at all. The admitted-
+    // estate set is dynamic daemon state (`GET /v1/estates`); baking a set
+    // into a file written once, atomically, at startup would contradict lazy
+    // admission. The serialized keys are asserted exactly, so a re-added
+    // estate field is a test failure rather than a silent re-narrowing of
+    // what the descriptor means.
+    let raw: Value = serde_json::from_slice(&bytes).expect("descriptor json");
+    let mut keys: Vec<&str> = raw
+        .as_object()
+        .expect("object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec!["api_revision", "endpoint", "pid", "schema", "token"],
+        "D3: descriptor v3 is schema/endpoint/pid/api_revision/token — nothing else"
+    );
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
@@ -382,34 +393,34 @@ async fn t1_descriptor_lifecycle_and_healthz() {
     );
     successor.shutdown().await;
 
-    // The other half of §5.1: a daemon started *against* an estate publishes
-    // the canonical root and its manifest, because that is what every client
-    // compares its own exact root to before using the endpoint. Recorded, not
-    // reconstructed — a reader must never have to re-derive
-    // `<root>/sergeant.toml` (or, worse, walk for it).
+    // D3's other half, re-scoped from the retired "the descriptor publishes
+    // the one bound root" assertion: a daemon that has an estate in play
+    // publishes exactly the same five-key descriptor. The estate is not a
+    // property of the process any more, so it cannot be a property of the
+    // file the process writes once at startup.
     let estate = TempDir::new().expect("tempdir");
     support::scaffold_estate(estate.path(), "descriptor-lifecycle", &["solo"]);
-    let root = std::fs::canonicalize(estate.path()).expect("canonical estate root");
-    let bound_dir = TempDir::new().expect("tempdir");
-    let bound = daemon::start_with(
-        bound_dir.path(),
-        DaemonConfig {
-            estate_root: Some(estate.path().to_path_buf()),
-            ..DaemonConfig::default()
-        },
+    let host_dir = TempDir::new().expect("tempdir");
+    let host = daemon::start_with(host_dir.path(), DaemonConfig::default())
+        .await
+        .expect("daemon start");
+    let raw: Value = serde_json::from_slice(
+        &std::fs::read(daemon::descriptor_path(host_dir.path())).expect("descriptor readable"),
     )
-    .await
-    .expect("daemon start");
-    let descriptor = daemon::read_descriptor(bound_dir.path())
-        .expect("read descriptor")
-        .expect("descriptor published");
-    assert_eq!(descriptor.estate_root.as_deref(), Some(root.as_path()));
+    .expect("descriptor json");
+    let mut keys: Vec<&str> = raw
+        .as_object()
+        .expect("object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
     assert_eq!(
-        descriptor.manifest_path,
-        Some(root.join("sergeant.toml")),
-        "the manifest path travels with the root, so no client reconstructs it"
+        keys,
+        vec!["api_revision", "endpoint", "pid", "schema", "token"],
+        "D3: no estate ever reaches the descriptor, however many are in play"
     );
-    bound.shutdown().await;
+    host.shutdown().await;
 }
 
 /// A bearer token must be long, high-entropy-looking, and safe to put in a
@@ -1951,26 +1962,21 @@ fn t8_two_concurrent_auto_spawns_one_survivor_both_commands_complete() {
     stop_daemon(dir.path());
 }
 
-/// Hand-write a `sergeant.runtime/v2` descriptor into `dir`, bound to `dir`
-/// itself as its estate root.
+/// Hand-write a `sergeant.runtime/v3` descriptor into `dir`.
 ///
-/// The binding matters even for a descriptor whose whole point is to be
-/// dead: §5.1 has clients verify `estate_root` **before** they judge
-/// staleness or probe the endpoint, so a fabricated descriptor naming some
-/// other root would get the mismatch refusal and the staleness path under
-/// test would never run. The canonical form is what
-/// [`Estate::admit`](sergeant_rs::domain::estate::Estate::admit)
-/// puts in the descriptor, so it is what a fixture must reproduce.
+/// D3: no estate fields. The fixture used to have to reproduce the exact
+/// canonical bound root, because §5.1 had clients compare it *before* they
+/// judged staleness — a fabricated descriptor naming any other root got the
+/// mismatch refusal and the staleness path under test never ran. That
+/// refusal class is retired; a v3 descriptor says nothing about estates, so
+/// the staleness path is reached on its own terms.
 fn write_fabricated_descriptor(dir: &DataDir, endpoint: &str, pid: u32, token: &str) {
-    let root = std::fs::canonicalize(dir.path()).expect("canonical estate root");
     let descriptor = json!({
-        "schema": "sergeant.runtime/v2",
+        "schema": "sergeant.runtime/v3",
         "endpoint": endpoint,
         "pid": pid,
         "api_revision": "v1",
         "token": token,
-        "estate_root": root,
-        "manifest_path": root.join("sergeant.toml"),
     });
     std::fs::write(
         daemon::descriptor_path(dir.path()),
@@ -2019,21 +2025,24 @@ fn stale_descriptor_is_replaced_but_ambiguous_descriptor_fails_closed() {
 /// Half-interpreting it could mean talking to the wrong process, or spawning
 /// a second daemon on a data dir that already has an owner.
 ///
-/// **Both directions, since estate-root §5.1 bumped the schema to
-/// `sergeant.runtime/v2`.** A newer build's descriptor was always the
-/// forward case; `sergeant.runtime/v1` is now the backward one, and it is not
-/// hypothetical — it is what a daemon from the previous release leaves on
-/// disk. There is deliberately no compatibility shim: a v1 descriptor carries
-/// no `estate_root`, so a client could not verify §5.1's binding against it
-/// at all, and reading it half-way is exactly the "talking to the wrong
-/// process" failure above. Both refusals must also carry the *remedy* (stop
-/// the old daemon and let a restarted one republish), because an operator
-/// staring at a live-but-unusable daemon has no other way to know what to do.
+/// **Both directions, and now one release deeper.** H1's D3 bumped the
+/// schema to `sergeant.runtime/v3` (no estate fields at all), so
+/// `sergeant.runtime/v2` — an estate-*bound* daemon from the previous
+/// release, still running on a developer's machine at cutover — joins the
+/// backward cases beside v1, and `v4` stands in for the forward one. There
+/// is deliberately no compatibility shim in either direction: a v2
+/// descriptor names one bound estate this build no longer believes in, and
+/// half-reading it is exactly the "talking to the wrong process" failure
+/// above. Every refusal must also carry the *remedy* (stop the old daemon
+/// and let a restarted one republish), because an operator staring at a
+/// live-but-unusable daemon has no other way to know what to do — that
+/// remedy is H1 §6's cutover story with a real backstop under it.
 #[test]
 fn descriptor_with_an_unknown_schema_fails_closed() {
     for (label, schema) in [
-        ("from the future", "sergeant.runtime/v3"),
-        ("from the previous release", "sergeant.runtime/v1"),
+        ("from the future", "sergeant.runtime/v4"),
+        ("from the previous release", "sergeant.runtime/v2"),
+        ("from two releases back", "sergeant.runtime/v1"),
     ] {
         let dir = estate_data_dir();
         let unreadable = json!({

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -1509,6 +1509,36 @@ fn estate_data_dir() -> DataDir {
     dir
 }
 
+/// H1's two-estate fixture: a **second** estate root, elsewhere on disk, that
+/// addresses the *same* host runtime dir.
+///
+/// Additive on purpose (brief deliverable 10): [`estate_data_dir`] and every
+/// test built on it stay exactly as they were, because single-estate is a
+/// special case of host mode, not a removed mode. The second estate is a
+/// plain `TempDir` rather than a `DataDir` — nothing runs a daemon *for* it;
+/// its Work runs on the host daemon the first estate already spawned, which
+/// is the whole point.
+fn second_estate(name: &str) -> TempDir {
+    let dir = TempDir::new().expect("second estate tempdir");
+    support::scaffold_estate(dir.path(), name, &["solo"]);
+    dir
+}
+
+/// [`sgt_env`] run against `estate_root` with `-C`, while still pointing at
+/// `data_dir` as the host runtime root — the shape a second estate uses to
+/// reach a daemon it did not spawn.
+fn sgt_in(data_dir: &DataDir, estate_root: &Path, args: &[&str]) -> Output {
+    let mut command = std::process::Command::new(SGT);
+    command
+        .current_dir(estate_root)
+        .arg("-C")
+        .arg(estate_root)
+        .arg("--data-dir")
+        .arg(data_dir.path())
+        .args(args);
+    command.output().expect("run sgt")
+}
+
 /// Run the sgt binary with args against a data dir; capture output.
 ///
 /// The child runs in the data dir, not in whatever directory `cargo test` was
@@ -1781,9 +1811,29 @@ fn a_data_dir_defaults_onto_disk_not_the_hosts_tmpfs() {
     );
 }
 
+/// **The H1 pair**, replacing `t7_cli_end_to_end_auto_spawn_and_second_
+/// daemon_fails_closed`.
+///
+/// That test asserted one thing twice over: a second *anything* on this data
+/// dir fails closed. H1 splits it, because the two halves now have opposite
+/// answers and both matter:
+///
+/// - a second **estate** is *admitted* into the running daemon and its Work
+///   runs there (H1 §11 criterion 1: two exact-root estates submit Work to
+///   one daemon). This is the invariant H1 inverts, and the old test was its
+///   direct contradiction;
+/// - a second **process** over the host runtime root still fails closed on
+///   `daemon.lock` (H1 §2: one long-lived daemon per user installation).
+///   This is the invariant H1 keeps, and it is *load-bearing* precisely
+///   because the first half now shares one journal between estates.
+///
+/// Both halves live in one test so neither can be quietly dropped: proving
+/// only the first would leave a host that races two journals, and proving
+/// only the second would be the pre-H1 world.
 #[test]
-fn t7_cli_end_to_end_auto_spawn_and_second_daemon_fails_closed() {
+fn t7_cli_end_to_end_a_second_estate_is_admitted_and_a_second_process_fails_closed() {
     let dir = estate_data_dir();
+    let other = second_estate("m2-second");
 
     // No daemon running: `sgt run` auto-spawns one and submits.
     let output = sgt(&dir, &["run", "ship the M2 milestone"]);
@@ -1793,7 +1843,26 @@ fn t7_cli_end_to_end_auto_spawn_and_second_daemon_fails_closed() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // `sgt work list --json` shows it.
+    // --- Half one: a second estate, same daemon, no second process. ---
+    //
+    // This client never spawns: the descriptor is already there and healthy,
+    // so it connects to the daemon the *first* estate started and addresses
+    // its own root. Before H1 this was the `EstateBindingMismatch` refusal.
+    let before = daemon_pids(dir.path());
+    assert_eq!(before.len(), 1, "exactly one daemon so far: {before:?}");
+    let output = sgt_in(&dir, other.path(), &["run", "ship the second estate"]);
+    assert!(
+        output.status.success(),
+        "a second estate must be admitted, not refused: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        daemon_pids(dir.path()),
+        before,
+        "the second estate must reuse the running daemon, never start another"
+    );
+
+    // `sgt work list --json` shows both — one fleet, one daemon, two estates.
     let output = sgt(&dir, &["work", "list", "--json"]);
     assert!(
         output.status.success(),
@@ -1803,29 +1872,96 @@ fn t7_cli_end_to_end_auto_spawn_and_second_daemon_fails_closed() {
     let listed: Value =
         serde_json::from_slice(&output.stdout).expect("work list --json must print JSON");
     let works = listed["works"].as_array().expect("works array");
-    assert_eq!(works.len(), 1);
-    assert_eq!(works[0]["intent"], "ship the M2 milestone");
-    // §5.2: the auto-spawned daemon is bound to the estate this client
-    // admitted (`spawn_daemon` names it with `-C`), so the submission is
-    // planned and run rather than parked. `completed` is the fake backend's
-    // deterministic answer — every stage settles inside the submit call — and
-    // asserting it is what proves the spawned daemon really adopted *this*
-    // estate: a daemon bound to nothing would have left this `pending`.
-    assert_eq!(works[0]["state"], "completed");
-    assert_eq!(works[0]["repositories"], json!(["solo"]));
-    assert_eq!(works[0]["created_by"], "cli");
+    assert_eq!(
+        works.len(),
+        2,
+        "both estates' Work is on one daemon: {listed}"
+    );
+    let by_intent = |intent: &str| {
+        works
+            .iter()
+            .find(|w| w["intent"] == intent)
+            .unwrap_or_else(|| panic!("{intent} missing from {listed}"))
+            .clone()
+    };
+    for intent in ["ship the M2 milestone", "ship the second estate"] {
+        let work = by_intent(intent);
+        // `completed` is the fake backend's deterministic answer — every
+        // stage settles inside the submit call — and asserting it is what
+        // proves the daemon really planned against *that* submission's
+        // estate: an unaddressed submission would have stayed `pending`.
+        assert_eq!(work["state"], "completed", "{intent}: {work}");
+        assert_eq!(work["repositories"], json!(["solo"]));
+        assert_eq!(work["created_by"], "cli");
+    }
 
-    // A second daemon on the same data dir fails closed.
+    // H1 §11 criterion 5, on the same rig: **one journal reconstructs both
+    // estates.** Every Work's own canonical estate root is on the envelope
+    // (D1), so a replay can tell them apart without a second journal, a
+    // second projection, or an estate UUID.
+    let mut roots: Vec<String> = Journal::replay_data_dir(dir.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.kind == KIND_WORK_SUBMITTED)
+        .map(|e| {
+            e.workspace_id
+                .clone()
+                .expect("submitted carries its estate")
+        })
+        .collect();
+    roots.sort();
+    roots.dedup();
+    let mut expected = vec![
+        std::fs::canonicalize(dir.path())
+            .expect("canonical")
+            .to_string_lossy()
+            .into_owned(),
+        std::fs::canonicalize(other.path())
+            .expect("canonical")
+            .to_string_lossy()
+            .into_owned(),
+    ];
+    expected.sort();
+    assert_eq!(
+        roots, expected,
+        "one journal must reconstruct both estates by their own coordinates"
+    );
+
+    // And the registry says so out loud (H1 §4): both roots admitted,
+    // observationally, because both were addressed.
+    let output = sgt(&dir, &["daemon", "stop", "--json"]);
+    assert!(
+        output.status.success(),
+        "daemon stop failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stopped: Value =
+        serde_json::from_slice(&output.stdout).expect("daemon stop --json prints JSON");
+    // D5: the blast radius is stated, not left for the operator to infer —
+    // `sgt daemon stop` stops the *host* daemon, every admitted estate's.
+    let message = stopped["message"].as_str().expect("message");
+    assert!(
+        message.contains("host daemon") && message.contains("2 admitted estates"),
+        "daemon stop must name its blast radius: {message}"
+    );
+
+    // --- Half two: a second *process* still fails closed on the host lock. ---
+    let output = sgt(&dir, &["run", "restart the daemon"]);
+    assert!(
+        output.status.success(),
+        "sgt run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let output = sgt(&dir, &["daemon"]);
     assert!(
         !output.status.success(),
-        "second daemon must fail closed, got: {}",
+        "a second daemon process must fail closed, got: {}",
         String::from_utf8_lossy(&output.stdout)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("another daemon"),
-        "second daemon should explain the lock, got: {stderr}"
+        "the second process should explain the lock, got: {stderr}"
     );
 
     stop_daemon(dir.path());

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -74,10 +74,28 @@ async fn submit(
     command_id: &str,
     intent: &str,
 ) -> (reqwest::StatusCode, Vec<u8>, Value) {
+    submit_addressed(http, handle, None, command_id, intent).await
+}
+
+/// [`submit`] addressing an estate (D4). `None` is the captured-intent
+/// shape — no repository context offered — which is what most of this
+/// file's daemon-lifecycle rigs want, since they are about the daemon, not
+/// about an estate.
+async fn submit_addressed(
+    http: &reqwest::Client,
+    handle: &DaemonHandle,
+    estate_root: Option<&std::path::Path>,
+    command_id: &str,
+    intent: &str,
+) -> (reqwest::StatusCode, Vec<u8>, Value) {
     let resp = http
         .post(format!("{}/v1/work", handle.endpoint))
         .bearer_auth(&handle.token)
-        .json(&json!({"command_id": command_id, "intent": intent}))
+        .json(&json!({
+            "command_id": command_id,
+            "intent": intent,
+            "estate_root": estate_root,
+        }))
         .send()
         .await
         .expect("submit request");
@@ -601,18 +619,23 @@ async fn t3_submit_lists_pending_journals_and_survives_restart() {
     handle.shutdown().await;
 }
 
-/// H1 touch point #4/#5: `work.submitted` carries the daemon's bound
-/// estate — its canonical root, not the `[estate] name` — end to end
-/// through a real submission, not a hand-fabricated `Event`.
+/// H1 touch point #4/#5, re-scoped by D4/D10: `work.submitted` carries the
+/// estate the submission **addressed** — its canonical root, not the
+/// `[estate] name` — end to end through a real submission, not a
+/// hand-fabricated `Event`.
+///
+/// W1a wrote this against the daemon's *bound* estate. There is no binding
+/// left to read, and the fact is stronger for it: the root recorded is the
+/// one this request named and this daemon then admitted, so a second estate
+/// submitting to the same daemon records its own.
 #[tokio::test]
-async fn work_submitted_carries_the_bound_estate_root() {
+async fn work_submitted_carries_the_addressed_estate_root() {
     let estate_dir = TempDir::new().expect("estate tempdir");
     scaffold_solo_estate(estate_dir.path(), "target");
     let data_dir = TempDir::new().expect("data dir tempdir");
     let handle = daemon::start_with(
         data_dir.path(),
         DaemonConfig {
-            estate_root: Some(estate_dir.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -620,7 +643,14 @@ async fn work_submitted_carries_the_bound_estate_root() {
     .expect("daemon start");
     let http = client();
 
-    let (status, _, body) = submit(&http, &handle, &ulid(), "carry the estate root").await;
+    let (status, _, body) = submit_addressed(
+        &http,
+        &handle,
+        Some(estate_dir.path()),
+        &ulid(),
+        "carry the estate root",
+    )
+    .await;
     assert_eq!(status, 201, "submit must accept: {body}");
     let work_id = body["work"]["id"].as_str().expect("work id").to_string();
 
@@ -636,7 +666,7 @@ async fn work_submitted_carries_the_bound_estate_root() {
     assert_eq!(
         submitted.workspace_id.as_deref(),
         Some(canonical_root.to_string_lossy().as_ref()),
-        "work.submitted must carry the daemon's bound estate root"
+        "work.submitted must carry the estate root the submission addressed"
     );
 }
 
@@ -2902,14 +2932,13 @@ async fn start_with_fake(data_dir: &Path, fake: &FakeBackend) -> DaemonHandle {
 async fn start_with_fake_bound(
     data_dir: &Path,
     fake: &FakeBackend,
-    estate_root: Option<&Path>,
+    _estate_root: Option<&Path>,
 ) -> DaemonHandle {
     daemon::start_with(
         data_dir,
         DaemonConfig {
             backends: Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: estate_root.map(Path::to_path_buf),
             ..DaemonConfig::default()
         },
     )
@@ -3838,6 +3867,7 @@ async fn t12_submission_throughput_has_an_automated_floor() {
         let endpoint = handle.endpoint.clone();
         let token = handle.token.clone();
         let repo = repo.clone();
+        let estate_root = estate.path().to_path_buf();
         inflight.push(tokio::spawn(async move {
             let response = http
                 .post(format!("{endpoint}/v1/work"))
@@ -3846,6 +3876,8 @@ async fn t12_submission_throughput_has_an_automated_floor() {
                     "command_id": ulid(),
                     "intent": "throughput floor",
                     "backend": FAKE_BACKEND_NAME,
+                    // D4: `cwd` is the mount; the addressed estate is its root.
+                    "estate_root": estate_root,
                     "origin": {"client": "cli", "cwd": repo},
                 }))
                 .send()
@@ -4126,6 +4158,7 @@ async fn scope_all_combined_with_repos_refuses_with_conflicting_scope() {
         .json(&json!({
             "command_id": ulid(),
             "intent": "everything and also just this one",
+            "estate_root": estate.path(),
             "scope": {"repos": ["solo"], "all": true},
         }))
         .send()
@@ -4450,7 +4483,7 @@ async fn r_mvp1_10_start(
     data_dir: &Path,
     registry: BackendRegistry,
     completion_poll: Duration,
-    estate_root: &Path,
+    _estate_root: &Path,
 ) -> DaemonHandle {
     daemon::start_with(
         data_dir,
@@ -4458,7 +4491,6 @@ async fn r_mvp1_10_start(
             backends: Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             completion_poll,
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -4470,9 +4502,9 @@ async fn r_mvp1_10_start(
 ///
 /// `cwd` is sent because §13.3 still records it as origin evidence, and
 /// leaving it out would stop exercising the field — but since §5.2 it decides
-/// nothing: the daemon plans against the estate it was started against. It is
-/// passed the estate root here so the recorded evidence matches where the
-/// run actually happened.
+/// nothing. What decides is `estate_root` (D4), which every call site here
+/// passes as the same path: these tests run one estate, and the recorded
+/// evidence should match where the run actually happened.
 async fn r_mvp1_10_submit(
     http: &reqwest::Client,
     handle: &DaemonHandle,
@@ -4483,6 +4515,7 @@ async fn r_mvp1_10_submit(
     let mut req = json!({
         "command_id": ulid(),
         "intent": intent,
+        "estate_root": cwd,
         "origin": {"client": "cli", "cwd": cwd},
     });
     if let Some(name) = workflow {

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -232,7 +232,7 @@ async fn start_with(
     data_dir: &Path,
     registry: BackendRegistry,
     default: Option<&str>,
-    estate_root: Option<&Path>,
+    _estate_root: Option<&Path>,
 ) -> DaemonHandle {
     daemon::start_with(
         data_dir,
@@ -240,7 +240,6 @@ async fn start_with(
             backends: Arc::new(registry),
             default_backend: default.map(str::to_string),
             claude: None,
-            estate_root: estate_root.map(Path::to_path_buf),
             ..DaemonConfig::default()
         },
     )
@@ -286,10 +285,19 @@ async fn get(client: &reqwest::Client, handle: &DaemonHandle, path: &str) -> Val
         .expect("json body")
 }
 
-/// Submit work whose origin is `cwd`, merging any extra request fields.
+/// Submit work addressed at `estate_root`, whose origin is `cwd`, merging
+/// any extra request fields.
+///
+/// D4: the two are separate parameters on purpose. `estate_root` is what the
+/// daemon plans against (after admitting it); `cwd` is recorded evidence
+/// (§13.3) and decides nothing — which is the fact several tests in this
+/// file exist to pin, and which a helper that derived one from the other
+/// would quietly stop proving. `None` addresses no estate: the captured-
+/// intent path, exactly what a daemon bound to none used to give.
 async fn submit(
     client: &reqwest::Client,
     handle: &DaemonHandle,
+    estate_root: Option<&Path>,
     cwd: &Path,
     intent: &str,
     extra: Value,
@@ -297,6 +305,7 @@ async fn submit(
     let mut body = json!({
         "command_id": ulid(),
         "intent": intent,
+        "estate_root": estate_root,
         "origin": {"client": "cli", "cwd": cwd},
     });
     if let Some(fields) = extra.as_object() {
@@ -526,7 +535,15 @@ async fn t1_a_bound_estate_submit_materializes_a_real_worktree() {
     .await;
     let client = http();
 
-    let (status, body) = submit(&client, &handle, &estate, "one bound estate", json!({})).await;
+    let (status, body) = submit(
+        &client,
+        &handle,
+        Some(&estate),
+        &estate,
+        "one bound estate",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 201, "submit failed: {body}");
     let work_id = body["work"]["id"].as_str().expect("work id").to_string();
     assert_eq!(body["work"]["state"], "active");
@@ -637,6 +654,7 @@ async fn t2_multi_repo_workspace_binds_one_worktree_per_repository() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "multi repo",
         json!({"scope": {"all": true}}),
@@ -751,6 +769,7 @@ async fn r_mvp1_4_mixed_instructions_policy_refuses_at_submit_naming_both_repos(
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "mixed policy",
         json!({"scope": {"all": true}}),
@@ -798,7 +817,15 @@ async fn r_mvp1_4_local_instructions_policy_is_accepted_at_submit_and_reaches_th
     .await;
     let client = http();
 
-    let (status, body) = submit(&client, &handle, &estate, "local measured", json!({})).await;
+    let (status, body) = submit(
+        &client,
+        &handle,
+        Some(&estate),
+        &estate,
+        "local measured",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 201, "local must be accepted at submit now: {body}");
     assert_eq!(body["work"]["state"], "active");
 
@@ -856,6 +883,7 @@ async fn r_mvp1_11_a_stage_requiring_ask_refuses_at_submit_over_http() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "needs a real ask",
         json!({"workflow": "asks"}),
@@ -919,6 +947,7 @@ async fn r_mvp1_4_workflow_bound_carries_repositories_and_instruction_identities
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "uniform policy",
         json!({"scope": {"all": true}}),
@@ -983,6 +1012,7 @@ async fn t3_full_run_completes_every_stage_and_retires_the_surface() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "run to completion",
         json!({"workflow": "tiny"}),
@@ -1147,6 +1177,7 @@ async fn t3b_tagged_stage_definitions_are_pinned_and_survive_file_edits_after_bi
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "tagged run",
         json!({"workflow": "tagged-tiny"}),
@@ -1271,6 +1302,7 @@ async fn t4_needs_input_parks_the_run_and_input_resumes_it() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "ask me something",
         json!({"workflow": "tiny"}),
@@ -1368,6 +1400,7 @@ async fn t10_a_stage_completed_without_its_declared_output_is_reprompted_then_ne
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "finish without the declared output",
         json!({"workflow": "tiny"}),
@@ -1494,6 +1527,7 @@ async fn t11_a_present_but_untyped_declared_artifact_is_refused_the_same_way_as_
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "finish with untyped prose instead of a typed table",
         json!({"workflow": "tiny"}),
@@ -1623,6 +1657,7 @@ async fn the_finalize_sweep_removes_evidence_class_output_and_keeps_promote_clas
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "sweep evidence, keep promote",
         json!({"workflow": "sweep"}),
@@ -1718,6 +1753,7 @@ async fn a_finalize_sweep_never_launders_unrelated_dirty_content_into_its_own_co
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "evidence plus a stray mess",
         json!({"workflow": "sweep"}),
@@ -1810,7 +1846,6 @@ async fn deferred_finish_does_not_let_the_engine_observe_a_conclusion_before_lau
             backends: Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             completion_poll: Duration::from_millis(20),
-            estate_root: Some(estate.clone()),
             ..DaemonConfig::default()
         },
     )
@@ -1821,6 +1856,7 @@ async fn deferred_finish_does_not_let_the_engine_observe_a_conclusion_before_lau
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "resolves over real polls",
         json!({"workflow": "tiny"}),
@@ -1896,6 +1932,7 @@ async fn a_resumed_stage_journals_a_queued_item_and_the_live_send_as_one_turn() 
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "queue then answer live",
         json!({"workflow": "tiny"}),
@@ -1979,6 +2016,7 @@ async fn t5_failure_records_the_reason_and_retry_re_enters_the_stage() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "fail then retry",
         json!({"workflow": "tiny"}),
@@ -2080,6 +2118,7 @@ async fn t6_cancel_mid_stage_leaves_no_zombie_work_state() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "cancel me mid stage",
         json!({"workflow": "tiny"}),
@@ -2273,7 +2312,7 @@ async fn t7_routing_precedence_and_structured_failure() {
         ),
     ];
     for (handle, cwd, extra, expected_backend, expected_source) in cases {
-        let (status, body) = submit(&client, handle, cwd, "route me", extra).await;
+        let (status, body) = submit(&client, handle, Some(cwd), cwd, "route me", extra).await;
         assert_eq!(status, 201, "submit failed: {body}");
         assert_eq!(
             body["backend"], expected_backend,
@@ -2288,6 +2327,7 @@ async fn t7_routing_precedence_and_structured_failure() {
     let (status, body) = submit(
         &client,
         &plain_handle,
+        Some(&plain),
         &plain,
         "unknown backend",
         // Since W2 the daemon registers a real Opencode adapter by default
@@ -2326,7 +2366,15 @@ async fn t7_routing_precedence_and_structured_failure() {
     let data = TempDir::new().expect("tempdir");
     let registry = BackendRegistry::new().with(Arc::new(FakeBackend::new("claude")));
     let handle = start_with(data.path(), registry, None, Some(&plain)).await;
-    let (status, body) = submit(&http(), &handle, &plain, "nothing selected", json!({})).await;
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        Some(&plain),
+        &plain,
+        "nothing selected",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 422, "unroutable work must be refused: {body}");
     assert_eq!(body["error"]["code"], "no_backend_selected");
     // The scripted fake occupies the "claude" slot, so the daemon adds
@@ -2429,6 +2477,7 @@ async fn t7b_a_mixed_harness_workflow_runs_a_then_b_then_a() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "A then B then A",
         json!({"workflow": "mixed"}),
@@ -2512,6 +2561,7 @@ async fn t7c_an_unusable_stage_harness_fails_before_any_side_effect() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "unavailable stage harness",
         json!({"workflow": "mixed"}),
@@ -2568,6 +2618,7 @@ async fn t7c_an_unusable_stage_harness_fails_before_any_side_effect() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "unknown stage harness",
         json!({"workflow": "mixed"}),
@@ -2616,6 +2667,7 @@ async fn t7c_an_unusable_stage_harness_fails_before_any_side_effect() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "profile belongs elsewhere",
         json!({"workflow": "mixed"}),
@@ -2666,6 +2718,7 @@ async fn t7d_retry_and_restart_replay_the_pinned_stage_decision() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "retry the pinned stage",
         json!({"workflow": "mixed"}),
@@ -2794,6 +2847,7 @@ async fn t7f_a_bound_stage_whose_harness_left_the_daemon_blocks_rather_than_subs
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "the harness leaves between the bind and the stage",
         json!({"workflow": "mixed"}),
@@ -2934,20 +2988,23 @@ async fn t7e_every_harness_a_run_will_use_is_probed_before_the_lock_is_taken() {
         ),
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
-    )
-    // §5.2: the estate is bound to the engine, not read off the request.
-    // `cwd` below is still set because a real submission carries one, but it
-    // decides nothing — deleting `with_estate_root` leaves this engine
-    // planning against no estate at all and `plan` answering `Ok(None)`.
-    .with_estate_root(estate.clone());
+    );
     assert_eq!(alt.probe_count(), 0, "cold, as a fresh registry is");
 
+    // D10: the estate is a per-call argument, not an engine field. §5.2 is
+    // unchanged — `cwd` below is still set because a real submission carries
+    // one, and it still decides nothing. What decides is the *addressed*
+    // root passed here; pass `None` instead and `plan` answers `Ok(None)`,
+    // exactly as an unbound engine used to.
     let plan = engine
-        .plan(&SubmitContext {
-            cwd: Some(&estate),
-            workflow: Some("mixed"),
-            ..SubmitContext::default()
-        })
+        .plan(
+            Some(&estate),
+            &SubmitContext {
+                cwd: Some(&estate),
+                workflow: Some("mixed"),
+                ..SubmitContext::default()
+            },
+        )
         .expect("plan")
         .expect("a estate");
     assert!(
@@ -2990,6 +3047,7 @@ async fn t8_restart_resumes_unambiguous_work_and_blocks_ambiguous_work() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "survives the restart",
         json!({"workflow": "tiny", "backend": "durable"}),
@@ -3001,6 +3059,7 @@ async fn t8_restart_resumes_unambiguous_work_and_blocks_ambiguous_work() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "loses its session",
         json!({"workflow": "tiny", "backend": "volatile"}),
@@ -3197,7 +3256,6 @@ async fn a_known_never_forgotten_execution_whose_signal_never_arrives_parks_rath
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             completion_poll: poll,
             turn_ceiling: ceiling,
-            estate_root: Some(estate.clone()),
             ..DaemonConfig::default()
         },
     )
@@ -3208,6 +3266,7 @@ async fn a_known_never_forgotten_execution_whose_signal_never_arrives_parks_rath
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "never resolves on its own",
         json!({"workflow": "tiny"}),
@@ -3283,6 +3342,7 @@ async fn native_liveness_never_decides_work_state_in_either_direction() {
     let (_, body) = submit(
         &http(),
         &handle,
+        Some(&estate),
         &estate,
         "exited but silent",
         json!({"workflow": "tiny"}),
@@ -3308,6 +3368,7 @@ async fn native_liveness_never_decides_work_state_in_either_direction() {
     let (_, body) = submit(
         &http(),
         &handle,
+        Some(&estate),
         &estate,
         "alive but done",
         json!({"workflow": "tiny"}),
@@ -3357,7 +3418,6 @@ async fn native_liveness_after_interrupt_never_decides_work_state_either_way() {
                 default_backend: Some(FAKE_BACKEND_NAME.to_string()),
                 completion_poll: poll,
                 turn_ceiling: ceiling,
-                estate_root: Some(estate.to_path_buf()),
                 ..DaemonConfig::default()
             },
         )
@@ -3367,6 +3427,7 @@ async fn native_liveness_after_interrupt_never_decides_work_state_either_way() {
         let (_, body) = submit(
             &client,
             &handle,
+            Some(estate),
             estate,
             "overdue by construction",
             json!({"workflow": "tiny"}),
@@ -3456,6 +3517,7 @@ async fn waiting_and_blocked_park_the_work_and_retry_re_enters() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "park me",
         json!({"workflow": "tiny"}),
@@ -3517,6 +3579,7 @@ async fn cancelling_a_failed_work_does_not_rewrite_the_stage_failure() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "fail then cancel",
         json!({"workflow": "tiny"}),
@@ -3572,6 +3635,7 @@ async fn a_dirty_worktree_is_retained_and_recorded_at_teardown() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "leaves a mess",
         json!({"workflow": "tiny"}),
@@ -3655,6 +3719,7 @@ async fn retained_lists_a_dirty_teardown_and_reap_disposes_of_it_only_when_confi
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "leaves a mess for #109",
         json!({"workflow": "tiny"}),
@@ -3781,6 +3846,7 @@ async fn a_stranded_completion_is_not_reported_as_plain_completed() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "declares a commit, never makes one",
         json!({"workflow": "tiny"}),
@@ -3914,6 +3980,7 @@ async fn a_run_that_ends_on_the_wrong_branch_completes_dirty_and_keeps_both_bran
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "commits somewhere else entirely",
         json!({"workflow": "tiny"}),
@@ -4055,6 +4122,7 @@ async fn a_stage_that_opts_in_receives_the_branch_status_fact_others_do_not() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "opt in to the branch status fact",
         json!({"workflow": "tiny"}),
@@ -4167,6 +4235,7 @@ async fn a_repository_that_cannot_be_materialized_rolls_back_the_ones_that_could
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "half a surface",
         json!({"scope": {"all": true}}),
@@ -4285,7 +4354,15 @@ async fn r_mvp1_1_surfaces_root_is_split_from_data_dir_and_the_checkout_guard_fo
     )
     .await;
     let client = http();
-    let (status, body) = submit(&client, &handle, &estate, "split surfaces root", json!({})).await;
+    let (status, body) = submit(
+        &client,
+        &handle,
+        Some(&estate),
+        &estate,
+        "split surfaces root",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 201, "submit failed: {body}");
     assert_eq!(
         body["work"]["state"], "active",
@@ -4343,6 +4420,7 @@ async fn r_mvp1_1_surfaces_root_is_split_from_data_dir_and_the_checkout_guard_fo
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "unsplit still refuses",
         json!({}),
@@ -4466,6 +4544,7 @@ async fn retry_rebuilds_from_base_sha_when_the_retained_branch_is_gone() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "branch vanishes before retry",
         json!({"workflow": "tiny"}),
@@ -4637,6 +4716,7 @@ async fn a_worktree_git_refuses_to_remove_is_retained_with_the_error_and_journal
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "git cannot delete this worktree",
         json!({"workflow": "tiny"}),
@@ -4740,6 +4820,7 @@ async fn cancelling_a_blocked_work_retires_the_stage_it_was_parked_in() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "block then cancel",
         json!({"workflow": "tiny"}),
@@ -4802,6 +4883,7 @@ async fn a_backend_that_cannot_start_the_next_stage_blocks_with_the_stage_named(
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "lose the backend mid run",
         json!({"workflow": "tiny"}),
@@ -4876,6 +4958,7 @@ async fn input_for_a_forgotten_execution_blocks_with_the_stage_named() {
     let (_, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "answer a session that did not survive",
         json!({"workflow": "tiny"}),
@@ -4959,6 +5042,7 @@ async fn a_backend_that_cannot_observe_its_execution_fails_the_work_closed() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "observe me if you can",
         json!({"workflow": "tiny"}),
@@ -5018,6 +5102,7 @@ async fn an_unknown_native_state_blocks_even_when_the_signal_says_completed() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "complete me from an unknown context",
         json!({"workflow": "tiny"}),
@@ -5103,6 +5188,7 @@ async fn a_workflow_name_that_escapes_the_workflows_directory_is_refused_at_subm
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "read someone else's workflow",
         json!({"workflow": "../../elsewhere/.sergeant/workflows/outside"}),
@@ -5162,6 +5248,7 @@ async fn a_profile_is_launch_configuration_carried_to_the_backend() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "with a profile",
         json!({"profile": "enterprise"}),
@@ -5183,6 +5270,7 @@ async fn a_profile_is_launch_configuration_carried_to_the_backend() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "unknown profile",
         json!({"profile": "nope"}),
@@ -5233,6 +5321,7 @@ async fn a_profile_that_names_another_backend_is_refused_with_the_tier_that_rout
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "a profile for a backend this work is not routed to",
         json!({"profile": "elsewhere"}),
@@ -5297,7 +5386,15 @@ async fn a_submission_with_no_workspace_is_captured_but_still_routed() {
     // A cwd this daemon's estate knows nothing about is the same answer, not
     // an error — the cwd was never what decided it.
     let elsewhere = TempDir::new().expect("tempdir");
-    let (status, body) = submit(&client, &handle, elsewhere.path(), "not a repo", json!({})).await;
+    let (status, body) = submit(
+        &client,
+        &handle,
+        None,
+        elsewhere.path(),
+        "not a repo",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 201);
     assert_eq!(body["work"]["state"], "pending");
     assert!(body["surface"].is_null());
@@ -5307,6 +5404,7 @@ async fn a_submission_with_no_workspace_is_captured_but_still_routed() {
     let (status, body) = submit(
         &client,
         &handle,
+        None,
         elsewhere.path(),
         "route me nowhere",
         // Deliberately not the bare canonical name "opencode": since the
@@ -5379,7 +5477,15 @@ async fn a_multi_repo_estate_refuses_an_empty_scope_with_the_7_1_remedy() {
     .await;
     let client = http();
 
-    let (status, body) = submit(&client, &handle, &estate, "no scope at all", json!({})).await;
+    let (status, body) = submit(
+        &client,
+        &handle,
+        Some(&estate),
+        &estate,
+        "no scope at all",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 422, "an empty scope must refuse: {body}");
     assert_eq!(body["error"]["code"], "missing_scope");
     assert_eq!(body["error"]["repo_count"], 2);
@@ -5439,6 +5545,7 @@ async fn run_all_resolves_every_repository_and_journals_the_request_form() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "everything, explicitly",
         json!({"scope": {"all": true}}),
@@ -5591,7 +5698,15 @@ async fn a_malformed_workspace_file_fails_closed() {
         "[estate]\nname = \"solo\"\ndefault_backends = \"fake\"\n\n[[repo]]\nname = \"solo\"\n",
     )
     .expect("sergeant.toml");
-    let (status, body) = submit(&http(), &handle, &estate, "typo in config", json!({})).await;
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        Some(&estate),
+        &estate,
+        "typo in config",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 422, "a typo'd key must not be ignored: {body}");
     assert_eq!(body["error"]["code"], "workspace_error");
     assert!(
@@ -5610,7 +5725,15 @@ async fn a_malformed_workspace_file_fails_closed() {
         "[estate]\nname = \"solo\"\n\n[[repo]]\nname = \"ghost\"\n",
     )
     .expect("sergeant.toml");
-    let (status, body) = submit(&http(), &handle, &estate, "missing repo", json!({})).await;
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        Some(&estate),
+        &estate,
+        "missing repo",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 422);
     assert!(
         body["error"]["message"]
@@ -5632,7 +5755,15 @@ async fn a_malformed_workspace_file_fails_closed() {
          [[repo]]\nname = \"solo\"\npath = \".\"\n",
     )
     .expect("sergeant.toml");
-    let (status, body) = submit(&http(), &handle, &estate, "a path key survives", json!({})).await;
+    let (status, body) = submit(
+        &http(),
+        &handle,
+        Some(&estate),
+        &estate,
+        "a path key survives",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 422, "a declared path must be refused: {body}");
     assert_eq!(body["error"]["code"], "workspace_error");
     let message = body["error"]["message"].as_str().expect("message");
@@ -5724,7 +5855,15 @@ async fn t9_a_repository_with_a_submodule_completes_and_tears_down_clean() {
     )
     .await;
     let client = http();
-    let (status, body) = submit(&client, &handle, &estate, "check the submodule", json!({})).await;
+    let (status, body) = submit(
+        &client,
+        &handle,
+        Some(&estate),
+        &estate,
+        "check the submodule",
+        json!({}),
+    )
+    .await;
     assert_eq!(status, 201, "submit failed: {body}");
     let work_id = body["work"]["id"].as_str().expect("work id").to_string();
     let worktree = PathBuf::from(
@@ -5824,6 +5963,7 @@ async fn t9b_a_linked_worktree_as_a_repository_mount_is_refused_at_submit() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "bind from a linked worktree",
         json!({"workflow": "tiny"}),
@@ -5914,6 +6054,7 @@ async fn t9c_a_symlinked_estate_root_materializes_and_completes() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&via_symlink),
         &via_symlink,
         "bind through a symlink",
         json!({"workflow": "tiny"}),
@@ -5975,6 +6116,7 @@ async fn t9d_a_path_with_a_space_and_non_ascii_completes_and_tears_down() {
     let (status, body) = submit(
         &client,
         &handle,
+        Some(&estate),
         &estate,
         "a path with a space",
         json!({"workflow": "tiny"}),
@@ -6190,6 +6332,7 @@ async fn scope_resolution_is_identical_across_the_cli_and_a_direct_api_submissio
     let (status, api_body) = submit(
         &client,
         &handle,
+        Some(&api_root),
         &api_root,
         "direct api scope.group",
         json!({"scope": {"group": "pair"}}),

--- a/tests/m3_execution.rs
+++ b/tests/m3_execution.rs
@@ -5670,12 +5670,22 @@ async fn a_crash_inside_the_submit_window_fails_closed_with_the_git_evidence() {
 /// that silently means nothing is worse than a refusal.
 ///
 /// The daemon starts on a *valid* manifest and each case rewrites it
-/// underneath: §5.1 admits the estate root before the data dir is even
-/// created, so a daemon started against a broken manifest would never come up
-/// at all and there would be no submit to refuse. Re-reading the manifest at
-/// every `plan` — the root is what startup pins, not the file's contents — is
-/// what makes the edit visible here, and it is the same property `sgt repo
-/// add` relies on to reach a running daemon.
+/// underneath. Re-reading the manifest on every submission is what makes the
+/// edit visible here, and it is the same property `sgt repo add` relies on
+/// to reach a running daemon — H1 only moved *where* that re-read happens
+/// (per admitted estate rather than once per daemon), not whether it does.
+///
+/// **Two refusals, and the split between them is the point (H1 D4).** A
+/// submission is now admitted before it is planned, so a manifest fault the
+/// *exact-root check* can see — an unknown key, a schema violation — is
+/// caught at admission and refused as `invalid_estate`: the estate itself is
+/// inadmissible, so nothing about it is served, not merely this submission.
+/// A fault only the strict load can see — a declared repository with no
+/// mount, a legacy `path` key — is `Estate::admit`'s deliberate blind spot
+/// ("a broken repo blocks Works targeting it, not the estate") and still
+/// surfaces from `Engine::plan` as `workspace_error`. Both are 422 and both
+/// name the offending line; asserting *which* is what keeps the two checks
+/// from quietly collapsing into one.
 #[tokio::test]
 async fn a_malformed_workspace_file_fails_closed() {
     let repos = TempDir::new().expect("tempdir");
@@ -5708,7 +5718,10 @@ async fn a_malformed_workspace_file_fails_closed() {
     )
     .await;
     assert_eq!(status, 422, "a typo'd key must not be ignored: {body}");
-    assert_eq!(body["error"]["code"], "workspace_error");
+    assert_eq!(
+        body["error"]["code"], "invalid_estate",
+        "a schema fault makes the estate itself inadmissible: {body}"
+    );
     assert!(
         body["error"]["message"]
             .as_str()
@@ -5719,7 +5732,10 @@ async fn a_malformed_workspace_file_fails_closed() {
 
     // A declared repository with no mount at `repos/<name>` is refused too
     // (§6.1: the mount is derived, so "declared but absent" is the only shape
-    // a missing repository can now take).
+    // a missing repository can now take) — and this is the case on the *plan*
+    // side of the split above: `Estate::admit` never resolves mounts, by
+    // design, so the estate stays admissible and only the Work targeting the
+    // absent repository is refused.
     std::fs::write(
         &manifest,
         "[estate]\nname = \"solo\"\n\n[[repo]]\nname = \"ghost\"\n",
@@ -5735,6 +5751,10 @@ async fn a_malformed_workspace_file_fails_closed() {
     )
     .await;
     assert_eq!(status, 422);
+    assert_eq!(
+        body["error"]["code"], "workspace_error",
+        "a missing mount is a repository problem, not an estate-identity one: {body}"
+    );
     assert!(
         body["error"]["message"]
             .as_str()
@@ -5765,7 +5785,10 @@ async fn a_malformed_workspace_file_fails_closed() {
     )
     .await;
     assert_eq!(status, 422, "a declared path must be refused: {body}");
-    assert_eq!(body["error"]["code"], "workspace_error");
+    assert_eq!(
+        body["error"]["code"], "invalid_estate",
+        "the legacy `path` key is a schema fault, so it too is caught at          admission rather than at plan: {body}"
+    );
     let message = body["error"]["message"].as_str().expect("message");
     assert!(
         message.contains("solo") && message.contains("`path`"),

--- a/tests/m4_backends.rs
+++ b/tests/m4_backends.rs
@@ -55,7 +55,7 @@
 //! derived `<estate-root>/repos/<name>`, and the *daemon* — not the request
 //! — names which estate is in play. So the fixture here is
 //! [`support::scaffold_solo_estate`]'s root, the engine carries
-//! [`Engine::with_estate_root`], and every `daemon::start_with` that expects
+//! `Engine::plan`'s per-call estate (D10), and every `daemon::start_with` that expects
 //! its submission to reach a surface passes `estate_root`. A daemon bound to
 //! nothing plans against nothing and leaves work `pending` (§5.2), which is
 //! the shape an unmigrated fixture now fails as. `origin.cwd` is still
@@ -104,6 +104,7 @@ use sergeant_rs::runtime::engine::{
     DEFAULT_TURN_CAP, Engine, EngineError, KIND_TURN_CEILING_INTERRUPTED, Next, PendingLaunch,
     Step, SubmitContext,
 };
+use sergeant_rs::runtime::estates::EstateRegistry;
 use sergeant_rs::runtime::journal::Journal;
 use sergeant_rs::runtime::projection::{WorkRun, rederive_run, work_registry_projection};
 use sergeant_rs::runtime::recovery;
@@ -1081,7 +1082,6 @@ async fn the_real_adapter_journals_from_the_daemon_request_path() {
             // really spawned, and a daemon bound to no estate never plans one
             // — the submission would stop at `pending` with the adapter never
             // reached.
-            estate_root: Some(estate.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -1095,6 +1095,8 @@ async fn the_real_adapter_journals_from_the_daemon_request_path() {
         .json(&json!({
             "command_id": ulid(),
             "intent": "drive the real adapter",
+            // D4: `cwd` is the mount; the addressed estate is its root.
+            "estate_root": estate.path(),
             "origin": {"client": "cli", "cwd": repo},
         }))
         .send()
@@ -1244,7 +1246,7 @@ async fn start_with_stub(
 /// `pending` and no window ever opens.
 async fn start_with_stub_polling(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     stub: &StubClaude,
     completion_poll: Duration,
 ) -> daemon::DaemonHandle {
@@ -1257,7 +1259,6 @@ async fn start_with_stub_polling(
             default_backend: Some(CLAUDE_BACKEND_NAME.to_string()),
             claude: Some(claude),
             completion_poll,
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -1276,10 +1277,11 @@ async fn start_with_stub_polling(
 async fn submit_over_api(
     http: &reqwest::Client,
     handle: &daemon::DaemonHandle,
+    estate_root: &Path,
     cwd: &Path,
     intent: &str,
 ) -> Value {
-    submit_scoped_over_api(http, handle, cwd, intent, &[]).await
+    submit_scoped_over_api(http, handle, estate_root, cwd, intent, &[]).await
 }
 
 /// [`submit_over_api`] naming an explicit `scope.repos` (§7.1's first scope
@@ -1288,6 +1290,7 @@ async fn submit_over_api(
 async fn submit_scoped_over_api(
     http: &reqwest::Client,
     handle: &daemon::DaemonHandle,
+    estate_root: &Path,
     cwd: &Path,
     intent: &str,
     repos: &[&str],
@@ -1297,6 +1300,10 @@ async fn submit_scoped_over_api(
         .json(&json!({
             "command_id": ulid(),
             "intent": intent,
+            // D4: two separate parameters on purpose — every call site here
+            // passes a *mount* as `cwd`, which is exactly the thing §5.2
+            // forbids being read as topology.
+            "estate_root": estate_root,
             "origin": {"client": "cli", "cwd": cwd},
             "scope": {"repos": repos},
         }))
@@ -1430,7 +1437,14 @@ async fn a_turn_that_ends_after_launch_settle_completes_and_cascades_with_no_cli
 
     let handle = start_with_stub(data.path(), estate.path(), &stub).await;
     let http = reqwest::Client::new();
-    let submitted = submit_over_api(&http, &handle, &repo, "settle me by yourself").await;
+    let submitted = submit_over_api(
+        &http,
+        &handle,
+        estate.path(),
+        &repo,
+        "settle me by yourself",
+    )
+    .await;
     let work_id = submitted["work"]["id"]
         .as_str()
         .expect("work id")
@@ -1579,7 +1593,14 @@ async fn a_turn_that_dies_without_an_envelope_blocks_the_stage_with_its_stderr()
 
     let handle = start_with_stub(data.path(), estate.path(), &stub).await;
     let http = reqwest::Client::new();
-    let submitted = submit_over_api(&http, &handle, &repo, "refuse me by yourself").await;
+    let submitted = submit_over_api(
+        &http,
+        &handle,
+        estate.path(),
+        &repo,
+        "refuse me by yourself",
+    )
+    .await;
     let work_id = submitted["work"]["id"]
         .as_str()
         .expect("work id")
@@ -1671,7 +1692,7 @@ async fn a_crash_after_the_turn_ended_is_re_derived_at_restart() {
     let handle =
         start_with_stub_polling(data.path(), estate.path(), &stub, Duration::from_secs(3600)).await;
     let http = reqwest::Client::new();
-    let submitted = submit_over_api(&http, &handle, &repo, "crash on me").await;
+    let submitted = submit_over_api(&http, &handle, estate.path(), &repo, "crash on me").await;
     let work_id = submitted["work"]["id"]
         .as_str()
         .expect("work id")
@@ -1736,7 +1757,6 @@ async fn a_crash_after_the_turn_ended_is_re_derived_at_restart() {
             // journal, not the manifest — but a restart that quietly dropped
             // the binding would be a different daemon, not this one coming
             // back.
-            estate_root: Some(estate.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -1799,7 +1819,7 @@ async fn a_turn_that_ends_after_a_respond_settles_and_cascades_with_no_client_cr
 
     let handle = start_with_stub(data.path(), estate.path(), &stub).await;
     let http = reqwest::Client::new();
-    let submitted = submit_over_api(&http, &handle, &repo, "ask me first").await;
+    let submitted = submit_over_api(&http, &handle, estate.path(), &repo, "ask me first").await;
     let work_id = submitted["work"]["id"]
         .as_str()
         .expect("work id")
@@ -1960,7 +1980,14 @@ async fn a_crash_during_a_resumed_turn_is_re_derived_at_restart() {
 
     let handle = start_with_stub(data.path(), estate.path(), &stub).await;
     let http = reqwest::Client::new();
-    let submitted = submit_over_api(&http, &handle, &repo, "crash me during a respond").await;
+    let submitted = submit_over_api(
+        &http,
+        &handle,
+        estate.path(),
+        &repo,
+        "crash me during a respond",
+    )
+    .await;
     let work_id = submitted["work"]["id"]
         .as_str()
         .expect("work id")
@@ -2029,7 +2056,6 @@ async fn a_crash_during_a_resumed_turn_is_re_derived_at_restart() {
             default_backend: Some(CLAUDE_BACKEND_NAME.to_string()),
             claude: Some(claude),
             // Same §5.1 restart binding as the launch-path sibling above.
-            estate_root: Some(estate.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -3527,7 +3553,8 @@ fn a4_restart_reattaches_a_surviving_session_and_blocks_with_resumable_evidence(
     journal_active_run(&mut core, work_id, CLAUDE_BACKEND_NAME, &session_id);
     journal_surface(&mut core, work_id, data.path());
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(
         report.resumed,
         vec![work_id.to_string()],
@@ -3601,7 +3628,8 @@ fn a4_restart_reattaches_a_surviving_session_and_blocks_with_resumable_evidence(
     // ...and reconciliation is idempotent: the work is no longer active,
     // so a second restart re-derives nothing (L6: every append window in
     // reconcile re-runs safely).
-    let again = recovery::reconcile(&engine, &mut core).expect("second reconcile");
+    let again =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("second reconcile");
     assert!(again.resumed.is_empty() && again.blocked.is_empty());
 }
 
@@ -3642,7 +3670,8 @@ fn a4_reconcile_reattaches_a_resumable_execution_before_it_classifies() {
     // While the daemon was down the stage finished and the context exited.
     fake.complete_live_executions();
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.resumed, vec![work_id.to_string()]);
     assert_eq!(
         work_of(&core, work_id).state,
@@ -3691,7 +3720,8 @@ fn a4_reconcile_that_cannot_reattach_stays_fail_closed() {
     journal_active_run(&mut core, work_id, FAKE_BACKEND_NAME, "fake-session-gone");
     journal_surface(&mut core, work_id, data.path());
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let reconciled = events_of(&core, work_id, KIND_EXECUTION_RECONCILED);
@@ -3748,7 +3778,8 @@ fn a4_reconcile_does_not_ask_a_backend_that_cannot_resume() {
     );
     fake.complete_live_executions();
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.resumed, vec![work_id.to_string()]);
     assert!(
         fake.resume_requests().is_empty(),
@@ -3779,7 +3810,8 @@ fn a4_restart_with_vanished_session_retires_the_execution_and_blocks() {
     let work_id = "01M4RECOVERB";
     journal_active_run(&mut core, work_id, CLAUDE_BACKEND_NAME, session_id);
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
 
@@ -3864,7 +3896,8 @@ fn a4_a_crash_inside_the_reconcile_append_window_rederives_on_restart() {
         }),
     );
 
-    let report = recovery::reconcile(&engine, &mut core).expect("re-run reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("re-run reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let stopped = events_of(&core, work_id, KIND_EXECUTION_STOPPED);
@@ -3950,7 +3983,8 @@ fn a4_a_crash_between_completion_and_teardown_is_swept_on_restart() {
         "the stranded worktree is still there"
     );
 
-    let report = recovery::reconcile(&engine, &mut core).expect("recovery must not abort");
+    let report = recovery::reconcile(&engine, &EstateRegistry::new(), &mut core)
+        .expect("recovery must not abort");
     assert_eq!(
         report.surfaces_retired,
         vec![stranded.to_string(), recorded.to_string()],
@@ -4016,7 +4050,8 @@ fn a4_a_crash_between_completion_and_teardown_is_swept_on_restart() {
     ));
 
     // And it converges: the next restart finds nothing left to do.
-    let again = recovery::reconcile(&engine, &mut core).expect("second restart");
+    let again =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("second restart");
     assert!(
         again.surfaces_retired.is_empty(),
         "a swept surface is not swept twice: {again:?}"
@@ -4089,7 +4124,8 @@ fn a4_a_swept_surface_that_cannot_be_removed_is_retained_named_and_not_re_swept(
     std::fs::write(worktree.join("half-done.txt"), "not committed anywhere\n")
         .expect("dirty the worktree");
 
-    let report = recovery::reconcile(&engine, &mut core).expect("recovery must not abort");
+    let report = recovery::reconcile(&engine, &EstateRegistry::new(), &mut core)
+        .expect("recovery must not abort");
     assert_eq!(
         report.surfaces_retired,
         vec![work_id.to_string()],
@@ -4142,7 +4178,8 @@ fn a4_a_swept_surface_that_cannot_be_removed_is_retained_named_and_not_re_swept(
 
     // The convergence property this branch does not share with the removed
     // one: the surface is still there, and it must still not be swept twice.
-    let again = recovery::reconcile(&engine, &mut core).expect("second restart");
+    let again =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("second restart");
     assert!(
         again.surfaces_retired.is_empty(),
         "a retained surface is recorded once, not once per restart: {again:?}"
@@ -4424,7 +4461,8 @@ fn a4_a_crash_between_spawn_and_execution_started_blocks_the_work() {
     // …and the daemon died here: the turn is running, `execution.started`
     // never landed.
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let reconciled = events_of(&core, work_id, KIND_EXECUTION_RECONCILED);
@@ -4662,7 +4700,8 @@ fn r2_daemon_dies_during_delivery_fails_closed_with_the_input_preserved() {
         json!({"reason": "input_received"}),
     );
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let inputs = events_of(&core, work_id, KIND_STAGE_INPUT_RECEIVED);
@@ -4705,7 +4744,8 @@ fn r3_native_dies_after_work_preserved_is_not_a_failure() {
     // While the daemon was down: the stage finished and the context exited.
     fake.complete_live_executions();
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.resumed, vec![work_id.to_string()]);
     assert_eq!(
         work_of(&core, work_id).state,
@@ -4785,7 +4825,8 @@ fn r5_stale_execution_identity_is_refused_not_adopted() {
         "stale-session-identity",
     );
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     let reconciled = events_of(&core, work_id, KIND_EXECUTION_RECONCILED);
     assert_eq!(reconciled[0]["disposition"], "ambiguous");
@@ -4815,7 +4856,6 @@ async fn r6_client_disconnect_mid_run_has_no_consequence() {
             backends: Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             claude: None,
-            estate_root: Some(estate.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -4839,6 +4879,8 @@ async fn r6_client_disconnect_mid_run_has_no_consequence() {
         .json(&json!({
             "command_id": ulid(),
             "intent": "outlive your client",
+            // D4: `cwd` is the mount; the addressed estate is its root.
+            "estate_root": estate.path(),
             "origin": {"client": "cli", "cwd": repo},
         }))
         .send()
@@ -4912,7 +4954,8 @@ fn r7_work_waiting_for_input_is_never_timed_out_or_reclassified() {
 
     // However many restarts later — hours of them — the parked state holds.
     for _ in 0..3 {
-        let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+        let report =
+            recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
         assert!(report.resumed.is_empty() && report.blocked.is_empty());
     }
     assert_eq!(work_of(&core, work_id).state, WorkState::NeedsInput);
@@ -4936,13 +4979,18 @@ fn r7_work_waiting_for_input_is_never_timed_out_or_reclassified() {
 // is now an estate root with its one mount at `repos/solo`, and the engine
 // carries the binding a daemon would have given it.
 
-/// The plan a submission into this engine's bound estate resolves to (§5.2:
-/// there is no other estate a submission could name, so this takes no path).
-fn plan_for(engine: &Engine) -> sergeant_rs::runtime::engine::StartPlan {
+/// The plan a submission addressed at `estate_root` resolves to. D10: the
+/// engine holds no estate, so the root is the caller's to name — §5.2 is
+/// unchanged, it is just kept by the caller (an *addressed* root) rather
+/// than by a field.
+fn plan_for(
+    engine: &Engine,
+    estate_root: &std::path::Path,
+) -> sergeant_rs::runtime::engine::StartPlan {
     engine
-        .plan(&SubmitContext::default())
+        .plan(Some(estate_root), &SubmitContext::default())
         .expect("plan")
-        .expect("the engine's bound estate")
+        .expect("the addressed estate")
 }
 
 /// §14.2 phase 1 for a surface: `begin_start` journals the *intent* to
@@ -4959,13 +5007,12 @@ fn n19_materializing_a_surface_is_an_effect_the_caller_performs() {
         Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
-    )
-    .with_estate_root(estate.path().to_path_buf());
+    );
     let mut core = core(data.path());
     let work_id = "01N3SURFACE1";
     submit_work(&mut core, work_id, "materialize me");
     let work = work_of(&core, work_id);
-    let plan = plan_for(&engine);
+    let plan = plan_for(&engine, estate.path());
 
     let step = engine
         .begin_start(&mut core, &work, &plan)
@@ -5025,13 +5072,12 @@ fn n20_tearing_a_surface_down_is_an_effect_the_caller_performs() {
         Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
-    )
-    .with_estate_root(estate.path().to_path_buf());
+    );
     let mut core = core(data.path());
     let work_id = "01N3SURFACE2";
     submit_work(&mut core, work_id, "cancel me");
     let work = work_of(&core, work_id);
-    let plan = plan_for(&engine);
+    let plan = plan_for(&engine, estate.path());
     engine.start(&mut core, &work, &plan).expect("start");
     let worktree = core.registry.state().runs[work_id]
         .surface
@@ -5082,13 +5128,12 @@ fn n21_a_cancel_during_materialization_records_the_surface_and_tears_it_down() {
         Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
-    )
-    .with_estate_root(estate.path().to_path_buf());
+    );
     let mut core = core(data.path());
     let work_id = "01N3SURFACE3";
     submit_work(&mut core, work_id, "cancel me mid-git");
     let work = work_of(&core, work_id);
-    let plan = plan_for(&engine);
+    let plan = plan_for(&engine, estate.path());
 
     let step = engine
         .begin_start(&mut core, &work, &plan)
@@ -5978,7 +6023,8 @@ fn n4_a_reservation_whose_launch_never_reported_fails_closed_at_restart() {
     );
     commit(&mut core, work_id, KIND_WORK_STARTED, json!({}));
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     let blocked = events_of(&core, work_id, KIND_WORK_BLOCKED);
@@ -6015,7 +6061,8 @@ fn n4_a_reservation_whose_launch_never_reported_fails_closed_at_restart() {
 
     // Idempotent: the work is no longer `active`, so a second restart leaves
     // it exactly where the first one put it.
-    let again = recovery::reconcile(&engine, &mut core).expect("reconcile again");
+    let again =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile again");
     assert!(again.blocked.is_empty() && again.resumed.is_empty());
     assert_eq!(
         events_of(&core, work_id, KIND_EXECUTION_ABANDONED).len(),
@@ -6312,7 +6359,7 @@ fn n17_an_actor_ask_survives_a_daemon_restart_and_the_answer_still_lands() {
     let engine = Engine::new(registry, None, data.path());
     let mut restarted = reopen(data.path());
     let core = &mut restarted;
-    let report = recovery::reconcile(&engine, core).expect("reconcile");
+    let report = recovery::reconcile(&engine, &EstateRegistry::new(), core).expect("reconcile");
     assert!(
         report.resumed.is_empty() && report.blocked.is_empty(),
         "a parked work is a decision; recovery must not re-decide it: {report:?}"
@@ -6867,7 +6914,8 @@ fn n10_window1_before_the_reservation_append() {
     let work_id = "01N3W1";
     journal_two_stage_prefix(&mut core, work_id, data.path());
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     assert_eq!(work_of(&core, work_id).state, WorkState::Blocked);
     assert_eq!(
@@ -6901,7 +6949,8 @@ fn n11_window2_after_the_reservation_append() {
         reservation_payload("01N3W2EXEC"),
     );
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     let evidence = events_of(&core, work_id, KIND_WORK_BLOCKED)
         .last()
@@ -6990,7 +7039,8 @@ fn n12_windows3_and_4_identity_created_and_process_started_are_one_window() {
         fake.launch(&prepared).expect("launch");
         let launched_before = fake.starts().len();
 
-        let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+        let report =
+            recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
         assert_eq!(report.blocked, vec![work_id.to_string()], "{label}");
         assert_eq!(
             fake.starts().len(),
@@ -7084,7 +7134,8 @@ fn n13_window5_result_observed_before_the_result_append() {
         .expect("prepare");
     fake.launch(&prepared).expect("launch");
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.resumed, vec![work_id.to_string()]);
     let completed: Vec<Value> = events_of(&core, work_id, "stage.completed")
         .into_iter()
@@ -7170,7 +7221,7 @@ fn n14_window6_result_appended_before_the_transition() {
         .expect("prepare");
     fake.launch(&prepared).expect("launch");
 
-    recovery::reconcile(&engine, &mut core).expect("reconcile");
+    recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(
         stage_coordinate(&core, work_id),
         ("10-second".to_string(), 1),
@@ -7227,7 +7278,8 @@ fn n15_window7_terminal_before_the_cleanup_request() {
         json!({"stages": 2}),
     );
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.surfaces_retired, vec![work_id.to_string()]);
     assert_eq!(
         work_of(&core, work_id).state,
@@ -7239,7 +7291,8 @@ fn n15_window7_terminal_before_the_cleanup_request() {
 
     // Idempotent: a second restart finds the teardown recorded and does
     // nothing at all.
-    let again = recovery::reconcile(&engine, &mut core).expect("reconcile again");
+    let again =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile again");
     assert!(again.surfaces_retired.is_empty());
     assert_eq!(events_of(&core, work_id, KIND_SURFACE_TORN_DOWN).len(), 1);
 }
@@ -7266,7 +7319,8 @@ fn n16_window8_cleanup_done_before_the_cleanup_append() {
         json!({"stages": 2}),
     );
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.surfaces_retired, vec![work_id.to_string()]);
     let torn = events_of(&core, work_id, KIND_SURFACE_TORN_DOWN);
     assert_eq!(torn.len(), 1);
@@ -7335,7 +7389,8 @@ fn n22_window7b_a_cancel_that_landed_during_a_launch_closes_its_reservation() {
         "the window this test is about must actually be open"
     );
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(
         report.reservations_retired,
         vec![work_id.to_string()],
@@ -7376,7 +7431,8 @@ fn n22_window7b_a_cancel_that_landed_during_a_launch_closes_its_reservation() {
     );
 
     // Convergent: a second restart finds nothing left to do.
-    let again = recovery::reconcile(&engine, &mut core).expect("reconcile twice");
+    let again =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile twice");
     assert!(again.reservations_retired.is_empty(), "{again:?}");
     assert_eq!(
         events_of(&core, work_id, KIND_EXECUTION_ABANDONED).len(),
@@ -8075,7 +8131,8 @@ fn n25_window2_over_a_producer_derived_prefix() {
     drop(pending);
     assert!(fake.starts().is_empty(), "the launch never happened");
 
-    let report = recovery::reconcile(&engine, &mut core).expect("reconcile");
+    let report =
+        recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     assert_eq!(report.blocked, vec![work_id.to_string()]);
     let abandoned = events_of(&core, work_id, KIND_EXECUTION_ABANDONED);
     assert_eq!(abandoned.len(), 1, "{abandoned:?}");
@@ -8354,7 +8411,7 @@ fn n32_every_prefix_a_grouped_lock_hold_can_crash_at_is_one_recovery_already_han
 
         // And the daemon that comes back up must converge, fail-closed, on
         // every one of them.
-        let report = recovery::reconcile(&engine, &mut core)
+        let report = recovery::reconcile(&engine, &EstateRegistry::new(), &mut core)
             .expect("reconcile must converge on every reachable prefix");
         let state = core.registry.state().works.get(work_id).map(|w| w.state);
         match complete {
@@ -8389,7 +8446,7 @@ fn n32_every_prefix_a_grouped_lock_hold_can_crash_at_is_one_recovery_already_han
     std::fs::create_dir_all(dir.join("journal")).expect("journal dir");
     std::fs::write(dir.join("journal").join("00000001.ndjson"), &bytes).expect("write");
     let mut core = core(&dir);
-    recovery::reconcile(&engine, &mut core).expect("reconcile");
+    recovery::reconcile(&engine, &EstateRegistry::new(), &mut core).expect("reconcile");
     let evidence = events_of(&core, work_id, KIND_WORK_BLOCKED)
         .last()
         .and_then(|b| b["evidence"].as_str())
@@ -8526,14 +8583,16 @@ fn r_mvp1_7_a_scripted_run_exceeding_the_cap_blocks_at_exactly_n_spawned_turns()
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
     )
-    .with_turn_cap(2)
-    .with_estate_root(estate.path().to_path_buf());
+    .with_turn_cap(2);
     let mut core = core(data.path());
     let plan = engine
-        .plan(&SubmitContext {
-            workflow: Some("capped"),
-            ..SubmitContext::default()
-        })
+        .plan(
+            Some(estate.path()),
+            &SubmitContext {
+                workflow: Some("capped"),
+                ..SubmitContext::default()
+            },
+        )
         .expect("plan")
         .expect("the engine's bound estate");
 
@@ -8700,14 +8759,16 @@ fn r_mvp1_11_a_stage_requiring_ask_refuses_against_a_backend_that_cannot_ask() {
         Arc::new(BackendRegistry::new().with(Arc::new(no_ask))),
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
-    )
-    .with_estate_root(estate.path().to_path_buf());
+    );
 
     let err = engine
-        .plan(&SubmitContext {
-            workflow: Some("asks"),
-            ..SubmitContext::default()
-        })
+        .plan(
+            Some(estate.path()),
+            &SubmitContext {
+                workflow: Some("asks"),
+                ..SubmitContext::default()
+            },
+        )
         .expect_err("must refuse before a Work or worktree exists");
     match &err {
         EngineError::AskCapabilityUnavailable {
@@ -8748,13 +8809,15 @@ fn r_mvp1_11_the_same_workflow_submits_against_a_backend_that_can_ask() {
         Arc::new(BackendRegistry::new().with(Arc::new(can_ask))),
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
-    )
-    .with_estate_root(estate.path().to_path_buf());
+    );
     let plan = engine
-        .plan(&SubmitContext {
-            workflow: Some("asks"),
-            ..SubmitContext::default()
-        })
+        .plan(
+            Some(estate.path()),
+            &SubmitContext {
+                workflow: Some("asks"),
+                ..SubmitContext::default()
+            },
+        )
         .expect("plan")
         .expect("the engine's bound estate");
     assert_eq!(plan.workflow.name, "asks");
@@ -8779,10 +8842,9 @@ fn r_mvp1_11_an_undeclared_workflow_is_unaffected_by_a_backend_that_cannot_ask()
         Arc::new(BackendRegistry::new().with(Arc::new(no_ask))),
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
-    )
-    .with_estate_root(estate.path().to_path_buf());
+    );
     let plan = engine
-        .plan(&SubmitContext::default())
+        .plan(Some(estate.path()), &SubmitContext::default())
         .expect("plan")
         .expect("the engine's bound estate");
     assert!(!plan.workflow.stages.is_empty());
@@ -8853,14 +8915,13 @@ async fn r_mvp1_7_a_hang_turn_is_interrupted_within_ceiling_plus_one_interval() 
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             completion_poll: poll,
             turn_ceiling: ceiling,
-            estate_root: Some(estate.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
     .await
     .expect("daemon start");
     let http = reqwest::Client::new();
-    let submitted = submit_over_api(&http, &handle, &repo, "hang forever").await;
+    let submitted = submit_over_api(&http, &handle, estate.path(), &repo, "hang forever").await;
     let work_id = submitted["work"]["id"]
         .as_str()
         .expect("work id")
@@ -8952,15 +9013,30 @@ async fn r_mvp1_7_two_simultaneously_overdue_hangs_are_both_interrupted() {
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             completion_poll: poll,
             turn_ceiling: ceiling,
-            estate_root: Some(estate.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
     .await
     .expect("daemon start");
     let http = reqwest::Client::new();
-    let a = submit_scoped_over_api(&http, &handle, &mount("repo-a"), "hang a", &["repo-a"]).await;
-    let b = submit_scoped_over_api(&http, &handle, &mount("repo-b"), "hang b", &["repo-b"]).await;
+    let a = submit_scoped_over_api(
+        &http,
+        &handle,
+        estate.path(),
+        &mount("repo-a"),
+        "hang a",
+        &["repo-a"],
+    )
+    .await;
+    let b = submit_scoped_over_api(
+        &http,
+        &handle,
+        estate.path(),
+        &mount("repo-b"),
+        "hang b",
+        &["repo-b"],
+    )
+    .await;
     let work_a = a["work"]["id"].as_str().expect("work id").to_string();
     let work_b = b["work"]["id"].as_str().expect("work id").to_string();
     assert_eq!(a["work"]["state"], "active");
@@ -9022,14 +9098,16 @@ fn r_mvp1_7_a_consumed_crossing_whose_turn_ended_is_journaled_stale_not_delivere
         Some(FAKE_BACKEND_NAME.to_string()),
         data.path(),
     )
-    .with_turn_ceiling(Duration::ZERO)
-    .with_estate_root(estate.path().to_path_buf());
+    .with_turn_ceiling(Duration::ZERO);
     let mut core = core(data.path());
     let plan = engine
-        .plan(&SubmitContext {
-            workflow: Some("hangs"),
-            ..SubmitContext::default()
-        })
+        .plan(
+            Some(estate.path()),
+            &SubmitContext {
+                workflow: Some("hangs"),
+                ..SubmitContext::default()
+            },
+        )
         .expect("plan")
         .expect("the engine's bound estate");
     let work_id = "01MVP17STALE";

--- a/tests/m5_projections.rs
+++ b/tests/m5_projections.rs
@@ -114,7 +114,7 @@ fn estate() -> (TempDir, PathBuf, String) {
 /// sit at `pending` forever.
 async fn start_fake(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     script: impl IntoIterator<Item = FakeStep>,
 ) -> (DaemonHandle, FakeBackend) {
     let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, script);
@@ -124,7 +124,6 @@ async fn start_fake(
         DaemonConfig {
             backends: Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -168,14 +167,19 @@ async fn get_status(handle: &DaemonHandle, path: &str) -> (reqwest::StatusCode, 
     (status, resp.json().await.expect("json body"))
 }
 
-/// Submit work. `cwd` is §13.3 recorded evidence and nothing else — since
-/// §5.2 the plan is made against the estate the daemon was *bound* to, so
-/// this argument decides nothing about topology; it is passed the estate root
-/// only so `origin.cwd` in the journal names something real.
+/// Submit work addressed at `estate_root` (D4), which every call site here
+/// also passes as `cwd`.
+///
+/// `cwd` is still §13.3 recorded evidence and nothing else: §5.2 gave it no
+/// authority over topology, and H1 does not give it any back — what decides
+/// is the addressed root, which the daemon then admits. `extra` can override
+/// `estate_root` (a `null` addresses none), which is how the no-topology
+/// cases in this file stay reachable.
 async fn submit(handle: &DaemonHandle, cwd: &Path, intent: &str, extra: Value) -> Value {
     let mut body = json!({
         "command_id": ulid(),
         "intent": intent,
+        "estate_root": cwd,
         "origin": {"client": "cli", "cwd": cwd},
     });
     if let Some(fields) = extra.as_object() {
@@ -1365,7 +1369,6 @@ async fn t5_enabled_export_emits_the_span_tree_and_metrics() {
             // §5.1, spelled out here rather than through `start_fake`: this
             // rig needs its own `telemetry` field, and an unbound daemon
             // would export a `work` span with no stages under it.
-            estate_root: Some(estate.path().to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -2028,7 +2031,7 @@ fn stub_claude(dir: &Path) -> PathBuf {
 /// adapter itself, so nothing here is a fake wearing the adapter's name.
 async fn start_claude(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     telemetry: Option<Arc<Telemetry>>,
 ) -> DaemonHandle {
     let mut claude = ClaudeConfig::new(data_dir);
@@ -2040,7 +2043,6 @@ async fn start_claude(
             default_backend: Some(CLAUDE_BACKEND_NAME.to_string()),
             claude: Some(claude),
             telemetry,
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -151,16 +151,21 @@ fn write_solo_workflow(root: &Path) {
     std::fs::write(dir.join("00-only").join("CONTEXT.md"), "context").expect("CONTEXT.md");
 }
 
-/// Start an in-process daemon **bound** to `estate_root` (estate-root §5.1).
+/// Start an in-process host daemon over `data_dir`.
 ///
-/// The binding is not optional decoration: `Engine::plan` reads the estate the
-/// daemon was started against, never the request's `origin.cwd` (§13.3), so a
-/// daemon left with `estate_root: None` plans against nothing and every
-/// submission below would sit on `pending` forever — no surface, no stage, no
-/// backend, and every content assertion in this file reading a blank row.
+/// **H1: no estate binding.** The daemon comes up serving zero estates and
+/// admits `estate_root` the first time a request addresses it — which is why
+/// [`submit`] below sends `estate_root` explicitly. A submission that names
+/// no estate still plans against nothing and sits on `pending` forever, so
+/// the addressing is exactly as load-bearing as the old binding was; it just
+/// lives on the request now.
+///
+/// `estate_root` is kept as a parameter — unused by the start itself — so
+/// every call site still reads as "this rig's estate is that one", and the
+/// helper stays the one place a multi-estate variant would grow from.
 async fn start_fake(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     script: impl IntoIterator<Item = FakeStep>,
 ) -> (DaemonHandle, FakeBackend) {
     let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, script);
@@ -170,7 +175,6 @@ async fn start_fake(
         DaemonConfig {
             backends: Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -179,11 +183,23 @@ async fn start_fake(
     (handle, fake)
 }
 
-async fn submit(handle: &DaemonHandle, cwd: &Path, intent: &str, workflow: &str) -> String {
+/// D4: a submission names the estate it addresses and, separately, the cwd
+/// it came from. Keeping them two parameters is the point — every call site
+/// here passes a *mount* as `cwd`, which is exactly the thing §5.2 forbids
+/// being read as topology, and a rig that conflated them would stop proving
+/// that.
+async fn submit(
+    handle: &DaemonHandle,
+    estate_root: &Path,
+    cwd: &Path,
+    intent: &str,
+    workflow: &str,
+) -> String {
     let body = json!({
         "command_id": ulid(),
         "intent": intent,
         "workflow": workflow,
+        "estate_root": estate_root,
         "origin": {"client": "cli", "cwd": cwd},
     });
     let response = http()
@@ -198,8 +214,13 @@ async fn submit(handle: &DaemonHandle, cwd: &Path, intent: &str, workflow: &str)
     value["work"]["id"].as_str().expect("work id").to_string()
 }
 
-fn client_for(handle: &DaemonHandle) -> ApiClient {
-    ApiClient::new(&handle.endpoint, &handle.token).expect("client")
+/// D4: a client addresses the estate its estate-scoped requests mean. The
+/// daemon binds none, so a client that named none would be refused by name
+/// on every estate-scoped route — which is the contract, not a rig quirk.
+fn client_for(handle: &DaemonHandle, estate_root: &Path) -> ApiClient {
+    ApiClient::new(&handle.endpoint, &handle.token)
+        .expect("client")
+        .with_estate_root(estate_root)
 }
 
 /// The `TestBackend` buffer as plain text lines — the content assertions in
@@ -275,10 +296,10 @@ async fn t1_the_tui_renders_and_drives_the_fleet_over_the_api() {
         ],
     )
     .await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, estate.path());
 
-    let done = submit(&handle, &mount, "finish this one", "tiny").await;
-    let asking = submit(&handle, &mount, "ask me something", "tiny").await;
+    let done = submit(&handle, estate.path(), &mount, "finish this one", "tiny").await;
+    let asking = submit(&handle, estate.path(), &mount, "ask me something", "tiny").await;
 
     let mut app = App::new();
     app.refresh(&client).await.expect("first read");
@@ -379,7 +400,14 @@ async fn t1_the_tui_renders_and_drives_the_fleet_over_the_api() {
         .stream_events(app.last_seq)
         .await
         .expect("live tail attaches");
-    let fresh = submit(&handle, &mount, "arrived while watching", "tiny").await;
+    let fresh = submit(
+        &handle,
+        estate.path(),
+        &mount,
+        "arrived while watching",
+        "tiny",
+    )
+    .await;
     assert!(
         !screen_text(&render(&app)).contains(&fresh),
         "the new work must not be on screen before the TUI hears about it"
@@ -499,8 +527,8 @@ async fn t1c_respond_reaches_the_real_api_through_the_answer_composer() {
         ],
     )
     .await;
-    let client = client_for(&handle);
-    let id = submit(&handle, &mount, "ask a question", "solo").await;
+    let client = client_for(&handle, estate.path());
+    let id = submit(&handle, estate.path(), &mount, "ask a question", "solo").await;
 
     let mut app = App::new();
     app.refresh(&client).await.expect("first read");
@@ -568,8 +596,8 @@ async fn t1c_cancel_reaches_the_real_api_through_the_confirmation() {
         [FakeStep::waiting("queued upstream")],
     )
     .await;
-    let client = client_for(&handle);
-    let id = submit(&handle, &mount, "wait around", "solo").await;
+    let client = client_for(&handle, estate.path());
+    let id = submit(&handle, estate.path(), &mount, "wait around", "solo").await;
 
     let mut app = App::new();
     app.refresh(&client).await.expect("first read");
@@ -612,8 +640,8 @@ async fn t1c_retry_reaches_the_real_api_through_the_confirmation() {
         [FakeStep::fail("boom"), FakeStep::complete()],
     )
     .await;
-    let client = client_for(&handle);
-    let id = submit(&handle, &mount, "fail then retry", "solo").await;
+    let client = client_for(&handle, estate.path());
+    let id = submit(&handle, estate.path(), &mount, "fail then retry", "solo").await;
 
     let mut app = App::new();
     app.refresh(&client).await.expect("first read");
@@ -653,8 +681,8 @@ async fn t1c_extend_reaches_the_real_api_with_the_typed_turn_count() {
         [FakeStep::blocked("envelope exhausted")],
     )
     .await;
-    let client = client_for(&handle);
-    let id = submit(&handle, &mount, "run out of turns", "solo").await;
+    let client = client_for(&handle, estate.path());
+    let id = submit(&handle, estate.path(), &mount, "run out of turns", "solo").await;
 
     let before = client.work(&id).await.expect("read back");
     assert_eq!(before["work"]["state"], "blocked");
@@ -719,7 +747,7 @@ async fn t3_estate_add_repo_reaches_the_real_api_off_the_render_loop() {
     support::init_repo(source.path());
 
     let (handle, _fake) = start_fake(&data_dir, estate_root.path(), []).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, estate_root.path());
 
     let mut app = App::new();
     app.refresh(&client).await.expect("first read");
@@ -804,7 +832,7 @@ async fn t3_estate_health_renders_the_real_doctor_report() {
     let estate = TempDir::new().expect("tempdir");
     empty_estate(estate.path(), "t3-health-estate");
     let (handle, _fake) = start_fake(data.path(), estate.path(), []).await;
-    let client = client_for(&handle);
+    let client = client_for(&handle, estate.path());
 
     let mut app = App::new();
     app.on_key(ratatui::crossterm::event::KeyCode::Esc); // leave Home's form focus first
@@ -1288,9 +1316,9 @@ async fn t1_the_events_endpoint_filters_and_tails_by_work() {
     write_workflow(estate.path());
 
     let (handle, _fake) = start_fake(data.path(), estate.path(), []).await;
-    let client = client_for(&handle);
-    let first = submit(&handle, &mount, "first work", "tiny").await;
-    let second = submit(&handle, &mount, "second work", "tiny").await;
+    let client = client_for(&handle, estate.path());
+    let first = submit(&handle, estate.path(), &mount, "first work", "tiny").await;
+    let second = submit(&handle, estate.path(), &mount, "second work", "tiny").await;
 
     let all = client.get("/v1/events").await.expect("history");
     let all = all["events"].as_array().expect("events").len();
@@ -1349,8 +1377,8 @@ async fn a_work_view_whose_work_vanished_falls_back_to_fleet() {
         [FakeStep::needs_input("which budget?")],
     )
     .await;
-    let work_id = submit(&handle, &mount, "still here", "tiny").await;
-    let client = client_for(&handle);
+    let work_id = submit(&handle, estate.path(), &mount, "still here", "tiny").await;
+    let client = client_for(&handle, estate.path());
 
     let mut app = App::new();
     app.refresh(&client).await.expect("first read");

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -1464,6 +1464,36 @@ async fn h1_two_estates_submit_work_to_one_daemon_and_keep_their_own_surfaces() 
         );
     }
 
+    // D4/D6: `GET /v1/events?estate_root=` narrows the shared stream to one
+    // estate, server-side. Without it, "estate-wide watch" would silently
+    // become "host-wide watch" for every existing `sgt watch` the moment a
+    // second estate is admitted — this field is the wire half of keeping
+    // that from happening; routing the client onto it is W3's.
+    let payments_root = std::fs::canonicalize(payments.path())
+        .expect("canonical")
+        .to_string_lossy()
+        .into_owned();
+    let scoped = client
+        .get(&format!(
+            "/v1/events?estate_root={}",
+            payments_root.replace('/', "%2F")
+        ))
+        .await
+        .expect("filtered history");
+    let scoped = scoped["events"].as_array().expect("events").clone();
+    assert!(!scoped.is_empty(), "the filter must not empty the stream");
+    for event in &scoped {
+        assert_eq!(
+            event["workspace_id"], payments_root,
+            "an estate filter must return only that estate's events: {event}"
+        );
+    }
+    let whole = client.get("/v1/events").await.expect("whole history");
+    assert!(
+        whole["events"].as_array().expect("events").len() > scoped.len(),
+        "and it must actually remove events from the shared stream"
+    );
+
     handle.shutdown().await;
 }
 

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -188,6 +188,33 @@ async fn start_fake(
 /// here passes a *mount* as `cwd`, which is exactly the thing §5.2 forbids
 /// being read as topology, and a rig that conflated them would stop proving
 /// that.
+/// **The two-estate sibling of [`start_fake`]** (brief deliverable 10):
+/// one in-process host daemon, no estates bound, ready to admit whichever
+/// roots its requests address.
+///
+/// Additive — [`start_fake`] and every test on it are untouched, because
+/// single-estate is a special case of host mode rather than a removed one.
+/// The only difference is what the rig *says*: this one takes no estate at
+/// all, which is what a host daemon actually is.
+async fn start_fake_host(
+    data_dir: &Path,
+    script: impl IntoIterator<Item = FakeStep>,
+) -> (DaemonHandle, FakeBackend) {
+    let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, script);
+    let registry = BackendRegistry::new().with(Arc::new(fake.clone()));
+    let handle = daemon::start_with(
+        data_dir,
+        DaemonConfig {
+            backends: Arc::new(registry),
+            default_backend: Some(FAKE_BACKEND_NAME.to_string()),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start");
+    (handle, fake)
+}
+
 async fn submit(
     handle: &DaemonHandle,
     estate_root: &Path,
@@ -1309,6 +1336,137 @@ fn pid_alive(pid: u32) -> bool {
 /// The API extension the detail screens needed, tested where it lives: this
 /// milestone added `work_id` and `limit` to `/v1/events` rather than letting
 /// a client read the journal (§30's rule, applied).
+/// H1 §11 criterion 1, in process: **two exact-root estates submit Work to
+/// one daemon**, and each Work materializes its surface under its *own*
+/// estate's mount.
+///
+/// This is the fact the whole wave turns on, and the in-process shape is
+/// what makes it checkable at the surface level rather than only over the
+/// CLI: if `Engine::plan` were still reading one pinned estate, one of these
+/// two Works would have been planned against the other's manifest — the same
+/// mount name, `solo`, in a different estate, which is exactly the silent
+/// confusion a pinned field produces (and exactly why D1 makes the estate
+/// coordinate a canonical *root*, never a display name).
+#[tokio::test]
+async fn h1_two_estates_submit_work_to_one_daemon_and_keep_their_own_surfaces() {
+    let data = TempDir::new().expect("tempdir");
+    let (payments, payments_mount) = solo_estate("solo");
+    let (billing, billing_mount) = solo_estate("solo");
+    write_workflow(payments.path());
+    write_workflow(billing.path());
+    assert_ne!(
+        payments.path(),
+        billing.path(),
+        "the fixture must really be two estates"
+    );
+
+    let (handle, _fake) = start_fake_host(
+        data.path(),
+        [FakeStep::complete_with("done"), FakeStep::complete()],
+    )
+    .await;
+
+    let first = submit(
+        &handle,
+        payments.path(),
+        &payments_mount,
+        "payments work",
+        "tiny",
+    )
+    .await;
+    let second = submit(
+        &handle,
+        billing.path(),
+        &billing_mount,
+        "billing work",
+        "tiny",
+    )
+    .await;
+    assert_ne!(first, second);
+
+    let client = client_for(&handle, payments.path());
+    // Each Work's surface must be **cut from its own estate's mount**. Both
+    // estates declare a repository called `solo`, deliberately: a name is not
+    // an identity (D1), and a pinned engine field would have cut both Works
+    // from whichever estate it happened to hold.
+    let mut sources = Vec::new();
+    for (work_id, estate) in [(&first, payments.path()), (&second, billing.path())] {
+        let shown = client
+            .work(work_id)
+            .await
+            .unwrap_or_else(|e| panic!("show {work_id}: {e}"));
+        let source = shown["surface"]["bindings"][0]["canonical_top_level"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{work_id} has no surface: {shown}"))
+            .to_string();
+        let expected = std::fs::canonicalize(estate.join("repos").join("solo"))
+            .expect("canonical mount")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            source, expected,
+            "{work_id} must be cut from its own estate's mount"
+        );
+        sources.push(source);
+    }
+    assert_ne!(
+        sources[0], sources[1],
+        "the two estates' identically-named mounts must not collapse into one"
+    );
+
+    // H1 §4: the registry observed exactly the two roots that were addressed
+    // — no more (nothing was discovered) and no fewer (both were admitted).
+    let listed = client.estates().await.expect("GET /v1/estates");
+    let mut roots: Vec<String> = listed["estates"]
+        .as_array()
+        .expect("estates array")
+        .iter()
+        .map(|e| e["root"].as_str().expect("root").to_string())
+        .collect();
+    roots.sort();
+    let mut expected = vec![
+        std::fs::canonicalize(payments.path())
+            .expect("canonical")
+            .to_string_lossy()
+            .into_owned(),
+        std::fs::canonicalize(billing.path())
+            .expect("canonical")
+            .to_string_lossy()
+            .into_owned(),
+    ];
+    expected.sort();
+    assert_eq!(roots, expected, "{listed}");
+
+    // H1 §11 criterion 5: one journal, and a replay tells the two estates
+    // apart by their own coordinates.
+    let mut by_estate: std::collections::BTreeMap<String, Vec<String>> = Default::default();
+    for event in sergeant_rs::runtime::journal::Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+    {
+        if let (Some(root), Some(work_id)) = (&event.workspace_id, &event.work_id) {
+            let works = by_estate.entry(root.clone()).or_default();
+            if !works.contains(work_id) {
+                works.push(work_id.clone());
+            }
+        }
+    }
+    assert_eq!(
+        by_estate.len(),
+        2,
+        "one journal, two estates: {by_estate:?}"
+    );
+    for (root, works) in &by_estate {
+        assert_eq!(
+            works.len(),
+            1,
+            "{root} owns exactly its own Work: {works:?}"
+        );
+    }
+
+    handle.shutdown().await;
+}
+
 #[tokio::test]
 async fn t1_the_events_endpoint_filters_and_tails_by_work() {
     let data = TempDir::new().expect("tempdir");

--- a/tests/m7_docker_executor.rs
+++ b/tests/m7_docker_executor.rs
@@ -1175,7 +1175,6 @@ async fn a_kind_execute_stage_is_refused_at_submit_when_docker_is_unavailable() 
     let handle = daemon::start_with(
         data.path(),
         DaemonConfig {
-            estate_root: Some(estate.path().to_path_buf()),
             backends: Arc::new(BackendRegistry::new().with(fake.clone())),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             docker: Some(DockerConfig {
@@ -1195,6 +1194,8 @@ async fn a_kind_execute_stage_is_refused_at_submit_when_docker_is_unavailable() 
         .json(&json!({
             "command_id": ulid::Ulid::generate().to_string(),
             "intent": "must be refused before anything exists",
+            // D4: the estate this submission addresses.
+            "estate_root": estate.path(),
             "workflow": "execute-only",
             "origin": {"client": "cli", "cwd": mount},
         }))
@@ -1414,7 +1415,6 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
     let handle = daemon::start_with(
         data.path(),
         DaemonConfig {
-            estate_root: Some(estate.path().to_path_buf()),
             backends: Arc::new(BackendRegistry::new().with(fake)),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             docker: Some(DockerConfig::new(data.path())),
@@ -1431,6 +1431,8 @@ async fn mixed_actor_execute_actor_workflow_completes_with_evidence_handed_forwa
         .json(&json!({
             "command_id": ulid::Ulid::generate().to_string(),
             "intent": "prove actor -> execute -> actor",
+            // D4: the estate this submission addresses.
+            "estate_root": estate.path(),
             "workflow": "mixed-proof",
             "origin": {"client": "cli", "cwd": mount},
         }))
@@ -1667,7 +1669,6 @@ async fn cancel_of_a_dirty_multi_repo_estate_retains_a_patch_per_binding() {
     let handle = daemon::start_with(
         data.path(),
         DaemonConfig {
-            estate_root: Some(estate.path().to_path_buf()),
             backends: Arc::new(BackendRegistry::new().with(fake)),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
             ..DaemonConfig::default()
@@ -1683,6 +1684,8 @@ async fn cancel_of_a_dirty_multi_repo_estate_retains_a_patch_per_binding() {
         .json(&json!({
             "command_id": ulid::Ulid::generate().to_string(),
             "intent": "dirty two worktrees at once",
+            // D4: the estate this submission addresses.
+            "estate_root": estate.path(),
             "workflow": "tiny",
             "origin": {"client": "cli", "cwd": estate.path()},
             "scope": {"all": true},

--- a/tests/opencode_routing.rs
+++ b/tests/opencode_routing.rs
@@ -77,7 +77,7 @@ fn estate_with_manifest(root: &Path, manifest: &str, repos: &[&str]) {
 
 /// Start a daemon with one scripted fake (the global default) and opencode
 /// registered for real, but deterministically unavailable.
-async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
+async fn start(data_dir: &Path, _estate_root: &Path, global_default: Option<&str>) -> DaemonHandle {
     daemon::start_with(
         data_dir,
         DaemonConfig {
@@ -86,7 +86,6 @@ async fn start(data_dir: &Path, estate_root: &Path, global_default: Option<&str>
             ),
             default_backend: global_default.map(str::to_string),
             opencode: Some(deterministic_opencode_config(data_dir)),
-            estate_root: Some(estate_root.to_path_buf()),
             ..DaemonConfig::default()
         },
     )
@@ -136,6 +135,9 @@ async fn submit(
     let mut body = json!({
         "command_id": ulid(),
         "intent": "route me",
+        // D4: the estate this submission addresses (`extra` may override it,
+        // including to `null` for the no-topology cases).
+        "estate_root": cwd,
         "origin": {"client": "cli", "cwd": cwd},
     });
     if let Some(fields) = extra.as_object() {

--- a/tests/t2_workflow_catalog.rs
+++ b/tests/t2_workflow_catalog.rs
@@ -68,11 +68,10 @@ fn init_estate(path: &Path) {
     .expect("write sergeant.toml");
 }
 
-async fn start_bound(data_dir: &Path, estate_root: &Path) -> DaemonHandle {
+async fn start_bound(data_dir: &Path, _estate_root: &Path) -> DaemonHandle {
     daemon::start_with(
         data_dir,
         daemon::DaemonConfig {
-            estate_root: Some(estate_root.to_path_buf()),
             ..daemon::DaemonConfig::default()
         },
     )
@@ -169,10 +168,13 @@ async fn a_published_workflow_is_listed_fully_described() {
     let handle = start_bound(data.path(), repo.path()).await;
     let (status, body) = get_status(
         &handle,
-        &format!("/v1/workflows?cwd={}", {
+        &format!(
+            // D4: `cwd` is evidence; `estate_root` is what the catalog's
+            // estate-local half is read from, once admitted.
+            "/v1/workflows?cwd={0}&estate_root={0}",
             // Deliberately the same encoding the production client uses.
             urlencoding_stub(&repo.path().display().to_string())
-        }),
+        ),
     )
     .await;
     assert_eq!(status, reqwest::StatusCode::OK, "{body}");
@@ -270,7 +272,7 @@ async fn unindexed_directories_and_draft_rows_are_excluded() {
     let (status, body) = get_status(
         &handle,
         &format!(
-            "/v1/workflows?cwd={}",
+            "/v1/workflows?cwd={0}&estate_root={0}",
             urlencoding_stub(&repo.path().display().to_string())
         ),
     )
@@ -321,7 +323,7 @@ async fn the_route_appends_no_event() {
     let (status, _) = get_status(
         &handle,
         &format!(
-            "/v1/workflows?cwd={}",
+            "/v1/workflows?cwd={0}&estate_root={0}",
             urlencoding_stub(&repo.path().display().to_string())
         ),
     )

--- a/tests/w2_startup_cache.rs
+++ b/tests/w2_startup_cache.rs
@@ -35,14 +35,13 @@ fn daemon_started_payload(data_dir: &Path) -> Value {
 
 async fn start_and_stop(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     rebuild_cache: bool,
     segment_max_bytes: Option<u64>,
 ) {
     let handle = daemon::start_with(
         data_dir,
         DaemonConfig {
-            estate_root: Some(estate_root.to_path_buf()),
             rebuild_cache,
             segment_max_bytes,
             ..DaemonConfig::default()

--- a/tests/w3_prune_engine.rs
+++ b/tests/w3_prune_engine.rs
@@ -41,7 +41,7 @@ fn write_one_stage_workflow(root: &Path) {
 
 async fn start_with_retention(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     retention: u32,
     script: impl IntoIterator<Item = FakeStep>,
 ) -> (DaemonHandle, FakeBackend) {
@@ -52,7 +52,6 @@ async fn start_with_retention(
         DaemonConfig {
             backends: std::sync::Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(estate_root.to_path_buf()),
             // Tiny threshold: reaching many segments from a handful of Works
             // without a production-scale journal.
             segment_max_bytes: Some(256),
@@ -81,6 +80,9 @@ async fn submit(
         .json(&json!({
             "command_id": command_id,
             "intent": intent,
+            // D4: the estate this submission addresses. `cwd` stays §13.3
+            // recorded evidence, deciding nothing.
+            "estate_root": root,
             "origin": {"client": "cli", "cwd": root},
         }))
         .send()
@@ -430,7 +432,6 @@ async fn a_start_after_a_prune_with_no_cache_still_serves() {
         DaemonConfig {
             backends: std::sync::Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(root.path().to_path_buf()),
             segment_max_bytes: Some(256),
             retention: Some(RETENTION),
             ..DaemonConfig::default()

--- a/tests/w4_doctor_journal_growth.rs
+++ b/tests/w4_doctor_journal_growth.rs
@@ -54,7 +54,7 @@ fn write_one_stage_workflow(root: &Path) {
 
 async fn start_with_retention(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     retention: u32,
     script: impl IntoIterator<Item = FakeStep>,
 ) -> DaemonHandle {
@@ -65,7 +65,6 @@ async fn start_with_retention(
         DaemonConfig {
             backends: Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(estate_root.to_path_buf()),
             segment_max_bytes: Some(256),
             retention: Some(retention),
             ..DaemonConfig::default()
@@ -88,6 +87,8 @@ async fn submit(
         .json(&json!({
             "command_id": command_id,
             "intent": intent,
+            // D4: the estate this submission addresses.
+            "estate_root": root,
             "origin": {"client": "cli", "cwd": root},
         }))
         .send()

--- a/tests/w4_read_surfaces.rs
+++ b/tests/w4_read_surfaces.rs
@@ -66,7 +66,7 @@ async fn start(dir: &Path) -> DaemonHandle {
 /// `tests/w3_prune_engine.rs::start_with_retention` uses.
 async fn start_with_retention(
     data_dir: &Path,
-    estate_root: &Path,
+    _estate_root: &Path,
     retention: u32,
     script: impl IntoIterator<Item = FakeStep>,
 ) -> DaemonHandle {
@@ -77,7 +77,6 @@ async fn start_with_retention(
         DaemonConfig {
             backends: Arc::new(registry),
             default_backend: Some(FAKE_BACKEND_NAME.to_string()),
-            estate_root: Some(estate_root.to_path_buf()),
             segment_max_bytes: Some(256),
             retention: Some(retention),
             ..DaemonConfig::default()
@@ -100,6 +99,9 @@ async fn submit(
         .json(&json!({
             "command_id": command_id,
             "intent": intent,
+            // D4: the estate this submission addresses. `cwd` stays §13.3
+            // recorded evidence, deciding nothing.
+            "estate_root": root,
             "origin": {"client": "cli", "cwd": root},
         }))
         .send()


### PR DESCRIPTION
Wave W2 of sprint S1 (Host runtime): decisions D3/D4/D5/D10 per the workspace sprint plan. 7 commits + 1 rebase-conflict resolution.

- Host runtime root real: lock/journal/projections/blob/descriptor at the host root; estate admission moves out of startup (a zero-estate daemon is the normal state); `refuse_if_unreliable` per root.
- Descriptor v3 (`sergeant.runtime/v3`, no estate fields); v2 refuses via the existing fail-closed schema path.
- Observational admitted-estate registry (lazy `Estate::admit` on first contact, revalidation before resumed mutation, named per-estate refusal taxonomy); `GET /v1/estates`.
- Wire estate addressing (`estate_root` on SubmitRequest/estate-CRUD/doctor/EventsQuery); handlers resolve the requested estate, not a bound one; SSE gains a server-side estate filter.
- Engine per-call estate (D10): `estate_root` field and `with_estate_root` deleted; recovery resolves each Work's estate from its journaled `workspace_id` and fails closed to `blocked` when an estate no longer validates (two-estate recovery trap test included).
- `t7` rewritten as the H1 pair: second **estate** admitted into the running daemon; second **process** still fails closed on the host lock. Two-estate fixtures added; single-estate suites stay green.
- `daemon stop` names its blast radius. §26 exactly-once replay checks outrank admission (J5-over-J4 correctness fix found in self-review, with a journal-truncation-window repro test).

Gates: blind 4-axis panel + refuters — zero confirmed findings. Full-suite failures investigated to ground: a controlled A/B against the pre-rebase commit (alternated runs, quiet + synthetic load) proves the real-spawn failures are the pre-existing #293 startup-latency defect (measured: ~6.4s serial pre-descriptor backend probing vs a 10s client budget), identical on both builds — no regression from this wave. Fix lands as the next wave (W2fix) per the sprint plan. CI (no backend CLIs) is decisive here.

Rungs: J3 (sprint plan D3/D4/D5/D10), J5-over-J4 for the §26 ordering, R2 throughout (descriptor schema path, admission taxonomy on Estate::admit, existing lock/journal machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4