### PR TITLE
S1/W4a: per-estate retention partitioning over the host journal (D7)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -815,14 +815,25 @@ pub async fn drive_completions(state: ApiState, interval: Duration) {
 /// serving; [`crate::runtime::prune::stall_report`] is how that becomes
 /// visible, not a blocked tick.
 ///
-/// Phase A ([`crate::runtime::prune::candidate_horizon`]) and the cheap
-/// `take_rotation_signal`/`segment_bounds` reads run under the guard (they
-/// are in-memory and fast); Phase B
-/// ([`crate::runtime::prune::plan`], the mark scan) runs on a blocking
-/// thread with the guard released, since it is the unbounded part (§10.1's
-/// own split); [`crate::runtime::prune::run`] re-acquires the guard to
-/// re-validate and commit.
+/// Phase A ([`crate::runtime::prune::candidate_horizon_multi_estate`]) and
+/// the cheap `take_rotation_signal`/`segment_bounds` reads run under the
+/// guard (they are in-memory and fast); Phase B
+/// ([`crate::runtime::prune::plan_multi_estate`], the mark scan) runs on a
+/// blocking thread with the guard released, since it is the unbounded part
+/// (§10.1's own split); [`crate::runtime::prune::run`] re-acquires the guard
+/// to re-validate and commit.
+///
+/// H1 brief deliverable 1: `state.prune_policy` is no longer applied
+/// uniformly to every retained Work — it is the fallback
+/// [`crate::runtime::prune::EstatePolicies::from_registry`] resolves for a
+/// Work whose estate is unknown or no longer admitted. Each admitted
+/// estate's own `[estate] retention` is read fresh every tick (the same
+/// "re-read, never cache" discipline `Engine::plan` already has, now applied
+/// to this policy map too), from `state.estates` — the registry the
+/// estate-scoped HTTP surface already populates.
 async fn maybe_run_rotation_triggered_prune(state: &ApiState) {
+    let policies =
+        crate::runtime::prune::EstatePolicies::from_registry(&state.estates, state.prune_policy);
     let snapshot = {
         let mut core = CoreGuard::acquire(&state.core).await;
         let rotated = core.journal.take_rotation_signal();
@@ -836,11 +847,11 @@ async fn maybe_run_rotation_triggered_prune(state: &ApiState) {
                 return;
             }
         };
-        let (candidate, _stall) = crate::runtime::prune::candidate_horizon(
+        let (candidate, _stall) = crate::runtime::prune::candidate_horizon_multi_estate(
             &bounds,
             core.registry.state(),
             &core.first_seq_by_work,
-            &state.prune_policy,
+            &policies,
         );
         let eligible_segments = bounds.iter().filter(|b| b.last_seq <= candidate).count();
         if candidate == 0 || eligible_segments < crate::runtime::prune::PRUNE_BATCH_MIN_SEGMENTS {
@@ -856,15 +867,14 @@ async fn maybe_run_rotation_triggered_prune(state: &ApiState) {
     let (bounds, candidate, registry_snapshot, first_seq_snapshot) = snapshot;
 
     let data_dir = state.data_dir.clone();
-    let policy = state.prune_policy;
     let planned = tokio::task::spawn_blocking(move || {
-        crate::runtime::prune::plan(
+        crate::runtime::prune::plan_multi_estate(
             &data_dir,
             &bounds,
             candidate,
             &registry_snapshot,
             &first_seq_snapshot,
-            &policy,
+            &policies,
         )
     })
     .await;
@@ -2532,6 +2542,12 @@ fn pruned_work_view(
         "last_seq": row.last_seq,
         "pruned_at": row.pruned_at,
         "policy": {"retention": policy.retention, "source": policy.source},
+        // H1 brief deliverable 3: the report names estates. `policy` above
+        // stays the daemon-wide fallback the caller passed in (unchanged
+        // shape); `estate_root` is this specific residue row's own recorded
+        // coordinate, `None` for a Work pruned before H1 or submitted with
+        // no estate context at all.
+        "estate_root": row.estate_root,
     })
 }
 

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -156,6 +156,120 @@ pub struct PrunePolicy {
     pub source: PolicySource,
 }
 
+/// H1 brief deliverable 1 (D7 J3; partition mechanics R2 on `cap_seq`'s
+/// existing fold shape): how each retained Work's own retention floor is
+/// resolved, keyed by the canonical estate root [`WorkIndexRow::estate_root`]
+/// already carries (D1/D10 — folded once from the envelope's `workspace_id`,
+/// never re-derived here).
+///
+/// **What this is not.** It does not change where blobs are scanned for
+/// liveness (D7: that scan stays journal-wide regardless — see
+/// [`scan_condemned_range`]); it only changes which `retention` number a
+/// given Work's own group answers to when the segment horizon is computed.
+#[derive(Debug, Clone)]
+pub struct EstatePolicies {
+    /// Declared per canonical estate root — `AdmittedEstate::retention` read
+    /// per admitted estate (brief deliverable 1), never a daemon-wide value
+    /// applied to every root alike.
+    per_root: BTreeMap<String, PrunePolicy>,
+    /// Applied to a Work whose `estate_root` is `None` (no context at
+    /// submission) or names a root not in `per_root` (unadmitted, or no
+    /// longer admitted) — "the config override or built-in default applies",
+    /// per the brief's own wording.
+    fallback: PrunePolicy,
+}
+
+impl EstatePolicies {
+    /// A registry with no per-estate overrides at all: every root answers to
+    /// `fallback`.
+    pub fn new(fallback: PrunePolicy) -> Self {
+        Self {
+            per_root: BTreeMap::new(),
+            fallback,
+        }
+    }
+
+    /// Every retained Work answers to the same policy, regardless of its own
+    /// `estate_root` — the pre-H1 shape, and what every call site not yet
+    /// threading an [`crate::runtime::estates::EstateRegistry`] keeps getting
+    /// (R1: no forced churn on a call site that has not opted in). Byte-
+    /// identical in its cap arithmetic to the original single-policy
+    /// `cap_seq(&registry.work_index, n)` call, because a uniform policy
+    /// partitions the registry into exactly the groups it already was: one,
+    /// if every row shares an `estate_root` (or lacks one), or several groups
+    /// that all happen to answer to the same number.
+    pub fn uniform(policy: PrunePolicy) -> Self {
+        Self::new(policy)
+    }
+
+    /// Declare `root`'s own policy, overriding the fallback for that root
+    /// only.
+    pub fn with_estate(mut self, root: impl Into<String>, policy: PrunePolicy) -> Self {
+        self.per_root.insert(root.into(), policy);
+        self
+    }
+
+    /// Build directly from the daemon's admitted-estate registry: every
+    /// estate that declared its own `[estate] retention` gets that policy
+    /// (`PolicySource::Manifest`); an admitted estate that declared none
+    /// falls through to `fallback` exactly like an unadmitted root does —
+    /// there is nothing per-estate to read for it, so it answers to the same
+    /// config-override-or-default `fallback` already resolves.
+    pub fn from_registry(
+        estates: &crate::runtime::estates::EstateRegistry,
+        fallback: PrunePolicy,
+    ) -> Self {
+        let mut policies = Self::new(fallback);
+        for entry in estates.entries() {
+            if let Some(retention) = entry.estate.retention {
+                policies = policies.with_estate(
+                    entry.estate.root.to_string_lossy().into_owned(),
+                    PrunePolicy {
+                        retention,
+                        source: PolicySource::Manifest,
+                    },
+                );
+            }
+        }
+        policies
+    }
+
+    /// The policy a Work with this `estate_root` answers to.
+    pub fn resolve(&self, estate_root: Option<&str>) -> PrunePolicy {
+        estate_root
+            .and_then(|root| self.per_root.get(root))
+            .copied()
+            .unwrap_or(self.fallback)
+    }
+
+    /// The config-override-or-default policy applied to an unknown/unadmitted
+    /// estate — also what a report showing one aggregate number (rather than
+    /// a full per-estate breakdown) should cite.
+    pub fn fallback(&self) -> PrunePolicy {
+        self.fallback
+    }
+}
+
+/// One estate's own share of a prune cycle's before/after counts — brief
+/// deliverable 3: "the report names estates", not only an aggregate total.
+/// `examined` is this estate's retained Work count going into the cycle;
+/// `retired` is how many of those this cycle actually pruned (carried-forward
+/// residue excluded, matching [`PruneOutcome::works_pruned`]'s own
+/// convention); `kept = examined - retired`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EstatePruneStat {
+    /// Canonical estate root, or `None` for a Work with no known estate.
+    pub estate_root: Option<String>,
+    /// The policy this estate's Works answered to this cycle.
+    pub policy: PrunePolicy,
+    /// Retained Works belonging to this estate before this cycle.
+    pub examined: usize,
+    /// This estate's Works newly retired this cycle.
+    pub retired: usize,
+    /// This estate's Works still retained after this cycle.
+    pub kept: usize,
+}
+
 /// One pruned Work, as the journal remembers it after its events are gone.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PrunedWorkRow {
@@ -179,6 +293,14 @@ pub struct PrunedWorkRow {
     /// later replay reproduces it identically rather than reading a wall
     /// clock at fold time.
     pub pruned_at: String,
+    /// H1 brief deliverable 3: the estate this Work was submitted against
+    /// ([`WorkIndexRow::estate_root`], copied verbatim at prune time), so a
+    /// later reader can answer "estate X's Work … was pruned" from the
+    /// residue alone, with no cache in the loop. `#[serde(default)]` for a
+    /// record committed before this field existed (§20's forward-
+    /// compatibility stance) — an honest "not recorded", never invented.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estate_root: Option<String>,
 }
 
 /// One pruned command's ledger key — Q8's exemption made durable.
@@ -431,6 +553,11 @@ pub struct PrunePlan {
     pub scan_through: u64,
     /// Why pruning did not advance further than it did.
     pub stall: PruneStall,
+    /// H1 brief deliverable 3: this cycle's examined/retired/kept, broken
+    /// down by estate. Not journaled directly (not part of
+    /// [`PruneIntentRecord`]'s wire shape) — [`run`] copies it verbatim onto
+    /// [`PruneOutcome::per_estate`], which is.
+    pub per_estate: Vec<EstatePruneStat>,
 }
 
 /// What one cycle actually did — returned by [`run`]/[`run_startup`],
@@ -468,6 +595,12 @@ pub struct PruneOutcome {
     /// re-arms `prune_pending` from this so the next tick continues the
     /// backlog drain rather than waiting on an unrelated rotation (§7.4).
     pub truncated_by_cap: bool,
+    /// H1 brief deliverable 3: this cycle's examined/retired/kept, broken
+    /// down by estate rather than folded into the aggregate counts above.
+    /// `#[serde(default)]` for a `prune.completed.outcome` committed before
+    /// this field existed.
+    #[serde(default)]
+    pub per_estate: Vec<EstatePruneStat>,
 }
 
 /// Why pruning is not advancing further — Q7's whole answer: there is no
@@ -567,15 +700,149 @@ pub fn retired_whole(state: WorkState, run: Option<&crate::runtime::projection::
 /// Works can ever tie — the ranking is total, with no tie-break rule to get
 /// wrong.
 pub fn cap_seq(work_index: &BTreeMap<String, WorkIndexRow>, n: usize) -> u64 {
+    cap_seq_over(work_index.values().map(|row| row.last_seq), n)
+}
+
+/// [`cap_seq`]'s own ranking rule, factored out over a bare `last_seq`
+/// iterator rather than a whole `work_index` (R2) — the shape
+/// [`multi_estate_cap`] needs to apply the identical rule to one estate's
+/// own slice of Works without allocating a throwaway `WorkIndexRow` map just
+/// to satisfy [`cap_seq`]'s signature.
+fn cap_seq_over(last_seqs: impl Iterator<Item = u64>, n: usize) -> u64 {
     if n == 0 {
         return u64::MAX;
     }
-    if work_index.len() <= n {
+    let mut last_seqs: Vec<u64> = last_seqs.collect();
+    if last_seqs.len() <= n {
         return 0;
     }
-    let mut last_seqs: Vec<u64> = work_index.values().map(|row| row.last_seq).collect();
     last_seqs.sort_unstable_by(|a, b| b.cmp(a));
     last_seqs[n - 1].saturating_sub(1)
+}
+
+/// H1 brief deliverable 1 (D7 J3): the shared segment horizon must respect
+/// every estate's own floor *simultaneously* — so this is the most
+/// restrictive of the independently-computed per-estate caps
+/// ([`cap_seq_over`], reused per group, R2), never a single cap taken over
+/// the combined set. Taking the combined set's own cap would let one
+/// estate's population size dilute or tighten another's floor (a small
+/// estate's Works would count toward a large estate's "top N", or vice
+/// versa) — exactly the "one estate's retention silently governs another's
+/// Works" failure the recon doc names for this touch point.
+///
+/// The reverse direction (one group with `len <= n`, protecting all of its
+/// own Works via [`cap_seq_over`]'s `0` sentinel) is not a bug when it
+/// dominates the `min`: it means that group's floor genuinely requires
+/// protecting Works down to the very start of the shared journal, and no
+/// partitioning scheme can prune around a Work while also protecting it —
+/// the atom of deletion is the segment (ADR 0019's own eventually-exact
+/// tradeoff), and a segment shared with a protected Work cannot be unlinked
+/// regardless of which estate asked for the pruning.
+pub fn multi_estate_cap(
+    work_index: &BTreeMap<String, WorkIndexRow>,
+    policies: &EstatePolicies,
+) -> u64 {
+    let mut groups: BTreeMap<Option<String>, Vec<u64>> = BTreeMap::new();
+    for row in work_index.values() {
+        groups
+            .entry(row.estate_root.clone())
+            .or_default()
+            .push(row.last_seq);
+    }
+    if groups.is_empty() {
+        return cap_seq_over(std::iter::empty(), policies.fallback().retention as usize);
+    }
+    groups
+        .into_iter()
+        .map(|(root, seqs)| {
+            let n = policies.resolve(root.as_deref()).retention as usize;
+            cap_seq_over(seqs.into_iter(), n)
+        })
+        .min()
+        .expect("groups is non-empty, checked above")
+}
+
+/// What [`sweep_horizon`] resolves its cap and reported retention from —
+/// [`candidate_horizon`]/[`plan`]'s single-policy shape (unchanged, every
+/// existing call site) or the estate-partitioned shape
+/// ([`candidate_horizon_multi_estate`]/[`plan_multi_estate`]), sharing one
+/// sweep body rather than two independently-maintained copies (R2).
+enum PruneCapSource<'a> {
+    Uniform(&'a PrunePolicy),
+    MultiEstate(&'a EstatePolicies),
+}
+
+impl PruneCapSource<'_> {
+    fn cap(&self, work_index: &BTreeMap<String, WorkIndexRow>) -> u64 {
+        match self {
+            Self::Uniform(policy) => cap_seq(work_index, policy.retention as usize),
+            Self::MultiEstate(policies) => multi_estate_cap(work_index, policies),
+        }
+    }
+
+    /// What a single-number report (`PruneStall::retention`) shows: the
+    /// uniform policy's own number, or the fallback's — a per-estate
+    /// breakdown, when one is wanted, is [`EstatePruneStat`]'s job, not this
+    /// one field's.
+    fn retention_for_report(&self) -> u32 {
+        match self {
+            Self::Uniform(policy) => policy.retention,
+            Self::MultiEstate(policies) => policies.fallback().retention,
+        }
+    }
+
+    /// What [`PrunePlan::policy`]/[`PruneIntentRecord::policy`] journals —
+    /// same reasoning as `retention_for_report`.
+    fn reported_policy(&self) -> PrunePolicy {
+        match self {
+            Self::Uniform(policy) => **policy,
+            Self::MultiEstate(policies) => policies.fallback(),
+        }
+    }
+
+    /// The policy a specific estate root actually answered to — every
+    /// retained Work under `Uniform`, or [`EstatePolicies::resolve`] under
+    /// `MultiEstate`.
+    fn resolve(&self, estate_root: Option<&str>) -> PrunePolicy {
+        match self {
+            Self::Uniform(policy) => **policy,
+            Self::MultiEstate(policies) => policies.resolve(estate_root),
+        }
+    }
+}
+
+/// Brief deliverable 3: per-estate examined/kept, computed the same way
+/// regardless of `scope` — a uniform-policy caller gets one group's worth of
+/// honest reporting for free, not just the multi-estate path.
+fn estate_prune_stats(
+    work_index: &BTreeMap<String, WorkIndexRow>,
+    retired: &[PrunedWorkRow],
+    scope: &PruneCapSource,
+) -> Vec<EstatePruneStat> {
+    let mut examined: BTreeMap<Option<String>, usize> = BTreeMap::new();
+    for row in work_index.values() {
+        *examined.entry(row.estate_root.clone()).or_default() += 1;
+    }
+    let mut retired_counts: BTreeMap<Option<String>, usize> = BTreeMap::new();
+    for row in retired {
+        *retired_counts.entry(row.estate_root.clone()).or_default() += 1;
+    }
+    let mut roots: BTreeSet<Option<String>> = examined.keys().cloned().collect();
+    roots.extend(retired_counts.keys().cloned());
+    roots
+        .into_iter()
+        .map(|root| {
+            let examined = examined.get(&root).copied().unwrap_or(0);
+            let retired = retired_counts.get(&root).copied().unwrap_or(0);
+            EstatePruneStat {
+                policy: scope.resolve(root.as_deref()),
+                estate_root: root,
+                examined,
+                retired,
+                kept: examined.saturating_sub(retired),
+            }
+        })
+        .collect()
 }
 
 /// The Work whose retirement would let the horizon advance furthest: the
@@ -616,7 +883,30 @@ pub fn candidate_horizon(
     first_seq: &FirstSeqIndex,
     policy: &PrunePolicy,
 ) -> (u64, PruneStall) {
-    sweep_horizon(bounds, registry, first_seq, policy, u64::MAX)
+    sweep_horizon(
+        bounds,
+        registry,
+        first_seq,
+        &PruneCapSource::Uniform(policy),
+        u64::MAX,
+    )
+}
+
+/// H1 brief deliverable 1: [`candidate_horizon`]'s multi-estate sibling —
+/// same sweep, [`multi_estate_cap`] in place of a single [`cap_seq`] call.
+pub fn candidate_horizon_multi_estate(
+    bounds: &[SegmentBound],
+    registry: &WorkRegistry,
+    first_seq: &FirstSeqIndex,
+    policies: &EstatePolicies,
+) -> (u64, PruneStall) {
+    sweep_horizon(
+        bounds,
+        registry,
+        first_seq,
+        &PruneCapSource::MultiEstate(policies),
+        u64::MAX,
+    )
 }
 
 /// The sweep [`candidate_horizon`] runs, factored out so [`plan`]'s
@@ -626,15 +916,19 @@ pub fn candidate_horizon(
 /// the residue cross-check to catch a straddling Work the sweep itself
 /// would have refused. `ceiling = u64::MAX` (via [`candidate_horizon`])
 /// changes nothing versus every candidate being eligible on its own terms.
+///
+/// `scope` decides only how the retention *cap* is computed
+/// ([`PruneCapSource::cap`]) — every other predicate (nostraddle, the
+/// blocking-work check, the batch cap) is unchanged by H1 and stays exactly
+/// as it was pre-partitioning.
 fn sweep_horizon(
     bounds: &[SegmentBound],
     registry: &WorkRegistry,
     first_seq: &FirstSeqIndex,
-    policy: &PrunePolicy,
+    scope: &PruneCapSource,
     ceiling: u64,
 ) -> (u64, PruneStall) {
-    let n = policy.retention as usize;
-    let cap = cap_seq(&registry.work_index, n);
+    let cap = scope.cap(&registry.work_index);
 
     // I-W3-4: the segment the writer currently holds open is never
     // unlinked. `bounds`'s own last (newest) entry is always that segment
@@ -703,7 +997,7 @@ fn sweep_horizon(
         pinning_kind: None,
         pinning_seq: None,
         retained_works: registry.work_index.len(),
-        retention: policy.retention,
+        retention: scope.retention_for_report(),
         floor_seq: bounds.first().map(|b| b.first_seq).unwrap_or(1),
         horizon_seq: h,
         truncated_by_cap,
@@ -870,6 +1164,46 @@ pub fn plan(
     first_seq: &FirstSeqIndex,
     policy: &PrunePolicy,
 ) -> Result<Option<PrunePlan>, PruneError> {
+    plan_with_scope(
+        data_dir,
+        bounds,
+        candidate,
+        registry,
+        first_seq,
+        &PruneCapSource::Uniform(policy),
+    )
+}
+
+/// H1 brief deliverable 1: [`plan`]'s multi-estate sibling — same Phase B,
+/// [`multi_estate_cap`] in place of a single [`cap_seq`] call, and
+/// [`PrunePlan::per_estate`] populated from the real partition rather than
+/// left empty.
+pub fn plan_multi_estate(
+    data_dir: &Path,
+    bounds: &[SegmentBound],
+    candidate: u64,
+    registry: &WorkRegistry,
+    first_seq: &FirstSeqIndex,
+    policies: &EstatePolicies,
+) -> Result<Option<PrunePlan>, PruneError> {
+    plan_with_scope(
+        data_dir,
+        bounds,
+        candidate,
+        registry,
+        first_seq,
+        &PruneCapSource::MultiEstate(policies),
+    )
+}
+
+fn plan_with_scope(
+    data_dir: &Path,
+    bounds: &[SegmentBound],
+    candidate: u64,
+    registry: &WorkRegistry,
+    first_seq: &FirstSeqIndex,
+    scope: &PruneCapSource,
+) -> Result<Option<PrunePlan>, PruneError> {
     if candidate == 0 {
         return Ok(None);
     }
@@ -922,7 +1256,7 @@ pub fn plan(
         // instead of a correctly-computed, possibly-smaller-but-legal
         // horizon).
         let ceiling = pin_first_seq.saturating_sub(1);
-        let (admissible, _) = sweep_horizon(bounds, registry, first_seq, policy, ceiling);
+        let (admissible, _) = sweep_horizon(bounds, registry, first_seq, scope, ceiling);
         horizon = admissible.min(horizon);
         if horizon == 0 {
             return Ok(None);
@@ -956,6 +1290,7 @@ pub fn plan(
             updated_at: row.updated_at.clone(),
             last_seq: row.last_seq,
             pruned_at: String::new(), // stamped by `run`/`run_startup` at commit time
+            estate_root: row.estate_root.clone(),
         })
         .collect();
 
@@ -1048,7 +1383,7 @@ pub fn plan(
         }
     }
 
-    let (_, mut stall) = candidate_horizon(bounds, registry, first_seq, policy);
+    let (_, mut stall) = sweep_horizon(bounds, registry, first_seq, scope, u64::MAX);
     stall.horizon_seq = horizon;
     stall.pinning_seq = effective_pin_seq;
     if let Some(pin_seq) = effective_pin_seq {
@@ -1066,8 +1401,10 @@ pub fn plan(
             });
     }
 
+    let per_estate = estate_prune_stats(&registry.work_index, &residue.works, scope);
+
     Ok(Some(PrunePlan {
-        policy: *policy,
+        policy: scope.reported_policy(),
         horizon_seq: horizon,
         segments,
         residue,
@@ -1078,6 +1415,7 @@ pub fn plan(
         rescue_quarantined,
         scan_through: surviving_scan_through,
         stall,
+        per_estate,
     }))
 }
 
@@ -1265,6 +1603,7 @@ pub fn run(
         blobs_rescued_by_reference,
         floor_seq_after: record.floor_seq_after,
         truncated_by_cap: plan.stall.truncated_by_cap,
+        per_estate: plan.per_estate.clone(),
     };
 
     // Step 5 (T10, fsynced).
@@ -1384,6 +1723,11 @@ pub fn complete_interrupted(
         blobs_rescued_by_reference,
         floor_seq_after: pending.floor_seq_after,
         truncated_by_cap: false,
+        // §6.2's "record, apply nothing" boundary: `PruneIntentRecord`
+        // (what a crash leaves behind) never carried a per-estate
+        // breakdown, so a resumed cycle has nothing to report here beyond
+        // the aggregate counts above — an honest empty, not a guess.
+        per_estate: Vec::new(),
     };
 
     core.commit(EventDraft::new(
@@ -1487,6 +1831,7 @@ mod tests {
             updated_at: "2026-01-01T00:00:00.000Z".to_string(),
             last_seq: 1,
             pruned_at: "2026-01-02T00:00:00.000Z".to_string(),
+            estate_root: None,
         }
     }
 

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -2349,6 +2349,272 @@ mod tests {
         );
     }
 
+    /// Like [`commit`], but stamps the envelope's `workspace_id` (D1/D10) —
+    /// the coordinate `WorkIndexRow::estate_root` folds from at
+    /// `work.submitted`, and every multi-estate fixture this wave adds needs
+    /// a way to set.
+    fn commit_for_estate(
+        core: &mut crate::api::Core,
+        source: crate::domain::event::EventSource,
+        kind: &str,
+        work_id: Option<&str>,
+        estate_root: &str,
+        payload: serde_json::Value,
+    ) -> crate::domain::event::Event {
+        let mut draft = crate::domain::event::EventDraft::new(source, kind, payload)
+            .with_workspace_id(estate_root);
+        if let Some(id) = work_id {
+            draft = draft.with_work_id(id);
+        }
+        core.commit(draft).expect("commit")
+    }
+
+    /// [`submit_and_complete`]'s multi-estate sibling: `work.submitted`
+    /// carries `estate_root` as its `workspace_id` (folded into
+    /// `WorkIndexRow::estate_root`); the completion does not need it again
+    /// (D1: recorded once, at submission, never re-derived).
+    fn submit_and_complete_for_estate(
+        core: &mut crate::api::Core,
+        work_id: &str,
+        estate_root: &str,
+    ) {
+        commit_for_estate(
+            core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some(work_id),
+            estate_root,
+            serde_json::json!({"work": {
+                "id": work_id,
+                "intent": "multi-estate prune fixture",
+                "state": "pending",
+                "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some(work_id),
+            serde_json::json!({}),
+        );
+    }
+
+    // -------------------------------------------------------------
+    // plan_multi_estate over a real journal (brief deliverables 1, 2, 3, 5)
+    // -------------------------------------------------------------
+
+    /// Deliverable 5, end to end: two estates share one journal; A has no
+    /// floor at all, B keeps only its newest Work. `plan_multi_estate`
+    /// retires A's Work and B's own excess Work in one cycle, leaves B's
+    /// newest Work untouched, and reports the per-estate breakdown
+    /// (deliverable 3) that produced that outcome.
+    #[test]
+    fn plan_multi_estate_retires_each_estates_own_excess_and_reports_it_per_estate() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+
+        submit_and_complete_for_estate(&mut core, "a1", "/estates/a");
+        submit_and_complete_for_estate(&mut core, "b_old", "/estates/b");
+        submit_and_complete_for_estate(&mut core, "b_new", "/estates/b");
+        // I-W3-4: push the writer's own live segment off every Work above.
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off every Work's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        // Fallback retention 0 (never 1000): the untagged "anchor" fixture
+        // Work (no estate context, pushed in only to clear I-W3-4's live
+        // segment) would otherwise form its own single-Work fallback group
+        // and — being alone, under any retention — force the *shared* cap
+        // to 0 regardless of A's/B's own floors, the same "small group
+        // dominates the min" arithmetic `each_estates_cap_is_computed_over_
+        // its_own_works_only` exercises directly. This test is about A's
+        // and B's own floors, not the fallback's, so the fallback is given
+        // no floor at all here.
+        let policies = EstatePolicies::new(policy(0))
+            .with_estate("/estates/a", policy(0))
+            .with_estate("/estates/b", policy(1));
+        let (candidate, _) = candidate_horizon_multi_estate(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policies,
+        );
+        assert!(candidate > 0, "the fixture must actually be prunable");
+        let plan = plan_multi_estate(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policies,
+        )
+        .expect("plan")
+        .expect("something must be prunable");
+
+        let retired: BTreeSet<String> = plan.residue.works.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(
+            retired,
+            BTreeSet::from(["a1".to_string(), "b_old".to_string()]),
+            "A's sole Work and B's own excess (past its retention-1 floor) are retired; \
+             B's newest Work is not"
+        );
+        for row in &plan.residue.works {
+            let want = if row.id == "a1" {
+                "/estates/a"
+            } else {
+                "/estates/b"
+            };
+            assert_eq!(
+                row.estate_root.as_deref(),
+                Some(want),
+                "the residue row itself names the estate it belonged to"
+            );
+        }
+
+        let mut per_estate = plan.per_estate.clone();
+        per_estate.sort_by(|a, b| a.estate_root.cmp(&b.estate_root));
+        let a_stat = per_estate
+            .iter()
+            .find(|s| s.estate_root.as_deref() == Some("/estates/a"))
+            .expect("A's own stat row");
+        assert_eq!((a_stat.examined, a_stat.retired, a_stat.kept), (1, 1, 0));
+        assert_eq!(a_stat.policy.retention, 0);
+        let b_stat = per_estate
+            .iter()
+            .find(|s| s.estate_root.as_deref() == Some("/estates/b"))
+            .expect("B's own stat row");
+        assert_eq!((b_stat.examined, b_stat.retired, b_stat.kept), (2, 1, 1));
+        assert_eq!(b_stat.policy.retention, 1);
+    }
+
+    /// Brief deliverable 2 / D7's own named risk: a blob referenced only by
+    /// a live estate B Work must survive a prune pass that retires estate
+    /// A's Work — even though the blob's content is shared (deduped) with
+    /// what A's retired Work referenced. Both estates declare retention 0
+    /// here on purpose, so the *only* thing protecting B's Work is that it
+    /// is not yet terminal (the ordinary blocking-work mechanism) — isolating
+    /// this test from the retention-partitioning arithmetic the tests above
+    /// already cover, and proving the blob-reference scan really is
+    /// journal-wide regardless of which estate's retention triggered the
+    /// cycle (D7: "blob store and GC stay host-journal-wide").
+    #[test]
+    fn a_blob_referenced_only_by_a_live_estates_work_survives_retiring_another_estates_work() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut core = tiny_core(dir.path());
+
+        let shared_blob = BlobStore::open(dir.path())
+            .expect("open blob store")
+            .put(b"content shared by two estates' Works")
+            .expect("put");
+        let hex = shared_blob.hex().to_string();
+
+        // Estate A: a1 is retired whole, referencing the shared blob.
+        commit_for_estate(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("a1"),
+            "/estates/a",
+            serde_json::json!({"work": {
+                "id": "a1", "intent": "cross-estate blob GC fixture (A)",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_COMPLETED,
+            Some("a1"),
+            serde_json::json!({"result_blob": format!("b3:{hex}")}),
+        );
+
+        // Estate B: b1 stays non-terminal (never completed) — a live Work,
+        // above the eventual horizon by construction — and its own later
+        // event references the *same* blob content.
+        commit_for_estate(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("b1"),
+            "/estates/b",
+            serde_json::json!({"work": {
+                "id": "b1", "intent": "cross-estate blob GC fixture (B)",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            "conversation.turn.ended",
+            Some("b1"),
+            serde_json::json!({"raw": format!("b3:{hex}")}),
+        );
+        commit(
+            &mut core,
+            daemon_source(),
+            crate::domain::work::KIND_WORK_SUBMITTED,
+            Some("anchor"),
+            serde_json::json!({"work": {
+                "id": "anchor", "intent": "keep the writer off a1's/b1's segments",
+                "state": "pending", "created_by": "test",
+                "created_at": "2026-01-01T00:00:00.000Z",
+            }}),
+        );
+        core.flush().expect("flush");
+
+        let bounds = core.journal.segment_bounds().expect("bounds");
+        // Both estates at retention 0: nothing about the retention floor is
+        // what protects b1 here (see this test's own doc comment).
+        let policies = EstatePolicies::new(policy(0))
+            .with_estate("/estates/a", policy(0))
+            .with_estate("/estates/b", policy(0));
+        let (candidate, _) = candidate_horizon_multi_estate(
+            &bounds,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policies,
+        );
+        assert!(candidate > 0, "a1 must actually be prunable");
+        let plan = plan_multi_estate(
+            dir.path(),
+            &bounds,
+            candidate,
+            core.registry.state(),
+            &core.first_seq_by_work,
+            &policies,
+        )
+        .expect("plan")
+        .expect("something must be prunable");
+
+        let retired: BTreeSet<String> = plan.residue.works.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(
+            retired,
+            BTreeSet::from(["a1".to_string()]),
+            "only A's terminal Work is retired; B's non-terminal Work still pins the horizon \
+             above itself"
+        );
+        assert!(
+            !plan.condemn.iter().any(|r| r.hex() == hex),
+            "the shared blob must survive: B's still-live event references it, and the \
+             surviving-side scan is journal-wide, not scoped to the estate whose retention \
+             triggered this cycle (D7)"
+        );
+    }
+
     /// Build a two-segment, one-Work fixture and commit its `prune.intent`
     /// (step 1 of `run`'s cycle) — then stop, exactly as a crash would.
     /// Every `crash_window_f*` test starts here and diverges only in what

--- a/src/runtime/prune.rs
+++ b/src/runtime/prune.rs
@@ -2038,6 +2038,206 @@ mod tests {
     }
 
     // -------------------------------------------------------------
+    // EstatePolicies / multi_estate_cap (brief deliverable 1)
+    // -------------------------------------------------------------
+
+    fn estate_work_row(id: &str, estate_root: Option<&str>, last_seq: u64) -> WorkIndexRow {
+        WorkIndexRow {
+            estate_root: estate_root.map(str::to_string),
+            ..work_row(id, WorkState::Completed, last_seq)
+        }
+    }
+
+    #[test]
+    fn resolve_falls_back_for_an_unadmitted_or_unknown_estate() {
+        let policies = EstatePolicies::new(policy(1000)).with_estate("/estates/a", policy(5));
+        assert_eq!(policies.resolve(Some("/estates/a")).retention, 5);
+        assert_eq!(
+            policies.resolve(Some("/estates/vanished")).retention,
+            1000,
+            "an estate not in the map (unadmitted, or no longer admitted) answers to the fallback"
+        );
+        assert_eq!(
+            policies.resolve(None).retention,
+            1000,
+            "a Work with no estate context at all answers to the fallback too"
+        );
+    }
+
+    #[test]
+    fn uniform_matches_the_original_single_group_cap_seq_exactly() {
+        let mut idx = BTreeMap::new();
+        for (id, seq) in [("a", 10u64), ("b", 20), ("c", 30), ("d", 40), ("e", 50)] {
+            idx.insert(id.to_string(), work_row(id, WorkState::Completed, seq));
+        }
+        let policies = EstatePolicies::uniform(policy(2));
+        assert_eq!(
+            multi_estate_cap(&idx, &policies),
+            cap_seq(&idx, 2),
+            "a uniform policy over an un-partitioned registry must be byte-identical to the \
+             pre-H1 single-group cap"
+        );
+    }
+
+    /// Brief deliverable 5: two estates, different retention, one journal —
+    /// each estate's own floor honored independently. The most restrictive
+    /// per-estate cap wins (never a cap computed over the combined set,
+    /// which would let the smaller estate's population dilute the larger
+    /// one's floor, or vice versa).
+    #[test]
+    fn each_estates_cap_is_computed_over_its_own_works_only() {
+        let mut idx = BTreeMap::new();
+        // Estate A: 10 Works, retention 3 -> cap sits just below its own
+        // 3rd-newest (last_seq 8, interleaved with B below).
+        for (id, seq) in [
+            ("a1", 1u64),
+            ("a2", 3),
+            ("a3", 5),
+            ("a4", 7),
+            ("a5", 9),
+            ("a6", 11),
+            ("a7", 13),
+            ("a8", 15),
+            ("a9", 17),
+            ("a10", 19),
+        ] {
+            idx.insert(id.to_string(), estate_work_row(id, Some("/estates/a"), seq));
+        }
+        // Estate B: 10 Works, retention 7 -> a much tighter cap (protects
+        // its newest 7), interleaved with A's own seqs throughout.
+        for (id, seq) in [
+            ("b1", 2u64),
+            ("b2", 4),
+            ("b3", 6),
+            ("b4", 8),
+            ("b5", 10),
+            ("b6", 12),
+            ("b7", 14),
+            ("b8", 16),
+            ("b9", 18),
+            ("b10", 20),
+        ] {
+            idx.insert(id.to_string(), estate_work_row(id, Some("/estates/b"), seq));
+        }
+        let policies = EstatePolicies::new(policy(1000))
+            .with_estate("/estates/a", policy(3))
+            .with_estate("/estates/b", policy(7));
+
+        let cap_a_alone = cap_seq_over([1, 3, 5, 7, 9, 11, 13, 15, 17, 19].into_iter(), 3);
+        let cap_b_alone = cap_seq_over([2, 4, 6, 8, 10, 12, 14, 16, 18, 20].into_iter(), 7);
+        assert_eq!(
+            cap_a_alone, 14,
+            "A's 3rd-newest is a9 (last_seq 15); cap sits one below it"
+        );
+        assert_eq!(
+            cap_b_alone, 7,
+            "B's 7th-newest is b4 (last_seq 8); cap sits one below it"
+        );
+
+        let combined = multi_estate_cap(&idx, &policies);
+        assert_eq!(
+            combined,
+            cap_a_alone.min(cap_b_alone),
+            "the shared horizon is the more restrictive of the two independent floors"
+        );
+        assert_eq!(
+            combined, cap_b_alone,
+            "B's own floor is the tighter one here"
+        );
+
+        // B's own floor is honored *exactly*: 10 - 7 = 3 of its oldest Works
+        // fall at/below the shared cap, never more, never fewer. A's own
+        // floor (looser: cap 14) is honored too — the shared cap is only
+        // ever *more* conservative than either estate's own number, so more
+        // of A's Works happen to sit below it than A's own floor strictly
+        // requires, which never violates A's floor (a floor is a "keep at
+        // least this many", not a "prune exactly this many").
+        let below = |root: &str, cap: u64| {
+            idx.values()
+                .filter(|r| r.estate_root.as_deref() == Some(root) && r.last_seq <= cap)
+                .count()
+        };
+        assert_eq!(
+            below("/estates/b", combined),
+            3,
+            "b1..b3 fall at/below B's own 7-retention cap"
+        );
+        assert_eq!(
+            below("/estates/a", combined),
+            4,
+            "more of A's Works than A's own floor requires happen to fall below the tighter \
+             shared cap (a1..a4) — never fewer, which is the only direction that would violate A"
+        );
+    }
+
+    /// A group's own `count <= retention` (nothing of that estate is past
+    /// its floor) must not silently widen into "nothing of ANY estate may be
+    /// pruned" — reusing the combined-registry's total count would do
+    /// exactly that; per-group partitioning must not.
+    #[test]
+    fn a_small_estate_under_its_own_retention_does_not_forbid_a_large_estates_own_excess() {
+        let mut idx = BTreeMap::new();
+        // Estate A: 5 Works, retention 0 -> fully unconstrained by its own
+        // floor (cap_seq_over(_, 0) == u64::MAX).
+        for (id, seq) in [("a1", 1u64), ("a2", 2), ("a3", 3), ("a4", 4), ("a5", 5)] {
+            idx.insert(id.to_string(), estate_work_row(id, Some("/estates/a"), seq));
+        }
+        let policies = EstatePolicies::new(policy(1000)).with_estate("/estates/a", policy(0));
+        assert_eq!(
+            multi_estate_cap(&idx, &policies),
+            u64::MAX,
+            "the sole estate present declared retention 0 (no floor at all); nothing should cap it"
+        );
+    }
+
+    /// Brief deliverable 5, live via [`candidate_horizon_multi_estate`]:
+    /// estate A (retention 0, no floor at all) and estate B (retention 1,
+    /// keeps only its newest Work) share one journal. A's sole Work and B's
+    /// older Work are both eligible; B's newest Work is protected — each
+    /// estate's own floor honored independently, in one shared horizon.
+    #[test]
+    fn candidate_horizon_multi_estate_honors_each_estates_own_floor_in_one_shared_horizon() {
+        let bounds = vec![
+            bound(1, 1, 3),
+            bound(2, 4, 6),
+            bound(3, 7, 9),
+            bound(4, 10, 100),
+        ];
+        let mut registry = WorkRegistry::default();
+        registry.work_index.insert(
+            "a1".to_string(),
+            estate_work_row("a1", Some("/estates/a"), 3),
+        );
+        registry.work_index.insert(
+            "b_old".to_string(),
+            estate_work_row("b_old", Some("/estates/b"), 6),
+        );
+        registry.work_index.insert(
+            "b_new".to_string(),
+            estate_work_row("b_new", Some("/estates/b"), 9),
+        );
+        let mut first_seq = FirstSeqIndex::new();
+        first_seq.insert("a1".to_string(), 3);
+        first_seq.insert("b_old".to_string(), 6);
+        first_seq.insert("b_new".to_string(), 9);
+
+        let policies = EstatePolicies::new(policy(1000))
+            .with_estate("/estates/a", policy(0))
+            .with_estate("/estates/b", policy(1));
+        let (h, stall) = candidate_horizon_multi_estate(&bounds, &registry, &first_seq, &policies);
+        assert_eq!(
+            h, 6,
+            "a1 (A, no floor) and b_old (B's own excess past retention 1) are both eligible; \
+             b_new (B's protected newest) is not, so the horizon stops at b_old's own seq"
+        );
+        assert_eq!(
+            stall.retention, 1000,
+            "the single reported number is the fallback's own — a full breakdown is \
+             EstatePruneStat's job, not this field's"
+        );
+    }
+
+    // -------------------------------------------------------------
     // A real cycle over a real journal, via `Core` directly (no daemon).
     // -------------------------------------------------------------
 

--- a/src/runtime/sweep.rs
+++ b/src/runtime/sweep.rs
@@ -229,6 +229,22 @@ pub struct DeletedBranch {
 /// never evicted), so callers hand it straight over rather than replaying the
 /// journal a second time for the same fact.
 pub fn classify(estate: &Estate, works: &BTreeMap<String, WorkState>) -> SweepReport {
+    // W4a seam: this function is already correctly single-estate per call
+    // (recon-engine-journal touch point 8 names it "correct as-is") and
+    // needs no change here. What H1 still owes is the *caller*: every call
+    // to `classify` today is the per-request estate-scoped HTTP surface
+    // (`GET`/`POST /v1/sweep`, `api.rs`'s `sweep_estate`/its POST sibling) —
+    // there is no periodic daemon-side loop anywhere in this codebase yet to
+    // iterate admitted estates and call this once per estate (checked:
+    // `daemon.rs` has no periodic sweep caller at all — unlike
+    // `maybe_run_rotation_triggered_prune`'s rotation-triggered prune tick,
+    // which this wave *did* rewire onto `EstateRegistry`-backed multi-estate
+    // retention, see `prune::EstatePolicies`). When a periodic sweep caller
+    // is added, it must iterate `estates::EstateRegistry::entries()` and
+    // call `classify` once per admitted estate — never assume the
+    // one-estate world this function's own signature still lets a naive
+    // caller fall into. Named here rather than dropped (brief deliverable
+    // 4); a W5 item.
     SweepReport {
         repositories: estate
             .repositories


### PR DESCRIPTION
Wave W4a of sprint S1, per the workspace sprint plan (decision D7). 5 commits.

- `EstatePolicies` resolves each Work's retention floor from its journaled `estate_root` (W2's `AdmittedEstate::retention`); unknown/unadmitted Works take the config-override-or-default, reported as such. `multi_estate_cap` = min of independently-computed per-estate caps (never a cap over the combined population), wired into the rotation-triggered prune tick.
- **Blob liveness stays host-journal-wide (D7's crux)** — proven by a negative test: a blob deduped between a retired estate-A Work and a live estate-B Work survives.
- Prune plan/outcome report per-estate examined/retired/kept; `PrunedWorkRow` gains `estate_root` — all `#[serde(default)]`, no FloorState schema bump (28/28 startup cache tests unchanged).
- Sweep periodic caller: none exists in the codebase to widen; seam comment + named W5 item, per the brief's fallback.
- Startup-triggered prune path (daemon.rs, out of this wave's bounds) still single-policy — named W5 follow-up, not silently narrowed.
- Design note (owner-visible): min-of-caps is deliberately conservative under segment-atomic deletion — ADR 0019's "eventually-exact" tradeoff extended per-estate, documented on `multi_estate_cap`.

Gates: blind 4-axis panel + refuters — zero confirmed findings. Verify (rebased onto 729741fc, `TMPDIR=/var/tmp/sgt-test-tmp`): **full suite green, 0 failures, no tolerated list.**

Rungs: D7 J3; R2 (`cap_seq_over` factored and reused per group); R1 (no speculative sweep caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4