### PR TITLE
S1/W4d: TUI Host→Estate→Work view — Fleet estate filter, estate picker, root-keyed identity

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -4670,13 +4670,20 @@ impl ApiClient {
     }
 
     /// `?estate_root=<root>` for the GET/DELETE routes that have no body to
-    /// carry it in. Empty when this client addresses no estate, so the
-    /// daemon answers with refusal (c) rather than being handed a blank.
-    fn estate_query(&self) -> String {
-        match &self.estate_root {
+    /// carry it in. Empty when `root` is `None`, so the daemon answers with
+    /// refusal (c) rather than being handed a blank.
+    fn estate_query_for(root: Option<&std::path::Path>) -> String {
+        match root {
             Some(root) => format!("?estate_root={}", urlencode(&root.to_string_lossy())),
             None => String::new(),
         }
+    }
+
+    /// [`Self::estate_query_for`] over this client's own bound
+    /// [`Self::estate_root`] — the ordinary case every estate-scoped GET/
+    /// DELETE method below still uses by default.
+    fn estate_query(&self) -> String {
+        Self::estate_query_for(self.estate_root.as_deref())
     }
 
     /// Add this client's estate address to a request body, if it has one.
@@ -4862,8 +4869,23 @@ impl ApiClient {
 
     /// `GET /v1/estate/repos` (§16.2/§20.4) — declared repositories.
     pub async fn repos(&self) -> Result<Value, ClientError> {
-        self.get(&format!("/v1/estate/repos{}", self.estate_query()))
-            .await
+        self.repos_for(self.estate_root.as_deref()).await
+    }
+
+    /// [`Self::repos`], addressed at an explicit estate root rather than
+    /// this client's own bound one (W4d deliverable 3: the Estate screen's
+    /// picker reads whichever estate is picked, which under host mode is
+    /// independent of whatever this client otherwise addresses — a host-
+    /// scoped client addresses none at all).
+    pub async fn repos_for(
+        &self,
+        estate_root: Option<&std::path::Path>,
+    ) -> Result<Value, ClientError> {
+        self.get(&format!(
+            "/v1/estate/repos{}",
+            Self::estate_query_for(estate_root)
+        ))
+        .await
     }
 
     /// `POST /v1/estate/repos` (§16.2/§20.4) — `manifest::add_repo`.
@@ -4901,8 +4923,20 @@ impl ApiClient {
 
     /// `GET /v1/estate/groups` (§16.2/§20.4) — declared groups.
     pub async fn groups(&self) -> Result<Value, ClientError> {
-        self.get(&format!("/v1/estate/groups{}", self.estate_query()))
-            .await
+        self.groups_for(self.estate_root.as_deref()).await
+    }
+
+    /// [`Self::groups`], addressed at an explicit estate root — see
+    /// [`Self::repos_for`]'s doc comment for why this exists.
+    pub async fn groups_for(
+        &self,
+        estate_root: Option<&std::path::Path>,
+    ) -> Result<Value, ClientError> {
+        self.get(&format!(
+            "/v1/estate/groups{}",
+            Self::estate_query_for(estate_root)
+        ))
+        .await
     }
 
     /// `POST /v1/estate/groups` (§16.2/§20.4) — `manifest::add_group`'s
@@ -4937,8 +4971,20 @@ impl ApiClient {
     /// `GET /v1/doctor` (§16.3/§20.4) — the same `doctor::Report` `sgt doctor
     /// --json` prints.
     pub async fn doctor(&self) -> Result<Value, ClientError> {
-        self.get(&format!("/v1/doctor{}", self.estate_query()))
-            .await
+        self.doctor_for(self.estate_root.as_deref()).await
+    }
+
+    /// [`Self::doctor`], addressed at an explicit estate root — see
+    /// [`Self::repos_for`]'s doc comment for why this exists.
+    pub async fn doctor_for(
+        &self,
+        estate_root: Option<&std::path::Path>,
+    ) -> Result<Value, ClientError> {
+        self.get(&format!(
+            "/v1/doctor{}",
+            Self::estate_query_for(estate_root)
+        ))
+        .await
     }
 
     /// `GET /v1/estates` (H1 §4) — every estate this daemon has admitted.

--- a/src/api.rs
+++ b/src/api.rs
@@ -2187,12 +2187,13 @@ fn fleet_body(core: &Core, engine: &Engine) -> Value {
         .work_index
         .keys()
         .map(|id| {
+            let index_row = &registry.work_index[id];
             let Some(work) = registry
                 .works
                 .get(id)
                 .or_else(|| registry.terminal_works.get(id))
             else {
-                return evicted_fleet_row(&registry.work_index[id]);
+                return evicted_fleet_row(index_row);
             };
             // `registry.run_view` alone only reaches the bounded
             // in-memory cache (`TERMINAL_RUN_CACHE_CAPACITY`); once a
@@ -2249,6 +2250,23 @@ fn fleet_body(core: &Core, engine: &Engine) -> Value {
                         "turn_ceiling_secs": engine.effective_turn_ceiling(Some(work)).as_secs_f64(),
                     }),
                 );
+                // W4d deliverable 1 (H1): the per-Work estate *identity* —
+                // `Work::workspace` (the old display-name field) has been
+                // dead since estate-root Phase C (`Work`'s own doc comment:
+                // "deprecated, never written"); `WorkIndexRow::estate_root`
+                // is the live coordinate H1 actually folds per Work (D1: a
+                // canonical root, never a name — two estates may share a
+                // display name). Surfacing it here is what lets the TUI's
+                // Fleet filter (§10, this wave) narrow by estate at all
+                // against a real daemon; `null` for any Work journaled
+                // before the envelope carried it, or with no estate context.
+                object.insert(
+                    "estate_root".to_string(),
+                    index_row
+                        .estate_root
+                        .clone()
+                        .map_or(Value::Null, Value::String),
+                );
             }
             row
         })
@@ -2293,6 +2311,7 @@ fn evicted_fleet_row(row: &WorkIndexRow) -> Value {
         "created_at": row.created_at,
         "updated_at": row.updated_at,
         "evicted": true,
+        "estate_root": row.estate_root,
     })
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1461,7 +1461,25 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // no-spawn set like every other observation surface, and bare
             // `sgt` no longer falls into it by default.
             let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
-            crate::tui::run(client).await.map_err(CliError::from)
+            // brief deliverable 2 (W4d), H1 §9: cwd is consulted only to
+            // default Fleet's initial estate filter, mirroring `Watch`'s own
+            // opportunistic default a few arms up (that arm's own comment
+            // names this one as its analogue) — it never gates the
+            // connection above (`estate` is always `None` here,
+            // `is_host_scoped`), and a cwd that is not an estate root falls
+            // back to no initial filter rather than refusing. The lenient,
+            // `from_config_structural` loader is deliberate here too: a
+            // freshly cloned estate with an unresolved `[[repo]]` must still
+            // supply its name for this presentation-only default, the same
+            // reasoning `PolicySource`'s own retention re-read documents.
+            let initial_estate = Estate::admit(&root).ok().and_then(|admitted| {
+                Estate::from_config_structural(&admitted.manifest_path)
+                    .ok()
+                    .map(|estate| estate.name)
+            });
+            crate::tui::run(client, initial_estate)
+                .await
+                .map_err(CliError::from)
         }
         Command::Doctor => {
             let report = doctor::run(&data_dir, &root, data_dir_source.xdg_outranked()).await;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1467,16 +1467,18 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // names this one as its analogue) — it never gates the
             // connection above (`estate` is always `None` here,
             // `is_host_scoped`), and a cwd that is not an estate root falls
-            // back to no initial filter rather than refusing. The lenient,
-            // `from_config_structural` loader is deliberate here too: a
-            // freshly cloned estate with an unresolved `[[repo]]` must still
-            // supply its name for this presentation-only default, the same
-            // reasoning `PolicySource`'s own retention re-read documents.
-            let initial_estate = Estate::admit(&root).ok().and_then(|admitted| {
-                Estate::from_config_structural(&admitted.manifest_path)
-                    .ok()
-                    .map(|estate| estate.name)
-            });
+            // back to no initial filter rather than refusing.
+            //
+            // The canonical root (`EstateRoot::path`), not a parsed manifest
+            // name: `Filters::estate`/`WorkRow::estate` (W4d deliverable 1)
+            // key on the same root-is-identity coordinate the daemon itself
+            // folds per Work (`estate_root`, H1 D1) — "a name is not an
+            // identity" holds here exactly as it does there, and reusing it
+            // avoids a manifest read this presentation-only default has no
+            // real need for.
+            let initial_estate = Estate::admit(&root)
+                .ok()
+                .map(|admitted| admitted.path.to_string_lossy().into_owned());
             crate::tui::run(client, initial_estate)
                 .await
                 .map_err(CliError::from)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -299,21 +299,53 @@ impl App {
         // Best-effort, same reasoning as `work_screen`'s: a failed estate
         // read must not blank fleet/system data that loaded fine.
         if self.destination == Destination::Estate {
-            match client.repos().await {
-                Ok(result) => {
-                    self.estate.repos = result["repos"].as_array().cloned().unwrap_or_default();
+            // W4d deliverable 3: a client that already addresses one fixed
+            // estate (the pre-H1, still-supported single-estate-scoped
+            // shape) auto-picks it — no picker ever appears, and
+            // repos/groups/doctor below read exactly as they always have.
+            // A host-scoped client (no fixed `estate_root`) instead reads
+            // the admitted-estates list for the picker; its own choice (or
+            // none yet) decides what, if anything, gets addressed below.
+            if let Some(root) = client.estate_root() {
+                let name = self
+                    .estate
+                    .picked
+                    .as_ref()
+                    .filter(|p| p.root == root)
+                    .map(|p| p.name.clone())
+                    .unwrap_or_else(|| {
+                        root.file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| root.to_string_lossy().into_owned())
+                    });
+                self.estate.auto_pick(root, &name);
+            } else {
+                match client.estates().await {
+                    Ok(result) => {
+                        self.estate.estates =
+                            result["estates"].as_array().cloned().unwrap_or_default();
+                    }
+                    Err(e) => self.estate.last_error = Some(e.to_string()),
                 }
-                Err(e) => self.estate.last_error = Some(e.to_string()),
             }
-            match client.groups().await {
-                Ok(result) => {
-                    self.estate.groups = result["groups"].as_array().cloned().unwrap_or_default();
+            if let Some(picked) = self.estate.picked.clone() {
+                match client.repos_for(Some(&picked.root)).await {
+                    Ok(result) => {
+                        self.estate.repos = result["repos"].as_array().cloned().unwrap_or_default();
+                    }
+                    Err(e) => self.estate.last_error = Some(e.to_string()),
                 }
-                Err(e) => self.estate.last_error = Some(e.to_string()),
-            }
-            match client.doctor().await {
-                Ok(result) => self.estate.doctor = result,
-                Err(e) => self.estate.last_error = Some(e.to_string()),
+                match client.groups_for(Some(&picked.root)).await {
+                    Ok(result) => {
+                        self.estate.groups =
+                            result["groups"].as_array().cloned().unwrap_or_default();
+                    }
+                    Err(e) => self.estate.last_error = Some(e.to_string()),
+                }
+                match client.doctor_for(Some(&picked.root)).await {
+                    Ok(result) => self.estate.doctor = result,
+                    Err(e) => self.estate.last_error = Some(e.to_string()),
+                }
             }
             self.estate.clamp();
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -198,6 +198,15 @@ pub struct App {
     pub status: String,
     /// Set once the user asked to leave.
     pub quit: bool,
+    /// W4d deliverable 2 (H1 §9's "cwd... is used as an initial filter"):
+    /// the estate the CLI opportunistically admitted from cwd at launch, if
+    /// any — presentation-only state, set once by
+    /// [`App::apply_initial_estate`] and otherwise only read (never
+    /// re-derived) here — no module under `src/tui/` reads local disk
+    /// (§30's rule). Distinct from [`super::fleet::Filters::estate`], which
+    /// the operator is free to retoggle afterward with `e`; this slot only
+    /// ever supplies that filter's *initial* value.
+    pub selected_estate: Option<String>,
 }
 
 impl App {
@@ -223,7 +232,20 @@ impl App {
             live: Live::default(),
             status: "loading…".to_string(),
             quit: false,
+            selected_estate: None,
         }
+    }
+
+    /// Apply the CLI's opportunistic cwd estate (deliverable 2) as Fleet's
+    /// initial estate filter — called at most once, before the first
+    /// [`App::refresh`], so it is a starting point the operator can still
+    /// freely retoggle with `e`, never a re-imposed default. `None` (cwd is
+    /// not a valid estate root, or the TUI was launched from one that
+    /// hasn't been addressed) leaves Fleet showing every estate, the same
+    /// as it always has.
+    pub fn apply_initial_estate(&mut self, estate: Option<String>) {
+        self.selected_estate = estate.clone();
+        self.fleet.filters.estate = estate;
     }
 
     /// Re-read everything this app shows from the API.
@@ -1190,6 +1212,38 @@ mod tests {
             "state": state,
             "intent": format!("intent for {id}"),
         })).collect::<Vec<_>>()})
+    }
+
+    #[test]
+    fn apply_initial_estate_seeds_selected_estate_and_fleets_filter_once() {
+        let mut app = App::new();
+        assert_eq!(app.selected_estate, None);
+        assert_eq!(app.fleet.filters.estate, None);
+
+        app.apply_initial_estate(Some("payments".to_string()));
+        assert_eq!(app.selected_estate.as_deref(), Some("payments"));
+        assert_eq!(app.fleet.filters.estate.as_deref(), Some("payments"));
+
+        // The operator's own retoggle afterward is not re-imposed by a
+        // second call — deliberately not exercised here since a real
+        // caller never calls it twice; what matters is that Fleet's own `e`
+        // keystroke, once applied, is the filter's whole story from then on
+        // (this is a documentation test, not a behavioral guard: nothing
+        // re-applies `selected_estate` after startup).
+        app.fleet.filters.estate = None;
+        assert_eq!(
+            app.selected_estate.as_deref(),
+            Some("payments"),
+            "the initial slot itself is untouched by the operator's later retoggle"
+        );
+    }
+
+    #[test]
+    fn apply_initial_estate_with_no_cwd_estate_leaves_fleet_unfiltered() {
+        let mut app = App::new();
+        app.apply_initial_estate(None);
+        assert_eq!(app.selected_estate, None);
+        assert_eq!(app.fleet.filters.estate, None);
     }
 
     #[test]

--- a/src/tui/estate.rs
+++ b/src/tui/estate.rs
@@ -430,12 +430,40 @@ impl GroupForm {
     }
 }
 
+/// W4d deliverable 3: the estate this screen currently addresses, once
+/// picked. `root` is the canonical estate root — the key
+/// `repos_for`/`groups_for`/`doctor_for` and `GET /v1/estates` itself both
+/// address estates by (D1) — `name` is display-only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PickedEstate {
+    pub name: String,
+    pub root: std::path::PathBuf,
+}
+
 /// The Estate destination's whole state: three sub-screens' data and
 /// selection, plus the two edit forms and the retained-state preview
 /// [`super::overlay::Overlay::RepoAddRemove`]/[`super::overlay::Overlay::
 /// GroupEditRemove`]/[`super::overlay::Overlay::RetainedPreview`] need.
 pub struct EstateScreen {
     pub tab: EstateTab,
+    /// `GET /v1/estates`' entries (H1 §4) — every estate this daemon has
+    /// admitted, fed to the picker (W4d deliverable 3). Populated whenever
+    /// this screen is in front, the same discipline as `repos`/`groups`/
+    /// `doctor` below.
+    pub estates: Vec<Value>,
+    /// Which entry in `estates` the picker is currently highlighting,
+    /// before anything is picked.
+    pub picker_selected: usize,
+    /// The estate `repos`/`groups`/`doctor` below address, once chosen.
+    /// `None` shows only the picker: this screen's existing sub-tabs are
+    /// inherently single-estate-at-a-time (their own `/v1/estate/*` routes
+    /// address exactly one), so there is nothing of theirs to show before
+    /// one is addressed. A client that already addresses one fixed estate
+    /// (`ApiClient::estate_root` — the pre-H1, still-supported single-
+    /// estate-scoped shape) is auto-picked the moment this screen is
+    /// entered, so that shape's behavior is unchanged byte for byte: no
+    /// picker ever appears for it.
+    pub picked: Option<PickedEstate>,
     /// `GET /v1/estate/repos`'s `repos` array.
     pub repos: Vec<Value>,
     /// `GET /v1/estate/groups`'s `groups` array.
@@ -462,6 +490,9 @@ impl Default for EstateScreen {
     fn default() -> Self {
         Self {
             tab: EstateTab::Repositories,
+            estates: Vec::new(),
+            picker_selected: 0,
+            picked: None,
             repos: Vec::new(),
             groups: Vec::new(),
             doctor: Value::Null,
@@ -483,11 +514,61 @@ impl EstateScreen {
     /// discipline [`super::fleet::FleetScreen::clamp`] applies — a refresh
     /// that shrinks a list must never leave a selection pointing past its end.
     pub fn clamp(&mut self) {
+        self.picker_selected = clamp_index(self.picker_selected, self.estates.len());
         self.repo_selected = clamp_index(self.repo_selected, self.repos.len());
         self.group_selected = clamp_index(self.group_selected, self.groups.len());
         let checks = self.doctor["checks"].as_array().map_or(0, Vec::len);
         self.check_selected = clamp_index(self.check_selected, checks);
         self.retained_selected = clamp_index(self.retained_selected, self.retained.len());
+    }
+
+    /// Auto-pick for a client that already addresses one fixed estate
+    /// (`ApiClient::estate_root` — the pre-H1 single-estate-scoped shape) —
+    /// called by `App::refresh` every time this screen is in front, so it
+    /// is idempotent rather than a one-time seed: a `root` that has not
+    /// changed leaves `picked` alone (no selection reset mid-browse), and a
+    /// changed one (a different `-C`, in practice never mid-session) is
+    /// re-picked with a fresh name.
+    pub fn auto_pick(&mut self, root: &std::path::Path, name: &str) {
+        if self.picked.as_ref().is_some_and(|p| p.root == root) {
+            return;
+        }
+        self.picked = Some(PickedEstate {
+            name: name.to_string(),
+            root: root.to_path_buf(),
+        });
+    }
+
+    /// Whether the picker is actually in front of the sub-tabs right now.
+    ///
+    /// Deliberately **not** just `self.picked.is_none()`: before the first
+    /// `App::refresh` has run at all (this screen just entered, nothing
+    /// fetched yet — the exact moment the pre-existing T3 estate tests
+    /// press Tab/`a`/`x` against), `picked` is `None` and `estates` is
+    /// still empty too. Gating on `estates` being non-empty as well means
+    /// that ordinary "nothing loaded yet" moment renders and keys exactly
+    /// as it always has — exactly like every other lazily-loaded pane here
+    /// (`repos`/`groups`/`doctor` themselves start empty and are simply
+    /// blank until the first successful read). A client that never fetches
+    /// `estates` at all (the fixed-single-estate shape, `auto_pick`'s own
+    /// case) never shows a picker for exactly this reason: the condition
+    /// this method checks never both hold for it.
+    fn showing_picker(&self) -> bool {
+        self.picked.is_none() && !self.estates.is_empty()
+    }
+
+    /// The currently highlighted picker entry's name and root, if the list
+    /// is non-empty and its entry has both fields — the same tolerant
+    /// `field_text`-adjacent reading every other screen here already does
+    /// for a body it does not control the shape of.
+    fn picker_choice(&self) -> Option<PickedEstate> {
+        let entry = self.estates.get(self.picker_selected)?;
+        let name = entry["name"].as_str()?.to_string();
+        let root = entry["root"].as_str()?;
+        Some(PickedEstate {
+            name,
+            root: std::path::PathBuf::from(root),
+        })
     }
 
     pub fn selected_repo(&self) -> Option<&Value> {
@@ -529,7 +610,42 @@ impl EstateScreen {
     /// switching and list navigation are captured here, ahead of the global
     /// destination-nav keys, the same way [`super::work_view::WorkScreen`]
     /// captures its own `Tab`.
+    ///
+    /// W4d deliverable 3: while [`Self::showing_picker`] holds, every key
+    /// is the picker's own (Up/Down to browse, Enter to choose) — none of
+    /// the existing sub-tab keys below fire. See that method's own doc
+    /// comment for why this is not simply "nothing is picked yet".
     pub fn on_key(&mut self, key: KeyCode) -> EstateOutcome {
+        if self.showing_picker() {
+            match key {
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.picker_selected = (self.picker_selected + 1) % self.estates.len();
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.picker_selected =
+                        (self.picker_selected + self.estates.len() - 1) % self.estates.len();
+                }
+                KeyCode::Enter => {
+                    if let Some(choice) = self.picker_choice() {
+                        self.picked = Some(choice);
+                        self.repo_selected = 0;
+                        self.group_selected = 0;
+                        self.check_selected = 0;
+                    }
+                }
+                _ => {}
+            }
+            return EstateOutcome::None;
+        }
+        // `p` returns to the picker — a no-op unless `estates` actually has
+        // more than one candidate to offer (`showing_picker` needs it
+        // non-empty too), the same "harmless outside its own tier" shape
+        // Fleet's own `v` uses.
+        if key == KeyCode::Char('p') {
+            self.picked = None;
+            self.picker_selected = 0;
+            return EstateOutcome::None;
+        }
         match key {
             KeyCode::Tab => self.tab = self.tab.next(),
             KeyCode::BackTab => self.tab = self.tab.prev(),
@@ -597,9 +713,14 @@ fn clamp_index(index: usize, len: usize) -> usize {
 // -------------------------------------------------------------- rendering
 
 pub fn render(frame: &mut Frame, area: Rect, estate: &EstateScreen) {
+    if estate.showing_picker() {
+        render_picker(frame, area, estate);
+        return;
+    }
     let [tabs_area, body_area] =
         Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(area);
-    render_tabs(frame, tabs_area, estate.tab);
+    let picked_name = estate.picked.as_ref().map_or("-", |p| p.name.as_str());
+    render_tabs(frame, tabs_area, estate.tab, picked_name);
     match estate.tab {
         EstateTab::Repositories => render_repos(frame, body_area, estate),
         EstateTab::Groups => render_groups(frame, body_area, estate),
@@ -607,8 +728,41 @@ pub fn render(frame: &mut Frame, area: Rect, estate: &EstateScreen) {
     }
 }
 
-fn render_tabs(frame: &mut Frame, area: Rect, active: EstateTab) {
-    let mut spans = vec![Span::raw("Estate  ")];
+/// W4d deliverable 3: the picker above Repositories/Groups/Health,
+/// GET-/v1/estates-fed, shown in place of the sub-tabs until one is chosen.
+fn render_picker(frame: &mut Frame, area: Rect, estate: &EstateScreen) {
+    let block = bordered("Estate — pick one (↑/↓, Enter)");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if estate.estates.is_empty() {
+        frame.render_widget(
+            Paragraph::new("no estates admitted to this daemon yet").wrap(Wrap { trim: false }),
+            inner,
+        );
+        return;
+    }
+    let items: Vec<ListItem> = estate
+        .estates
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            let style = if i == estate.picker_selected {
+                Style::default().add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default()
+            };
+            let line = format!("{:<24} {}", field_text(&e["name"]), field_text(&e["root"]),);
+            ListItem::new(line).style(style)
+        })
+        .collect();
+    frame.render_widget(List::new(items), inner);
+}
+
+fn render_tabs(frame: &mut Frame, area: Rect, active: EstateTab, picked_name: &str) {
+    let mut spans = vec![Span::styled(
+        format!("Estate [{picked_name}]  "),
+        Style::default().fg(Token::Muted.rgb()),
+    )];
     for tab in EstateTab::ALL {
         let style = if tab == active {
             Style::default()
@@ -959,8 +1113,19 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// A picked estate for tests that exercise the existing sub-tab
+    /// behavior (W4d deliverable 3 gates every one of them on `picked` —
+    /// the picker itself is exercised separately below).
+    fn some_picked() -> Option<PickedEstate> {
+        Some(PickedEstate {
+            name: "acme".to_string(),
+            root: std::path::PathBuf::from("/estates/acme"),
+        })
+    }
+
     fn repos_estate() -> EstateScreen {
         EstateScreen {
+            picked: some_picked(),
             repos: vec![
                 json!({"name": "svc-a", "path": "repos/svc-a", "origin": "git@x:svc-a", "instructions": "suppress"}),
                 json!({"name": "svc-b", "path": "repos/svc-b", "origin": null, "instructions": "local"}),
@@ -972,7 +1137,10 @@ mod tests {
 
     #[test]
     fn tab_key_cycles_repositories_groups_health() {
-        let mut estate = EstateScreen::default();
+        let mut estate = EstateScreen {
+            picked: some_picked(),
+            ..EstateScreen::default()
+        };
         assert_eq!(estate.tab, EstateTab::Repositories);
         estate.on_key(KeyCode::Tab);
         assert_eq!(estate.tab, EstateTab::Groups);
@@ -1024,6 +1192,7 @@ mod tests {
     fn r_opens_retained_only_for_the_disk_pressure_check() {
         let mut estate = EstateScreen {
             tab: EstateTab::Health,
+            picked: some_picked(),
             doctor: json!({"checks": [
                 {"name": "git", "status": "ok", "detail": "found"},
                 {"name": "disk_pressure", "status": "warn", "detail": "82% full"},
@@ -1044,6 +1213,81 @@ mod tests {
         estate.repo_selected = 5;
         estate.clamp();
         assert_eq!(estate.repo_selected, 1);
+    }
+
+    fn two_estates() -> EstateScreen {
+        EstateScreen {
+            estates: vec![
+                json!({"name": "payments", "root": "/estates/payments"}),
+                json!({"name": "billing", "root": "/estates/billing"}),
+            ],
+            ..EstateScreen::default()
+        }
+    }
+
+    #[test]
+    fn nothing_picked_shows_only_the_picker_and_ignores_sub_tab_keys() {
+        let mut estate = two_estates();
+        // Tab is Repositories/Groups/Health's own key once picked; with
+        // nothing picked yet it must be a no-op, not a tab switch.
+        estate.on_key(KeyCode::Tab);
+        assert_eq!(estate.tab, EstateTab::Repositories);
+        assert!(estate.picked.is_none());
+    }
+
+    #[test]
+    fn up_down_browse_the_picker_and_enter_picks_the_highlighted_estate() {
+        let mut estate = two_estates();
+        assert_eq!(estate.picker_selected, 0);
+        estate.on_key(KeyCode::Down);
+        assert_eq!(estate.picker_selected, 1);
+        estate.on_key(KeyCode::Up);
+        assert_eq!(estate.picker_selected, 0);
+
+        estate.on_key(KeyCode::Down);
+        estate.on_key(KeyCode::Enter);
+        assert_eq!(
+            estate.picked,
+            Some(PickedEstate {
+                name: "billing".to_string(),
+                root: std::path::PathBuf::from("/estates/billing"),
+            })
+        );
+    }
+
+    #[test]
+    fn p_returns_a_picked_screen_to_the_picker() {
+        let mut estate = repos_estate();
+        assert!(estate.picked.is_some());
+        estate.on_key(KeyCode::Char('p'));
+        assert!(estate.picked.is_none());
+    }
+
+    #[test]
+    fn auto_pick_is_idempotent_over_an_unchanged_root() {
+        let mut estate = EstateScreen::default();
+        let root = std::path::Path::new("/estates/acme");
+        estate.auto_pick(root, "acme");
+        estate.auto_pick(root, "renamed"); // same root, e.g. a later manifest edit
+        assert_eq!(
+            estate.picked.as_ref().map(|p| p.name.as_str()),
+            Some("acme"),
+            "an unchanged root is not re-picked, even if the display name changed upstream"
+        );
+    }
+
+    #[test]
+    fn auto_pick_repicks_on_a_changed_root() {
+        let mut estate = EstateScreen::default();
+        estate.auto_pick(std::path::Path::new("/estates/a"), "a");
+        estate.auto_pick(std::path::Path::new("/estates/b"), "b");
+        assert_eq!(
+            estate.picked,
+            Some(PickedEstate {
+                name: "b".to_string(),
+                root: std::path::PathBuf::from("/estates/b"),
+            })
+        );
     }
 
     #[test]

--- a/src/tui/fleet.rs
+++ b/src/tui/fleet.rs
@@ -118,6 +118,12 @@ pub struct Filters {
     pub text: String,
     pub state: Option<String>,
     pub nonterminal_only: bool,
+    /// W4d deliverable 1 (H1 §9): the fleet-wide estate filter, following
+    /// the exact `state` pattern above — `None` is "every estate" (host-wide,
+    /// the honest default under host mode), `Some(name)` narrows to the one
+    /// estate whose `WorkRow.estate` (§10.2's already-wired per-Work
+    /// display name) matches exactly.
+    pub estate: Option<String>,
 }
 
 impl Filters {
@@ -127,6 +133,11 @@ impl Filters {
         }
         if let Some(state) = &self.state
             && &row.state != state
+        {
+            return false;
+        }
+        if let Some(estate) = &self.estate
+            && &row.estate != estate
         {
             return false;
         }
@@ -142,7 +153,10 @@ impl Filters {
     }
 
     fn is_default(&self) -> bool {
-        self.text.is_empty() && self.state.is_none() && !self.nonterminal_only
+        self.text.is_empty()
+            && self.state.is_none()
+            && !self.nonterminal_only
+            && self.estate.is_none()
     }
 }
 
@@ -234,6 +248,10 @@ impl FleetScreen {
                 self.filters.state = next_state_filter(self.filters.state.as_deref());
                 self.clamp(rows);
             }
+            KeyCode::Char('e') => {
+                self.filters.estate = next_estate_filter(self.filters.estate.as_deref(), rows);
+                self.clamp(rows);
+            }
             KeyCode::Char('x') if !self.filters.is_default() => {
                 self.filters = Filters::default();
             }
@@ -248,6 +266,30 @@ impl FleetScreen {
             _ => {}
         }
         FleetOutcome::None
+    }
+}
+
+/// All-estates → per-estate cycling (W4d deliverable 1), the same shape as
+/// [`next_state_filter`] but over whatever estate names are actually present
+/// in `rows` — unlike `state`, the estate dimension has no fixed enum, so
+/// the cycle is derived from the data rather than a `const` list, sorted for
+/// a deterministic keystroke order.
+fn next_estate_filter(current: Option<&str>, rows: &[WorkRow]) -> Option<String> {
+    let mut estates: Vec<&str> = rows
+        .iter()
+        .map(|r| r.estate.as_str())
+        .filter(|e| *e != "-")
+        .collect();
+    estates.sort_unstable();
+    estates.dedup();
+    match current {
+        None => estates.first().map(|s| s.to_string()),
+        Some(estate) => {
+            let index = estates.iter().position(|s| *s == estate);
+            index
+                .and_then(|i| estates.get(i + 1))
+                .map(|next| (*next).to_string())
+        }
     }
 }
 
@@ -366,12 +408,17 @@ fn filter_line(screen: &FleetScreen) -> Paragraph<'static> {
     } else {
         "off"
     };
+    let estate = screen
+        .filters
+        .estate
+        .clone()
+        .unwrap_or_else(|| "all".to_string());
     let text = if screen.filter_focus {
         format!("filter> {}_", screen.filters.text)
     } else {
         format!(
-            "filter: {} · state {state} · nonterminal {nonterminal}  \
-             ('/' filter · 's' state · 'a' nonterminal · 'v' preview · 'x' clear)",
+            "filter: {} · state {state} · estate {estate} · nonterminal {nonterminal}  \
+             ('/' filter · 's' state · 'e' estate · 'a' nonterminal · 'v' preview · 'x' clear)",
             if screen.filters.text.is_empty() {
                 "-"
             } else {
@@ -677,6 +724,53 @@ mod tests {
             None,
             "cycles back to 'all'"
         );
+    }
+
+    #[test]
+    fn the_estate_filter_matches_a_rows_estate_exactly() {
+        let mut fleet = fleet_of(&[("a", "pending"), ("b", "running")]);
+        fleet["works"][0]["workspace"] = json!("payments");
+        fleet["works"][1]["workspace"] = json!("billing");
+        let rows = fleet_rows(&fleet);
+        let filters = Filters {
+            estate: Some("payments".to_string()),
+            ..Filters::default()
+        };
+        let visible: Vec<&str> = rows
+            .iter()
+            .filter(|r| filters.matches(r))
+            .map(|r| r.id.as_str())
+            .collect();
+        assert_eq!(visible, vec!["a"]);
+    }
+
+    #[test]
+    fn the_estate_filter_cycles_through_every_estate_present_then_back_to_all() {
+        let mut fleet = fleet_of(&[("a", "pending"), ("b", "pending"), ("c", "pending")]);
+        fleet["works"][0]["workspace"] = json!("billing");
+        fleet["works"][1]["workspace"] = json!("payments");
+        fleet["works"][2]["workspace"] = json!("payments"); // duplicate, must not repeat
+        let rows = fleet_rows(&fleet);
+
+        let mut screen = FleetScreen::default();
+        screen.on_key(KeyCode::Char('e'), &rows);
+        assert_eq!(screen.filters.estate.as_deref(), Some("billing"));
+        screen.on_key(KeyCode::Char('e'), &rows);
+        assert_eq!(screen.filters.estate.as_deref(), Some("payments"));
+        screen.on_key(KeyCode::Char('e'), &rows);
+        assert_eq!(
+            screen.filters.estate, None,
+            "cycles back to 'all' after the last distinct estate"
+        );
+    }
+
+    #[test]
+    fn the_estate_filter_ignores_rows_with_no_estate() {
+        // `"-"` is `field_text`'s absent-value marker (§10.2) — it must
+        // never itself become a selectable filter value.
+        let rows = fleet_rows(&fleet_of(&[("a", "pending")]));
+        assert_eq!(rows[0].estate, "-");
+        assert_eq!(next_estate_filter(None, &rows), None);
     }
 
     #[test]

--- a/src/tui/fleet.rs
+++ b/src/tui/fleet.rs
@@ -23,6 +23,13 @@ pub struct WorkRow {
     pub backend: String,
     pub intent: String,
     pub workflow: String,
+    /// The canonical estate root this Work was submitted against
+    /// (`estate_root`, H1 D1) — an identity, never a display name: two
+    /// estates may share one, so this is deliberately not the old
+    /// `workspace` field (dead since estate-root Phase C; `Work::workspace`'s
+    /// own doc comment: "deprecated, never written"). `"-"` when the
+    /// daemon has none recorded (a Work journaled before the envelope
+    /// carried it, or with no estate context at all).
     pub estate: String,
     pub repositories: String,
     pub turns: String,
@@ -68,7 +75,7 @@ fn row_from(work: &Value) -> WorkRow {
         backend: field(work, "resolved_backend"),
         intent: field(work, "intent"),
         workflow: field(work, "workflow"),
-        estate: field(work, "workspace"),
+        estate: field(work, "estate_root"),
         repositories,
         turns,
         created_at: field(work, "created_at"),
@@ -120,9 +127,9 @@ pub struct Filters {
     pub nonterminal_only: bool,
     /// W4d deliverable 1 (H1 §9): the fleet-wide estate filter, following
     /// the exact `state` pattern above — `None` is "every estate" (host-wide,
-    /// the honest default under host mode), `Some(name)` narrows to the one
-    /// estate whose `WorkRow.estate` (§10.2's already-wired per-Work
-    /// display name) matches exactly.
+    /// the honest default under host mode), `Some(root)` narrows to the one
+    /// estate whose `WorkRow.estate` (its canonical root, D1 — see that
+    /// field's own doc comment) matches exactly.
     pub estate: Option<String>,
 }
 
@@ -729,8 +736,8 @@ mod tests {
     #[test]
     fn the_estate_filter_matches_a_rows_estate_exactly() {
         let mut fleet = fleet_of(&[("a", "pending"), ("b", "running")]);
-        fleet["works"][0]["workspace"] = json!("payments");
-        fleet["works"][1]["workspace"] = json!("billing");
+        fleet["works"][0]["estate_root"] = json!("payments");
+        fleet["works"][1]["estate_root"] = json!("billing");
         let rows = fleet_rows(&fleet);
         let filters = Filters {
             estate: Some("payments".to_string()),
@@ -747,9 +754,9 @@ mod tests {
     #[test]
     fn the_estate_filter_cycles_through_every_estate_present_then_back_to_all() {
         let mut fleet = fleet_of(&[("a", "pending"), ("b", "pending"), ("c", "pending")]);
-        fleet["works"][0]["workspace"] = json!("billing");
-        fleet["works"][1]["workspace"] = json!("payments");
-        fleet["works"][2]["workspace"] = json!("payments"); // duplicate, must not repeat
+        fleet["works"][0]["estate_root"] = json!("billing");
+        fleet["works"][1]["estate_root"] = json!("payments");
+        fleet["works"][2]["estate_root"] = json!("payments"); // duplicate, must not repeat
         let rows = fleet_rows(&fleet);
 
         let mut screen = FleetScreen::default();

--- a/src/tui/geometry_matrix_tests.rs
+++ b/src/tui/geometry_matrix_tests.rs
@@ -111,8 +111,8 @@ fn fleet_estate_filter() -> App {
     app.destination = Destination::Fleet;
     app.drawer_open = false;
     app.rows = fleet::fleet_rows(&json!({"works": [
-        {"id": "01PAY", "state": "pending", "intent": "payments work", "workspace": "payments"},
-        {"id": "01BILL", "state": "pending", "intent": "billing work", "workspace": "billing"},
+        {"id": "01PAY", "state": "pending", "intent": "payments work", "estate_root": "payments"},
+        {"id": "01BILL", "state": "pending", "intent": "billing work", "estate_root": "billing"},
     ]}));
     app.fleet.filters.estate = Some("payments".to_string());
     app
@@ -132,7 +132,7 @@ fn fleet_long_values() -> App {
         "state": "needs_input",
         "intent": long,
         "workflow": long,
-        "workspace": long,
+        "estate_root": long,
         "stage": {"stage_id": "10-implement", "index": 1, "of": 2, "status": "running", "detail": long},
         "resolved_backend": "fake",
     }]}));

--- a/src/tui/geometry_matrix_tests.rs
+++ b/src/tui/geometry_matrix_tests.rs
@@ -103,6 +103,21 @@ fn fleet_all_states() -> App {
     app
 }
 
+/// W4d deliverable 1/5: Fleet with its new estate filter dimension active —
+/// new persistent chrome (the header's `estate <name>` segment), so it gets
+/// its own geometry-matrix entry per the brief.
+fn fleet_estate_filter() -> App {
+    let mut app = App::new();
+    app.destination = Destination::Fleet;
+    app.drawer_open = false;
+    app.rows = fleet::fleet_rows(&json!({"works": [
+        {"id": "01PAY", "state": "pending", "intent": "payments work", "workspace": "payments"},
+        {"id": "01BILL", "state": "pending", "intent": "billing work", "workspace": "billing"},
+    ]}));
+    app.fleet.filters.estate = Some("payments".to_string());
+    app
+}
+
 /// A single row with every field near-worst-case long, so §19.10's "long
 /// values remain contained" has something real to check: the Fleet table's
 /// own `Fill`/`Length` constraints (not hand-padded strings, §10.1's
@@ -206,6 +221,20 @@ fn estate_health() -> App {
     // The remedy only shows on the Detail pane for the *selected* check
     // (§12.3) — select disk_pressure so its remedy is actually on screen.
     app.estate.check_selected = 1;
+    app
+}
+
+/// W4d deliverable 3/5: the Estate screen's picker, above its existing
+/// sub-tabs — new persistent chrome fed by `GET /v1/estates`, so it gets
+/// its own geometry-matrix entry per the brief.
+fn estate_picker() -> App {
+    let mut app = App::new();
+    app.destination = Destination::Estate;
+    app.drawer_open = false;
+    app.estate.estates = vec![
+        json!({"name": "payments", "root": "/estates/payments"}),
+        json!({"name": "billing", "root": "/estates/billing"}),
+    ];
     app
 }
 
@@ -330,6 +359,45 @@ fn geometry_fleet_long_values_stay_contained() {
         assert!(
             text.contains("needs_input"),
             "{w}x{h}: the state column must survive a huge intent: {text}"
+        );
+    }
+}
+
+#[test]
+fn geometry_fleet_estate_filter_shows_in_the_header() {
+    let app = fleet_estate_filter();
+    for (w, h) in SIZES {
+        let text = text_of(&draw_at(&app, w, h));
+        assert!(
+            text.contains("estate payments"),
+            "{w}x{h}: the active estate filter must show in the header: {text}"
+        );
+    }
+    // Only Wide is guaranteed room for both rows at once; the filter
+    // narrows to the one estate regardless of tier.
+    let text = text_of(&draw_at(&app, 180, 48));
+    assert!(text.contains("payments work"), "{text}");
+    assert!(
+        !text.contains("billing work"),
+        "the estate filter must actually narrow the visible rows: {text}"
+    );
+}
+
+#[test]
+fn geometry_estate_picker_lists_every_admitted_estate() {
+    let app = estate_picker();
+    for (w, h) in SIZES {
+        let text = text_of(&draw_at(&app, w, h));
+        assert!(text.contains("Estate"), "{w}x{h}: {text}");
+        assert!(text.contains("payments"), "{w}x{h}: {text}");
+        assert!(text.contains("billing"), "{w}x{h}: {text}");
+        // The picker replaces the sub-tabs entirely until one is chosen —
+        // deliverable 3: "the screen's own behavior is unchanged once an
+        // estate is picked", the other side of which is that there is
+        // nothing of theirs to show before one is.
+        assert!(
+            !text.contains("Repositories"),
+            "{w}x{h}: sub-tabs must not show before an estate is picked: {text}"
         );
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -317,8 +317,17 @@ fn footer_line(app: &App) -> Paragraph<'_> {
 ///
 /// The terminal is restored exactly once, on the way out, whatever ended the
 /// loop; `ratatui::try_init` covers the panic path with its own hook.
-pub async fn run(client: ApiClient) -> Result<(), TuiError> {
+///
+/// `initial_estate` (W4d deliverable 2, H1 §9) is the CLI's opportunistic
+/// cwd-derived estate name, if cwd happened to be a valid estate root —
+/// `None` otherwise, never a refusal: the connection above never depended
+/// on it (`is_host_scoped`), and this is presentation-only, the same
+/// "silently fall back rather than gate" shape `sgt watch`'s own D6 default
+/// already uses. Applied once, before the first paint, as Fleet's *initial*
+/// estate filter — the operator is free to retoggle it with `e` afterward.
+pub async fn run(client: ApiClient, initial_estate: Option<String>) -> Result<(), TuiError> {
     let mut app = App::new();
+    app.apply_initial_estate(initial_estate);
     // The first read happens before the terminal is touched: a daemon that
     // cannot answer should print an error to a normal terminal, not paint an
     // empty UI over an alternate screen.

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -1497,6 +1497,151 @@ async fn h1_two_estates_submit_work_to_one_daemon_and_keep_their_own_surfaces() 
     handle.shutdown().await;
 }
 
+/// W4d deliverable 4: a host-scoped client — one that addresses **no**
+/// fixed estate at all, `ApiClient::new` with no `.with_estate_root` — sees
+/// both estates' Work in Fleet, the estate filter cycles all/payments/
+/// billing correctly, and the Estate screen's picker lists both. Reuses
+/// [`start_fake_host`] (already landed for the daemon/journal seat's own
+/// acceptance test above) rather than adding a second multi-estate daemon
+/// fixture — the brief's "start_fake_host-style sibling" already exists.
+#[tokio::test]
+async fn t5_fleet_and_estate_screen_span_two_estates() {
+    let data = TempDir::new().expect("tempdir");
+    let (payments, payments_mount) = solo_estate("payments");
+    let (billing, billing_mount) = solo_estate("billing");
+    write_workflow(payments.path());
+    write_workflow(billing.path());
+
+    let (handle, _fake) =
+        start_fake_host(data.path(), [FakeStep::complete(), FakeStep::complete()]).await;
+
+    submit(
+        &handle,
+        payments.path(),
+        &payments_mount,
+        "payments work",
+        "tiny",
+    )
+    .await;
+    submit(
+        &handle,
+        billing.path(),
+        &billing_mount,
+        "billing work",
+        "tiny",
+    )
+    .await;
+
+    // Host-scoped: addresses no estate at all — the exact shape `sgt tui`
+    // builds under H1 (`ApiClient::new` with no `.with_estate_root`).
+    let client = ApiClient::new(&handle.endpoint, &handle.token).expect("client");
+
+    // D1: the estate filter's own identity is the canonical root the daemon
+    // folds per Work (`estate_root`), never the manifest's display name —
+    // two estates could share one.
+    let payments_root = std::fs::canonicalize(payments.path())
+        .expect("canonical")
+        .to_string_lossy()
+        .into_owned();
+    let billing_root = std::fs::canonicalize(billing.path())
+        .expect("canonical")
+        .to_string_lossy()
+        .into_owned();
+
+    let mut app = App::new();
+    app.refresh(&client).await.expect("first read");
+    app.on_key(ratatui::crossterm::event::KeyCode::Esc); // leave Home's form focus
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('2')); // Fleet
+    assert_eq!(app.destination, Destination::Fleet);
+    // The Attention drawer is a global, unfiltered cross-cut (both Works
+    // are non-terminal-free/`completed`... it lists recently-finished ones
+    // regardless of Fleet's own local filter) — closed here so this test's
+    // "must actually narrow" assertions read Fleet's own table alone,
+    // the same `drawer_open = false` every other Fleet geometry fixture
+    // already sets.
+    app.drawer_open = false;
+
+    // --- Fleet shows both estates' Work -------------------------------
+    let terminal = render(&app);
+    assert_shows(&terminal, "payments work", "payments estate's work");
+    assert_shows(&terminal, "billing work", "billing estate's work");
+    assert_shows(
+        &terminal,
+        "estate all",
+        "the header's default all-estates filter",
+    );
+
+    // --- the estate filter cycles all -> <one> -> <other> -> all ------
+    // `next_estate_filter` sorts distinct estate roots, and each estate's
+    // root is an independent fresh tempdir (`solo_estate` per estate), so
+    // which one sorts first is not fixed across runs — compare directly
+    // rather than asserting a specific order.
+    let (first_root, first_intent, second_root, second_intent) = if billing_root < payments_root {
+        (
+            &billing_root,
+            "billing work",
+            &payments_root,
+            "payments work",
+        )
+    } else {
+        (
+            &payments_root,
+            "payments work",
+            &billing_root,
+            "billing work",
+        )
+    };
+
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('e'));
+    assert_eq!(
+        app.fleet.filters.estate.as_deref(),
+        Some(first_root.as_str())
+    );
+    let terminal = render(&app);
+    assert_shows(&terminal, first_intent, "the filtered-in row");
+    assert!(
+        !screen_text(&terminal).contains(second_intent),
+        "the filter must actually narrow the fleet: {}",
+        screen_text(&terminal)
+    );
+
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('e'));
+    assert_eq!(
+        app.fleet.filters.estate.as_deref(),
+        Some(second_root.as_str())
+    );
+    let terminal = render(&app);
+    assert_shows(&terminal, second_intent, "the filtered-in row");
+    assert!(!screen_text(&terminal).contains(first_intent));
+
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('e'));
+    assert_eq!(app.fleet.filters.estate, None, "cycles back to all-estates");
+
+    // --- the Estate screen's picker lists both --------------------------
+    app.on_key(ratatui::crossterm::event::KeyCode::Char('4')); // Estate
+    assert_eq!(app.destination, Destination::Estate);
+    app.refresh(&client).await.expect("estate refresh");
+    assert!(
+        app.estate.picked.is_none(),
+        "a host-scoped client must not silently address either estate on its own"
+    );
+    let terminal = render(&app);
+    assert_shows(&terminal, "payments", "the picker's payments entry");
+    assert_shows(&terminal, "billing", "the picker's billing entry");
+
+    // Picking one addresses that estate's own repos/groups/doctor below.
+    app.on_key(ratatui::crossterm::event::KeyCode::Enter);
+    assert!(
+        app.estate.picked.is_some(),
+        "Enter picks the highlighted entry"
+    );
+    app.refresh(&client).await.expect("post-pick refresh");
+    let terminal = render(&app);
+    assert_shows(&terminal, "Repositories", "sub-tabs appear once picked");
+
+    handle.shutdown().await;
+}
+
 #[tokio::test]
 async fn t1_the_events_endpoint_filters_and_tails_by_work() {
     let data = TempDir::new().expect("tempdir");


### PR DESCRIPTION
Wave W4d of sprint S1 (decision D6). 4 commits, presentation-only per H1 §9 — no TUI-side database, single-round-trip refresh preserved (m6 t5 internals scan green).

- Fleet gains an `estate` filter (exact `Filters` pattern), keystroke-cycled, shown in the header; App gains the selected-estate slot with cwd-as-initial-filter (wired in cli.rs's Tui arm — the Watch arm's own landed comment names this wave for it).
- `Destination::Estate` gains an estate picker above its existing sub-tabs, fed by `GET /v1/estates`; single-estate clients auto-pick and never see it (T3 scenarios byte-identical).
- **Real bug found under the brief**: recon's "WorkRow.estate wiring already exists" premise was stale — the field read the dead pre-Phase-C `workspace` payload, so every row showed "-" against a real daemon and the filter would have shipped nonfunctional. Fixed by surfacing the live per-Work `estate_root` (canonical root per D1, not a display name) as an additive read-only field in fleet JSON; Filters/WorkRow re-keyed on it. J0-documented in the commit.
- New m6 scenario: two estates on one daemon rendered in Fleet, filter cycle, picker listing both. Geometry-matrix entries for the new chrome.
- Picker's mutation surface still addresses the client's own bound estate — named limitation, out of scope per brief.

Gates: blind 4-axis panel — zero findings. Verify (rebased onto e00029d7): full suite green except two failures that reproduce nowhere solo — m5's real-adapter event-ordering test and m6's t4 demo, both run while a second wave's build/verify saturated the host, both pass clean in isolation (6.6s/10.7s). Concurrent-load flakes, disclosed not tolerated; CI is decisive.

Rungs: D6 J3, R2 throughout; the estate_root surfacing J0-recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4