### PR TITLE
S1/W4e: drop dependency debuginfo (#299) — target 20G→12G, debug sgt 455M→238M

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,17 @@ ulid = "3.0.0"
 [profile.dev.package.libduckdb-sys]
 debug = false
 
+# #299 (owner-ratified 2026-08-26): generalize the same trade to every
+# dependency — nobody in this project steps through dependency code, and
+# the per-suite test binaries each carry the whole dep graph's DWARF.
+# The workspace crate itself keeps full debug info (a specific package
+# entry and the crate's own artifacts are unaffected by this wildcard),
+# so panic backtraces through sergeant code stay symbolized. Measured on
+# Cerberus at adoption: fresh `cargo build --tests` target 20 GB -> see
+# the qualification PR for the after numbers.
+[profile.dev.package."*"]
+debug = false
+
 [dev-dependencies]
 # Synchronously decoding an axum `Response` body in `tests/i9_floor_pinning.rs`
 # (spec §6.3 compensating assertion (c): calling the real `below_floor_refusal`


### PR DESCRIPTION
One-line profile change, owner-ratified, qualified per #299's criteria on Cerberus:

| Metric | Before | After |
|---|---|---|
| Fresh `cargo build --tests` target | 20 GB | **12 GB** |
| Debug `sgt` binary | 455 MB | **238 MB** |
| Cold build time | 2m18s | 2m13s |
| Sergeant-frame backtraces | file:line | **file:line (addr2line-proven: `src/api.rs:4263`)** |

Workspace crate keeps full debuginfo; only dependency artifacts drop DWARF — the same trade `libduckdb-sys` has carried since M5, generalized. Fresh-lane cost per sprint drops ~40%.

Rungs: J4 (owner ruling 2026-08-26 in-session), R6.

Fixes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4