### PR TITLE
S1/W3: client surface — host-daemon discovery, host-scoped verb bucket, watch estate scoping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,15 @@ Sergeant does not search parent directories for an estate and does not
 fall back to a plain Git checkout; every estate-scoped command refuses
 outright anywhere else, before daemon contact, naming the same remedy:
 `cd` to the estate root, `sgt -C <estate-root>` to name it without moving,
-or `sgt init` if this directory should become one. Only `sgt --help`,
-`--version`, `sgt init`, and `sgt doctor` work outside an estate at all.
+or `sgt init` if this directory should become one. `sgt --help`,
+`--version`, `sgt init`, `sgt doctor`, and the host-scoped bucket — `sgt
+tui`, `sgt status`, `sgt work show`/`list`/`transcript`, `sgt watch`, and
+every `sgt daemon` verb — all work outside an estate too: the daemon they
+reach is host-scoped (one process serving every estate ever admitted to
+it), so none of them needs a root to find it. `sgt watch` still consults
+`-C`/cwd opportunistically — inside a valid estate root it defaults to
+that estate's events, `--all` or a non-estate cwd watches every admitted
+estate. Nothing else works outside an estate at all.
 
 ## Estate and Git model
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,19 +2,26 @@
 
 The executable command graph is authoritative. Run `sgt --help` and `sgt <command> --help` for exact arguments, defaults, and closed vocabularies.
 
-Global options are `-C <ESTATE_ROOT>`, `--data-dir <PATH>`, and `--json`. Only help/version, `init`, and `doctor` are valid outside an estate. Harness launchers exec the native harness; estate client commands use the estate daemon and may auto-start it according to their help contract.
+Global options are `-C <ESTATE_ROOT>`, `--data-dir <PATH>`, and `--json`. A daemon is host-scoped (one long-lived process serving every estate ever admitted to it) — `sgt` verbs split into three sets accordingly:
 
-| Family | Purpose |
-|---|---|
-| `daemon` | run in the foreground, stop, or rebuild daemon state |
-| `status`, `doctor`, `tui` | health and human operation |
-| `init`, `repo`, `group` | estate topology |
-| `workflow` | fork a stock package into a local, editable copy |
-| `run` | submit accepted intent and scope |
-| `work` | list, show, transcript, retained-state, reap, and sweep operations |
-| `respond`, `retry`, `extend`, `cancel` | legal Work transitions |
-| `watch` | blocking attention/terminal notifications |
-| `analytics` | query operational projections |
-| `claude`, `codex`, `opencode`, `goose`, `agy` | launch Captain harnesses |
+- **Unscoped** — `--help`, `--version`, `init`, `doctor` — valid anywhere, touch no daemon.
+- **Host-scoped** — `tui`, `status`, `work show`/`list`/`transcript`, `watch`, and every `daemon` verb (foreground start, `stop`, `install-service`) — valid from any directory, no estate root required. `sgt watch` still consults `-C`/cwd opportunistically: inside a valid estate root it defaults to that estate's events; `--all`, or a cwd that is not one, watches every estate the daemon has admitted.
+- **Estate-scoped** — everything else (`run`, `repo`, `group`, `workflow`, `respond`, `retry`, `extend`, `cancel`, `work reap`/`sweep`/`retained`, `analytics`, and the harness launchers) — requires an exact estate root (`-C <ESTATE_ROOT>` or a cwd that is one); refused outside one.
+
+Harness launchers exec the native harness; estate client commands use the host daemon and may auto-start it according to their help contract — the spawned daemon addresses no estate itself (H1: every estate it ever serves is admitted per-request, over the wire, once it is already running).
+
+| Family | Purpose | Scope |
+|---|---|---|
+| `daemon` | run in the foreground, stop, install the native service unit, or rebuild daemon state | host |
+| `status`, `tui` | health and human operation | host |
+| `doctor` | diagnose this installation | unscoped |
+| `init`, `repo`, `group` | estate topology | unscoped (`init`) / estate (`repo`, `group`) |
+| `workflow` | fork a stock package into a local, editable copy | estate |
+| `run` | submit accepted intent and scope | estate |
+| `work` | list, show, transcript, retained-state, reap, and sweep operations | host (`list`/`show`/`transcript`) / estate (`retained`, `reap`, `sweep`) |
+| `respond`, `retry`, `extend`, `cancel` | legal Work transitions | estate |
+| `watch` | blocking attention/terminal notifications | host, `-C`/cwd-scoped by default (D6) |
+| `analytics` | query operational projections | estate |
+| `claude`, `codex`, `opencode`, `goose`, `agy` | launch Captain harnesses | estate |
 
 Human errors use a nonzero exit status. Successful `--json` output is JSON; streaming surfaces use JSONL where documented. Do not assume every error shape or exit status is stable across pre-1.0 releases unless a page explicitly promises it.

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -31,6 +31,15 @@ cov_run cargo llvm-cov --no-report --test m6_surfaces --locked || cov_fail "m6_s
 cov_stage_end 2 "m6 spawns daemons (TUI, doctor) and runs scripts/demo.sh; more than the test \
 binary's own profile must arrive, or no subprocess flushed"
 
+# Added with H1 W3 (lazy admission + host-scoped verbs): every test in this
+# suite spawns a real daemon (and, for the watch tests, a second `sgt watch`
+# client left running concurrently) — it belongs beside m2/m6, not in C2's
+# no-daemon-of-its-own bucket.
+cov_stage_begin c3-w3_client_surface
+cov_run cargo llvm-cov --no-report --test w3_client_surface --locked || cov_fail "w3_client_surface failed under instrumentation"
+cov_stage_end 2 "w3_client_surface spawns a daemon (and, in the watch tests, a second sgt client) \
+in every test; more than the test binary's own profile must arrive, or no subprocess flushed"
+
 # Added 2026-08-19 alongside C2's five, closing the same accounting gap: this
 # suite existed but no stage script invoked it, so backend/docker.rs's real
 # coverage never reached the report.

--- a/skills/estate-navigation/SKILL.md
+++ b/skills/estate-navigation/SKILL.md
@@ -55,9 +55,12 @@ group", "set up this estate", "file a ticket for a missing prerequisite").
    permission mode, and — inside an estate — the manifest's own health, the
    declared workflow catalog, a cheap Git-surface summary of active and
    retained worktrees/patches and terminal-dirty Works, and disk pressure).
-   It is one of the four surfaces that work outside an estate at all
-   (`sgt --help`, `--version`, `sgt init`, `sgt doctor`), so it can also
-   answer "am I anywhere near an estate?" before anything else is tried.
+   It is one of the surfaces that work outside an estate at all
+   (`sgt --help`, `--version`, `sgt init`, `sgt doctor`, plus the
+   host-scoped bucket — `sgt status`, `sgt tui`, `sgt work show`/`list`/
+   `transcript`, `sgt watch`, every `sgt daemon` verb — H1 §5), so it can
+   also answer "am I anywhere near an estate?" before anything else is
+   tried.
 3. `sgt repo list` — every declared `[[repo]]`: name, local path, instruction
    policy, origin, and upstream.
 4. `sgt group list` — every declared `[group.<name>]` and its members, if the

--- a/skills/sergeant-help/SKILL.md
+++ b/skills/sergeant-help/SKILL.md
@@ -70,10 +70,17 @@ Every row below names a primary source that resolves inside any estate
    `run`, `work`, `respond`, `retry`, `extend`, `cancel`, `watch`,
    `analytics`, `tui`, `doctor`, `init`, `repo`, `group`. Bare `sgt` (no
    subcommand) is a homepage, not a listed subcommand (ADR 0010); the
-   embedded dashboard and its `web` verb are gone (ADR 0011). Every
-   subcommand but `init` and `doctor` is estate-scoped: run it from the
-   exact estate root, or name that root with the global `-C <estate-root>`
-   instead of `cd`-ing there — reading `--help` itself never needs either.
+   embedded dashboard and its `web` verb are gone (ADR 0011). `init` and
+   `doctor` need no estate at all; `status`, `tui`, `work show`/`list`/
+   `transcript`, `watch`, and every `daemon` verb are host-scoped (H1 §5) —
+   they reach the one host daemon from any directory, no estate root
+   required (`watch` still defaults to the addressed estate's events when
+   cwd/`-C` is one, `--all` widens it). Every other subcommand (`run`,
+   `respond`, `retry`, `extend`, `cancel`, `work reap`/`sweep`/`retained`,
+   `analytics`, `repo`, `group`, `workflow`) is estate-scoped: run it from
+   the exact estate root, or name that root with the global
+   `-C <estate-root>` instead of `cd`-ing there — reading `--help` itself
+   never needs any of this.
 5. Answer with the exact command, required preconditions, expected evidence,
    and links to repository-relative documentation paths.
 6. If sources disagree, use this precedence:
@@ -111,7 +118,7 @@ confirmation for them and the user explicitly requested them.
 |---|---|
 | Primary document missing | Report its expected path and stop before guessing. |
 | Command behavior differs from documentation | Report the mismatch, trust the measured `--help`/observed behavior, and name the stale doc as a fix candidate — don't silently paper over it. |
-| A command the user ran refused with the root gate ("no estate found in ...", or "this command must be run from the estate root") | Say plainly what the refusal means — sergeant does not search parent directories for an estate and does not fall back to a plain Git checkout — and repeat the remedy the refusal itself names: `cd <estate-root>`, `sgt -C <estate-root> <command>`, or `sgt init` if this directory should become an estate. Never suggest running the command from a parent, a `repos/<name>` mount, or a Work surface; only `sgt --help`, `--version`, `sgt init`, and `sgt doctor` work outside an estate at all. |
+| A command the user ran refused with the root gate ("no estate found in ...", or "this command must be run from the estate root") | Say plainly what the refusal means — sergeant does not search parent directories for an estate and does not fall back to a plain Git checkout — and repeat the remedy the refusal itself names: `cd <estate-root>`, `sgt -C <estate-root> <command>`, or `sgt init` if this directory should become an estate. Never suggest running the command from a parent, a `repos/<name>` mount, or a Work surface; the root gate applies only to estate-scoped commands — `sgt --help`, `--version`, `sgt init`, `sgt doctor`, and the host-scoped bucket (`sgt status`, `sgt tui`, `sgt work show`/`list`/`transcript`, `sgt watch`, every `sgt daemon` verb) all work outside an estate too. |
 | A submission was refused by the Git preflight (a dirty or detached `repos/<name>` mount) | Report the mount's own named remedy verbatim — commit or stash it (`git -C <mount> status`), or check it out onto the intended branch (`git -C <mount> switch <branch>`). Name `--override-git-preflight` only as what it is: a per-submission waiver of a dirty or detached mount and nothing else, basing the Work on the committed HEAD; it is unavailable when the mount has no commit to pin, and it never waives any other preflight finding. |
 | Question actually requires estate/repo state | Load `estate-navigation` (`sgt repo list`, `sgt doctor`) rather than answering from memory. |
 | Question actually requires submitting or mutating work | Hand off per `AGENTS.md`'s routing table / `sgt run`; this skill stays strictly read-only. |

--- a/src/api.rs
+++ b/src/api.rs
@@ -4931,18 +4931,35 @@ impl ApiClient {
         self.get("/v1/estates").await
     }
 
-    /// Open the SSE live tail at `GET /v1/events/stream?from=N`.
+    /// Open the SSE live tail at
+    /// `GET /v1/events/stream?from=N[&estate_root=R]`.
+    ///
+    /// `estate_root` (H1 sprint-plan D4/D6) is a parameter of this call, not
+    /// of the client itself: `sgt watch`'s filter (`WatchOptions`,
+    /// `src/watch.rs`) is a separate decision from what estate this client
+    /// otherwise addresses (`Self::with_estate_root`) — `--all` must be able
+    /// to ask for every estate's events even from a client that *does*
+    /// address one for its other requests. `None` is host-wide: every
+    /// admitted estate's events, unfiltered.
     ///
     /// A separate reqwest client is built with no total timeout: the response
     /// body of a live tail is *supposed* to stay open, and the per-request
     /// timeout that keeps a stuck command honest would kill it on schedule.
-    pub async fn stream_events(&self, from: u64) -> Result<EventStream, ClientError> {
+    pub async fn stream_events(
+        &self,
+        from: u64,
+        estate_root: Option<&std::path::Path>,
+    ) -> Result<EventStream, ClientError> {
         let http = reqwest::Client::builder().build()?;
-        let response = http
-            .get(format!("{}/v1/events/stream?from={from}", self.endpoint))
-            .bearer_auth(&self.token)
-            .send()
-            .await?;
+        let url = match estate_root {
+            Some(root) => format!(
+                "{}/v1/events/stream?from={from}&estate_root={}",
+                self.endpoint,
+                urlencode(&root.to_string_lossy())
+            ),
+            None => format!("{}/v1/events/stream?from={from}", self.endpoint),
+        };
+        let response = http.get(url).bearer_auth(&self.token).send().await?;
         let status = response.status();
         if !status.is_success() {
             let body: Value = response.json().await.unwrap_or(Value::Null);
@@ -5454,7 +5471,7 @@ mod tests {
 
         let client = ApiClient::new(&format!("http://{addr}"), "unused-token").expect("client");
         let mut stream = client
-            .stream_events(0)
+            .stream_events(0, None)
             .await
             .expect("connect to the stand-in server");
         let outcome = stream.next_event().await;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -249,6 +249,15 @@ enum Command {
         /// one-shot mode and re-arms.
         #[arg(long)]
         follow: bool,
+        /// D6: watch every admitted estate's events, even when the current
+        /// directory (or `-C`) happens to be a valid estate root. Without
+        /// this, `sgt watch` inside an estate defaults to that estate's
+        /// events only (estate-wide meaning preserved) — the same default
+        /// this verb has always had, now made explicit rather than implicit
+        /// in a single-estate daemon's binding. Outside any estate root the
+        /// watch is already host-wide with no flag needed.
+        #[arg(long)]
+        all: bool,
     },
     /// Ask the daemon one of the canned §22 analytical questions.
     ///
@@ -821,15 +830,57 @@ fn resolve_host_runtime_dir(
         .map_err(CliError::new)
 }
 
-/// §4.2: which commands require an exact estate root, and which are
-/// deliberately usable outside one.
+/// §4.2/H1 §5: which commands require an exact estate root before any
+/// daemon contact is even attempted, and which are deliberately usable
+/// outside one.
 ///
-/// Estate-scoped: `run`, `status`, `work *`, `respond`/`retry`/`extend`/
-/// `cancel`, `watch`, `analytics`, `tui`, `daemon`(+`stop`), `repo *`,
-/// `group *`, `workflow *`, and the five harnesses. Unscoped: bare `sgt`,
-/// `--help`, `--version`, `init`, `doctor` — nothing else.
+/// Estate-scoped: `run`, `respond`/`retry`/`extend`/`cancel`,
+/// `work reap`/`sweep`/`retained`, `analytics`, `repo *`, `group *`,
+/// `workflow *`, and the five harnesses — H1 §11.3, preserved verbatim
+/// (brief deliverable 2). Unscoped: bare `sgt`, `--help`, `--version`,
+/// `init`, `doctor`. **Host-scoped** ([`is_host_scoped`]) is the third
+/// bucket H1 §5 adds: `tui`, `status`, `work show`/`list`/`transcript`,
+/// `watch`, and every `daemon` verb — no estate root is required, but one
+/// addressed via `-C`/cwd is still validated where the command actually
+/// consults it (`watch`'s D6 default, `daemon stop`'s ordinary directory
+/// check).
 fn is_estate_scoped(command: &Command) -> bool {
-    !matches!(command, Command::Doctor | Command::Init { .. })
+    !matches!(command, Command::Doctor | Command::Init { .. }) && !is_host_scoped(command)
+}
+
+/// H1 §5's host-scoped bucket (brief deliverable 2): exactly the existing
+/// no-spawn set (ADR 0009) plus the two `daemon` variants that never
+/// consulted an estate to begin with — `sgt daemon` (foreground) serves
+/// every estate admitted to it later, and `sgt daemon install-service`
+/// touches no daemon and no estate at all. `-C`/cwd is never *required* for
+/// any of these; [`dispatch`] never calls [`admit_root`] on their account,
+/// so a directory mistake here is not a root-gate refusal — it is simply
+/// not consulted.
+fn is_host_scoped(command: &Command) -> bool {
+    matches!(
+        command,
+        Command::Tui
+            | Command::Status
+            | Command::Watch { .. }
+            | Command::Work {
+                command: WorkCommand::List
+            }
+            | Command::Work {
+                command: WorkCommand::Show { .. }
+            }
+            | Command::Work {
+                command: WorkCommand::Transcript { .. }
+            }
+            | Command::Daemon { command: None, .. }
+            | Command::Daemon {
+                command: Some(DaemonCommand::Stop),
+                ..
+            }
+            | Command::Daemon {
+                command: Some(DaemonCommand::InstallService { .. }),
+                ..
+            }
+    )
 }
 
 async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
@@ -857,24 +908,25 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
         sgt.data_dir.clone(),
         estate.as_ref().map(|e| e.path.as_path()).unwrap_or(&root),
     )?;
-    // W1b's caller classification, W2 consuming the first of it. The HOST
-    // bucket — daemon discovery/spawn/stop and `exec_harness`'s adapter
-    // state — is what `resolve_host_runtime_dir` is for; the ESTATE bucket
-    // (`doctor::run`'s journal-replay-derived checks) keeps
-    // `resolve_data_dir`.
+    // W1b's caller classification, W2/W3 consuming it fully. The HOST bucket
+    // — daemon discovery/spawn/stop and the foreground daemon start that
+    // creates the runtime root — is what `resolve_host_runtime_dir` is for;
+    // the ESTATE bucket (`doctor::run`'s journal-replay-derived checks,
+    // `exec_harness`'s adapter state) keeps `resolve_data_dir`.
     //
-    // **This wave wires exactly one caller: the foreground daemon**, which
-    // is the one that actually *creates* the runtime root and therefore the
-    // one that has to name it correctly for `daemon.lock`, the journal, the
-    // blob store and the descriptor to live where D2 says. The client-side
-    // discovery/spawn callers (`ensure_daemon`/`observe_connect`/
-    // `daemon_stop`/`spawn_daemon`) are W3's, per this wave's brief, and
-    // still resolve as they did — which stays consistent because
-    // `spawn_daemon` passes `--data-dir` explicitly, so the child it starts
-    // takes the flag rung and lands in the same directory its parent looked
-    // in. The two ladders only diverge for a `sgt daemon` typed by hand with
-    // no flag and no `SGT_DATA_DIR`, which is exactly the case that *should*
-    // now be the host root.
+    // **W3 wires every remaining client-side daemon-contact caller onto the
+    // host root**: `ensure_daemon`/`observe_connect`/`daemon_stop` (and
+    // through it, `spawn_daemon`) all take `host_root` below, never the
+    // estate-derived `data_dir` above — brief deliverable 1's whole point
+    // is that a second estate's client must discover the *same* running
+    // daemon a first estate's client found, which is only true once both
+    // resolve to one path regardless of which estate admitted them. This
+    // stays consistent with `--data-dir`/`SGT_DATA_DIR` (both resolvers'
+    // top two rungs are identical, D2) and only actually diverges from the
+    // old estate-derived path for an operator who relied on neither flag
+    // nor env — exactly the case D2 moves to the host runtime root.
+    let (host_root, _host_root_source) =
+        resolve_host_runtime_dir(data_dir_flag.clone(), |name| std::env::var_os(name))?;
     match command {
         Command::Daemon {
             command: None,
@@ -885,9 +937,9 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // convention, with no estate rung at all. `-C` on this verb
             // named the estate this invocation addresses; it does not bind
             // the process (deliverable 8), and the daemon it starts serves
-            // every estate admitted to it later.
-            let (host_root, _) =
-                resolve_host_runtime_dir(sgt.data_dir.clone(), |name| std::env::var_os(name))?;
+            // every estate admitted to it later. Host-scoped
+            // ([`is_host_scoped`]): no root was admitted above, so this
+            // never required one to begin with.
             daemon::run_until_signal(&host_root, rebuild_cache).await?;
             Ok(())
         }
@@ -905,7 +957,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                      `sgt daemon stop` does not start a daemon",
                 ));
             }
-            daemon_stop(&data_dir, &estate_root(&estate), sgt.json).await
+            daemon_stop(&host_root, estate_root_opt(&estate), sgt.json).await
         }
         Command::Daemon {
             command: Some(DaemonCommand::InstallService { print }),
@@ -920,7 +972,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             install_service(data_dir_flag, print, sgt.json)
         }
         Command::Status => {
-            let client = observe_connect(&data_dir, &estate_root(&estate)).await?;
+            let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
             let system = client.get("/v1/system").await?;
             let works = client.get("/v1/work").await?;
             let mut counts = std::collections::BTreeMap::<String, u64>::new();
@@ -1019,7 +1071,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                     ));
                 }
             };
-            let client = ensure_daemon(&data_dir, &estate_root(&estate)).await?;
+            let client = ensure_daemon(&host_root, &estate_root(&estate)).await?;
             let envelope = if turns.is_some() || ceiling_secs.is_some() {
                 Some(json!({"turn_cap": turns, "ceiling_secs": ceiling_secs}))
             } else {
@@ -1057,7 +1109,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             Ok(())
         }
         Command::Respond { id, input } => {
-            let client = ensure_daemon(&data_dir, &estate_root(&estate)).await?;
+            let client = ensure_daemon(&host_root, &estate_root(&estate)).await?;
             let body = json!({
                 "command_id": ulid::Ulid::generate().to_string(),
                 "input": input,
@@ -1071,7 +1123,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             Ok(())
         }
         Command::Retry { id } => {
-            let client = ensure_daemon(&data_dir, &estate_root(&estate)).await?;
+            let client = ensure_daemon(&host_root, &estate_root(&estate)).await?;
             let body = json!({"command_id": ulid::Ulid::generate().to_string()});
             let result = client.post(&format!("/v1/work/{id}/retry"), &body).await?;
             if sgt.json {
@@ -1085,7 +1137,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             id,
             additional_turns,
         } => {
-            let client = ensure_daemon(&data_dir, &estate_root(&estate)).await?;
+            let client = ensure_daemon(&host_root, &estate_root(&estate)).await?;
             let body = json!({
                 "command_id": ulid::Ulid::generate().to_string(),
                 "additional_turns": additional_turns,
@@ -1109,7 +1161,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // `retained` (ADR 0009: observation must not materialize the
             // thing observed) rather than auto-spawning a daemon.
             if !yes {
-                let client = observe_connect(&data_dir, &estate_root(&estate)).await?;
+                let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
                 let retained = client.retained().await?;
                 let mine: Vec<&Value> = retained["retained"]
                     .as_array()
@@ -1136,7 +1188,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                 }
                 return Ok(());
             }
-            let client = ensure_daemon(&data_dir, &estate_root(&estate)).await?;
+            let client = ensure_daemon(&host_root, &estate_root(&estate)).await?;
             let result = client.reap(&id, true).await?;
             if sgt.json {
                 print_json(&result);
@@ -1157,9 +1209,9 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // observed). Only the confirmed deletion joins `reap`'s bucket
             // and may spawn a daemon.
             let client = if delete_redundant && yes {
-                ensure_daemon(&data_dir, &estate_root(&estate)).await?
+                ensure_daemon(&host_root, &estate_root(&estate)).await?
             } else {
-                observe_connect(&data_dir, &estate_root(&estate)).await?
+                observe_connect(&host_root, estate_root_opt(&estate)).await?
             };
             let report = client.sweep().await?;
             if !delete_redundant {
@@ -1206,7 +1258,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             Ok(())
         }
         Command::Work { command } => {
-            let client = observe_connect(&data_dir, &estate_root(&estate)).await?;
+            let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
             match command {
                 WorkCommand::List => {
                     let result = client.get("/v1/work").await?;
@@ -1315,7 +1367,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             }
         }
         Command::Analytics { name } => {
-            let client = observe_connect(&data_dir, &estate_root(&estate)).await?;
+            let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
             let result = match &name {
                 Some(name) => client.get(&format!("/v1/analytics/{name}")).await?,
                 None => client.get("/v1/analytics").await?,
@@ -1330,7 +1382,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             Ok(())
         }
         Command::Cancel { id } => {
-            let client = ensure_daemon(&data_dir, &estate_root(&estate)).await?;
+            let client = ensure_daemon(&host_root, &estate_root(&estate)).await?;
             let body = json!({"command_id": ulid::Ulid::generate().to_string()});
             let result = client.post(&format!("/v1/work/{id}/cancel"), &body).await?;
             if sgt.json {
@@ -1344,13 +1396,29 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             }
             Ok(())
         }
-        Command::Watch { id, follow } => {
+        Command::Watch { id, follow, all } => {
             // R-WATCH-3 / ADR 0009: never `ensure_daemon` — this verb
-            // refuses rather than spawns.
-            let client = observe_connect(&data_dir, &estate_root(&estate)).await?;
+            // refuses rather than spawns. Host-scoped (H1 §5): connection
+            // itself never requires or addresses an estate — `estate` is
+            // always `None` here (`is_host_scoped`).
+            let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
+            // D6, brief deliverable 3: cwd is consulted **only** to default
+            // the watch filter, never to gate the connection above (H1 §5's
+            // "opportunistic filter" — the one case this wave itself owns,
+            // distinct from the TUI's own screens, W4d). `--all` always
+            // wins; otherwise an exact-root cwd/`-C` scopes the watch to
+            // that one estate, silently falling back to host-wide when it
+            // is not one — never a refusal, because this verb never
+            // required an estate to begin with.
+            let watch_estate = if all {
+                None
+            } else {
+                Estate::admit(&root).ok().map(|admitted| admitted.path)
+            };
             let options = crate::watch::WatchOptions {
                 work_id: id,
                 follow,
+                estate_root: watch_estate,
             };
             let json = sgt.json;
             crate::watch::watch(&client, &options, |notice| {
@@ -1373,7 +1441,7 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // ADR 0009/0010: the TUI never auto-spawns — it is in the
             // no-spawn set like every other observation surface, and bare
             // `sgt` no longer falls into it by default.
-            let client = observe_connect(&data_dir, &estate_root(&estate)).await?;
+            let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
             crate::tui::run(client).await.map_err(CliError::from)
         }
         Command::Doctor => {
@@ -1586,6 +1654,20 @@ fn estate_root(estate: &Option<EstateRoot>) -> PathBuf {
         .expect("dispatch admits the root for every estate-scoped command")
         .path
         .clone()
+}
+
+/// The addressed root, for [`observe_connect`]/[`daemon_stop`] call sites
+/// shared by the estate-scoped and host-scoped buckets (H1 §5, brief
+/// deliverable 2).
+///
+/// Never panics, unlike [`estate_root`]: `estate` is `Some` exactly when
+/// [`dispatch`] admitted a root ([`is_estate_scoped`] answered `true`), and
+/// `None` exactly when the command is host-scoped or unscoped — which this
+/// simply forwards as the `Option` those two functions' host-scoped shape
+/// already expects, so a single call site works unchanged whichever bucket
+/// the matched command turned out to be in.
+fn estate_root_opt(estate: &Option<EstateRoot>) -> Option<&Path> {
+    estate.as_ref().map(|e| e.path.as_path())
 }
 
 /// The most an `--intent-file` may hold (#166).
@@ -2271,13 +2353,25 @@ fn print_homepage(root: &Path) {
     println!("sgt <command> --help for the full verb list");
 }
 
-/// Connect to the daemon for `data_dir`, auto-spawning one if needed.
+/// Connect to the host daemon at `data_dir` (the **host runtime root**,
+/// [`resolve_host_runtime_dir`] — never a per-estate data dir under H1),
+/// auto-spawning one if needed, then address it at `estate_root` (D4).
 ///
 /// This is the CLI's half of the client contract — descriptor discovery,
 /// staleness judgement, detached spawn — and it hands back the crate's one
 /// API client ([`ApiClient`], defined next to the router it speaks to). Only
 /// the mutating verbs (ADR 0009) come through here; every observation verb,
 /// TUI included, goes through [`observe_connect`] instead.
+///
+/// **Deliverable 1's second-estate case.** A second estate's first mutating
+/// command reaches this same function. Because `data_dir` is now the host
+/// root regardless of which estate is addressed, its descriptor read finds
+/// the *same* already-running daemon the first estate's client found —
+/// [`spawn_daemon`] is only ever reached when no host daemon answers at
+/// all, never to compete with one that already admitted a different
+/// estate. The addressed estate is validated and sent on every request
+/// (`check_binding`, `client_for`); nothing here re-spawns to "fix" a
+/// binding, because a v3 host daemon has none to fix.
 async fn ensure_daemon(data_dir: &Path, estate_root: &Path) -> Result<ApiClient, CliError> {
     let http = reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
@@ -2319,7 +2413,7 @@ async fn ensure_daemon(data_dir: &Path, estate_root: &Path) -> Result<ApiClient,
         None
     };
 
-    spawn_daemon(data_dir, estate_root)?;
+    spawn_daemon(data_dir)?;
 
     // Wait for a healthy descriptor. It may be written by our child or by a
     // concurrently racing client's child — either is fine; the daemon lock
@@ -2412,7 +2506,19 @@ fn check_binding(estate_root: &Path, operation: &str) -> Result<(), CliError> {
 /// 3. A descriptor naming a live PID that does not answer `/healthz` → the
 ///    same ambiguous, fail-closed refusal `ensure_daemon` gives, spawn
 ///    nothing.
-async fn observe_connect(data_dir: &Path, estate_root: &Path) -> Result<ApiClient, CliError> {
+///
+/// **`estate_root: None` (H1 §5, brief deliverable 2) is the host-scoped
+/// shape.** `tui`, `status`, `work show`/`list`/`transcript` and `watch`
+/// reach this with no estate at all — connection to the host daemon must
+/// succeed regardless, because none of them needs one. `check_binding` is
+/// skipped entirely rather than called with a fabricated root: there is
+/// nothing to validate when the command addressed nothing, and
+/// `check_estate_root(None, ..)` would otherwise manufacture exactly the
+/// `NoEstateAddressed` refusal a host-scoped verb must never hit.
+async fn observe_connect(
+    data_dir: &Path,
+    estate_root: Option<&Path>,
+) -> Result<ApiClient, CliError> {
     let path = daemon::descriptor_path(data_dir);
     let Some(descriptor) = daemon::read_descriptor(data_dir)? else {
         return Err(CliError::new(format!(
@@ -2423,13 +2529,16 @@ async fn observe_connect(data_dir: &Path, estate_root: &Path) -> Result<ApiClien
         )));
     };
     // D4, before the endpoint is touched at all — the same gate
-    // `ensure_daemon` applies, for the same reason.
-    check_binding(estate_root, "this command")?;
+    // `ensure_daemon` applies, for the same reason. Only when an estate was
+    // actually addressed: see the host-scoped note above.
+    if let Some(root) = estate_root {
+        check_binding(root, "this command")?;
+    }
     let http = reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
         .build()?;
     if healthz_ok(&http, &descriptor.endpoint).await {
-        return client_for(&descriptor, Some(estate_root));
+        return client_for(&descriptor, estate_root);
     }
     if daemon::pid_alive(descriptor.pid) {
         return Err(CliError::new(format!(
@@ -2473,11 +2582,24 @@ async fn healthz_ok(http: &reqwest::Client, endpoint: &str) -> bool {
     )
 }
 
-/// Spawn a detached `sgt daemon` for `data_dir`: own process group, stdio to
-/// `daemon.log` in the data dir. The child is *not* waited on — it outlives
-/// this client by design; losing the daemon-lock race makes it exit on its
-/// own.
-fn spawn_daemon(data_dir: &Path, estate_root: &Path) -> Result<(), CliError> {
+/// Spawn a detached `sgt daemon` for `data_dir` (H1: the **host runtime
+/// root**, never a per-estate data dir — see [`resolve_host_runtime_dir`]):
+/// own process group, stdio to `daemon.log` in the data dir. The child is
+/// *not* waited on — it outlives this client by design; losing the
+/// daemon-lock race makes it exit on its own.
+///
+/// **No `-C <estate_root>` scalar (H1 §4, brief deliverable 1).** Before H1
+/// the spawned daemon was bound to exactly the one estate this client had
+/// already admitted, named explicitly with `-C` because a detached child
+/// does not reliably keep the parent's cwd. A host daemon serves every
+/// estate admitted to it *later*, over the wire (D4) — baking one estate
+/// into the child's argv would make a second estate's first `sgt run`
+/// either hit this same estate's binding (wrong) or spawn a second,
+/// competing host process (exactly what H1 §2 rules out: "one long-lived
+/// daemon per Sergeant user installation"). The child therefore addresses
+/// no estate at all; every estate it ever serves is admitted per-request
+/// once it is already running.
+fn spawn_daemon(data_dir: &Path) -> Result<(), CliError> {
     std::fs::create_dir_all(data_dir)?;
     let exe = std::env::current_exe()?;
     let log = std::fs::OpenOptions::new()
@@ -2485,12 +2607,7 @@ fn spawn_daemon(data_dir: &Path, estate_root: &Path) -> Result<(), CliError> {
         .append(true)
         .open(data_dir.join("daemon.log"))?;
     let mut command = std::process::Command::new(exe);
-    // §5.1, C10: the spawned daemon is bound to the estate this client
-    // already admitted — named explicitly with `-C` rather than inherited
-    // from a cwd the detached child does not reliably keep.
     command
-        .arg("-C")
-        .arg(estate_root)
         .arg("--data-dir")
         .arg(data_dir)
         .arg("daemon")
@@ -2623,7 +2740,18 @@ const STOP_POLL: Duration = Duration::from_millis(100);
 /// Deliberately does **not** auto-spawn a daemon — asking to stop something
 /// that is not running is answered "already stopped", never "let me start
 /// one so I can stop it", mirroring `sgt doctor`'s own no-auto-spawn rule.
-async fn daemon_stop(data_dir: &Path, estate_root: &Path, json: bool) -> Result<(), CliError> {
+///
+/// `estate_root: None` (H1 §5, brief deliverable 2): `sgt daemon stop` is a
+/// host-scoped verb — it works from any cwd, because it addresses no
+/// estate at all (it stops the host daemon, D5, not "my estate's"). When
+/// `estate_root` is `Some` (cwd happened to be a valid root), it is
+/// validated the ordinary way; when it is `None`, there is nothing to
+/// validate and nothing is skipped by skipping it.
+async fn daemon_stop(
+    data_dir: &Path,
+    estate_root: Option<&Path>,
+    json: bool,
+) -> Result<(), CliError> {
     let Some(descriptor) = daemon::read_descriptor(data_dir)? else {
         report_daemon_stop(
             json,
@@ -2634,9 +2762,12 @@ async fn daemon_stop(data_dir: &Path, estate_root: &Path, json: bool) -> Result<
     };
     // D4/D5, before the endpoint is touched: `sgt daemon stop` stops the
     // *host* daemon — every admitted estate's — so the estate this
-    // invocation stands in is validated for the ordinary reason (a directory
-    // mistake must not reach a daemon), not because it owns the daemon.
-    check_binding(estate_root, "sgt daemon stop")?;
+    // invocation stands in (if any) is validated for the ordinary reason (a
+    // directory mistake must not reach a daemon), not because it owns the
+    // daemon.
+    if let Some(root) = estate_root {
+        check_binding(root, "sgt daemon stop")?;
+    }
     let http = reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
         .build()?;
@@ -2661,7 +2792,7 @@ async fn daemon_stop(data_dir: &Path, estate_root: &Path, json: bool) -> Result<
         );
         return Ok(());
     }
-    let client = client_for(&descriptor, Some(estate_root))?;
+    let client = client_for(&descriptor, estate_root)?;
 
     // 0. D5: **say what is about to stop.** `sgt daemon stop` stops the
     // *host* daemon — every admitted estate's, not just the one this

--- a/src/tui/connection.rs
+++ b/src/tui/connection.rs
@@ -129,7 +129,11 @@ pub enum Attach {
 /// caller (first attach, `r`, and the backoff loop) reacts to the outcome
 /// differently, through [`reconnected`].
 pub async fn try_attach(client: &ApiClient, from: u64) -> Attach {
-    match client.stream_events(from).await {
+    // No estate filter: the TUI's own estate-filter wiring is W4d's
+    // deliverable (H1 sprint plan), not this wave's — `sgt watch`'s D6
+    // filter (`src/watch.rs`) is the only client this wave routes onto the
+    // new `estate_root` parameter.
+    match client.stream_events(from, None).await {
         Ok(stream) => Attach::Opened(stream),
         Err(e) if is_auth_failure(&e) => Attach::AuthFailed(e.to_string()),
         Err(e) => Attach::Retry(e.to_string()),

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -23,6 +23,7 @@
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
@@ -248,13 +249,23 @@ fn normalize_whitespace(s: &str) -> String {
 // The watch loop
 // ---------------------------------------------------------------------------
 
-/// `sgt watch [WORK_ID] [--follow]`'s parsed options (proposal §13.1).
+/// `sgt watch [WORK_ID] [--follow] [--all]`'s parsed options (proposal
+/// §13.1; `estate_root` added by H1 sprint-plan D6, brief deliverable 3).
 #[derive(Debug, Clone)]
 pub struct WatchOptions {
     /// The Work to scope to, or `None` for an estate-wide watch.
     pub work_id: Option<String>,
     /// Whether to remain attached after a nonterminal match (§6.4).
     pub follow: bool,
+    /// D6: restrict the SSE stream to one estate's events, by canonical
+    /// exact root — matched server-side against each event's own
+    /// `workspace_id` coordinate (D1). `None` is host-wide: every admitted
+    /// estate's events, the only meaning this field could have before H1
+    /// (a single-estate daemon's journal held nothing else). The CLI is
+    /// what decides *which* this is for a given invocation (cwd/`-C`
+    /// default, `--all` override) — this module only carries the already-
+    /// decided filter through to the stream.
+    pub estate_root: Option<PathBuf>,
 }
 
 /// Why a completed [`watch`] call returned.
@@ -333,7 +344,13 @@ pub async fn watch(
     let head = system["journal_head"].as_u64().unwrap_or(0);
 
     // 2. Attach the stream before any Work read (§8.1 step 2, §8.2 step 2).
-    let mut stream = client.stream_events(head).await?;
+    // D6: the estate filter rides the same request as `head` — never
+    // client-side post-filtering, which would require every event to carry
+    // an estate coordinate the pre-envelope journal does not (recon-api-
+    // clients touch point 6).
+    let mut stream = client
+        .stream_events(head, options.estate_root.as_deref())
+        .await?;
 
     // R-WATCH-6's test-only rendezvous — zero-cost no-op unless the test
     // process set SGT_WATCH_TEST_HOLD.

--- a/tests/f_doctrine_skew.rs
+++ b/tests/f_doctrine_skew.rs
@@ -61,10 +61,11 @@ fn bare_dir() -> tempfile::TempDir {
     tempfile::TempDir::new().expect("bare temp dir")
 }
 
-/// AGENTS.md's "Session start" section names exactly the unscoped command
-/// set `is_estate_scoped` (`src/cli.rs`) computes, and the real refusal an
-/// estate-scoped command gives outside an estate carries the exact wording
-/// AGENTS.md quotes for it.
+/// AGENTS.md's "Session start" section names exactly the unscoped-plus-
+/// host-scoped command set `is_estate_scoped`/`is_host_scoped`
+/// (`src/cli.rs`) compute, and the real refusal an estate-scoped command
+/// gives outside an estate carries the exact wording AGENTS.md quotes for
+/// it.
 #[test]
 fn agents_md_session_start_matches_the_real_root_gate() {
     let agents_md = std::fs::read_to_string(repo_root().join("AGENTS.md")).expect("read AGENTS.md");
@@ -73,16 +74,18 @@ fn agents_md_session_start_matches_the_real_root_gate() {
     // its logical text rather than its accidental line layout.
     let agents_md_flat = agents_md.split_whitespace().collect::<Vec<_>>().join(" ");
 
-    // The claim, quoted verbatim from `is_estate_scoped`'s own doc comment
-    // ("Unscoped: bare `sgt`, `--help`, `--version`, `init`, `doctor` —
-    // nothing else") in AGENTS.md's own voice.
+    // The claim, quoted verbatim from `is_estate_scoped`/`is_host_scoped`'s
+    // own doc comments (H1 sprint plan, W3 brief deliverable 2) in
+    // AGENTS.md's own voice.
     assert!(
         agents_md_flat.contains(
-            "Only `sgt --help`, `--version`, `sgt init`, and `sgt doctor` work outside an \
-             estate at all."
+            "`sgt --help`, `--version`, `sgt init`, `sgt doctor`, and the host-scoped bucket \
+             — `sgt tui`, `sgt status`, `sgt work show`/`list`/`transcript`, `sgt watch`, and \
+             every `sgt daemon` verb — all work outside an estate too"
         ),
-        "AGENTS.md's Session start section no longer states the unscoped command set — \
-         update this test and the claim together, from `is_estate_scoped`'s own doc comment"
+        "AGENTS.md's Session start section no longer states the unscoped-plus-host-scoped \
+         command set — update this test and the claim together, from is_estate_scoped's and \
+         is_host_scoped's own doc comments"
     );
 
     // The refusal wording AGENTS.md quotes must be the real one
@@ -95,8 +98,8 @@ fn agents_md_session_start_matches_the_real_root_gate() {
 
     let dir = bare_dir();
 
-    // The four commands AGENTS.md claims work outside an estate must
-    // actually run there — none of them the root-gate refusal.
+    // The four fully unscoped commands AGENTS.md claims work outside an
+    // estate must actually run there — none of them the root-gate refusal.
     for args in [
         vec!["--help"],
         vec!["--version"],
@@ -112,16 +115,48 @@ fn agents_md_session_start_matches_the_real_root_gate() {
     }
 
     // `sgt init` above already turned `dir` into an estate — re-run the
-    // refusal checks from a second, still-bare directory so they test the
+    // remaining checks from a second, still-bare directory so they test the
     // "no estate at all" case, not "estate exists but I'm not at its root".
+    // `--data-dir` names a fresh, guaranteed-empty directory for every host-
+    // scoped invocation below: none of them may hit the root gate, but
+    // without an isolated data dir they could instead attach to whatever
+    // real host daemon this machine happens to be running — the wrong
+    // failure mode for a test that means to pin "no root gate", not "no
+    // daemon either".
     let refused = bare_dir();
-    for args in [
-        vec!["status"],
-        vec!["work", "list"],
-        vec!["watch"],
-        vec!["analytics"],
-        vec!["repo", "list"],
-    ] {
+
+    // H1 §5 / brief deliverable 2: the host-scoped bucket. Each of these
+    // must reach past the root gate — refusing, if at all, only on "no
+    // daemon is running", never on "does not search parent directories".
+    for args in [vec!["status"], vec!["work", "list"], vec!["watch"]] {
+        let host_data_dir = bare_dir();
+        let mut full = vec![
+            "--data-dir".to_string(),
+            host_data_dir.path().display().to_string(),
+        ];
+        full.extend(args.iter().map(|s| s.to_string()));
+        let full: Vec<&str> = full.iter().map(String::as_str).collect();
+        let output = run(refused.path(), &full);
+        assert!(
+            !output.status.success(),
+            "{args:?} must refuse (no daemon at a fresh data dir): {}",
+            stderr(&output)
+        );
+        assert!(
+            !stderr(&output).contains("does not search parent directories for an estate"),
+            "{args:?} is host-scoped and must never hit the root gate outside an estate: {}",
+            stderr(&output)
+        );
+        assert!(
+            stderr(&output).contains("no daemon is running for"),
+            "{args:?} must refuse for the host-scoped reason (no daemon), not something else: {}",
+            stderr(&output)
+        );
+    }
+
+    // Estate-scoped verbs (H1 §11.3, unchanged) still refuse with the
+    // root-gate diagnostic AGENTS.md quotes.
+    for args in [vec!["analytics"], vec!["repo", "list"]] {
         let output = run(refused.path(), &args);
         assert!(
             !output.status.success(),
@@ -176,9 +211,13 @@ fn embedded_skills_carry_the_real_root_and_preflight_remedies() {
             .expect("read skills/estate-navigation/SKILL.md");
 
     // 1. The root-gate refusal a real estate-scoped command gives outside an
-    //    estate — every remedy it names must be one `sergeant-help` names too.
+    //    estate — every remedy it names must be one `sergeant-help` names
+    //    too. `analytics`, not `status`: H1 (sprint plan D6, brief
+    //    deliverable 2) moved `status` into the host-scoped bucket, so it no
+    //    longer hits this gate at all — `analytics` stays estate-scoped
+    //    (H1 §11.3).
     let refused = bare_dir();
-    let refusal = stderr(&run(refused.path(), &["status"]));
+    let refusal = stderr(&run(refused.path(), &["analytics"]));
     for quoted in [
         "no estate found in",
         "does not search parent directories",

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -424,7 +424,7 @@ async fn t1_the_tui_renders_and_drives_the_fleet_over_the_api() {
 
     // --- an SSE event drives a re-render ------------------------------------
     let mut stream = client
-        .stream_events(app.last_seq)
+        .stream_events(app.last_seq, None)
         .await
         .expect("live tail attaches");
     let fresh = submit(

--- a/tests/m9_watch.rs
+++ b/tests/m9_watch.rs
@@ -12,11 +12,20 @@
 //! test.
 //!
 //! **Every invocation in this suite runs from an estate root** (estate-root
-//! §4.1/§4.2). `watch`, `run`, `respond`, `cancel`, `work show` and `daemon`
-//! are all estate-scoped, and §4.3 puts the exact-root check ahead of
-//! descriptor lookup — so a test whose cwd is merely a git repository no
-//! longer reaches the behavior it means to pin at all; it collects §4.4's
-//! refusal instead. The fixtures are therefore [`support::scaffold_estate`]
+//! §4.1/§4.2), even though H1 (sprint-plan D6, brief deliverable 2) moved
+//! `watch` and `work show` into the host-scoped bucket alongside `daemon
+//! stop` — none of the three requires one any more
+//! (`r_watch_3_watch_against_a_dataless_dir_refuses_and_spawns_nothing`
+//! pins that directly). `run`/`respond`/`cancel` stay estate-scoped
+//! (H1 §11.3), and §4.3 puts their exact-root check ahead of descriptor
+//! lookup — so a test of *those* verbs whose cwd is merely a git repository
+//! no longer reaches the behavior it means to pin; it collects §4.4's
+//! refusal instead. Running host-scoped verbs from an estate root anyway is
+//! not wrong, just no longer required — cwd is still meaningful for
+//! `watch`'s own D6 default (an estate-wide watch inside an estate stays
+//! scoped to it, `--all` widens it), which is exactly why this suite keeps
+//! its estates rather than switching to bare directories. The fixtures are
+//! therefore [`support::scaffold_estate`]
 //! estates with derived `repos/<name>` mounts (§6.1), never bare
 //! `init_repo`'d temp dirs, and the daemon a `run` auto-spawns is bound to
 //! that one estate (§5.1) — which is why the scenarios below that need two
@@ -111,13 +120,16 @@ impl Output {
 /// work submitted, no state transitions to race a freshly attached watch
 /// against) has to start it this way instead.
 ///
-/// `-C <estate>` is what binds it (§5.1): `sgt daemon` is itself
-/// estate-scoped, and a daemon started with no estate would plan against
-/// nothing — but more to the point here, the client that later attaches
-/// checks `descriptor.estate_root` against its own resolved root, so a
-/// daemon bound to a different estate (or to none) is refused rather than
-/// used. `-C` names it explicitly instead of relying on this child's cwd,
-/// exactly as `spawn_daemon` in `src/cli.rs` does.
+/// **`-C <estate>` is now purely informational (H1, `is_host_scoped`).**
+/// Before H1 this named the one estate the daemon would ever serve, and a
+/// later client's own resolved root was checked against exactly that
+/// binding. A v3 descriptor carries no estate at all (D3): every estate a
+/// daemon started this way ever serves is admitted per-request, over the
+/// wire, the first time a client addresses it — `-C` here does nothing a
+/// bare `sgt daemon --data-dir <dir> daemon` would not also do. It is kept
+/// only because several call sites below reuse `estate` for the `sgt`
+/// helper's own admitted-root arguments elsewhere in this file, not because
+/// this spawn needs it.
 ///
 /// `DataDir`'s own Drop reaps this by /proc scan (SIGTERM, then SIGKILL) —
 /// never by waiting on this `Child`.
@@ -983,17 +995,23 @@ fn r_watch_2_a_repeated_identical_question_does_not_re_emit() {
 // ---------------------------------------------------------------------------
 
 /// R-WATCH-3: inverse of `m2_daemon_api.rs`'s
-/// `t7_cli_end_to_end_auto_spawn_and_second_daemon_fails_closed` — a data
-/// dir with zero daemons gets a refusal naming the remedy, exit nonzero, and
-/// the process table proves nothing was spawned.
+/// `t7_cli_end_to_end_a_second_estate_is_admitted_and_a_second_process_fails_closed`
+/// — a data dir with zero daemons gets a refusal naming the remedy, exit
+/// nonzero, and the process table proves nothing was spawned.
 ///
-/// Both refusal *causes* are pinned here, because §4.3 reorders them and the
-/// no-spawn promise has to survive either one. From a valid estate root the
-/// refusal is still `observe_connect`'s: there is no descriptor, and an
-/// observation verb declines to make one. From a directory that is not an
-/// estate root the refusal comes even earlier — root admission precedes
-/// descriptor lookup, so `sgt watch` never even learns whether a daemon
-/// exists — and the process table must be just as empty afterward.
+/// **Re-scoped for H1 (sprint-plan D6, brief deliverable 2): `watch` moved
+/// into the host-scoped bucket.** Before H1 this pinned *two different*
+/// refusal causes at two different gates — root admission (§4.3, before any
+/// descriptor lookup) from a non-estate directory, and `observe_connect`'s
+/// own "no daemon" from a valid one — because `watch` required an exact
+/// estate root to even attempt daemon discovery. `is_host_scoped` retires
+/// that requirement for exactly this verb: `sgt watch` never admits a root
+/// at all now, so both directories below reach the *same* gate
+/// (`observe_connect`) and the *same* refusal. What survives unchanged is
+/// the property this test actually exists to prove — the no-spawn
+/// guarantee — and it is stronger evidence of it than before: two cwds that
+/// used to fail closed for two unrelated reasons now fail closed for the
+/// identical one, which is what "host-scoped, no estate required" means.
 #[test]
 fn r_watch_3_watch_against_a_dataless_dir_refuses_and_spawns_nothing() {
     let data = DataDir::new();
@@ -1022,23 +1040,23 @@ fn r_watch_3_watch_against_a_dataless_dir_refuses_and_spawns_nothing() {
         "sgt watch must never have spawned a daemon"
     );
 
-    // §4.3/§4.4: the same no-spawn guarantee one gate earlier. `repos/solo`
-    // is a real git checkout *inside* a real estate — precisely what the
-    // deleted upward walk and git fallback used to admit — and it is refused
-    // with §4.4's first line, having touched no descriptor.
+    // H1 §5: `repos/solo` — a real git checkout *inside* a real estate, not
+    // itself an estate root — no longer hits the root gate at all for this
+    // host-scoped verb. It reaches exactly the same daemon-discovery
+    // refusal the estate root above did, having admitted no root and
+    // consulted no `sergeant.toml`.
     let mount = estate.path().join("repos").join("solo");
     let outside = sgt(&mount, &data, &["watch", "01SOMENONEXISTENTWORKID000"]);
     assert_ne!(outside.code, Some(0), "must exit nonzero: {outside:?}");
     assert!(
-        outside
-            .stderr
-            .contains("no estate found in the current directory"),
-        "§4.4's own first line, not a daemon diagnostic: {}",
+        outside.stderr.contains("no daemon is running for"),
+        "host-scoped: a non-estate cwd must reach the same daemon-discovery refusal as an \
+         estate root, never §4.4's root-gate text: {}",
         outside.stderr
     );
     assert!(
         data.daemon_pids().is_empty(),
-        "a root refusal must spawn nothing either — it happens before descriptor lookup"
+        "a non-estate cwd must spawn nothing either — `watch` never auto-spawns, root or not"
     );
 
     data.reap();

--- a/tests/w3_client_surface.rs
+++ b/tests/w3_client_surface.rs
@@ -1,0 +1,356 @@
+//! W3 acceptance evidence (H1 sprint plan; brief deliverable 6): lazy
+//! admission's client-side half and the host-scoped verb bucket, pinned
+//! against the real `sgt` binary.
+//!
+//! `t7_cli_end_to_end_a_second_estate_is_admitted_and_a_second_process_fails_closed`
+//! (`tests/m2_daemon_api.rs`) already proves H1 §11 criterion 1 ("two exact-
+//! root estates submit Work to one daemon") end to end, including the
+//! journal/registry evidence — this file is additive, not a duplicate: it
+//! pins the specific mechanical claims that test's `--data-dir`-explicit
+//! fixtures don't exercise — the spawned child's own argv, host-scoped
+//! discovery from a directory that is not any estate, the spawned daemon's
+//! process-group independence from the client that started it, and `sgt
+//! watch`'s D6 estate filter.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+mod support;
+use support::DataDir;
+
+const SGT: &str = env!("CARGO_BIN_EXE_sgt");
+
+// ---------------------------------------------------------------- helpers
+
+struct Output {
+    code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+impl Output {
+    fn json(&self) -> Value {
+        serde_json::from_str(&self.stdout)
+            .unwrap_or_else(|e| panic!("stdout is not JSON ({e}): {}", self.stdout))
+    }
+
+    fn assert_ok(&self, what: &str) -> &Self {
+        assert_eq!(
+            self.code,
+            Some(0),
+            "{what} must succeed, got {:?}\nstdout: {}\nstderr: {}",
+            self.code,
+            self.stdout,
+            self.stderr
+        );
+        self
+    }
+}
+
+fn run(cwd: &Path, data_dir: &Path, args: &[&str]) -> Output {
+    let output = Command::new(SGT)
+        .current_dir(cwd)
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args(args)
+        .output()
+        .expect("run sgt");
+    Output {
+        code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    }
+}
+
+fn wait_for<F: FnMut() -> bool>(deadline: Duration, mut cond: F) -> bool {
+    let end = Instant::now() + deadline;
+    loop {
+        if cond() {
+            return true;
+        }
+        if Instant::now() >= end {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// This process's own argv[0]-derived PATH, plus the pgid a fresh child of
+/// this test process gets by default — used by the process-group test below
+/// to prove the spawned daemon's group actually differs.
+fn pgid_of(pid: u32) -> Option<u32> {
+    let output = Command::new("ps")
+        .args(["-o", "pgid=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
+fn ppid_of(pid: u32) -> Option<u32> {
+    let output = Command::new("ps")
+        .args(["-o", "ppid=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
+// ---------------------------------------------------------- deliverable 1
+
+/// Brief deliverable 1: `spawn_daemon` bakes no `-C <estate_root>` scalar
+/// into the child's argv (H1 §2/§4). Before this wave the spawned daemon's
+/// own command line named exactly one estate — a hard blocker for a second
+/// estate's later admission (recon-daemon-lifecycle's highest-risk finding).
+#[test]
+fn spawn_daemon_never_puts_a_dash_c_estate_root_in_the_hosts_argv() {
+    let data = DataDir::new();
+    let estate = tempfile::TempDir::new().expect("estate tempdir");
+    support::scaffold_estate(estate.path(), "w3-argv", &["solo"]);
+
+    let submitted = run(estate.path(), data.path(), &["--json", "run", "ship it"]);
+    submitted.assert_ok("sgt run");
+
+    let pids = data.daemon_pids();
+    assert_eq!(pids.len(), 1, "exactly one daemon must have been spawned");
+    let daemon_pid = pids[0];
+
+    let processes =
+        sergeant_rs::platform::process::running_processes().expect("enumerate processes");
+    let argv = &processes
+        .iter()
+        .find(|p| p.pid == daemon_pid)
+        .expect("the spawned daemon's own argv")
+        .argv;
+
+    assert!(
+        !argv.iter().any(|a| a == "-C"),
+        "the spawned daemon's argv must never carry -C (a single-estate scalar): {argv:?}"
+    );
+    assert!(
+        argv.iter().any(|a| a == "--data-dir"),
+        "the spawned daemon must still be addressable by its --data-dir: {argv:?}"
+    );
+    assert!(
+        argv.iter().any(|a| a == "daemon"),
+        "the spawned process must actually be `daemon`: {argv:?}"
+    );
+
+    data.reap();
+}
+
+// ---------------------------------------------------------- deliverable 2
+
+/// Brief deliverable 2 (H1 §5): `status`, `work show`/`list`, and
+/// `daemon stop` reach the already-running host daemon from a directory
+/// that is not, and has no ancestor that is, an estate root — no `-C`
+/// needed, no root-gate refusal collected along the way.
+#[test]
+fn host_scoped_verbs_reach_the_daemon_from_a_directory_with_no_estate_above_it() {
+    let data = DataDir::new();
+    let estate = tempfile::TempDir::new().expect("estate tempdir");
+    support::scaffold_estate(estate.path(), "w3-host-scoped", &["solo"]);
+
+    let submitted = run(estate.path(), data.path(), &["--json", "run", "ship it"]);
+    submitted.assert_ok("sgt run");
+    let work_id = submitted.json()["work"]["id"]
+        .as_str()
+        .expect("work id")
+        .to_string();
+
+    // A directory wholly unrelated to the estate — no `sergeant.toml`
+    // anywhere above it.
+    let elsewhere = tempfile::TempDir::new().expect("bare dir");
+
+    let status = run(elsewhere.path(), data.path(), &["--json", "status"]);
+    status.assert_ok("sgt status from a non-estate cwd");
+    assert!(
+        !status.stderr.contains("does not search parent directories"),
+        "status must never hit the root gate: {}",
+        status.stderr
+    );
+
+    let list = run(elsewhere.path(), data.path(), &["--json", "work", "list"]);
+    list.assert_ok("sgt work list from a non-estate cwd");
+    let works = list.json()["works"].as_array().cloned().unwrap_or_default();
+    assert!(
+        works.iter().any(|w| w["id"] == work_id),
+        "work list from a non-estate cwd must still see the estate's Work: {}",
+        list.stdout
+    );
+
+    let show = run(
+        elsewhere.path(),
+        data.path(),
+        &["--json", "work", "show", &work_id],
+    );
+    show.assert_ok("sgt work show from a non-estate cwd");
+    assert_eq!(show.json()["work"]["id"], work_id);
+
+    let stopped = run(elsewhere.path(), data.path(), &["--json", "daemon", "stop"]);
+    stopped.assert_ok("sgt daemon stop from a non-estate cwd");
+    assert_eq!(stopped.json()["status"], "stopped");
+
+    assert!(
+        wait_for(Duration::from_secs(15), || data.daemon_pids().is_empty()),
+        "daemon stop must actually stop the daemon"
+    );
+}
+
+// ---------------------------------------------------------- deliverable 6
+
+/// Brief deliverable 6: terminal-close independence at the host root — the
+/// spawned daemon outlives the short-lived client that spawned it (every
+/// `sgt run` invocation above already exits while the daemon keeps
+/// serving), and it does so in its own process group and reparented off the
+/// client's process tree, not merely by accident of timing.
+#[test]
+fn the_spawned_daemon_survives_its_client_in_its_own_process_group() {
+    let data = DataDir::new();
+    let estate = tempfile::TempDir::new().expect("estate tempdir");
+    support::scaffold_estate(estate.path(), "w3-detach", &["solo"]);
+
+    let submitted = run(estate.path(), data.path(), &["--json", "run", "ship it"]);
+    submitted.assert_ok("sgt run");
+    // The client (this `run` call) has already returned — its process is
+    // gone. The daemon is still there and still healthy.
+    let pids = data.daemon_pids();
+    assert_eq!(pids.len(), 1, "exactly one daemon");
+    let daemon_pid = pids[0];
+
+    let status = run(estate.path(), data.path(), &["--json", "status"]);
+    status.assert_ok("the daemon must answer after its launching client exited");
+
+    // Reparented off the test process's own tree: PPID 1 (init) is the
+    // ordinary shape once the immediate parent (the short-lived spawning
+    // client) has exited and nothing waited on the orphan.
+    if let Some(ppid) = ppid_of(daemon_pid) {
+        assert_eq!(
+            ppid,
+            1,
+            "the daemon must be reparented to init once its launching client exits, not still \
+             parented to this test process (pid {})",
+            std::process::id()
+        );
+    }
+
+    // Own process group: `command.process_group(0)` (`spawn_daemon`) means
+    // the daemon's pgid equals its own pid, not this test process's pgid —
+    // proof it never receives a signal sent to this test's group (a SIGINT
+    // to a hung `cargo test`, e.g.).
+    if let (Some(daemon_pgid), Some(my_pgid)) = (pgid_of(daemon_pid), pgid_of(std::process::id())) {
+        assert_ne!(
+            daemon_pgid, my_pgid,
+            "the daemon must sit in its own process group, not this test's"
+        );
+        assert_eq!(
+            daemon_pgid, daemon_pid,
+            "a process group leader's pgid equals its own pid"
+        );
+    }
+
+    data.reap();
+}
+
+// ---------------------------------------------------------- deliverable 3
+
+/// Brief deliverable 3 (D6): `sgt watch` (no work id — fleet-wide) inside an
+/// estate defaults to that estate's own events; a second estate's
+/// transition on the *same* host daemon is invisible to it. `--all` widens
+/// the same watch to see every admitted estate.
+#[test]
+fn watch_defaults_to_the_addressed_estate_and_all_widens_it_to_the_host() {
+    let data = DataDir::new();
+    let estate_a = tempfile::TempDir::new().expect("estate a");
+    let estate_b = tempfile::TempDir::new().expect("estate b");
+    support::scaffold_estate(estate_a.path(), "w3-watch-a", &["solo"]);
+    support::scaffold_estate(estate_b.path(), "w3-watch-b", &["solo"]);
+
+    // Start the host daemon via estate A, then admit B too (mirrors t7).
+    run(estate_a.path(), data.path(), &["--json", "run", "warm a"]).assert_ok("warm a");
+    run(estate_b.path(), data.path(), &["--json", "run", "warm b"]).assert_ok("warm b");
+
+    // A scoped-to-A, one-shot, non-follow watch attached *before* B's next
+    // transition — an estate-wide watch is edge-triggered (§6.6), so it
+    // only reports events after it attaches.
+    let mut watch_a = Command::new(SGT)
+        .current_dir(estate_a.path())
+        .arg("--data-dir")
+        .arg(data.path())
+        .args(["--json", "watch"])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn sgt watch (estate A, scoped)");
+
+    // Give the watcher time to attach (read journal head, open the SSE
+    // stream) before triggering B's transition — otherwise this is racing
+    // an unstarted subscriber, not testing the filter.
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Trigger a transition in B only: cancel B's already-completed Work is
+    // illegal (terminal), so submit a second Work in B and cancel it
+    // in-flight is unavailable too (the fake backend settles synchronously)
+    // — submitting a fresh Work is itself a `work.submitted`/`work.completed`
+    // pair, which is enough to prove the filter: A's watcher must see
+    // nothing from it.
+    run(
+        estate_b.path(),
+        data.path(),
+        &["--json", "run", "b transition"],
+    )
+    .assert_ok("b transition");
+
+    // A's scoped watch must NOT have exited (nothing of its own transitioned)
+    // within a bounded wait — it is still blocking, silently, exactly as
+    // §6.6 promises for an estate-wide watch with no matching event.
+    let quiet = wait_for(Duration::from_millis(800), || {
+        matches!(watch_a.try_wait(), Ok(Some(_)))
+    });
+    assert!(
+        !quiet,
+        "estate A's watch must stay silent on estate B's transition (D6 default scoping)"
+    );
+    let _ = watch_a.kill();
+    let _ = watch_a.wait();
+
+    // `--all` from inside A sees B's transition too: submit one more Work in
+    // B while an --all watcher (from A) is attached.
+    let mut watch_all = Command::new(SGT)
+        .current_dir(estate_a.path())
+        .arg("--data-dir")
+        .arg(data.path())
+        .args(["--json", "watch", "--all"])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn sgt watch --all");
+    std::thread::sleep(Duration::from_millis(300));
+
+    run(
+        estate_b.path(),
+        data.path(),
+        &["--json", "run", "b transition under --all"],
+    )
+    .assert_ok("b transition under --all");
+
+    let matched = wait_for(Duration::from_secs(10), || {
+        matches!(watch_all.try_wait(), Ok(Some(_)))
+    });
+    assert!(
+        matched,
+        "--all must see estate B's transition from inside estate A"
+    );
+    let status = watch_all.wait().expect("wait for --all watch");
+    assert!(
+        status.success(),
+        "a matched one-shot watch exits 0: {status:?}"
+    );
+
+    data.reap();
+}


### PR DESCRIPTION
Wave W3 of sprint S1, per the workspace sprint plan (decisions D2/D4/D6). 4 commits.

- `spawn_daemon` spawns the host daemon (no `-C` scalar in child argv); `ensure_daemon`/`observe_connect`/`daemon_stop` discover via the host runtime root — a second estate's client finds the running daemon and proceeds by admission instead of racing to spawn a competitor. Never-double-spawn-over-a-live-PID preserved at the host root.
- New host-scoped verb bucket: `tui`, `status`, `work show/list/transcript`, `watch`, and daemon verbs work from any cwd; estate-scoped verbs still refuse outside an exact root before daemon contact (H1 §11.3 verbatim; ADR 0009 no-spawn set unchanged).
- `WatchOptions.estate_root` + `sgt watch --all`: inside an estate, watch defaults to that estate (D6 — estate-wide meaning preserved); host-wide is explicit. Wired onto W2's server-side `EventsQuery` filter; proven with two real `sgt watch` subprocesses against two estates on one daemon.
- docs_contract pass: `docs/reference/cli.md` Scope column, AGENTS.md Session-start correction, both affected SKILL.md files; `f_doctrine_skew` re-pointed to prove the new refusal shapes (stronger assertions, not loosened).
- New `w3_client_surface` suite (argv proof, non-estate-cwd discovery, terminal-close independence via process-group check, watch D6 e2e), wired into coverage stage C3.

Gates: blind 4-axis panel + refuters — zero confirmed findings. Full-suite verify green except the #293 startup-latency signature set (each named with its signature in the wave record); no new tolerated failures. W2fix (in flight) removes that class.

Rungs: J3 (D2/D4/D6), J5-shaped preservation of §11.3, R2 (resolve_host_runtime_dir landed caller-less by W1b for exactly this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4