### PR TITLE
S1/W2fix: publish descriptor before probes, probe concurrently (#293)

### DIFF
--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -150,3 +150,15 @@ cov_stage_end 1 "the docs_contract test binary must write its own profile"
 cov_stage_begin c2-w4c_service_doctor
 cov_run cargo llvm-cov --no-report --test w4c_service_doctor --locked || cov_fail "w4c_service_doctor failed under instrumentation"
 cov_stage_end 1 "the w4c_service_doctor test binary must write its own profile (its fake systemctl/launchctl binaries are shell-script stand-ins, uninstrumented and no loss, per codex_backend's precedent)"
+
+# Added 2026-08-25, in the same wave that creates the suite (W2fix, #293) —
+# wired at birth rather than recovered later, which is exactly what the
+# #231(b) guard that caught this one exists to force. Sits in C2, not C3:
+# every case starts an in-process `daemon::start_with` against a hermetic
+# fake registry that pre-empts all five real adapters, so nothing here spawns
+# an `sgt` subprocess, a real CLI, or even a shell-script stand-in. The suite
+# reads the runtime descriptor *file* as a client would, which is a read and
+# not a spawn. Floor 1.
+cov_stage_begin c2-w2fix_probe_ordering
+cov_run cargo llvm-cov --no-report --test w2fix_probe_ordering --locked || cov_fail "w2fix_probe_ordering failed under instrumentation"
+cov_stage_end 1 "the w2fix_probe_ordering test binary must write its own profile"

--- a/src/backend/agy.rs
+++ b/src/backend/agy.rs
@@ -316,12 +316,17 @@ const STDERR_DRAIN_BUDGET: Duration = Duration::from_secs(5);
 /// zero-interaction the way the doc comment above it claims** — an
 /// unauthenticated `agy` (no cached credentials under the effective
 /// `settings_home`/`HOME`) answers it by printing an OAuth URL and blocking
-/// on an interactive login for up to 60s before giving up on its own. `run_probe`
-/// runs synchronously inside daemon registration (`daemon::start_with`,
-/// before the descriptor is published), so an unbounded wait here is exactly
-/// the class of regression this project already tracks for a blocking HTTP
-/// client built during registration — its subprocess analogue, on any host
-/// that has `agy` installed but not yet logged in. Five seconds is
+/// on an interactive login for up to 60s before giving up on its own.
+/// `run_probe` runs inside the daemon's startup backend probe walk, which
+/// since #293 happens *after* the runtime descriptor is published and
+/// alongside a daemon that is already serving — so an unbounded wait here no
+/// longer delays the descriptor the way it did when registration was
+/// synchronous. It is still bounded, for two reasons the reordering did not
+/// retire: the walk holds this backend's routing gate closed
+/// (`backend::ProbeGate`) until its evidence lands, and a stopping daemon has
+/// to wait out whatever probe child is in flight. An unbounded wait would put
+/// an interactive login prompt on both, on any host that has `agy` installed
+/// but is not logged in. Five seconds is
 /// generous headroom over the sub-second reply a real, authenticated `agy`
 /// gave in measurement; a probe that cannot answer inside it is killed and
 /// treated exactly like any other probe failure — best-effort by

--- a/src/backend/fake.rs
+++ b/src/backend/fake.rs
@@ -742,6 +742,15 @@ pub struct FakeBackend {
     /// Where a STOP [`Completion`] can be made to stall — the fake's stand-in
     /// for the Claude adapter's transcript-archive join (issue #14/B3).
     archive_gate: Arc<Gate>,
+    /// Where PROBE can be made to stall — the instrument for #293's
+    /// publish-then-probe ordering. A real adapter's probe is one or more
+    /// `--version`/`--help` subprocess runs (measured at up to ~3.2s for
+    /// opencode on Cerberus, 2026-08-25), and the durable pin for that fix
+    /// has to be an *ordering* assertion rather than a wall clock: park one
+    /// probe indefinitely and assert what the daemon can already do while it
+    /// is parked. Same rendezvous-not-sleep reasoning as
+    /// [`FakeBackend::hold_launches`].
+    probe_gate: Arc<Gate>,
     /// Whether STOP/INTERRUPT hand back a deferred completion at all.
     archive_armed: Arc<Mutex<bool>>,
     /// W4 (2026-08-23): whether PREPARE mints no native identity at all —
@@ -795,6 +804,7 @@ impl FakeBackend {
             send_gate: Arc::new(Gate::default()),
             observe_gate: Arc::new(Gate::default()),
             archive_gate: Arc::new(Gate::default()),
+            probe_gate: Arc::new(Gate::default()),
             archive_armed: Arc::new(Mutex::new(false)),
             server_minted_native_ids: false,
         }
@@ -942,6 +952,27 @@ impl FakeBackend {
     /// Block until `n` stop/interrupt completions are parked, or time out.
     pub fn await_stalled_archives(&self, n: usize, timeout: Duration) -> bool {
         self.archive_gate.wait_for_waiting(n, timeout)
+    }
+
+    /// Stall every later PROBE until [`FakeBackend::release_probes`].
+    ///
+    /// The #293 instrument. A probe parked here stands in for the slowest
+    /// real adapter's subprocess walk; anything the daemon answers while it
+    /// is parked is something the startup path demonstrably does not wait on.
+    pub fn hold_probes(&self) {
+        self.probe_gate.hold();
+    }
+
+    /// Let stalled probes through.
+    pub fn release_probes(&self) {
+        self.probe_gate.release();
+    }
+
+    /// Block until `n` probes are parked in the gate, or the timeout expires.
+    /// Returns whether the rendezvous happened — a test asserts on it rather
+    /// than sleeping and hoping.
+    pub fn await_stalled_probes(&self, n: usize, timeout: Duration) -> bool {
+        self.probe_gate.wait_for_waiting(n, timeout)
     }
 
     /// Make PROBE report unavailable (routing must then fail closed).
@@ -1169,6 +1200,10 @@ impl Backend for FakeBackend {
     }
 
     fn probe(&self) -> ProbeReport {
+        // Outside the backend's own lock, exactly like the other gates: a
+        // caller parked here must not be holding it, or the instrument would
+        // measure the fake's contention instead of the daemon's ordering.
+        self.probe_gate.pass();
         let mut state = self.lock();
         state.probes += 1;
         ProbeReport {
@@ -2187,6 +2222,30 @@ mod tests {
             fake.observe(&e2).expect("observe").signal,
             BackendSignal::StageCompleted { summary: None }
         );
+    }
+
+    /// #293's instrument: PROBE parks in its own gate, and it parks *outside*
+    /// the backend's own lock — otherwise a daemon test could not read this
+    /// backend's state (or any other backend's) while one probe is stalled,
+    /// and the ordering pin would be measuring the fake instead of the daemon.
+    #[test]
+    fn probe_parks_in_its_own_gate_without_holding_the_backend_lock() {
+        let fake = Arc::new(FakeBackend::new("fake"));
+        fake.hold_probes();
+        let prober = {
+            let fake = fake.clone();
+            std::thread::spawn(move || fake.probe())
+        };
+        assert!(
+            fake.await_stalled_probes(1, Duration::from_secs(5)),
+            "the probe must park in the gate"
+        );
+        // The lock is free while the probe is parked: a state read answers.
+        assert_eq!(fake.probe_count(), 0, "no probe has completed yet");
+        fake.release_probes();
+        let report = prober.join().expect("probe thread");
+        assert!(report.available);
+        assert_eq!(fake.probe_count(), 1, "the released probe completed");
     }
 
     /// §15's capability flags are advertised, and an unsupported capability is

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -56,9 +56,9 @@ pub mod fake;
 /// and contract-tested, and is reachable by nothing yet.
 pub mod opencode;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -872,6 +872,120 @@ pub trait Backend: Send + Sync + std::fmt::Debug {
     fn stop(&self, handle: &ExecutionHandle) -> Result<Completion, BackendError>;
 }
 
+/// Per-backend probe readiness (#293) — what a caller waits on when it needs
+/// a backend's PROBE evidence and the daemon has not finished collecting it.
+///
+/// **Why this exists.** The daemon publishes its runtime descriptor and starts
+/// serving *before* it walks the backend probes, because the walk is a set of
+/// real CLI invocations (measured on Cerberus 2026-08-25: ~6.4s serially with
+/// five adapters installed, against a 10s client auto-spawn budget) and a
+/// daemon is healthy when it can accept and route requests, not when every
+/// third-party CLI has printed `--help`. That leaves a window in which a
+/// backend's evidence does not exist yet, and exactly one thing may happen in
+/// it: a caller that needs the evidence **waits**. Nothing fabricates a
+/// capability, nothing defaults one, and no submission is refused that the
+/// old probe-walk-first ordering would have accepted — the only difference a
+/// client can observe is *when* the answer arrives.
+///
+/// **Per backend, not per walk.** The wait is keyed by backend name and is
+/// released by that backend's own `backend.probed` record becoming durable,
+/// so a Work routed to a fast adapter is never held up by a slow one it will
+/// never touch. That is also what keeps the M4 evidence order intact:
+/// `backend.probed` for a backend is durable before any Work routed to it is.
+///
+/// **Blocking, not async, deliberately (R2).** Its one real caller is
+/// [`crate::runtime::router`]'s tier walk, which is synchronous and runs
+/// inside the planning path's `block_in_place`; a `Condvar` rendezvous is the
+/// same primitive `fake::Gate` already uses here and needs no runtime
+/// assumptions at all. An async gate would have forced the wait up into the
+/// handler, where the backend the request will route to is not yet known.
+#[derive(Debug, Default)]
+pub struct ProbeGate {
+    state: Mutex<ProbeGateState>,
+    changed: Condvar,
+}
+
+#[derive(Debug, Default)]
+struct ProbeGateState {
+    /// Backends still owed a durable `backend.probed` record. Empty means
+    /// nothing waits — which is both the initial state and the final one.
+    pending: BTreeSet<String>,
+}
+
+impl ProbeGate {
+    /// A gate that owes nothing: every wait returns at once.
+    ///
+    /// This is the resting state for every registry that is not a running
+    /// daemon's — unit tests, `sgt doctor`'s own in-process adapters, the CLI
+    /// preflight — and it is also the daemon's own state until it arms the
+    /// gate, which matters: restart reconciliation reads capabilities before
+    /// the walk is spawned, and a gate armed any earlier would wait for a
+    /// walk that has not started.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Arm the gate: these backends now owe evidence, and waits for them
+    /// block until [`ProbeGate::mark`] or [`ProbeGate::settle`] says
+    /// otherwise. Called once, immediately before the probe walk is spawned.
+    pub fn expect(&self, names: impl IntoIterator<Item = String>) {
+        self.state.lock().expect("probe gate lock").pending = names.into_iter().collect();
+        self.changed.notify_all();
+    }
+
+    /// Record that `name`'s probe evidence is durable, releasing its waiters.
+    pub fn mark(&self, name: &str) {
+        self.state
+            .lock()
+            .expect("probe gate lock")
+            .pending
+            .remove(name);
+        self.changed.notify_all();
+    }
+
+    /// Record that the walk is over, however it ended.
+    ///
+    /// Called unconditionally when the walk drains, so a probe that panicked,
+    /// a backend that left the registry, or a journal append that failed
+    /// cannot leave a request waiting forever on evidence that is never
+    /// coming. Failing open here is right: the alternative is a daemon that
+    /// serves reads and hangs every submission, which is worse than the
+    /// defect the reordering fixed.
+    pub fn settle(&self) {
+        self.state.lock().expect("probe gate lock").pending.clear();
+        self.changed.notify_all();
+    }
+
+    /// Whether nothing is owed.
+    pub fn is_settled(&self) -> bool {
+        self.state
+            .lock()
+            .expect("probe gate lock")
+            .pending
+            .is_empty()
+    }
+
+    /// Block until `name`'s probe evidence is durable.
+    ///
+    /// Returns immediately for a backend the gate is not waiting on — an
+    /// unarmed gate, an already-probed backend, or a name that is not in the
+    /// registry at all.
+    pub fn wait_for(&self, name: &str) {
+        let mut state = self.state.lock().expect("probe gate lock");
+        while state.pending.contains(name) {
+            state = self.changed.wait(state).expect("probe gate wait");
+        }
+    }
+
+    /// Block until every backend the gate is waiting on has its evidence.
+    pub fn wait_all(&self) {
+        let mut state = self.state.lock().expect("probe gate lock");
+        while !state.pending.is_empty() {
+            state = self.changed.wait(state).expect("probe gate wait");
+        }
+    }
+}
+
 /// The set of backends this daemon can route to.
 ///
 /// Compiled-in rather than configured: M3 has exactly one backend to register,
@@ -880,12 +994,31 @@ pub trait Backend: Send + Sync + std::fmt::Debug {
 #[derive(Debug, Default, Clone)]
 pub struct BackendRegistry {
     backends: BTreeMap<String, Arc<dyn Backend>>,
+    /// #293's probe readiness, carried here because the registry is what is
+    /// already threaded through every path that resolves a backend by name —
+    /// the router's tier walk above all. A registry that is not a running
+    /// daemon's keeps the owed-nothing default and never waits; a clone
+    /// shares the original's gate, which is what makes
+    /// `daemon::start_with`'s "clone the configured registry, add the real
+    /// adapters" step carry one gate rather than forking it.
+    probe_gate: Arc<ProbeGate>,
 }
 
 impl BackendRegistry {
     /// An empty registry.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Attach the probe-readiness gate this registry's callers wait on.
+    pub fn with_probe_gate(mut self, gate: Arc<ProbeGate>) -> Self {
+        self.probe_gate = gate;
+        self
+    }
+
+    /// This registry's probe-readiness gate.
+    pub fn probe_gate(&self) -> &Arc<ProbeGate> {
+        &self.probe_gate
     }
 
     /// Register a backend under its own name.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -621,7 +621,26 @@ pub fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    match runtime.block_on(dispatch(sgt)) {
+    let outcome = runtime.block_on(dispatch(sgt));
+    // Dropping a runtime waits, unboundedly, for every blocking task that has
+    // started — and `dispatch` has already returned, so anything still inside
+    // one is a straggler whose answer nothing is left to read. That was
+    // harmless until #293 put the daemon's backend probe walk on the blocking
+    // pool: a daemon SIGTERMed inside its startup window has already journaled
+    // `daemon.stopped` and retired its descriptor (`daemon::start_with`'s
+    // shutdown tail bounds that) but could not *exit* until its in-flight
+    // `--help` child processes returned — measured on Cerberus 2026-08-25 at
+    // 13.7s under an eighteen-daemon burst, well past the ten seconds a
+    // supervisor gives a SIGTERMed process before escalating to SIGKILL.
+    //
+    // The bound introduces no hazard that was not already there, which is what
+    // makes it the right lever rather than a shortcut: the thing it gives up —
+    // a probe child still running when its parent goes — is precisely what the
+    // SIGKILL it replaces already did, and this way the process leaves by
+    // itself, with its exit code intact and everything registered at exit
+    // (coverage profiles included) actually flushed.
+    runtime.shutdown_timeout(Duration::from_secs(2));
+    match outcome {
         Ok(()) => ExitCode::SUCCESS,
         Err(CliError(message)) if message.is_empty() => ExitCode::FAILURE,
         Err(e) => {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -291,15 +291,45 @@ const DRIVER_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// journaling `daemon.stopped` and going.
 ///
 /// The walk is joined at all — rather than dropped — for the same reason the
-/// completion driver is: it commits events, and `daemon.stopped` must be the
-/// last one this daemon writes. It gets its own, longer grace because what it
-/// is waiting on is a different thing: not someone else's git checkout, but a
-/// bounded set of local `--version`/`--help` subprocess runs whose worst
-/// measured total on a fully-provisioned host is ~6.4s serial (#293, Cerberus
-/// 2026-08-25) and roughly the slowest single adapter concurrently. Thirty
-/// seconds is that with room, and it is still a bound: a daemon that will not
-/// die is a lock nobody can take.
-const PROBE_WALK_SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
+/// completion driver is: it commits events, and `daemon.stopped` should be
+/// the last one this daemon writes. It gets the same grace for the same
+/// reason too, and makes the same trade past it, stated rather than hidden: a
+/// probe still inside a child process when the grace runs out may journal its
+/// `backend.probed` after `daemon.stopped`. That is tolerable exactly where
+/// the driver's version is — the journal is append-only and crash-tolerant
+/// per append, `daemon.stopped` is a lifecycle record nothing reconciles
+/// against, and `backend.probed` is on `prune::NON_WORK_ALLOWLIST` as a kind
+/// with *no registry effect at all*, so a replay cannot tell the two orders
+/// apart.
+///
+/// Why it is bounded at all, measured (#293, Cerberus 2026-08-25): a probe is
+/// a real CLI invocation, and under `m6`'s own parallel load the walk ran past
+/// ten seconds — long enough that a rig SIGTERMing a fresh daemon escalated to
+/// SIGKILL, which flushes nothing at exit. Waiting that out unbounded would
+/// put "how loaded is this box" on the shutdown path, and a daemon that will
+/// not die is a lock nobody can take.
+const PROBE_WALK_SHUTDOWN_GRACE: Duration = DRIVER_SHUTDOWN_GRACE;
+
+/// How many backend probes the startup walk runs at once.
+///
+/// **Bounded rather than "all of them", and the number has provenance.**
+/// Measured on Cerberus, 2026-08-25, with all five adapters installed: one
+/// cold daemon alone completes its walk in ~2.5s, and **twenty cold daemons
+/// started simultaneously take 13.8-14.7s each** — 20 × 6 unbounded lanes is
+/// 120 concurrent third-party CLI startups on a 20-core box, and every one of
+/// them gets slower. That is not a hypothetical: it is `m6`'s own suite at
+/// default parallelism, where a daemon SIGTERMed the instant its descriptor
+/// appeared could not finish its walk inside the rig's ten-second grace and
+/// was escalated to SIGKILL, flushing nothing at exit.
+///
+/// Two lanes, not more, because the walk's floor is its slowest single
+/// adapter either way: opencode alone is +3.24s of a ~2.5s-to-3.3s walk, and
+/// the four fast adapters together are +0.74s, so two lanes finish in the
+/// same time one unbounded fan-out does while forking a third as many
+/// children. Raise it only against a measurement showing the *fast* adapters'
+/// sum has overtaken the slowest one's time — that is the condition under
+/// which a lane cap starts costing something, and nothing else is.
+const PROBE_WALK_LANES: usize = 2;
 
 /// Handle to a running in-process daemon. Dropping it does NOT stop the
 /// daemon; call [`DaemonHandle::shutdown`] for a clean stop (journals
@@ -400,6 +430,28 @@ pub struct DaemonConfig {
     /// replay, and write a fresh one. `false` — the default and every
     /// auto-spawn — uses the cache when it verifies.
     pub rebuild_cache: bool,
+    /// W2fix (#293): whether [`start_with`] returns only after the backend
+    /// probe walk has finished.
+    ///
+    /// The descriptor is published before the walk either way — that is the
+    /// fix, and it is not negotiable by this flag. What the flag decides is
+    /// what the *caller* of `start_with` is waiting for, and the two callers
+    /// genuinely want different things:
+    ///
+    /// - `true`, the default, for an in-process embedder. Every rig in
+    ///   `tests/` holds a [`DaemonHandle`] and reads it as "this daemon has
+    ///   started"; one that snapshots the journal on the next line must not
+    ///   race a startup append.
+    /// - `false`, set by [`run_until_signal`], for the daemon binary. Its
+    ///   caller is a signal loop, and a process that cannot answer SIGTERM
+    ///   until its slowest adapter has finished printing `--help` is exactly
+    ///   the "daemon that will not die is a lock nobody can take" this file
+    ///   already refuses elsewhere. Measured on Cerberus 2026-08-25: with the
+    ///   wait in place, a SIGTERM arriving the instant the descriptor
+    ///   appeared took 3.27s to be answered on an idle host, and over ten
+    ///   seconds under `m6`'s own parallel load — long enough that the rig
+    ///   escalated to SIGKILL and the daemon flushed nothing at exit.
+    pub await_probe_walk: bool,
     /// Segment rotation threshold for this daemon's journal. `None` is
     /// [`DEFAULT_SEGMENT_MAX_BYTES`] (8 MiB) — production, always.
     ///
@@ -450,6 +502,7 @@ impl Default for DaemonConfig {
             surfaces_root: None,
             turn_cap: None,
             rebuild_cache: false,
+            await_probe_walk: true,
             segment_max_bytes: None,
             retention: None,
         }
@@ -1015,10 +1068,12 @@ pub async fn start_with(
     // first request axum takes off it is therefore handled by a routing path
     // that already knows what evidence is outstanding.
     probe_gate.expect(probe_backends.names());
+    let probe_lanes = Arc::new(tokio::sync::Semaphore::new(PROBE_WALK_LANES));
     let probes = tokio::spawn(probe_walk(
         state.core.clone(),
         probe_backends,
         probe_gate.clone(),
+        probe_lanes.clone(),
     ));
 
     let app = router(state.clone());
@@ -1062,28 +1117,43 @@ pub async fn start_with(
         // crash-tolerant per append, and `daemon.stopped` is a lifecycle
         // record that nothing reconciles against — whereas a daemon that will
         // not die is a lock nobody can take.
-        match tokio::time::timeout(DRIVER_SHUTDOWN_GRACE, completions).await {
-            Ok(Err(e)) => tracing::warn!(error = %e, "the completion driver panicked"),
-            Err(_) => tracing::warn!(
-                grace = ?DRIVER_SHUTDOWN_GRACE,
-                "the completion driver was still inside an external effect at shutdown; \
-                 stopping anyway"
-            ),
-            Ok(Ok(())) => {}
-        }
-        // The probe walk is the other non-request writer (#293), and the same
-        // rule binds it: `daemon.stopped` is the last event this daemon
-        // writes, so a walk still forking `--help` at shutdown is joined
-        // rather than raced. Bounded for the same reason the driver's join is
-        // — see `PROBE_WALK_SHUTDOWN_GRACE`.
-        match tokio::time::timeout(PROBE_WALK_SHUTDOWN_GRACE, probes).await {
-            Ok(Err(e)) => tracing::warn!(error = %e, "the backend probe walk panicked"),
-            Err(_) => tracing::warn!(
-                grace = ?PROBE_WALK_SHUTDOWN_GRACE,
-                "the backend probe walk was still running at shutdown; stopping anyway"
-            ),
-            Ok(Ok(())) => {}
-        }
+        //
+        // The probe walk (#293) is the other non-request writer and the same
+        // rule binds it, so it is joined here too — **concurrently, not after**.
+        // Two graces run one after the other add up, and their sum was
+        // measured to be the whole budget a rig gives a SIGTERMed daemon: with
+        // the joins sequential, `m6`'s
+        // `the_dropped_spawned_daemon_leaves_the_evidence_of_a_clean_shutdown`
+        // still escalated to SIGKILL under its own parallel load (Cerberus,
+        // 2026-08-25). Neither wait needs the other's answer, so neither
+        // should wait for it.
+        let driver = async {
+            match tokio::time::timeout(DRIVER_SHUTDOWN_GRACE, completions).await {
+                Ok(Err(e)) => tracing::warn!(error = %e, "the completion driver panicked"),
+                Err(_) => tracing::warn!(
+                    grace = ?DRIVER_SHUTDOWN_GRACE,
+                    "the completion driver was still inside an external effect at shutdown; \
+                     stopping anyway"
+                ),
+                Ok(Ok(())) => {}
+            }
+        };
+        // A stopping daemon starts no probe it has not already started: the
+        // in-flight ones are uninterruptible child processes it must wait out,
+        // but the queued ones are free to drop, and `PROBE_WALK_LANES` is what
+        // bounds how many can be in the first category.
+        probe_lanes.close();
+        let walk = async {
+            match tokio::time::timeout(PROBE_WALK_SHUTDOWN_GRACE, probes).await {
+                Ok(Err(e)) => tracing::warn!(error = %e, "the backend probe walk panicked"),
+                Err(_) => tracing::warn!(
+                    grace = ?PROBE_WALK_SHUTDOWN_GRACE,
+                    "the backend probe walk was still running at shutdown; stopping anyway"
+                ),
+                Ok(Ok(())) => {}
+            }
+        };
+        tokio::join!(driver, walk);
         // Clean shutdown: journal the stop, then retire the descriptor.
         let mut core = CoreGuard::acquire(&state.core).await;
         if let Err(e) = core.commit(EventDraft::new(
@@ -1104,32 +1174,21 @@ pub async fn start_with(
         }
     });
 
-    // The handle is handed back only once startup is *complete* — descriptor
-    // published, listener accepting, recovery settled, and the probe walk
-    // done — while everything a client waits for happened at the top of that
-    // list. This is the one place the two audiences differ, and the
-    // difference is deliberate (#293, R2):
+    // Whether the handle is handed back mid-walk or after it is the one
+    // question `await_probe_walk` answers — see its doc for why the two
+    // callers want different things. What a *client* waits on is settled
+    // either way and much earlier: the descriptor was published above, before
+    // this walk was even armed.
     //
-    // - a **client** waits on the descriptor file, which is published before
-    //   the walk starts and is the thing #293 measured at ~6.4s and now
-    //   measures in the low hundreds of milliseconds. Nothing about this wait
-    //   delays it, and the pending window between publish and walk-completion
-    //   is real, served, and covered by `ProbeGate`;
-    // - an **in-process embedder** (every test rig in `tests/`, and any
-    //   future library user) holds a `DaemonHandle` and reasonably reads it
-    //   as "this daemon has started". Handing it back mid-walk would make
-    //   every journal read taken straight after `start_with` race a startup
-    //   append — which is a rig contract quietly changing under ~65 call
-    //   sites, not a property anyone asked for.
-    //
-    // Waiting on the gate rather than the `probes` join handle is what lets
-    // the serve task keep that handle and join it at shutdown, so
-    // `daemon.stopped` stays last even if this future is dropped mid-await.
-    // The gate is a `Condvar`, so the wait goes on the blocking pool where
-    // blocking waits belong.
-    let settled = probe_gate.clone();
-    if let Err(e) = tokio::task::spawn_blocking(move || settled.wait_all()).await {
-        tracing::warn!(error = %e, "waiting for the backend probe walk failed");
+    // Waiting on the gate rather than on the `probes` join handle is what
+    // lets the serve task keep that handle and join it at shutdown. The gate
+    // is a `Condvar`, so the wait goes on the blocking pool, where blocking
+    // waits belong.
+    if config.await_probe_walk {
+        let settled = probe_gate.clone();
+        if let Err(e) = tokio::task::spawn_blocking(move || settled.wait_all()).await {
+            tracing::warn!(error = %e, "waiting for the backend probe walk failed");
+        }
     }
 
     Ok(DaemonHandle {
@@ -1182,34 +1241,48 @@ async fn probe_walk(
     core: Arc<tokio::sync::Mutex<Core>>,
     backends: Arc<BackendRegistry>,
     gate: Arc<ProbeGate>,
+    lanes: Arc<tokio::sync::Semaphore>,
 ) {
     let mut walking = tokio::task::JoinSet::new();
     for name in backends.names() {
         let backends = backends.clone();
-        walking.spawn_blocking(move || {
-            let Some(backend) = backends.get(&name) else {
-                return (name, None);
+        let lanes = lanes.clone();
+        walking.spawn(async move {
+            // The lane permit is held across the blocking probe and released
+            // when it returns — see `PROBE_WALK_LANES` for why the fan-out is
+            // bounded at all. A closed semaphore means shutdown began before
+            // this probe ever started one: skip it rather than fork a child
+            // the stopping daemon would then have to wait out.
+            let Ok(_lane) = lanes.acquire_owned().await else {
+                return Ok((name, None));
             };
-            let report = backend.probe();
-            // `capabilities()` is read here, inside the blocking task, and
-            // not on the runtime: for the opencode and agy adapters it
-            // resolves the transport, which is itself a subprocess gate, and
-            // for Claude it reads a claim the probe may have withdrawn.
-            let payload = json!({
-                "backend": name,
-                "available": report.available,
-                "detail": report.detail,
-                "capabilities": backend.capabilities(),
-                // §17: the adapter's declared runtime scope, recorded with
-                // the probe because it is a claim about the adapter, and the
-                // core is forbidden from assuming one.
-                "runtime_scope": backend.runtime_scope(),
-            });
-            (name, Some(payload))
+            tokio::task::spawn_blocking(move || {
+                let Some(backend) = backends.get(&name) else {
+                    return (name, None);
+                };
+                let report = backend.probe();
+                // `capabilities()` is read here, inside the blocking task,
+                // and not on the runtime: for the opencode and agy adapters
+                // it resolves the transport, which is itself a subprocess
+                // gate, and for Claude it reads a claim the probe may have
+                // withdrawn.
+                let payload = json!({
+                    "backend": name,
+                    "available": report.available,
+                    "detail": report.detail,
+                    "capabilities": backend.capabilities(),
+                    // §17: the adapter's declared runtime scope, recorded
+                    // with the probe because it is a claim about the adapter,
+                    // and the core is forbidden from assuming one.
+                    "runtime_scope": backend.runtime_scope(),
+                });
+                (name, Some(payload))
+            })
+            .await
         });
     }
     while let Some(joined) = walking.join_next().await {
-        let (name, payload) = match joined {
+        let (name, payload) = match joined.and_then(|probed| probed) {
             Ok(probed) => probed,
             Err(e) => {
                 // A panicked probe takes its own name with it, so nothing
@@ -1220,10 +1293,12 @@ async fn probe_walk(
             }
         };
         let Some(payload) = payload else {
-            // The backend left the registry between scheduling and running,
-            // which nothing does today — but a name owed a record and never
-            // getting one must not wedge a submission.
-            tracing::warn!(backend = %name, "backend vanished from the registry before its probe");
+            // Either shutdown closed the lanes before this probe started, or
+            // the backend left the registry between scheduling and running
+            // (which nothing does today). Both leave a name owed a record it
+            // will never get, and neither may wedge a submission waiting on
+            // it — so the gate is released without one.
+            tracing::debug!(backend = %name, "backend probe skipped; no evidence recorded");
             gate.mark(&name);
             continue;
         };
@@ -1469,6 +1544,9 @@ pub async fn run_until_signal(data_dir: &Path, rebuild_cache: bool) -> Result<()
             surfaces_root,
             turn_cap,
             rebuild_cache,
+            // The signal loop below must be able to answer SIGTERM while the
+            // probe walk is still running — see the field's own doc (#293).
+            await_probe_walk: false,
             ..DaemonConfig::default()
         },
     )

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -43,6 +43,17 @@
 //! once. A daemon is healthy when it can accept and route requests, not when
 //! every third-party CLI has printed `--help`.
 //!
+//! **After, measured the same way on the same host** (five cold starts each,
+//! fresh estate and data dir per start, polled at 10ms from `exec`; Cerberus,
+//! 2026-08-25): the descriptor lands at **0.06-0.10s**, and the whole probe
+//! walk is durable — the sixth `backend.probed` flushed — at **3.22-3.27s**.
+//! The same instrument re-run against the pre-#293 build measures **6.03-6.32s
+//! for both**, which is what "both" meant back then: the descriptor could not
+//! precede the walk it was waiting on. So the client-visible number falls by
+//! ~85x and stops being the walk's hostage, while the walk itself roughly
+//! halves — its floor is now its slowest single adapter (opencode ~3.2s)
+//! rather than the sum of all six, exactly as `probe_walk`'s own doc predicts.
+//!
 //! **The capability-pending contract**, which is what makes the reordering
 //! safe rather than merely faster. Between serving and a backend's probe
 //! completing:

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12,14 +12,57 @@
 //! 2. open the journal (which holds its own exclusive lock — belt and
 //!    braces) and rebuild the Work registry by full replay;
 //! 3. bind `127.0.0.1` on an ephemeral port;
-//! 4. journal `daemon.started`;
+//! 4. journal `daemon.started`, register the backend adapters, reconcile work
+//!    believed in flight (§25) and clear a stale admission pause (L6) — no
+//!    request may observe a Work whose prior ownership has not been settled,
+//!    so those stay ahead of the descriptor;
 //! 5. write the runtime descriptor (endpoint, PID, API revision, random
 //!    bearer token) atomically with owner-only permissions — the descriptor
-//!    only ever points at a live, already-listening daemon.
+//!    only ever points at a live, already-listening daemon;
+//! 6. **then** walk the backend probes, concurrently, journaling
+//!    `backend.probed` per backend as each completes.
 //!
 //! Clean shutdown journals `daemon.stopped` and removes the descriptor; a
 //! crash leaves a stale descriptor, which clients detect (dead PID + refused
 //! endpoint) and replace.
+//!
+//! ## Publish, then probe (#293)
+//!
+//! Step 6 used to be step 4b-ii — the whole probe walk, serially, *before*
+//! the bind and the descriptor. The argument for that ordering was that a
+//! daemon should not be reachable before it knows what it can route to. The
+//! measurement retires it: on a fully-provisioned host (all five adapters
+//! installed) the descriptor appeared **~6.4s after exec across five cold
+//! starts** on Cerberus, 2026-08-25, every millisecond of it serial probing —
+//! agy ~2.3s, opencode ~3.2s over four invocations, codex ~0.4s, claude
+//! ~0.2s — against a client auto-spawn budget of 10s (`SPAWN_WAIT`,
+//! `src/cli.rs`). The ~3.6s of headroom left meant any concurrent load,
+//! including a test suite's own parallel daemon spawns, pushed the first
+//! `sgt run` past the budget; #293's A/B evidence showed that one defect
+//! explaining every real-spawn failure across the m2/m3/m6/m8/m9 suites at
+//! once. A daemon is healthy when it can accept and route requests, not when
+//! every third-party CLI has printed `--help`.
+//!
+//! **The capability-pending contract**, which is what makes the reordering
+//! safe rather than merely faster. Between serving and a backend's probe
+//! completing:
+//!
+//! - a caller whose preflight needs capability evidence **waits** for it —
+//!   [`crate::backend::ProbeGate`], waited on by the router's tier walk at the
+//!   one point where a backend name becomes decisive. The wait is per backend
+//!   and bounded by that backend's own probe completing, so a Work bound for a
+//!   fast adapter is never held up by a slow one it will never touch;
+//! - no capability is ever fabricated, defaulted, or inferred to fill the
+//!   window, and no submission is refused that the old ordering would have
+//!   accepted. The only difference observable to a client is *when* the
+//!   answer arrives;
+//! - the journal's evidence order per backend is unchanged: `backend.probed`
+//!   is durable before any Work routed to that backend is.
+//!
+//! What did *not* move is everything ahead of the descriptor in the list
+//! above. Restart reconciliation and the L6 pause clear stay before it,
+//! because those are claims about state a request could act on; a probe is a
+//! claim about an adapter, and the request that needs it can wait for it.
 
 use std::collections::HashMap;
 use std::fs::OpenOptions;
@@ -41,7 +84,7 @@ use crate::backend::codex::{CODEX_BACKEND_NAME, CodexBackend, CodexConfig};
 use crate::backend::docker::{DOCKER_BACKEND_NAME, DockerBackend, DockerConfig};
 use crate::backend::fake::FAKE_BACKEND_NAME;
 use crate::backend::opencode::{OPENCODE_BACKEND_NAME, OpencodeBackend, OpencodeConfig};
-use crate::backend::{BackendRegistry, EventSink};
+use crate::backend::{BackendRegistry, EventSink, ProbeGate};
 use crate::domain::event::{EventDraft, EventSource};
 use crate::platform::fs_locking::{self, Reliability};
 use crate::runtime::analytics::{Analytics, AnalyticsError};
@@ -244,6 +287,20 @@ pub enum DaemonError {
 /// checkout still exits on its own rather than being escalated to SIGKILL.
 const DRIVER_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 
+/// How long shutdown waits for the backend probe walk to finish before
+/// journaling `daemon.stopped` and going.
+///
+/// The walk is joined at all — rather than dropped — for the same reason the
+/// completion driver is: it commits events, and `daemon.stopped` must be the
+/// last one this daemon writes. It gets its own, longer grace because what it
+/// is waiting on is a different thing: not someone else's git checkout, but a
+/// bounded set of local `--version`/`--help` subprocess runs whose worst
+/// measured total on a fully-provisioned host is ~6.4s serial (#293, Cerberus
+/// 2026-08-25) and roughly the slowest single adapter concurrently. Thirty
+/// seconds is that with room, and it is still a bound: a daemon that will not
+/// die is a lock nobody can take.
+const PROBE_WALK_SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
+
 /// Handle to a running in-process daemon. Dropping it does NOT stop the
 /// daemon; call [`DaemonHandle::shutdown`] for a clean stop (journals
 /// `daemon.stopped`, removes the descriptor).
@@ -421,8 +478,16 @@ fn refuse_if_unreliable(data_dir: &Path, reliability: Reliability) -> Result<(),
     }
 }
 
-/// Start the daemon on `data_dir`. Returns once it is serving and the
-/// runtime descriptor is published.
+/// Start the daemon on `data_dir`. Returns once startup is complete: serving,
+/// runtime descriptor published, and the backend probe walk finished.
+///
+/// Those three do not happen at the same moment any more (#293). The
+/// descriptor is published — and the daemon starts accepting — *before* the
+/// probe walk runs; this call returns after the walk, because an in-process
+/// handle is read as "started" and a rig that takes a journal snapshot right
+/// after it must not race a startup append. A client waiting on the
+/// descriptor file is unblocked at the earlier moment, which is the whole
+/// point of the reordering; see this module's `Publish, then probe` doc.
 pub async fn start_with(
     data_dir: &Path,
     config: DaemonConfig,
@@ -810,38 +875,17 @@ pub async fn start_with(
     } else {
         None
     };
-    let backends = Arc::new(backends);
-
-    // 4b-ii. The capability/version probe, recorded at registration (M4
-    // contract). Probing is offline and token-free (`--version`, `--help`),
-    // and journaling the answer is the point: a version and flag set that
-    // only ever appear inside a later refusal's message are not a record.
-    // An unavailable backend is registered anyway and refuses work with this
-    // same evidence — routing must be able to say *why*, not pretend the
-    // backend does not exist.
-    for name in backends.names() {
-        let Some(backend) = backends.get(&name) else {
-            continue;
-        };
-        let report = backend.probe();
-        core.commit(EventDraft::new(
-            EventSource::new("daemon", "sergeant"),
-            KIND_BACKEND_PROBED,
-            json!({
-                "backend": name,
-                "available": report.available,
-                "detail": report.detail,
-                "capabilities": backend.capabilities(),
-                // §17: the adapter's declared runtime scope, recorded with
-                // the probe because it is a claim about the adapter, and the
-                // core is forbidden from assuming one.
-                "runtime_scope": backend.runtime_scope(),
-            }),
-        ))?;
-    }
-    // Same reasoning as the daemon.started flush above: durable before
-    // recovery starts acting on it (INV-R2-01).
-    core.flush()?;
+    // 4b-ii. The capability/version probe is *scheduled* here and runs at
+    // step 6, after the descriptor is published — see this module's
+    // startup-order doc and [`ProbeGate`] for why (#293). What happens here is
+    // only that the registry gains the readiness gate its routing path will
+    // wait on; not one subprocess is forked, and the gate is still **unarmed**,
+    // which is load-bearing: restart reconciliation two steps below reads
+    // capabilities, and a gate armed this early would make it wait for a walk
+    // that has not started.
+    let probe_gate = Arc::new(ProbeGate::new());
+    let backends = Arc::new(backends.with_probe_gate(probe_gate.clone()));
+    let probe_backends = backends.clone();
 
     // 4c. Reconcile work believed in flight *before* serving (§25): no
     // request may observe — or act on — a work whose prior ownership has not
@@ -958,6 +1002,25 @@ pub async fn start_with(
     if let Some(agy) = agy {
         agy.set_event_sink(journaling_sink(state.core.clone()));
     }
+
+    // 6. The capability/version probe walk (#293), started the moment the
+    // daemon is reachable and run concurrently across backends. Spawned after
+    // the adapter sinks are wired above so a probe can never race an adapter
+    // that has no sink yet, and joined at shutdown below so `daemon.stopped`
+    // stays the last event this daemon writes.
+    //
+    // Arming the gate is the line before the spawn, and both are ahead of the
+    // serve task: the listener is bound, so a client that read the descriptor
+    // a moment ago has its connection sitting in the accept backlog, and the
+    // first request axum takes off it is therefore handled by a routing path
+    // that already knows what evidence is outstanding.
+    probe_gate.expect(probe_backends.names());
+    let probes = tokio::spawn(probe_walk(
+        state.core.clone(),
+        probe_backends,
+        probe_gate.clone(),
+    ));
+
     let app = router(state.clone());
 
     // The one writer that is not a request (issue #46): a turn that ends on
@@ -1008,6 +1071,19 @@ pub async fn start_with(
             ),
             Ok(Ok(())) => {}
         }
+        // The probe walk is the other non-request writer (#293), and the same
+        // rule binds it: `daemon.stopped` is the last event this daemon
+        // writes, so a walk still forking `--help` at shutdown is joined
+        // rather than raced. Bounded for the same reason the driver's join is
+        // — see `PROBE_WALK_SHUTDOWN_GRACE`.
+        match tokio::time::timeout(PROBE_WALK_SHUTDOWN_GRACE, probes).await {
+            Ok(Err(e)) => tracing::warn!(error = %e, "the backend probe walk panicked"),
+            Err(_) => tracing::warn!(
+                grace = ?PROBE_WALK_SHUTDOWN_GRACE,
+                "the backend probe walk was still running at shutdown; stopping anyway"
+            ),
+            Ok(Ok(())) => {}
+        }
         // Clean shutdown: journal the stop, then retire the descriptor.
         let mut core = CoreGuard::acquire(&state.core).await;
         if let Err(e) = core.commit(EventDraft::new(
@@ -1028,12 +1104,128 @@ pub async fn start_with(
         }
     });
 
+    // The handle is handed back only once startup is *complete* — descriptor
+    // published, listener accepting, recovery settled, and the probe walk
+    // done — while everything a client waits for happened at the top of that
+    // list. This is the one place the two audiences differ, and the
+    // difference is deliberate (#293, R2):
+    //
+    // - a **client** waits on the descriptor file, which is published before
+    //   the walk starts and is the thing #293 measured at ~6.4s and now
+    //   measures in the low hundreds of milliseconds. Nothing about this wait
+    //   delays it, and the pending window between publish and walk-completion
+    //   is real, served, and covered by `ProbeGate`;
+    // - an **in-process embedder** (every test rig in `tests/`, and any
+    //   future library user) holds a `DaemonHandle` and reasonably reads it
+    //   as "this daemon has started". Handing it back mid-walk would make
+    //   every journal read taken straight after `start_with` race a startup
+    //   append — which is a rig contract quietly changing under ~65 call
+    //   sites, not a property anyone asked for.
+    //
+    // Waiting on the gate rather than the `probes` join handle is what lets
+    // the serve task keep that handle and join it at shutdown, so
+    // `daemon.stopped` stays last even if this future is dropped mid-await.
+    // The gate is a `Condvar`, so the wait goes on the blocking pool where
+    // blocking waits belong.
+    let settled = probe_gate.clone();
+    if let Err(e) = tokio::task::spawn_blocking(move || settled.wait_all()).await {
+        tracing::warn!(error = %e, "waiting for the backend probe walk failed");
+    }
+
     Ok(DaemonHandle {
         endpoint,
         token,
         shutdown_tx: Some(shutdown_tx),
         served,
     })
+}
+
+/// The capability/version probe walk, recorded at registration (M4 contract):
+/// one `backend.probed` event per registered backend, carrying what the probe
+/// found — a version and flag set that only ever appear inside a later
+/// refusal's message are not a record. An unavailable backend is probed and
+/// journaled anyway and refuses work with this same evidence; routing must be
+/// able to say *why*, not pretend the backend does not exist.
+///
+/// **Concurrent, and on the blocking pool, both deliberately (#293).** A
+/// probe is one or more real CLI invocations — measured on Cerberus
+/// 2026-08-25: agy ~2.3s, opencode ~3.2s across four invocations, codex
+/// ~0.4s, claude ~0.2s — and they are independent of one another, so running
+/// them one at a time bought nothing but their sum. They are also *blocking*
+/// (`std::process::Command::output`), which the old serial walk ran straight
+/// on the async runtime; `spawn_blocking` is where blocking work belongs, and
+/// it is what makes the concurrency real rather than five futures taking
+/// turns on one worker thread.
+///
+/// Each result is journaled and flushed as it lands, then marked on the gate
+/// — in that order, so a caller released by the gate is released over durable
+/// evidence, never over an append still in a group.
+async fn probe_walk(
+    core: Arc<tokio::sync::Mutex<Core>>,
+    backends: Arc<BackendRegistry>,
+    gate: Arc<ProbeGate>,
+) {
+    let mut walking = tokio::task::JoinSet::new();
+    for name in backends.names() {
+        let backends = backends.clone();
+        walking.spawn_blocking(move || {
+            let Some(backend) = backends.get(&name) else {
+                return (name, None);
+            };
+            let report = backend.probe();
+            // `capabilities()` is read here, inside the blocking task, and
+            // not on the runtime: for the opencode and agy adapters it
+            // resolves the transport, which is itself a subprocess gate, and
+            // for Claude it reads a claim the probe may have withdrawn.
+            let payload = json!({
+                "backend": name,
+                "available": report.available,
+                "detail": report.detail,
+                "capabilities": backend.capabilities(),
+                // §17: the adapter's declared runtime scope, recorded with
+                // the probe because it is a claim about the adapter, and the
+                // core is forbidden from assuming one.
+                "runtime_scope": backend.runtime_scope(),
+            });
+            (name, Some(payload))
+        });
+    }
+    while let Some(joined) = walking.join_next().await {
+        let (name, payload) = match joined {
+            Ok(probed) => probed,
+            Err(e) => {
+                // A panicked probe takes its own name with it, so nothing
+                // can be marked here; `settle` below is what keeps that from
+                // stranding a waiter.
+                tracing::error!(error = %e, "a backend probe panicked");
+                continue;
+            }
+        };
+        let Some(payload) = payload else {
+            // The backend left the registry between scheduling and running,
+            // which nothing does today — but a name owed a record and never
+            // getting one must not wedge a submission.
+            tracing::warn!(backend = %name, "backend vanished from the registry before its probe");
+            gate.mark(&name);
+            continue;
+        };
+        {
+            let mut core = CoreGuard::acquire(&core).await;
+            let committed = core
+                .commit(EventDraft::new(
+                    EventSource::new("daemon", "sergeant"),
+                    KIND_BACKEND_PROBED,
+                    payload,
+                ))
+                .and_then(|_| core.flush());
+            if let Err(e) = committed {
+                tracing::error!(error = %e, backend = %name, "failed to journal backend.probed");
+            }
+        }
+        gate.mark(&name);
+    }
+    // Unconditional: see `ProbeGate::settle`.
+    gate.settle();
 }
 
 /// Build the [`EventSink`] that journals an adapter's normalized events.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1148,14 +1148,32 @@ pub async fn start_with(
 /// able to say *why*, not pretend the backend does not exist.
 ///
 /// **Concurrent, and on the blocking pool, both deliberately (#293).** A
-/// probe is one or more real CLI invocations — measured on Cerberus
-/// 2026-08-25: agy ~2.3s, opencode ~3.2s across four invocations, codex
-/// ~0.4s, claude ~0.2s — and they are independent of one another, so running
-/// them one at a time bought nothing but their sum. They are also *blocking*
+/// probe is one or more real CLI invocations — measured per backend on
+/// Cerberus 2026-08-25, from `daemon.started` to each `backend.probed`:
+/// fake +0.03s, docker +0.05s, claude +0.27s, codex +0.39s, agy +2.40s,
+/// opencode +3.24s — and they are independent of one another, so running them
+/// one at a time bought nothing but their sum. They are also *blocking*
 /// (`std::process::Command::output`), which the old serial walk ran straight
 /// on the async runtime; `spawn_blocking` is where blocking work belongs, and
 /// it is what makes the concurrency real rather than five futures taking
 /// turns on one worker thread.
+///
+/// **Within-adapter invocation parallelism: measured, then declined (R1).**
+/// The obvious next step is to fan out the invocations *inside* the two slow
+/// adapters, and the same measurement says not to. Opencode's three probe
+/// invocations are genuinely independent, but timed individually on this host
+/// they are 0.354s / 0.359s / 0.362s — about 1.1s of its 3.24s. The rest is
+/// `serve_gates`' probe child (`opencode serve --port 0` plus the
+/// authenticated `/doc` fetch), and agy's 2.40s is almost entirely
+/// `read_config_probe`'s `agy -p /config` child, neither of which is a
+/// `--help` that fanning out helps. Parallelising opencode's helps would move
+/// it to roughly agy's number and the walk's completion barely at all — while
+/// costing a real behaviour change, since `run_probe` short-circuits today
+/// and a fan-out would fork two more doomed children on every host with no
+/// opencode installed (which is every CI runner). Revisit if a future
+/// adapter's cost is actually in its help invocations; the walk is off the
+/// startup critical path either way, and the per-backend gate means a Work
+/// waits only on the adapter it routes to.
 ///
 /// Each result is journaled and flushed as it lands, then marked on the gate
 /// — in that order, so a caller released by the gate is released over durable

--- a/src/runtime/router.rs
+++ b/src/runtime/router.rs
@@ -244,6 +244,15 @@ fn resolve_tiers(
                 available,
             });
         };
+        // #293's capability-pending contract, applied at the one point in the
+        // system where a backend name becomes decisive *and* its evidence is
+        // read. The daemon now serves before its probe walk finishes, so this
+        // backend's `backend.probed` record may not be durable yet — wait for
+        // it rather than route over evidence nobody has written. Keyed by
+        // this backend alone, so a Work bound for a fast adapter is never
+        // held up by a slow one it will never touch; a registry that is not a
+        // running daemon's owes nothing and does not wait at all.
+        registry.probe_gate().wait_for(requested);
         let probe = backend.probe();
         if !probe.available {
             return Err(RouteError::Unavailable {

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -2984,8 +2984,25 @@ fn resolve_data_dir_falls_back_through_sgt_data_dir_then_xdg_then_home() {
         sgt_dir.path().join("journal").is_dir(),
         "SGT_DATA_DIR must win over XDG_DATA_HOME and HOME"
     );
+    // Both negatives name **sergeant's own** path under the overridden root,
+    // not the root itself. The `HOME` this test hands `sgt` is inherited by
+    // every process `sgt` starts, including the backend probe walk's
+    // third-party CLI children, and those write their own state where their
+    // own conventions put it: measured on Cerberus 2026-08-25 with all five
+    // adapters installed, a single `sgt run` here leaves
+    // `$HOME/.local/state/opencode/locks`, `$HOME/.codex/`, `$HOME/.config/`,
+    // `$HOME/.cache/` and `$XDG_DATA_HOME/opencode/` behind — none of it
+    // sergeant's, none of it evidence about `resolve_data_dir`. Asserting
+    // `!$HOME/.local` therefore failed deterministically on a
+    // fully-provisioned host while passing on a runner with no such CLI
+    // installed, which is a fact about the host rather than about the rung
+    // under test. (Ordering-independent: it failed identically on the
+    // pre-#293 build.) The XDG line was already scoped this way; this makes
+    // the HOME line say the same thing — sgt did not fall through to the
+    // platform tail — which is the claim the doc comment above actually
+    // makes.
     assert!(!xdg.path().join("sergeant").exists());
-    assert!(!home.path().join(".local").exists());
+    assert!(!home.path().join(".local/share/sergeant").exists());
     assert!(
         !estate.path().join(".sergeant").exists(),
         "SGT_DATA_DIR must also outrank the estate's own `.sergeant/data` default \
@@ -3032,7 +3049,8 @@ fn resolve_data_dir_falls_back_through_sgt_data_dir_then_xdg_then_home() {
             "macOS's convention must ignore XDG_DATA_HOME, not merely prefer its own path"
         );
     } else {
-        assert!(!home2.path().join(".local").exists());
+        // Same narrowing, same reason as the first rung's pair above.
+        assert!(!home2.path().join(".local/share/sergeant").exists());
     }
 
     // Absent both, `$HOME`'s own convention-suffix is the last resort. Same

--- a/tests/w2fix_probe_ordering.rs
+++ b/tests/w2fix_probe_ordering.rs
@@ -1,0 +1,263 @@
+//! W2fix (#293): the daemon serves before it has finished probing, and a
+//! submission that needs capability evidence waits for it instead of being
+//! answered from thin air.
+//!
+//! ## What went wrong, and what these tests pin
+//!
+//! Startup used to run the whole backend probe walk — serially, one
+//! subprocess set per adapter — *before* binding-and-publishing, so the
+//! runtime descriptor appeared only after every installed third-party CLI had
+//! printed `--help`. Measured on Cerberus 2026-08-25 with all five backends
+//! installed: descriptor at ~6.4s against a 10s client spawn budget, which
+//! meant any concurrent load pushed the first `sgt run` on a cold daemon past
+//! the budget and failed every real-spawn suite at once (#293's A/B evidence).
+//!
+//! The fix is an ordering change, so the pins here are **ordering assertions
+//! and nothing else** — no wall-clock thresholds, which would only re-encode
+//! one host's timings as a contract. Each test parks a probe in
+//! [`FakeBackend::hold_probes`]'s gate, which stands in for an arbitrarily
+//! slow real adapter, and then acts exactly as a client does — through the
+//! **runtime descriptor file**, not through the in-process handle, because
+//! the descriptor is the thing whose lateness was the defect and
+//! `daemon::start_with` deliberately waits for the walk before handing a
+//! handle back (see its doc). What the tests assert while a probe is parked:
+//!
+//! 1. the descriptor exists and `/healthz` answers;
+//! 2. reads are served in that window, a submission arriving in it is *not*
+//!    answered from unprobed capabilities, and it completes correctly once
+//!    the probe lands;
+//! 3. `backend.probed` still precedes the first Work routed to that backend
+//!    in the journal — the evidence order the M4 contract requires, which the
+//!    new ordering must not have bought its latency with.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend};
+use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle, RuntimeDescriptor};
+use sergeant_rs::domain::event::Event;
+use sergeant_rs::domain::work::KIND_WORK_SUBMITTED;
+use sergeant_rs::runtime::journal::Journal;
+
+mod support;
+use support::DataDir;
+
+/// How long a rendezvous may take before the test calls it a hang. This is a
+/// deadlock guard, not a latency pin: nothing here asserts that any operation
+/// was *fast*, only that it happened at all before the suite gave up.
+const RENDEZVOUS: Duration = Duration::from_secs(30);
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client")
+}
+
+/// A registry that pre-empts every real adapter `start_with` would otherwise
+/// register, so this suite probes no third-party CLI at all.
+///
+/// `start_with` only adds an adapter when the configured registry has no
+/// backend under that name, which is exactly the substitution seam tests are
+/// meant to use. Hermetic matters here beyond speed: a host with opencode
+/// installed would otherwise put a ~3s real probe inside every rendezvous
+/// below and make the suite's own timings depend on what is on the box —
+/// which is the class of coupling this whole wave exists to remove.
+fn hermetic_registry(subject: &Arc<FakeBackend>) -> BackendRegistry {
+    let mut registry = BackendRegistry::new().with(subject.clone());
+    for name in ["claude", "docker", "codex", "opencode", "agy"] {
+        registry = registry.with(Arc::new(FakeBackend::new(name)));
+    }
+    registry
+}
+
+/// Releases the subject's probe gate on drop.
+///
+/// Not politeness: a probe parked in the gate is a live `spawn_blocking`
+/// task, and dropping a tokio runtime waits for those. A failing assertion
+/// between `hold_probes` and `release_probes` would therefore hang the whole
+/// test binary instead of reporting the failure — a suite that cannot fail
+/// out loud is worse than no suite. `CONTRIBUTING.md`'s rule for exactly this
+/// shape: clean up in an RAII guard, never in the happy-path test body.
+struct ReleaseProbes(Arc<FakeBackend>);
+
+impl Drop for ReleaseProbes {
+    fn drop(&mut self) {
+        self.0.release_probes();
+    }
+}
+
+/// Begin a daemon start with the subject's probe held, and return once that
+/// probe is provably parked — i.e. once the process is inside the window this
+/// suite is about. The join handle finishes when the whole startup does.
+async fn start_into_the_pending_window(
+    dir: &DataDir,
+    subject: &Arc<FakeBackend>,
+) -> tokio::task::JoinHandle<DaemonHandle> {
+    subject.hold_probes();
+    let starting = {
+        let data_dir = dir.path().to_path_buf();
+        let config = DaemonConfig {
+            backends: Arc::new(hermetic_registry(subject)),
+            default_backend: Some(FAKE_BACKEND_NAME.to_string()),
+            ..DaemonConfig::default()
+        };
+        tokio::spawn(async move {
+            daemon::start_with(&data_dir, config)
+                .await
+                .expect("daemon start")
+        })
+    };
+    let gate = subject.clone();
+    let parked = tokio::task::spawn_blocking(move || gate.await_stalled_probes(1, RENDEZVOUS))
+        .await
+        .expect("gate rendezvous task");
+    assert!(parked, "a probe must be parked in the gate");
+    starting
+}
+
+/// The descriptor a client would read, refusing the "not published yet" case
+/// as the failure it is rather than polling for it.
+fn published_descriptor(dir: &DataDir) -> RuntimeDescriptor {
+    daemon::read_descriptor(dir.path())
+        .expect("descriptor readable")
+        .expect("the descriptor is published before the probe walk completes")
+}
+
+/// Deliverable 4(a). The runtime descriptor — the thing every client and test
+/// rig waits for — exists, and the daemon behind it is already accepting,
+/// while the backend probe walk is still running.
+///
+/// Revert-sensitive by construction: restore the probe-walk-before-publish
+/// ordering and no descriptor exists at all while the gate is held, so this
+/// fails on a missing file rather than on a threshold.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_descriptor_is_published_while_a_backend_probe_is_still_running() {
+    let dir = DataDir::new();
+    let subject = Arc::new(FakeBackend::new(FAKE_BACKEND_NAME));
+    let starting = start_into_the_pending_window(&dir, &subject).await;
+    let _release = ReleaseProbes(subject.clone());
+
+    assert_eq!(
+        subject.probe_count(),
+        0,
+        "the subject's probe has not completed yet"
+    );
+    let descriptor = published_descriptor(&dir);
+    assert_eq!(descriptor.pid, std::process::id());
+
+    // Published *and* live: a descriptor pointing at a socket nobody is
+    // accepting on would trade one broken promise for another.
+    let health = client()
+        .get(format!("{}/healthz", descriptor.endpoint))
+        .send()
+        .await
+        .expect("healthz request");
+    assert!(
+        health.status().is_success(),
+        "the daemon is already serving"
+    );
+
+    subject.release_probes();
+    let handle = tokio::time::timeout(RENDEZVOUS, starting)
+        .await
+        .expect("startup must complete once the probe lands")
+        .expect("start task");
+    handle.shutdown().await;
+    assert!(dir.reap().is_empty(), "no daemon left on this data dir");
+}
+
+/// Deliverables 4(b) and 4(c). During the pending window the daemon serves
+/// reads, a submission arriving in it is not answered from capabilities
+/// nobody measured, and once the probe lands the submission completes — with
+/// `backend.probed` ahead of `work.submitted` in the journal.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_submission_during_probe_pending_lands_after_the_probe_it_needs() {
+    let dir = DataDir::new();
+    let subject = Arc::new(FakeBackend::new(FAKE_BACKEND_NAME));
+    let starting = start_into_the_pending_window(&dir, &subject).await;
+    let _release = ReleaseProbes(subject.clone());
+    let descriptor = published_descriptor(&dir);
+
+    let http = client();
+    let submit = {
+        let http = http.clone();
+        let endpoint = descriptor.endpoint.clone();
+        let token = descriptor.token.clone();
+        tokio::spawn(async move {
+            http.post(format!("{endpoint}/v1/work"))
+                .bearer_auth(&token)
+                .json(&json!({
+                    "command_id": ulid::Ulid::generate().to_string(),
+                    "intent": "a submission that arrived during the probe-pending window",
+                }))
+                .send()
+                .await
+                .expect("submit request")
+        })
+    };
+
+    // The daemon is serving reads in the pending window — and the submission
+    // is genuinely still pending in it. Asserted on the daemon's own state
+    // rather than on `is_finished()`, so nothing here depends on scheduling.
+    let listed: Value = http
+        .get(format!("{}/v1/work", descriptor.endpoint))
+        .bearer_auth(&descriptor.token)
+        .send()
+        .await
+        .expect("list request")
+        .json()
+        .await
+        .expect("list json");
+    assert_eq!(
+        listed["works"].as_array().map(Vec::len),
+        Some(0),
+        "no Work may be recorded while the backend it would route to is unprobed"
+    );
+
+    subject.release_probes();
+    let response = tokio::time::timeout(RENDEZVOUS, submit)
+        .await
+        .expect("the pending submission must complete once its probe lands")
+        .expect("submit task");
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::CREATED,
+        "the submission completes correctly after the probe lands"
+    );
+    let body: Value = response.json().await.expect("submit json");
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+
+    let handle = tokio::time::timeout(RENDEZVOUS, starting)
+        .await
+        .expect("startup must complete once the probe lands")
+        .expect("start task");
+    handle.shutdown().await;
+    assert!(dir.reap().is_empty(), "no daemon left on this data dir");
+
+    // Deliverable 4(c): the evidence order the M4 contract requires is
+    // unchanged — the probe record for a backend is durable before any Work
+    // routed to it is.
+    let events: Vec<Event> = Journal::replay_data_dir(dir.path())
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .collect();
+    let probed = events
+        .iter()
+        .find(|e| {
+            e.kind == daemon::KIND_BACKEND_PROBED && e.payload["backend"] == FAKE_BACKEND_NAME
+        })
+        .expect("a backend.probed record for the fake");
+    let submitted = events
+        .iter()
+        .find(|e| e.kind == KIND_WORK_SUBMITTED && e.work_id.as_deref() == Some(work_id.as_str()))
+        .expect("a work.submitted record");
+    assert!(
+        probed.seq < submitted.seq,
+        "backend.probed (seq {}) must precede the first Work routed to that backend (seq {})",
+        probed.seq,
+        submitted.seq
+    );
+}


### PR DESCRIPTION
Wave W2fix of sprint S1, closing #293. 7 commits.

**Measured on Cerberus (same instrument, both builds, 5 cold starts each, all five backend CLIs installed):**
- Before (`eb9affb6`): descriptor published at 6.03–6.32s — identical to probe-walk completion, which was the defect.
- After: **descriptor at 0.06–0.10s (~85× faster)**; probe walk completes at 3.22–3.27s (floor = slowest single adapter, opencode, instead of the sum of six).
- Acceptance at its strongest: m2/m3/m6/m8/m9 = **227 passed / 0 failed, run twice, default parallelism, no tolerated-failure list** on the dev host that previously failed dozens of these under any load.

Mechanics: descriptor/serve first; probes run concurrently on the blocking pool, `backend.probed` journaled per backend as each completes (per-backend evidence order preserved: probed still precedes any Work routed to it); `ProbeGate` capability-pending — a submission needing an unprobed backend awaits that backend's probe (fail-open on walk drain, proven to hold neither the core lock nor the runtime); ordering pins, not wall-clock pins (revert-tested). SIGTERM-during-probe-window exits cleanly (`runtime.shutdown_timeout`, the one out-of-brief cli.rs touch, J5-cited — a SIGTERMed daemon must not linger 13s waiting on third-party --help children).

Also fixed en route (both baseline-verified as pre-existing): the `resolve_data_dir` HOME-fallback test asserted against third-party CLI state written into the test's `$HOME` (narrowed to sergeant's own path — the claim its doc comment always made); the new suite wired into coverage stage C2 (#231(b)).

Known intermittent: one unidentified single-test failure in 1 of 5 full-suite runs at final HEAD, unreproduced in three subsequent runs — recorded, not hidden.

Gates: blind 4-axis panel + refuters (3 confirmed findings, all verified already-resolved), verify green with an empty failing list. Rungs per commit subject; D-citations inline.

Fixes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4