### PR TITLE
S1/W4b: bounded execution capacity lane; intelligence lane config stub (H1-15)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -601,6 +601,50 @@ async fn crank(state: &ApiState, step: Step) -> Option<CoreGuard<'_>> {
         let settled = match next {
             EngineNext::Parked => unreachable!("returned above"),
             EngineNext::Launch(pending) => {
+                // H1-15's execution lane: admitted strictly between the
+                // reservation (already committed under the lock, in
+                // `reserve_stage`) and the launch below — outside the core
+                // lock, never under it (recon's §22.6 hazard). A lane at
+                // capacity does not stall this task silently: the wait is
+                // journaled first (distinct from turn-cap exhaustion — see
+                // `Engine::park_on_execution_lane`) so a concurrent
+                // `sgt work show` can see why this Work is parked, then the
+                // task actually waits for a slot.
+                let launch_work_id = pending.work_id().to_string();
+                if !state.engine.try_admit_execution(&launch_work_id) {
+                    {
+                        let mut core = CoreGuard::acquire(&state.core).await;
+                        if let Err(e) = state
+                            .engine
+                            .park_on_execution_lane(&mut core, &launch_work_id)
+                        {
+                            tracing::error!(
+                                work_id = %launch_work_id,
+                                error = %e,
+                                "journaling the execution-lane wait failed"
+                            );
+                        }
+                    }
+                    state.engine.admit_execution(&launch_work_id).await;
+                    let mut core = CoreGuard::acquire(&state.core).await;
+                    if let Err(e) = state
+                        .engine
+                        .resume_after_execution_lane(&mut core, &launch_work_id)
+                    {
+                        // A concurrent transition (e.g. a cancel while this
+                        // Work sat parked on the lane) can make this an
+                        // illegal edge — logged, not fatal: `settle_launch`'s
+                        // own staleness check (§14.5) is what actually
+                        // adjudicates a launch whose reservation the wait
+                        // outlived, exactly as it does for every other cause
+                        // of the same race.
+                        tracing::error!(
+                            work_id = %launch_work_id,
+                            error = %e,
+                            "resuming after the execution-lane wait failed"
+                        );
+                    }
+                }
                 let outcome = blocking(|| pending.perform()).await;
                 let work_id = pending.work_id().to_string();
                 let mut core = CoreGuard::acquire(&state.core).await;

--- a/src/api.rs
+++ b/src/api.rs
@@ -572,7 +572,21 @@ fn blocking_sync<T>(f: impl FnOnce() -> T) -> T {
 /// completion wait, which are the only places §22.6 cares about — in one place
 /// each, so there is no arm that can be missed and no arm whose drop is
 /// decoration.
-async fn crank(state: &ApiState, step: Step) -> Option<CoreGuard<'_>> {
+fn crank(
+    state: &ApiState,
+    step: Step,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<CoreGuard<'_>>> + Send + '_>> {
+    Box::pin(crank_inner(state, step))
+}
+
+/// [`crank`]'s actual body, split out only so `crank` itself can box the
+/// future: the H1-15 lane-full path below (`EngineNext::Launch`) hands an
+/// admitted-later launch to a detached task that drives it the rest of the
+/// way by calling `crank` again, and a directly-recursive `async fn` cannot
+/// prove its own future `Send` (the auto-trait solver has nothing closed to
+/// check against) — `tokio::spawn` then refuses it outright. Boxing the
+/// *outer* call breaks that cycle; nothing about the loop below changes.
+async fn crank_inner(state: &ApiState, step: Step) -> Option<CoreGuard<'_>> {
     let mut step = step;
     let mut held: Option<CoreGuard<'_>> = None;
     loop {
@@ -608,8 +622,7 @@ async fn crank(state: &ApiState, step: Step) -> Option<CoreGuard<'_>> {
                 // capacity does not stall this task silently: the wait is
                 // journaled first (distinct from turn-cap exhaustion — see
                 // `Engine::park_on_execution_lane`) so a concurrent
-                // `sgt work show` can see why this Work is parked, then the
-                // task actually waits for a slot.
+                // `sgt work show` can see why this Work is parked.
                 let launch_work_id = pending.work_id().to_string();
                 if !state.engine.try_admit_execution(&launch_work_id) {
                     {
@@ -625,25 +638,61 @@ async fn crank(state: &ApiState, step: Step) -> Option<CoreGuard<'_>> {
                             );
                         }
                     }
-                    state.engine.admit_execution(&launch_work_id).await;
-                    let mut core = CoreGuard::acquire(&state.core).await;
-                    if let Err(e) = state
-                        .engine
-                        .resume_after_execution_lane(&mut core, &launch_work_id)
-                    {
-                        // A concurrent transition (e.g. a cancel while this
-                        // Work sat parked on the lane) can make this an
-                        // illegal edge — logged, not fatal: `settle_launch`'s
-                        // own staleness check (§14.5) is what actually
-                        // adjudicates a launch whose reservation the wait
-                        // outlived, exactly as it does for every other cause
-                        // of the same race.
-                        tracing::error!(
-                            work_id = %launch_work_id,
-                            error = %e,
-                            "resuming after the execution-lane wait failed"
-                        );
-                    }
+                    // The Work is now durably `waiting` on the lane, visible
+                    // to any concurrent `work show` — the client's own
+                    // command has been accepted, same as every other
+                    // two-phase effect in this file. Waiting for a slot to
+                    // free is not part of that acceptance and must not block
+                    // the request that triggered it (a request into a full
+                    // lane would otherwise hang for however long another
+                    // Work takes to vacate a slot, with no client-visible
+                    // signal but the connection simply not returning). So
+                    // the rest of this launch — admit, resume, perform,
+                    // settle, and drive on — is handed to a detached task,
+                    // and this crank call returns now with nothing held,
+                    // exactly as it would for `Next::Parked`.
+                    let bg_state = state.clone();
+                    tokio::spawn(async move {
+                        bg_state.engine.admit_execution(&launch_work_id).await;
+                        {
+                            let mut core = CoreGuard::acquire(&bg_state.core).await;
+                            if let Err(e) = bg_state
+                                .engine
+                                .resume_after_execution_lane(&mut core, &launch_work_id)
+                            {
+                                // A concurrent transition (e.g. a cancel
+                                // while this Work sat parked on the lane)
+                                // can make this an illegal edge — logged,
+                                // not fatal: `settle_launch`'s own staleness
+                                // check (§14.5) is what actually adjudicates
+                                // a launch whose reservation the wait
+                                // outlived, exactly as it does for every
+                                // other cause of the same race.
+                                tracing::error!(
+                                    work_id = %launch_work_id,
+                                    error = %e,
+                                    "resuming after the execution-lane wait failed"
+                                );
+                            }
+                        }
+                        let outcome = blocking(|| pending.perform()).await;
+                        let work_id = pending.work_id().to_string();
+                        let mut core = CoreGuard::acquire(&bg_state.core).await;
+                        match bg_state.engine.settle_launch(&mut core, pending, outcome) {
+                            Ok(next_step) => {
+                                drop(core);
+                                crank(&bg_state, next_step).await;
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    work_id = %work_id,
+                                    error = %e,
+                                    "settling an external effect failed"
+                                );
+                            }
+                        }
+                    });
+                    return held;
                 }
                 let outcome = blocking(|| pending.perform()).await;
                 let work_id = pending.work_id().to_string();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -495,6 +495,20 @@ pub struct DaemonConfig {
     /// from a typo in a file, not a runtime bound; a test rig setting
     /// `Some(4)` has not typed anything into a manifest.
     pub retention: Option<u32>,
+    /// H1-15 (W4b) execution lane: daemon-wide cap on native adapter
+    /// processes admitted between PREPARE and LAUNCH concurrently
+    /// (`SGT_EXECUTION_LANE_CAP`). `None` keeps [`Engine::new`]'s default
+    /// ([`crate::runtime::engine::default_execution_lane_cap`]). `Some` is
+    /// wired via [`Engine::with_execution_lane_cap`] in [`start_with`], the
+    /// same way `turn_cap` above is.
+    pub execution_lane_cap: Option<usize>,
+    /// H1-15's second lane: config-only capacity for A1/S3's future
+    /// intelligence workers (`SGT_INTELLIGENCE_LANE_CAP`). `None` keeps
+    /// [`crate::runtime::engine::default_intelligence_lane_cap`]. Nothing
+    /// in this build acquires from it yet (deliverable 3 — config surface,
+    /// no scheduling behavior); it exists so the two lanes' independence is
+    /// provable now rather than retrofitted later.
+    pub intelligence_lane_cap: Option<usize>,
 }
 
 impl Default for DaemonConfig {
@@ -516,6 +530,8 @@ impl Default for DaemonConfig {
             await_probe_walk: true,
             segment_max_bytes: None,
             retention: None,
+            execution_lane_cap: None,
+            intelligence_lane_cap: None,
         }
     }
 }
@@ -966,6 +982,12 @@ pub async fn start_with(
     }
     if let Some(turn_cap) = config.turn_cap {
         engine = engine.with_turn_cap(turn_cap);
+    }
+    if let Some(cap) = config.execution_lane_cap {
+        engine = engine.with_execution_lane_cap(cap);
+    }
+    if let Some(cap) = config.intelligence_lane_cap {
+        engine = engine.with_intelligence_lane_cap(cap);
     }
     let engine = Arc::new(engine);
     let reconciled = recovery::reconcile(&engine, &estates, &mut core)?;
@@ -1548,12 +1570,48 @@ pub async fn run_until_signal(data_dir: &Path, rebuild_cache: bool) -> Result<()
                 None
             }
         });
+    // H1-15's execution/intelligence lane overrides: same fail-open
+    // discipline as `SGT_TURN_CAP` above — unset or unparseable both mean
+    // "keep the built-in, host-parallelism-derived default", and 0 (which
+    // parses) is honored with a warning rather than silently ignored.
+    let execution_lane_cap = std::env::var("SGT_EXECUTION_LANE_CAP")
+        .ok()
+        .and_then(|v| match v.parse::<usize>() {
+            Ok(0) => {
+                tracing::warn!(
+                    "SGT_EXECUTION_LANE_CAP=0 blocks every Work at LAUNCH; honoring it"
+                );
+                Some(0)
+            }
+            Ok(n) => Some(n),
+            Err(_) => {
+                tracing::warn!(
+                    value = %v,
+                    "SGT_EXECUTION_LANE_CAP is not a whole number of permits — keeping the built-in default"
+                );
+                None
+            }
+        });
+    let intelligence_lane_cap = std::env::var("SGT_INTELLIGENCE_LANE_CAP")
+        .ok()
+        .and_then(|v| match v.parse::<usize>() {
+            Ok(n) => Some(n),
+            Err(_) => {
+                tracing::warn!(
+                    value = %v,
+                    "SGT_INTELLIGENCE_LANE_CAP is not a whole number of permits — keeping the built-in default"
+                );
+                None
+            }
+        });
     let handle = start_with(
         data_dir,
         DaemonConfig {
             telemetry: telemetry.clone(),
             surfaces_root,
             turn_cap,
+            execution_lane_cap,
+            intelligence_lane_cap,
             rebuild_cache,
             // The signal loop below must be able to answer SIGTERM while the
             // probe walk is still running — see the field's own doc (#293).

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -26,6 +26,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::api::{Core, CoreError};
 use crate::backend::docker::DOCKER_BACKEND_NAME;
@@ -1126,6 +1127,48 @@ pub const DEFAULT_TURN_CAP: u32 = 12;
 /// override with [`Engine::with_turn_ceiling`].
 pub const DEFAULT_TURN_CEILING: Duration = Duration::from_secs(15 * 60);
 
+/// H1-15 (W4b) execution lane: the default bounded number of native adapter
+/// processes this daemon admits to LAUNCH concurrently.
+///
+/// Recon evidence (`recon-workers-capacity-release.md`): nothing in
+/// `engine.rs`/`api.rs`/`daemon.rs` throttled concurrent native processes
+/// before this — the turn cap bounds one Work's own lifetime, never a
+/// fleet-wide process count. Numbers-need-provenance: this is grounded in
+/// the one thing "how many can genuinely run at once" is actually about —
+/// the host's own hardware parallelism
+/// ([`std::thread::available_parallelism`]), not an arbitrary round number.
+/// A native adapter process is CPU/IO-bound work this host schedules like
+/// any other; oversubscribing it past the core count buys nothing but
+/// context-switch overhead and degrades every process's own turnaround.
+/// Falls back to `4` only when the platform cannot answer the question at
+/// all (containers with no cgroup cpu info, `wasm32` — never routine on a
+/// host this daemon actually runs on). Override with
+/// [`Engine::with_execution_lane_cap`] (`DaemonConfig::execution_lane_cap` /
+/// `SGT_EXECUTION_LANE_CAP`, wired the same way `SGT_TURN_CAP` is).
+pub fn default_execution_lane_cap() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(4)
+}
+
+/// H1-15's second lane: config surface only in S1 (deliverable 3 — no
+/// workers, no scheduling behavior). The eventual consumer is A1/S3's
+/// intelligence workers (host-runtime batch/analysis work distinct from
+/// execution's per-Work native processes); until that lands, nothing ever
+/// acquires from [`Engine::intelligence_lane`], so this cap only proves the
+/// two lanes are structurally independent (separate `Arc<Semaphore>`s —
+/// see the config-only test pinning that the execution lane's occupancy
+/// never touches this one's `available_permits`).
+///
+/// Same host-parallelism grounding as [`default_execution_lane_cap`] (R2:
+/// reusing the one number this build can trace to something real, rather
+/// than inventing a second unrelated rationale for a lane nothing consumes
+/// yet). Override with [`Engine::with_intelligence_lane_cap`]
+/// (`DaemonConfig::intelligence_lane_cap` / `SGT_INTELLIGENCE_LANE_CAP`).
+pub fn default_intelligence_lane_cap() -> usize {
+    default_execution_lane_cap()
+}
+
 /// The workflow engine: backends, defaults, and the data dir surfaces live in.
 #[derive(Debug, Clone)]
 pub struct Engine {
@@ -1158,6 +1201,37 @@ pub struct Engine {
     /// half, and the two are independent by design. Keyed by work id, one
     /// entry per Work with a turn currently in flight.
     turn_started: Arc<Mutex<BTreeMap<String, Instant>>>,
+    /// H1-15's execution lane: bounded fleet-wide admission between PREPARE
+    /// and LAUNCH ([`Self::try_admit_execution`]/[`Self::admit_execution`]),
+    /// acquired **outside the core lock** (recon: acquiring under the guard
+    /// reintroduces the §22.6 hazard the PREPARE/LAUNCH split exists to
+    /// prevent — see `crank`'s `Launch` arm in `api.rs`, the one caller).
+    pub execution_lane: Arc<Semaphore>,
+    /// The cap [`Self::execution_lane`] was built with — kept alongside it
+    /// (a `Semaphore` cannot report the total it started with, only what is
+    /// currently free) so waiting evidence and API views can name the bound
+    /// a Work is actually parked against.
+    pub execution_lane_cap: usize,
+    /// Permits currently held, keyed by work id — one execution in flight
+    /// per Work at a time (the turn model's own invariant; mirrors
+    /// [`Self::turn_started`]'s per-work keying). Inserted the moment a
+    /// permit is admitted, in `api::crank`'s `Launch` arm, and removed
+    /// exactly where an execution stops being "in flight":
+    /// [`Self::stop_execution`] (completion, failure, cancel, interrupt) and
+    /// [`Self::settle_launch`]'s two no-live-execution branches (a
+    /// daemon-side launch error, a superseded reservation). Never durable —
+    /// a restart starts with an empty lane and every Work re-admits on its
+    /// next launch, which is correct: nothing native survived the restart
+    /// either.
+    execution_permits: Arc<Mutex<BTreeMap<String, OwnedSemaphorePermit>>>,
+    /// H1-15's intelligence lane: config-only stub (deliverable 3). A
+    /// separate `Arc<Semaphore>` from [`Self::execution_lane`] by
+    /// construction — nothing here ever acquires from it, so it cannot draw
+    /// down the execution lane's budget no matter how many intelligence
+    /// workers a later sprint adds.
+    pub intelligence_lane: Arc<Semaphore>,
+    /// The cap [`Self::intelligence_lane`] was built with.
+    pub intelligence_lane_cap: usize,
 }
 
 impl Engine {
@@ -1177,6 +1251,11 @@ impl Engine {
             turn_cap: DEFAULT_TURN_CAP,
             turn_ceiling: DEFAULT_TURN_CEILING,
             turn_started: Arc::new(Mutex::new(BTreeMap::new())),
+            execution_lane: Arc::new(Semaphore::new(default_execution_lane_cap())),
+            execution_lane_cap: default_execution_lane_cap(),
+            execution_permits: Arc::new(Mutex::new(BTreeMap::new())),
+            intelligence_lane: Arc::new(Semaphore::new(default_intelligence_lane_cap())),
+            intelligence_lane_cap: default_intelligence_lane_cap(),
         }
     }
 
@@ -1199,6 +1278,136 @@ impl Engine {
     pub fn with_turn_ceiling(mut self, turn_ceiling: Duration) -> Self {
         self.turn_ceiling = turn_ceiling;
         self
+    }
+
+    /// Override the daemon-wide execution-lane cap (H1-15). Wired from
+    /// `DaemonConfig::execution_lane_cap` / `SGT_EXECUTION_LANE_CAP`
+    /// (`daemon::run_until_signal`), the same way [`Self::with_turn_cap`]
+    /// is. Rebuilds the semaphore fresh — called only at daemon startup,
+    /// before any Work has admitted a permit.
+    pub fn with_execution_lane_cap(mut self, cap: usize) -> Self {
+        self.execution_lane = Arc::new(Semaphore::new(cap));
+        self.execution_lane_cap = cap;
+        self
+    }
+
+    /// Override the daemon-wide intelligence-lane cap (H1-15, deliverable
+    /// 3 — config surface only; nothing yet acquires from this lane).
+    pub fn with_intelligence_lane_cap(mut self, cap: usize) -> Self {
+        self.intelligence_lane = Arc::new(Semaphore::new(cap));
+        self.intelligence_lane_cap = cap;
+        self
+    }
+
+    /// Try to admit `work_id` to the execution lane without waiting. `true`
+    /// stores a held permit for `work_id` and admits it; `false` means the
+    /// lane is at [`Self::execution_lane_cap`] and nothing was taken.
+    ///
+    /// **R7 for the lane primitive.** `tokio::sync::Semaphore` is a bounded,
+    /// async-aware admission counter built for exactly this shape; R1–R6 do
+    /// not supply one — the recon evidence's own grep found no existing cap
+    /// or lane concept anywhere in this tree (R2), the standard library has
+    /// no async-aware semaphore (R3), no OS primitive substitutes for an
+    /// in-process cooperative admission gate shared across `tokio` tasks
+    /// (R4), and a hand-rolled counter+waker would re-implement — worse,
+    /// and untested — exactly what R5's already-installed `tokio::sync`
+    /// gives in one line.
+    pub(crate) fn try_admit_execution(&self, work_id: &str) -> bool {
+        match Arc::clone(&self.execution_lane).try_acquire_owned() {
+            Ok(permit) => {
+                self.execution_permits
+                    .lock()
+                    .expect("execution permit map poisoned")
+                    .insert(work_id.to_string(), permit);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Block until `work_id` is admitted to the execution lane.
+    ///
+    /// **Never call this while holding the core lock.** Mirrors every
+    /// `Pending*::perform`'s own discipline (§22.6): a slow or fully-loaded
+    /// lane must never stall another core-lock holder, which is exactly the
+    /// hazard the recon evidence names for a permit taken under the guard —
+    /// this is why the lane is acquired in `api::crank`'s `Launch` arm,
+    /// strictly between the reservation (`reserve_stage`, under the lock)
+    /// and the launch (`PendingLaunch::perform`, without it).
+    pub(crate) async fn admit_execution(&self, work_id: &str) {
+        let permit = Arc::clone(&self.execution_lane)
+            .acquire_owned()
+            .await
+            .expect("execution lane semaphore is never closed for the daemon's life");
+        self.execution_permits
+            .lock()
+            .expect("execution permit map poisoned")
+            .insert(work_id.to_string(), permit);
+    }
+
+    /// Release `work_id`'s held execution-lane permit, if it holds one.
+    /// Idempotent (a work with nothing held is a no-op) — see
+    /// [`Self::execution_permits`]'s own doc for exactly which call sites
+    /// make this call and why those are the complete set (deliverable 4's
+    /// "no leak — hunt the drop path": every one of them is a plain
+    /// `BTreeMap::remove`, so the guard's own `Drop` releases the permit;
+    /// there is no path that could forget it without also forgetting to
+    /// call this).
+    pub(crate) fn release_execution_permit(&self, work_id: &str) {
+        self.execution_permits
+            .lock()
+            .expect("execution permit map poisoned")
+            .remove(work_id);
+    }
+
+    /// Journal the execution lane's own "no capacity" park — deliverable 2's
+    /// observability requirement. Reuses the existing `Active -> Waiting`
+    /// edge [`Self::drive`]'s `BackendSignal::Waiting` arm already commits
+    /// through (R2: no new event kind, no new terminal state — "waiting" is
+    /// already legal and already nonterminal), with a lane-specific reason
+    /// so it can never be confused with turn-cap exhaustion
+    /// ([`Self::check_turn_envelope`]'s `KIND_WORK_BLOCKED`, a different
+    /// event kind *and* a different [`WorkState`] — `Blocked`, not
+    /// `Waiting`). Called from `api::crank`'s `Launch` arm, under the core
+    /// lock it briefly reacquires to journal this before awaiting the lane
+    /// (never while performing the external wait itself).
+    pub(crate) fn park_on_execution_lane(
+        &self,
+        core: &mut Core,
+        work_id: &str,
+    ) -> Result<(), EngineError> {
+        self.transition(
+            core,
+            work_id,
+            KIND_WORK_WAITING,
+            json!({
+                "reason": "execution lane at capacity",
+                "cap": self.execution_lane_cap,
+            }),
+        )
+    }
+
+    /// The lane admitted `work_id`: resume it exactly as any other
+    /// `Waiting -> Active` recovery does ([`Self::begin_input`],
+    /// [`Self::reenter_stage`] — same edge, same `KIND_WORK_RESUMED` event
+    /// kind), with a reason naming what actually happened. A Work that left
+    /// `Waiting` for some other reason while parked here (e.g. a concurrent
+    /// cancel) makes this an illegal transition; the caller logs and
+    /// proceeds regardless — [`Self::settle_launch`]'s own staleness check
+    /// (§14.5) is what actually adjudicates a launch that outlived the
+    /// state it was reserved against, exactly as it already does for every
+    /// other cause of the same race.
+    pub(crate) fn resume_after_execution_lane(
+        &self,
+        core: &mut Core,
+        work_id: &str,
+    ) -> Result<(), EngineError> {
+        self.transition(
+            core,
+            work_id,
+            KIND_WORK_RESUMED,
+            json!({"reason": "execution_lane_admitted"}),
+        )
     }
 
     /// R-MVP1-7's effective turn cap for one specific Work: MVP-3's
@@ -3551,6 +3760,13 @@ impl Engine {
         let work_id = pending.work_id.clone();
         let reservation = &pending.reservation;
         if let Some(why) = self.reservation_is_stale(core, &pending) {
+            // H1-15: superseded before or after the launch actually
+            // happened, this reservation's execution-lane permit is never
+            // going to be released by `stop_execution` — no `run.execution`
+            // is ever recorded for it (that only happens below, past this
+            // branch). Release it here or it leaks for the lane's whole
+            // remaining life.
+            self.release_execution_permit(&work_id);
             let stop = match &outcome {
                 Ok(handle) => match pending.backend.stop(handle) {
                     Ok(completion) => {
@@ -3588,6 +3804,12 @@ impl Engine {
         let handle = match outcome {
             Ok(handle) => handle,
             Err(e) => {
+                // H1-15: a daemon-side launch error — nothing was ever
+                // launched, so `stop_execution` will never see a
+                // `run.execution` to release this permit through. Release
+                // it here (deliverable 4's explicit test: no leak on a
+                // launch error).
+                self.release_execution_permit(&work_id);
                 // The reservation named an identity nothing ever created.
                 // Saying so explicitly is what keeps the window closed:
                 // without this event the journal would show a reservation
@@ -4352,6 +4574,10 @@ impl Engine {
         if execution.stop_requested {
             return Ok(());
         }
+        // H1-15: this Work's execution is definitively no longer in flight
+        // (completion, failure, cancel, or interrupt-driven stop — every
+        // call site above) — release the execution-lane permit it holds.
+        self.release_execution_permit(work_id);
         let outcome = match self.backends.get(&execution.backend) {
             Some(backend) => match backend.stop(&handle_of(&execution)) {
                 Ok(completion) => {

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -4931,6 +4931,79 @@ mod tests {
         );
     }
 
+    /// Numbers-need-provenance: the execution lane's built-in default must
+    /// trace to the one thing this repo actually measured it against — the
+    /// host's own hardware parallelism — not an arbitrary round number.
+    #[test]
+    fn default_execution_lane_cap_is_grounded_in_host_parallelism() {
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(4);
+        assert_eq!(default_execution_lane_cap(), expected);
+        assert_eq!(
+            default_intelligence_lane_cap(),
+            expected,
+            "the intelligence lane's stub default reuses the same grounding (R2)"
+        );
+    }
+
+    /// D4's structural admission test: a lane of `cap` admits exactly `cap`
+    /// concurrent work ids without blocking, and the `cap + 1`th is refused
+    /// — never blocked internally, never silently oversubscribed.
+    #[test]
+    fn try_admit_execution_is_bounded_by_the_configured_cap() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let engine = engine(dir.path()).with_execution_lane_cap(2);
+
+        assert!(engine.try_admit_execution("w1"));
+        assert!(engine.try_admit_execution("w2"));
+        assert!(
+            !engine.try_admit_execution("w3"),
+            "a third admission must be refused once the cap-2 lane is full"
+        );
+
+        engine.release_execution_permit("w1");
+        assert!(
+            engine.try_admit_execution("w3"),
+            "releasing a held permit must free exactly one slot"
+        );
+    }
+
+    /// Releasing a work id that holds no permit is a documented no-op
+    /// (idempotent), not a panic — the same posture as `block`'s repeat call
+    /// (above) and every other release-on-a-path-that-may-not-apply engine
+    /// helper.
+    #[test]
+    fn release_execution_permit_is_idempotent_for_a_work_holding_none() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let engine = engine(dir.path()).with_execution_lane_cap(1);
+        engine.release_execution_permit("never-admitted");
+        engine.release_execution_permit("never-admitted");
+        assert!(engine.try_admit_execution("w1"), "the lane is still whole");
+    }
+
+    /// D3's structural proof: draining every execution-lane permit must
+    /// leave the intelligence lane's own capacity completely untouched —
+    /// they are two separate `Arc<Semaphore>`s, not one budget split two
+    /// ways. Revert-sensitive: a shared-semaphore implementation would fail
+    /// this by starving the intelligence lane's `available_permits` too.
+    #[test]
+    fn execution_lane_exhaustion_never_touches_the_intelligence_lane() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let engine = engine(dir.path())
+            .with_execution_lane_cap(1)
+            .with_intelligence_lane_cap(3);
+
+        assert_eq!(engine.intelligence_lane.available_permits(), 3);
+        assert!(engine.try_admit_execution("w1"));
+        assert!(!engine.try_admit_execution("w2"), "execution lane is full");
+        assert_eq!(
+            engine.intelligence_lane.available_permits(),
+            3,
+            "the intelligence lane's own capacity must be untouched by execution-lane pressure"
+        );
+    }
+
     /// H1 touch point #4 as D10 leaves it: `Engine::commit` is still the one
     /// chokepoint every engine-emitted event goes through, but the
     /// coordinate it stamps is now the **Work's own**, not the engine's.

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -1216,13 +1216,20 @@ pub struct Engine {
     /// per Work at a time (the turn model's own invariant; mirrors
     /// [`Self::turn_started`]'s per-work keying). Inserted the moment a
     /// permit is admitted, in `api::crank`'s `Launch` arm, and removed
-    /// exactly where an execution stops being "in flight":
-    /// [`Self::stop_execution`] (completion, failure, cancel, interrupt) and
-    /// [`Self::settle_launch`]'s two no-live-execution branches (a
-    /// daemon-side launch error, a superseded reservation). Never durable —
-    /// a restart starts with an empty lane and every Work re-admits on its
-    /// next launch, which is correct: nothing native survived the restart
-    /// either.
+    /// exactly where an execution is *confirmed* no longer in flight:
+    /// [`Self::stop_execution`] releases immediately only when there is
+    /// nothing left to confirm (an immediate completion, a `stop()` error,
+    /// or no registered backend); when `backend.stop()` returns a pending
+    /// completion, the removal is folded into that completion's own tail
+    /// work and happens only once `Deferred::wait` actually joins it,
+    /// outside the core lock — never at stop-request time, so a
+    /// cancel/interrupt never transiently frees a lane slot for a native
+    /// process that may still be alive. [`Self::settle_launch`]'s two
+    /// no-live-execution branches (a daemon-side launch error, a superseded
+    /// reservation) remove immediately, since there is no native process to
+    /// wait for in either. Never durable — a restart starts with an empty
+    /// lane and every Work re-admits on its next launch, which is correct:
+    /// nothing native survived the restart either.
     execution_permits: Arc<Mutex<BTreeMap<String, OwnedSemaphorePermit>>>,
     /// H1-15's intelligence lane: config-only stub (deliverable 3). A
     /// separate `Arc<Semaphore>` from [`Self::execution_lane`] by
@@ -4558,6 +4565,20 @@ impl Engine {
     /// goes into `deferred` rather than being joined here (issue #14/B3):
     /// this runs under the daemon's core lock, and §22.6 forbids a thread
     /// join under it.
+    ///
+    /// H1-15: the execution-lane permit is released on *confirmed* stop, not
+    /// on request. `backend.stop()` returning a pending [`Completion`] means
+    /// the native process's actual teardown is still outstanding — freeing
+    /// the lane slot here would let a new Work admit and launch its own
+    /// native process while the one being canceled/interrupted may still be
+    /// alive, transiently oversubscribing `execution_lane_cap` in exactly
+    /// the cancel/interrupt scenario the lane exists to bound. So the permit
+    /// is folded into the deferred completion's own tail work and released
+    /// only once that tail actually runs (in `Deferred::wait`, outside the
+    /// core lock — never here). Only when there is no tail to defer to (an
+    /// immediate completion, a `stop()` error, or no registered backend —
+    /// nothing left to confirm) is the permit released immediately, since
+    /// no further observation of native teardown is coming.
     fn stop_execution(
         &self,
         core: &mut Core,
@@ -4574,19 +4595,40 @@ impl Engine {
         if execution.stop_requested {
             return Ok(());
         }
-        // H1-15: this Work's execution is definitively no longer in flight
-        // (completion, failure, cancel, or interrupt-driven stop — every
-        // call site above) — release the execution-lane permit it holds.
-        self.release_execution_permit(work_id);
         let outcome = match self.backends.get(&execution.backend) {
             Some(backend) => match backend.stop(&handle_of(&execution)) {
                 Ok(completion) => {
-                    deferred.push(completion);
+                    if completion.is_pending() {
+                        // Confirmed-stop release: fold the permit drop into
+                        // the tail work itself, so it only happens once the
+                        // native process's teardown has actually been
+                        // joined — never at request time.
+                        let permits = Arc::clone(&self.execution_permits);
+                        let permit_work_id = work_id.to_string();
+                        deferred.push(Completion::deferred(move || {
+                            completion.wait();
+                            permits
+                                .lock()
+                                .expect("execution permit map poisoned")
+                                .remove(&permit_work_id);
+                        }));
+                    } else {
+                        // Nothing outstanding to confirm — release now.
+                        self.release_execution_permit(work_id);
+                    }
                     json!({"requested": true})
                 }
-                Err(e) => json!({"requested": true, "error": e.to_string()}),
+                Err(e) => {
+                    // `stop()` itself failed: no tail to defer to, so there
+                    // is nothing further to observe before releasing.
+                    self.release_execution_permit(work_id);
+                    json!({"requested": true, "error": e.to_string()})
+                }
             },
-            None => json!({"requested": false, "error": "backend not registered"}),
+            None => {
+                self.release_execution_permit(work_id);
+                json!({"requested": false, "error": "backend not registered"})
+            }
         };
         self.commit(
             core,

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -4306,6 +4306,237 @@ async fn t_execution_lane_permit_releases_on_execution_failure() {
     assert!(status_b.is_success(), "B's retry answered {status_b}");
 }
 
+/// The fixed defect: a stop *request* must not free the execution-lane
+/// permit — only a *confirmed* stop (the native context's own tail work,
+/// joined) may. `stop_execution` used to call `release_execution_permit`
+/// unconditionally, before `backend.stop()`'s completion was ever awaited;
+/// on a lane of 1 that let a canceled Work's slot free the instant the
+/// cancel was issued, while the fake's "evidence archive" completion —
+/// standing in for the native process's own teardown — was still stalled.
+/// A second Work could then admit and launch while the canceled one might
+/// still be alive: exactly the transient oversubscription the finding
+/// named.
+///
+/// Decisive shape: cancel A with its archive completion held open (so the
+/// "native process" is provably still un-torn-down), and prove B *cannot*
+/// admit to a lane of 1 while that hold is in effect — only after the
+/// archive is released (and the completion actually joined) does B's
+/// admission become possible.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn t_execution_lane_permit_stays_held_until_stop_is_confirmed_not_merely_requested() {
+    let dir = TempDir::new().expect("tempdir");
+    let (work_a, work_b) = ("01LANECONFIRMA00000000000A", "01LANECONFIRMB00000000000B");
+    seed_blocked_run(dir.path(), work_a);
+    seed_blocked_run(dir.path(), work_b);
+
+    // `hang` keeps A's execution alive so the cancel below has a real native
+    // context to stop; B just needs to complete once admitted.
+    let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, [FakeStep::hang(), FakeStep::complete()]);
+    let handle = start_with_fake_capped(dir.path(), &fake, 1).await;
+    let http = client();
+
+    let status_a = http
+        .post(format!("{}/v1/work/{work_a}/retry", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&json!({"command_id": ulid()}))
+        .send()
+        .await
+        .expect("A retry")
+        .status();
+    assert!(status_a.is_success(), "A's retry answered {status_a}");
+
+    // Arm the archive gate — A's coming STOP will hand back a *pending*
+    // `Completion` that stalls here, standing in for a native process still
+    // tearing down.
+    fake.hold_archives();
+    let cancel_a = {
+        let http = http.clone();
+        let endpoint = handle.endpoint.clone();
+        let token = handle.token.clone();
+        tokio::spawn(async move {
+            http.post(format!("{endpoint}/v1/work/{work_a}/cancel"))
+                .bearer_auth(token)
+                .json(&json!({"command_id": ulid()}))
+                .send()
+                .await
+                .expect("cancel A request")
+                .status()
+        })
+    };
+    assert!(
+        fake.await_stalled_archives(1, Duration::from_secs(30)),
+        "A's stop completion never reached its gate — cancel A never actually stopped anything"
+    );
+
+    // The decisive check: with A's stop merely *requested* (its completion
+    // still stalled, unconfirmed), B must not be able to admit to a lane of
+    // 1. Give it a bounded window rather than asserting instantaneously —
+    // enough to catch a leaked permit without making the test itself slow.
+    let retry_b = {
+        let http = http.clone();
+        let endpoint = handle.endpoint.clone();
+        let token = handle.token.clone();
+        tokio::spawn(async move {
+            http.post(format!("{endpoint}/v1/work/{work_b}/retry"))
+                .bearer_auth(token)
+                .json(&json!({"command_id": ulid()}))
+                .send()
+                .await
+                .expect("B retry request")
+                .status()
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let show_b: Value = http
+        .get(format!("{}/v1/work/{work_b}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("show B")
+        .json()
+        .await
+        .expect("show B json");
+    assert_eq!(
+        show_b["work"]["state"], "waiting",
+        "B must still be parked on the lane while A's stop is only requested, not confirmed: \
+         {show_b}"
+    );
+
+    // Now confirm the stop: release the archive, let A's cancel finish
+    // joining it, and only then does the permit free for B.
+    fake.release_archives();
+    let status_a2 = cancel_a.await.expect("cancel A task");
+    assert!(status_a2.is_success(), "cancel A answered {status_a2}");
+
+    let status_b = tokio::time::timeout(Duration::from_secs(10), retry_b)
+        .await
+        .expect("B's retry never answered after A's stop was confirmed — the permit leaked")
+        .expect("B retry task");
+    handle.shutdown().await;
+    assert!(status_b.is_success(), "B's retry answered {status_b}");
+}
+
+/// The other fixed defect: `crank`'s `Launch` arm blocking the *client's own
+/// request* on execution-lane admission, not just the Work's internal
+/// state. With the fix, a request that lands in a full lane journals the
+/// wait and returns promptly — it does not sit open until another Work
+/// vacates a slot.
+///
+/// Decisive shape: hold A's launch at the fake's own launch gate (a stall
+/// downstream of, and much longer than, lane admission itself), then send
+/// B's retry into the full lane and require its HTTP response to land
+/// quickly — long before A's stall is ever released. The old behavior
+/// (blocking inline on `Engine::admit_execution`) would make this request
+/// hang until `release_launches` below runs; this test never calls that
+/// until after asserting B's response already arrived.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn t_a_request_into_a_full_execution_lane_returns_promptly_rather_than_blocking() {
+    let dir = TempDir::new().expect("tempdir");
+    let (work_a, work_b) = ("01LANEFASTA000000000000000", "01LANEFASTB000000000000000");
+    seed_blocked_run(dir.path(), work_a);
+    seed_blocked_run(dir.path(), work_b);
+
+    let fake = FakeBackend::scripted(
+        FAKE_BACKEND_NAME,
+        [FakeStep::complete(), FakeStep::complete()],
+    );
+    let handle = start_with_fake_capped(dir.path(), &fake, 1).await;
+    let http = client();
+
+    fake.hold_launches();
+    let retry = |work_id: &'static str| {
+        let http = http.clone();
+        let endpoint = handle.endpoint.clone();
+        let token = handle.token.clone();
+        tokio::spawn(async move {
+            http.post(format!("{endpoint}/v1/work/{work_id}/retry"))
+                .bearer_auth(token)
+                .json(&json!({"command_id": ulid()}))
+                .send()
+                .await
+                .expect("retry request")
+                .status()
+        })
+    };
+
+    // A takes the lane's one slot and stalls inside the fake's own launch
+    // gate — a stall this test deliberately never releases until well after
+    // judging B.
+    let retry_a = retry(work_a);
+    assert!(
+        fake.await_stalled_launches(1, Duration::from_secs(30)),
+        "A's launch never reached its gate"
+    );
+
+    // The decisive check: B's retry into the full lane must answer well
+    // inside a short bound, without waiting on A's still-held launch.
+    let started = Instant::now();
+    let status_b = tokio::time::timeout(Duration::from_secs(2), retry(work_b))
+        .await
+        .expect("B's retry blocked on execution-lane admission instead of returning promptly")
+        .expect("B retry task");
+    let elapsed = started.elapsed();
+    assert!(status_b.is_success(), "B's retry answered {status_b}");
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "B's retry took {elapsed:?} — it must return as soon as the lane wait is journaled, \
+         not once a slot actually frees"
+    );
+
+    let show_b: Value = http
+        .get(format!("{}/v1/work/{work_b}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("show B")
+        .json()
+        .await
+        .expect("show B json");
+    assert_eq!(
+        show_b["work"]["state"], "waiting",
+        "B's request returned promptly, but the Work itself must still be durably parked on \
+         the lane: {show_b}"
+    );
+
+    // Only now release A — proving B's earlier prompt response was not an
+    // artifact of the lane already having freed by coincidence.
+    fake.release_launches();
+    let status_a = retry_a.await.expect("A retry task");
+    assert!(status_a.is_success(), "A's retry answered {status_a}");
+
+    let both_completed = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let list: Value = client()
+                .get(format!("{}/v1/work", handle.endpoint))
+                .bearer_auth(&handle.token)
+                .send()
+                .await
+                .expect("list")
+                .json()
+                .await
+                .expect("list json");
+            let done = list["works"]
+                .as_array()
+                .expect("works")
+                .iter()
+                .filter(|w| {
+                    w["state"]
+                        .as_str()
+                        .is_some_and(|s| s.starts_with("completed"))
+                })
+                .count();
+            if done == 2 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(both_completed.is_ok(), "both Works must reach completed");
+
+    handle.shutdown().await;
+}
+
 // ------------------------------------- the throughput floor, as a guard
 //
 // N3-10: adjudication A-N3-1 amended the burst-50 floor to ">=24 works/s with

--- a/tests/m2_daemon_api.rs
+++ b/tests/m2_daemon_api.rs
@@ -40,7 +40,7 @@ use sergeant_rs::domain::event::{EVENT_SCHEMA, Event};
 use sergeant_rs::domain::event::{EventDraft, EventSource};
 use sergeant_rs::domain::work::{
     KIND_COMMAND_ACCEPTED, KIND_COMMAND_REJECTED, KIND_WORK_BLOCKED, KIND_WORK_CANCELED,
-    KIND_WORK_RESUMED, KIND_WORK_SUBMITTED, WorkState,
+    KIND_WORK_RESUMED, KIND_WORK_SUBMITTED, KIND_WORK_WAITING, WorkState,
 };
 use sergeant_rs::domain::workflow::{KIND_STAGE_ENTERED, KIND_WORKFLOW_BOUND};
 use sergeant_rs::runtime::engine::DEFAULT_TURN_CAP;
@@ -4003,6 +4003,307 @@ async fn t11e_a_stalled_drivers_completed_settle_lands_before_daemon_stopped() {
          or this test proves nothing about ordering: {:?}",
         events.iter().map(|e| &e.kind).collect::<Vec<_>>()
     );
+}
+
+// ------------------------------------- H1-15 (W4b) execution lane
+
+/// [`start_with_fake`], with the execution lane capped at `cap` — the one
+/// knob the lane tests below need beyond what `start_with_fake` already
+/// gives every §22.6 test above.
+async fn start_with_fake_capped(data_dir: &Path, fake: &FakeBackend, cap: usize) -> DaemonHandle {
+    daemon::start_with(
+        data_dir,
+        DaemonConfig {
+            backends: Arc::new(BackendRegistry::new().with(Arc::new(fake.clone()))),
+            default_backend: Some(FAKE_BACKEND_NAME.to_string()),
+            execution_lane_cap: Some(cap),
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start")
+}
+
+/// Every `KIND_WORK_WAITING`/`KIND_WORK_BLOCKED` payload journaled for
+/// `work_id`'s `reason`, in order — the direct-journal read the lane tests
+/// use to tell "waiting on the lane" from "blocked on the turn cap" apart,
+/// the same instrument `t3`/the SGT_TURN_CAP CLI test already use for
+/// journal-level assertions.
+fn park_reasons(data_dir: &Path, work_id: &str, kind: &str) -> Vec<String> {
+    Journal::replay_data_dir(data_dir)
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.kind == kind && e.work_id.as_deref() == Some(work_id))
+        .map(|e| e.payload["reason"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+/// Deliverable 4's decisive test: a lane capped at 1, two Works retried
+/// concurrently — the second must wait for the first rather than both
+/// launching at once, and both must still complete once the first frees its
+/// slot. Deliverable 2 rides along for free: the second Work's wait is
+/// journaled as `KIND_WORK_WAITING` (state `waiting`), never
+/// `KIND_WORK_BLOCKED` (state `blocked`) — the turn-cap vocabulary — so the
+/// two are observably distinct via the same journal a `work show` reads.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn t_execution_lane_caps_concurrent_launches_second_waits_both_complete() {
+    let dir = TempDir::new().expect("tempdir");
+    let (work_a, work_b) = ("01LANEWORKA000000000000000", "01LANEWORKB000000000000000");
+    seed_blocked_run(dir.path(), work_a);
+    seed_blocked_run(dir.path(), work_b);
+
+    let fake = FakeBackend::scripted(
+        FAKE_BACKEND_NAME,
+        [FakeStep::complete(), FakeStep::complete()],
+    );
+    let handle = start_with_fake_capped(dir.path(), &fake, 1).await;
+    let http = client();
+
+    fake.hold_launches();
+    let retry = |work_id: &'static str| {
+        let http = http.clone();
+        let endpoint = handle.endpoint.clone();
+        let token = handle.token.clone();
+        tokio::spawn(async move {
+            http.post(format!("{endpoint}/v1/work/{work_id}/retry"))
+                .bearer_auth(token)
+                .json(&json!({"command_id": ulid()}))
+                .send()
+                .await
+                .expect("retry request")
+                .status()
+        })
+    };
+
+    // A is admitted (the lane has one slot) and parks inside the fake's own
+    // launch gate — the external effect itself, one seam past the lane.
+    let retry_a = retry(work_a);
+    assert!(
+        fake.await_stalled_launches(1, Duration::from_secs(30)),
+        "A's launch never reached its gate"
+    );
+
+    // B cannot be admitted: the lane is full. It must not park in the fake's
+    // gate at all (there is only one slot, A holds it) — it parks *before*
+    // ever reaching LAUNCH, on the lane itself.
+    let retry_b = retry(work_b);
+    let b_waiting = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let show: Value = client()
+                .get(format!("{}/v1/work/{work_b}", handle.endpoint))
+                .bearer_auth(&handle.token)
+                .send()
+                .await
+                .expect("show B")
+                .json()
+                .await
+                .expect("show B json");
+            if show["work"]["state"] == "waiting" {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(
+        b_waiting.is_ok(),
+        "B never reported `waiting` while the lane was held by A"
+    );
+    // Only one launch ever reached the fake's gate — B's is genuinely
+    // parked earlier, on the lane, not queued behind A inside the backend.
+    assert!(
+        !fake.await_stalled_launches(2, Duration::from_millis(200)),
+        "B must not reach LAUNCH while the lane is full"
+    );
+
+    fake.release_launches();
+    let (status_a, status_b) = (
+        retry_a.await.expect("A retry task"),
+        retry_b.await.expect("B retry task"),
+    );
+    assert!(status_a.is_success(), "A's retry answered {status_a}");
+    assert!(status_b.is_success(), "B's retry answered {status_b}");
+
+    // Both actually finish (B's admission unblocked once A released).
+    let both_completed = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let list: Value = client()
+                .get(format!("{}/v1/work", handle.endpoint))
+                .bearer_auth(&handle.token)
+                .send()
+                .await
+                .expect("list")
+                .json()
+                .await
+                .expect("list json");
+            // `completed_dirty` (ADR 0007(b)) counts too: the seeded surface
+            // points at a non-git `data_dir`, so teardown strands it — an
+            // artifact of this test's fixture, not of the lane feature under
+            // test, which only cares that both Works reached a completed
+            // disposition rather than staying `active`/`waiting`.
+            let done = list["works"]
+                .as_array()
+                .expect("works")
+                .iter()
+                .filter(|w| {
+                    w["state"]
+                        .as_str()
+                        .is_some_and(|s| s.starts_with("completed"))
+                })
+                .count();
+            if done == 2 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(both_completed.is_ok(), "both Works must reach completed");
+
+    handle.shutdown().await;
+
+    // Deliverable 2: distinct journal vocabulary. B waited on the lane
+    // (`KIND_WORK_WAITING`, a lane-specific reason) and never touched the
+    // turn-cap's own `KIND_WORK_BLOCKED` vocabulary.
+    let waiting = park_reasons(dir.path(), work_b, KIND_WORK_WAITING);
+    assert!(
+        waiting.iter().any(|r| r.contains("execution lane")),
+        "B's wait must be journaled with a lane-specific reason, got {waiting:?}"
+    );
+    // `seed_blocked_run` itself journals one `blocked` ("seeded") to give the
+    // retry something to retry from — the fixture's own starting position,
+    // not evidence about the lane. What must never appear is a *second* one
+    // caused by the retry itself (a turn-cap-style block).
+    let blocked = park_reasons(dir.path(), work_b, KIND_WORK_BLOCKED);
+    assert_eq!(
+        blocked,
+        vec!["seeded".to_string()],
+        "B waited on the lane, not the turn cap — retrying it must never add \
+         a second `blocked` reason: {blocked:?}"
+    );
+}
+
+/// Deliverable 4: a permit released on a **daemon-side launch error** (the
+/// backend's own `launch()` returning `Err`, settled in `settle_launch`'s
+/// no-live-execution branch, never `stop_execution`). If this leaked, B's
+/// retry below would hang forever on a lane of 1 with A's permit never
+/// freed — this test would time out rather than merely fail.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn t_execution_lane_permit_releases_on_a_daemon_side_launch_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let (work_a, work_b) = ("01LANEFAILA0000000000000000", "01LANEFAILB0000000000000000");
+    seed_blocked_run(dir.path(), work_a);
+    seed_blocked_run(dir.path(), work_b);
+
+    let fake = FakeBackend::scripted(
+        FAKE_BACKEND_NAME,
+        [
+            FakeStep::invalid_model_refusal("no such model"),
+            FakeStep::complete(),
+        ],
+    );
+    let handle = start_with_fake_capped(dir.path(), &fake, 1).await;
+    let http = client();
+
+    let status_a = http
+        .post(format!("{}/v1/work/{work_a}/retry", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&json!({"command_id": ulid()}))
+        .send()
+        .await
+        .expect("A retry")
+        .status();
+    assert!(status_a.is_success(), "A's retry answered {status_a}");
+
+    let show_a: Value = http
+        .get(format!("{}/v1/work/{work_a}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("show A")
+        .json()
+        .await
+        .expect("show A json");
+    assert_eq!(
+        show_a["work"]["state"], "blocked",
+        "A's launch error must fail it closed, not leave it waiting: {show_a}"
+    );
+
+    // The decisive check: B's retry must not hang. A bounded timeout — not
+    // a bare `.await` — is what turns "the permit leaked" into a named test
+    // failure instead of a wedged suite.
+    let retried_b = tokio::time::timeout(Duration::from_secs(10), async {
+        http.post(format!("{}/v1/work/{work_b}/retry", handle.endpoint))
+            .bearer_auth(&handle.token)
+            .json(&json!({"command_id": ulid()}))
+            .send()
+            .await
+            .expect("B retry")
+            .status()
+    })
+    .await;
+    handle.shutdown().await;
+
+    let status_b = retried_b
+        .expect("B's retry never answered — A's execution-lane permit leaked on the launch error");
+    assert!(status_b.is_success(), "B's retry answered {status_b}");
+}
+
+/// Deliverable 4: a permit released on **execution failure** — an
+/// observed `BackendSignal::Failed`, settled through `drive`'s `Failed` arm
+/// and released in `stop_execution`, the other release chokepoint from the
+/// launch-error one above. Same shape, same decisive check: B's retry must
+/// not hang on a lane of 1.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn t_execution_lane_permit_releases_on_execution_failure() {
+    let dir = TempDir::new().expect("tempdir");
+    let (work_a, work_b) = ("01LANESTOPA0000000000000000", "01LANESTOPB0000000000000000");
+    seed_blocked_run(dir.path(), work_a);
+    seed_blocked_run(dir.path(), work_b);
+
+    let fake = FakeBackend::scripted(
+        FAKE_BACKEND_NAME,
+        [FakeStep::fail("the turn failed"), FakeStep::complete()],
+    );
+    let handle = start_with_fake_capped(dir.path(), &fake, 1).await;
+    let http = client();
+
+    let status_a = http
+        .post(format!("{}/v1/work/{work_a}/retry", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&json!({"command_id": ulid()}))
+        .send()
+        .await
+        .expect("A retry")
+        .status();
+    assert!(status_a.is_success(), "A's retry answered {status_a}");
+
+    let show_a: Value = http
+        .get(format!("{}/v1/work/{work_a}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("show A")
+        .json()
+        .await
+        .expect("show A json");
+    assert_eq!(show_a["work"]["state"], "failed", "A must fail: {show_a}");
+
+    let retried_b = tokio::time::timeout(Duration::from_secs(10), async {
+        http.post(format!("{}/v1/work/{work_b}/retry", handle.endpoint))
+            .bearer_auth(&handle.token)
+            .json(&json!({"command_id": ulid()}))
+            .send()
+            .await
+            .expect("B retry")
+            .status()
+    })
+    .await;
+    handle.shutdown().await;
+
+    let status_b = retried_b
+        .expect("B's retry never answered — A's execution-lane permit leaked on stage failure");
+    assert!(status_b.is_success(), "B's retry answered {status_b}");
 }
 
 // ------------------------------------- the throughput floor, as a guard


### PR DESCRIPTION
Wave W4b of sprint S1 (H1-15's execution half). 3 commits (implement ×2 + panel-driven fixer).

- Execution lane: `Arc<Semaphore>` admitted strictly between PREPARE and LAUNCH, outside the core lock (the recon's §22.6 hazard); default cap = `available_parallelism()` (provenance stated, R7-cited); `SGT_EXECUTION_LANE_CAP` following `SGT_TURN_CAP`'s exact discipline. Lane-parked Works journal via the existing WAITING/RESUMED events — observably distinct from turn-cap's BLOCKED, no new event kind, no new terminal state.
- Intelligence lane: config surface only, doc names A1/S3 as consumer, structurally separate permits.
- **Panel caught two real ones, both fixed with red→green-verified TDD**: (1) the permit released on stop *request* rather than stop *confirmation* — now folded into the Completion's own joined tail; (2) a lane-full launch blocked the client's HTTP request inline — now detaches once the Work is durably `waiting`, request returns immediately.
- Named gap (not silently covered): the raw env-parsing closures lack a subprocess round-trip test — same untested posture as `SGT_TURN_CAP`'s own parsing; the DaemonConfig path they feed is fully tested.

Gates: 4-axis panel → 2 confirmed → fixed → verify: **full suite green, 0 failures across 47 test binaries** (rebased onto #302's merge, `TMPDIR=/var/tmp/sgt-test-tmp`, docker round-trips included).

Held from merge pending the m5-intermittent diagnosis wave (workspace record: merged-on-red-302).

Rungs: H1-15 J3; R7 (lane primitive, lower rungs named); R2 (Deferred/Completion reuse, SGT_TURN_CAP pattern); fixer J1/J4 as cited in its commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4