### PR TITLE
S2/V1a: recursive workflow loader — nested packages flatten at load (E1/E2/E11/E12/E15)

### DIFF
--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -332,16 +332,27 @@ impl DockerBackend {
     /// journaled, separately, as evidence (`emit_image_resolved`); this file
     /// is what retry actually reads.
     fn pin_path(&self, work_id: &str, stage_id: &str) -> PathBuf {
-        // Stage ids are already constrained to plain directory names
-        // (`domain::is_plain_name`, enforced at workflow load); work ids are
-        // ULIDs. Neither can carry a path separator, so joining them with
-        // `__` cannot collide across different (work, stage) pairs and
-        // cannot escape the pins directory.
+        // E12: the stage id is interpolated *inside* one filename, and
+        // `PathBuf::join` splits an embedded `/` into path components — so a
+        // hierarchical stage id (W1 §3, `10-investigate/00-lead`) would send
+        // this pin into a directory nothing creates, and image-pin caching
+        // would silently fall back to unpinned resolution for every nested
+        // leaf. Each *component* of a stage id is still a plain directory
+        // name (`domain::is_plain_name`, enforced at workflow load) and a
+        // work id is a ULID, so `/` is the only character that has to be
+        // encoded here; `%` is encoded with it to keep the encoding
+        // injective, so two distinct stage ids can never land on one pin.
+        //
+        // The encoded name is bound to its own variable rather than
+        // interpolated from `stage_id` directly so the guard test below —
+        // which reads this source text — stays a decisive scan for the raw
+        // shape, with no allowlisted exception to keep in sync.
+        let encoded = stage_id.replace('%', "%25").replace('/', "%2F");
         self.config
             .data_dir
             .join("docker-adapter")
             .join("image-pins")
-            .join(format!("{work_id}__{stage_id}.json"))
+            .join(format!("{work_id}__{encoded}.json"))
     }
 
     fn read_pin(&self, work_id: &str, stage_id: &str) -> Option<ResolvedImage> {
@@ -1538,6 +1549,113 @@ mod tests {
         assert_eq!(read_back, image);
         // A different stage of the same work never sees this pin.
         assert!(backend.read_pin("w1", "s2").is_none());
+    }
+
+    /// E12: a hierarchical stage id (W1 §3) must not turn one pin *filename*
+    /// into a path. `format!("{work_id}__{stage_id}.json")` interpolates the
+    /// stage id **inside** the filename, and `PathBuf::join` then splits an
+    /// embedded `/` into two components — so a nested leaf's pin would have
+    /// been written under a directory that never exists, image-pin caching
+    /// silently falling back to unpinned resolution for every nested stage
+    /// with no loud failure. The encoding is injective, so two distinct
+    /// stage ids can never share a pin.
+    #[test]
+    fn a_hierarchical_stage_id_pins_to_one_filename_not_a_path() {
+        let (_dir, config) = config();
+        let pins = config.data_dir.join("docker-adapter").join("image-pins");
+        let backend = DockerBackend::new(config).expect("backend");
+
+        let path = backend.pin_path("w1", "10-investigate/00-lead");
+        assert_eq!(
+            path.parent(),
+            Some(pins.as_path()),
+            "the pin must stay directly in the pins directory: {path:?}"
+        );
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("pin file name");
+        assert!(
+            !file_name.contains('/'),
+            "the stage id must be encoded, not interpolated raw: {file_name}"
+        );
+
+        let image = ResolvedImage {
+            image_requested: "alpine:3.24".into(),
+            image_id: "sha256:deadbeef".into(),
+            repo_digests: vec![],
+            platform: "linux/amd64".into(),
+        };
+        backend.write_pin("w1", "10-investigate/00-lead", &image);
+        assert_eq!(
+            backend
+                .read_pin("w1", "10-investigate/00-lead")
+                .expect("a nested leaf's pin must round-trip"),
+            image
+        );
+        // Injective: a sibling leaf has its own pin, and the encoding of `/`
+        // never collides with a stage id that literally contains it.
+        assert!(backend.read_pin("w1", "10-investigate/10-code").is_none());
+        assert_ne!(
+            backend.pin_path("w1", "a/b"),
+            backend.pin_path("w1", "a%2Fb"),
+            "distinct stage ids must never share a pin file"
+        );
+    }
+
+    /// E12's standing guard: `stage_id` never reaches a filesystem path
+    /// un-encoded. The dangerous shape is interpolating it *into* a string
+    /// that is then joined — `PathBuf::join` splits the embedded `/`, so the
+    /// result is a path, not the filename the author meant. `pin_path` was
+    /// the one instance the recon found; this asserts it stays at zero.
+    ///
+    /// Plainly joining a stage id (`dir.join(stage_id)`) is a different
+    /// thing and stays legal: there the split into components is exactly the
+    /// intent — a composed id resolves its own nested directory (W1 §3).
+    #[test]
+    fn no_source_file_interpolates_a_stage_id_into_a_joined_filename() {
+        // Split so this scanner's own detector line is not itself a match —
+        // `concat!` rejoins it at compile time, but no *source* line here
+        // ever contains the contiguous pattern.
+        const JOINED_FORMAT: &str = concat!(".join(format", "!(");
+
+        fn scan(dir: &Path, offenders: &mut Vec<String>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    scan(&path, offenders);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                for (number, line) in text.lines().enumerate() {
+                    let code = line.trim_start();
+                    if code.starts_with("//") {
+                        continue;
+                    }
+                    if code.contains(JOINED_FORMAT) && code.contains("stage_id") {
+                        offenders.push(format!("{}:{}: {code}", path.display(), number + 1));
+                    }
+                }
+            }
+        }
+
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        scan(&src, &mut offenders);
+        assert!(
+            offenders.is_empty(),
+            "E12: a stage id interpolated into a filename that is then joined splits on `/` \
+             into path components — encode it (see DockerBackend::pin_path):\n{}",
+            offenders.join("\n")
+        );
     }
 
     /// `sgt doctor`'s disk-pressure measurement over a store that actually

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -1603,58 +1603,213 @@ mod tests {
         );
     }
 
-    /// E12's standing guard: `stage_id` never reaches a filesystem path
-    /// un-encoded. The dangerous shape is interpolating it *into* a string
-    /// that is then joined — `PathBuf::join` splits the embedded `/`, so the
-    /// result is a path, not the filename the author meant. `pin_path` was
-    /// the one instance the recon found; this asserts it stays at zero.
+    /// The index in `bytes` of the `)` that closes the `(` at `open_idx`,
+    /// tracking paren depth and skipping parens inside `"` string literals
+    /// (so a stray `)` in an interpolated string can't close the call
+    /// early). Shared by [`e12_scan`] and its own regression test.
+    fn e12_matching_paren(bytes: &[u8], open_idx: usize) -> Option<usize> {
+        let mut depth = 0i32;
+        let mut in_string = false;
+        let mut i = open_idx;
+        while i < bytes.len() {
+            let b = bytes[i];
+            if in_string {
+                if b == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if b == b'"' {
+                    in_string = false;
+                }
+            } else {
+                match b {
+                    b'"' => in_string = true,
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(i);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
+        None
+    }
+
+    /// Whether `word` appears in `haystack` as a whole identifier, not
+    /// merely as a substring of a longer one.
+    fn e12_contains_word(haystack: &str, word: &str) -> bool {
+        haystack
+            .split(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .any(|token| token == word)
+    }
+
+    /// E12's standing guard, factored out so both
+    /// [`no_source_file_interpolates_a_stage_id_into_a_joined_filename`] (run
+    /// against `src/`) and
+    /// [`the_e12_scanner_catches_the_ampersand_and_multiline_forms`] (run
+    /// against throwaway fixtures) share one implementation: recurse into
+    /// `dir`, and in every `.rs` file scan for `stage_id` reaching a
+    /// filesystem path un-encoded — interpolated *into* a string that is
+    /// then joined, which lets `PathBuf::join` split the embedded `/` into
+    /// path components the author never meant (`pin_path` was the one
+    /// instance the recon found; this keeps it at zero).
     ///
     /// Plainly joining a stage id (`dir.join(stage_id)`) is a different
     /// thing and stays legal: there the split into components is exactly the
     /// intent — a composed id resolves its own nested directory (W1 §3).
-    #[test]
-    fn no_source_file_interpolates_a_stage_id_into_a_joined_filename() {
-        // Split so this scanner's own detector line is not itself a match —
-        // `concat!` rejoins it at compile time, but no *source* line here
-        // ever contains the contiguous pattern.
-        const JOINED_FORMAT: &str = concat!(".join(format", "!(");
-
-        fn scan(dir: &Path, offenders: &mut Vec<String>) {
-            let Ok(entries) = std::fs::read_dir(dir) else {
-                return;
+    ///
+    /// A same-line, exact-substring scan misses the idiomatic forms of this
+    /// exact bug: `.join(&format!(...))` (a `&` between the two literals)
+    /// and a `format!(` call whose args wrap onto their own line. So this
+    /// scans each file as one whitespace-collapsed token stream — every
+    /// `.join(` call, optionally followed by `&`, whose very next token is
+    /// `format!(` — and inspects that `format!` call's *whole* (possibly
+    /// multi-line) argument list for a `stage_id` token, rather than
+    /// requiring both literals adjacent on one physical line.
+    fn e12_scan(dir: &Path, offenders: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                e12_scan(&path, offenders);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                continue;
             };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    scan(&path, offenders);
-                    continue;
+            // Drop whole-line comments, then collapse every run of
+            // whitespace (including the newlines a wrapped `format!` call
+            // introduces) to a single space, so `.join(`, an optional `&`,
+            // `format!(` and its args line up as one contiguous token
+            // stream regardless of the source's own line breaks.
+            let stripped = text
+                .lines()
+                .filter(|line| !line.trim_start().starts_with("//"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let flat = stripped.split_whitespace().collect::<Vec<_>>().join(" ");
+            let bytes = flat.as_bytes();
+
+            let mut search_from = 0;
+            while let Some(rel) = flat[search_from..].find(".join(") {
+                let join_paren = search_from + rel + ".join(".len() - 1;
+                let mut cursor = join_paren + 1;
+                // Skip an optional `&` (whitespace collapsing may have left
+                // a space on either side) between `.join(` and the
+                // `format!(` it wraps.
+                if bytes.get(cursor) == Some(&b' ') {
+                    cursor += 1;
                 }
-                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
-                    continue;
-                }
-                let Ok(text) = std::fs::read_to_string(&path) else {
-                    continue;
-                };
-                for (number, line) in text.lines().enumerate() {
-                    let code = line.trim_start();
-                    if code.starts_with("//") {
-                        continue;
+                let had_ampersand = bytes.get(cursor) == Some(&b'&');
+                if had_ampersand {
+                    cursor += 1;
+                    if bytes.get(cursor) == Some(&b' ') {
+                        cursor += 1;
                     }
-                    if code.contains(JOINED_FORMAT) && code.contains("stage_id") {
-                        offenders.push(format!("{}:{}: {code}", path.display(), number + 1));
+                }
+                if flat[cursor..].starts_with("format!(") {
+                    let fmt_paren = cursor + "format!(".len() - 1;
+                    if let Some(close) = e12_matching_paren(bytes, fmt_paren)
+                        && e12_contains_word(&flat[fmt_paren + 1..close], "stage_id")
+                    {
+                        offenders.push(format!(
+                            "{}: .join({}format!({})",
+                            path.display(),
+                            if had_ampersand { "&" } else { "" },
+                            flat[fmt_paren + 1..close].trim()
+                        ));
                     }
                 }
+                search_from = join_paren + 1;
             }
         }
+    }
 
+    /// E12's standing guard, run against this crate's own `src/`: proves a
+    /// future raw `stage_id`-into-a-joined-filename path stays at zero. See
+    /// [`e12_scan`] for the detection rule, and
+    /// [`the_e12_scanner_catches_the_ampersand_and_multiline_forms`] for
+    /// proof the scanner itself actually catches the shapes it claims to.
+    #[test]
+    fn no_source_file_interpolates_a_stage_id_into_a_joined_filename() {
         let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
         let mut offenders = Vec::new();
-        scan(&src, &mut offenders);
+        e12_scan(&src, &mut offenders);
         assert!(
             offenders.is_empty(),
             "E12: a stage id interpolated into a filename that is then joined splits on `/` \
              into path components — encode it (see DockerBackend::pin_path):\n{}",
             offenders.join("\n")
+        );
+    }
+
+    /// [`e12_scan`] must actually catch the shapes E12 names as missed by a
+    /// same-line, exact-substring detector: `&format!(` between the
+    /// literals, and a `format!` call whose interpolated args wrap onto
+    /// their own line. Exercised against throwaway fixture files rather
+    /// than `src/`, so this stays a regression test for the scanner itself
+    /// and never depends on — or is defeated by — whatever `src/` happens
+    /// to contain.
+    #[test]
+    fn the_e12_scanner_catches_the_ampersand_and_multiline_forms() {
+        // `FORMAT_BANG_OPEN` exists only so the fixture bodies below, when
+        // assembled, do not themselves leave the literal contiguous text
+        // `format!(` sitting in *this* file's own source next to a
+        // `.join(` — which would make `no_source_file_interpolates_a_
+        // stage_id_into_a_joined_filename`'s scan of `src/` flag this very
+        // test file. `concat!` joins it at compile time; no source line
+        // here ever contains the two pieces adjacent.
+        const FORMAT_BANG_OPEN: &str = concat!("format", "!(");
+
+        fn offenders_for(source: &str) -> Vec<String> {
+            let dir = tempfile::TempDir::new().expect("tempdir");
+            std::fs::write(dir.path().join("fixture.rs"), source).expect("fixture file");
+            let mut offenders = Vec::new();
+            e12_scan(dir.path(), &mut offenders);
+            offenders
+        }
+
+        let ampersand = format!(
+            "fn pin_path(work_id: &str, stage_id: &str) -> PathBuf {{\n\
+                 self.pins_dir().join(&{FORMAT_BANG_OPEN}\"{{work_id}}__{{stage_id}}.json\"))\n\
+             }}"
+        );
+        assert_eq!(
+            offenders_for(&ampersand).len(),
+            1,
+            "an `&format!(` between `.join(` and the stage id must still be caught"
+        );
+
+        let multiline = format!(
+            "fn pin_path(work_id: &str, stage_id: &str) -> PathBuf {{\n\
+                 self.pins_dir().join({FORMAT_BANG_OPEN}\n\
+                     \"{{work_id}}__{{stage_id}}.json\"\n\
+                 ))\n\
+             }}"
+        );
+        assert_eq!(
+            offenders_for(&multiline).len(),
+            1,
+            "a `format!(` call whose args wrap onto their own line must still be caught"
+        );
+
+        let benign = r#"
+            fn pin_path(&self, work_id: &str, stage_id: &str) -> PathBuf {
+                self.pins_dir().join(encode(stage_id))
+            }
+        "#;
+        assert!(
+            offenders_for(benign).is_empty(),
+            "a stage id that never reaches a `.join(format!(...))` must not be flagged"
         );
     }
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -47,4 +47,23 @@ mod tests {
             assert!(!is_plain_name(bad), "{bad:?} must not be a plain name");
         }
     }
+
+    /// W1 §3: a nested workflow package's stage id is a `/`-joined path of
+    /// components (`10-investigate/00-lead`). This guard stays
+    /// per-*component*: the composite is deliberately never a plain name, so
+    /// a caller that passed a whole hierarchical stage id here would refuse
+    /// every valid nested stage rather than validate one. Only
+    /// [`workflow::WorkflowDefinition::load_dir`] joins components, and only
+    /// after checking each one through here.
+    #[test]
+    fn a_composed_hierarchical_stage_id_is_never_a_plain_name() {
+        let composed = "10-investigate/00-lead";
+        assert!(
+            !is_plain_name(composed),
+            "the composite must not pass the per-component guard"
+        );
+        for component in composed.split('/') {
+            assert!(is_plain_name(component), "{component:?} is a plain name");
+        }
+    }
 }

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -720,6 +720,30 @@ const EMBEDDED_CONTEXTS: &[(&str, &str)] = &[
     ),
 ];
 
+/// The embedded loader's equivalent of a workflow package directory (W1 §2,
+/// [`WorkflowDefinition::load_embedded`]): a `workflow.toml`, the leaf
+/// `CONTEXT.md` contents it can splice in directly, and any stage ids that
+/// are themselves nested embedded packages — the embedded parity to
+/// [`WorkflowDefinition::load_dir`]'s directory-marker recursion, over a
+/// static representation since `include_str!` content has no directory to
+/// walk at runtime.
+struct EmbeddedPackage<'a> {
+    /// The package's `workflow.toml` text.
+    workflow_toml: &'a str,
+    /// `(stage id, CONTEXT.md)` pairs for this package's own leaf stages.
+    contexts: &'a [(&'a str, &'a str)],
+    /// `(stage id, nested package)` pairs: a stage id here is this loader's
+    /// positive marker for "this stage is a container", mirroring
+    /// `load_dir`'s `stage_dir.join(WORKFLOW_FILE).is_file()` check.
+    ///
+    /// A lifetime parameter rather than a hardcoded `'static`: the real
+    /// `EMBEDDED_CONTEXTS`/`EMBEDDED_WORKFLOW_TOML` consts are `'static`, but
+    /// the parity tests below build a synthetic `EmbeddedPackage` out of
+    /// stack-local strings, and the recursion/splice mechanism is exactly
+    /// the same either way.
+    nested: &'a [(&'a str, EmbeddedPackage<'a>)],
+}
+
 impl WorkflowDefinition {
     /// Resolve `name` for a estate rooted at `root`.
     ///
@@ -885,13 +909,67 @@ impl WorkflowDefinition {
     /// The built-in `software-change` workflow.
     pub fn embedded() -> Result<Self, WorkflowError> {
         let path = format!("<embedded>/{DEFAULT_WORKFLOW}/{WORKFLOW_FILE}");
-        let parsed = parse_descriptor(EMBEDDED_WORKFLOW_TOML, &path)?;
+        let pkg = EmbeddedPackage {
+            workflow_toml: EMBEDDED_WORKFLOW_TOML,
+            contexts: EMBEDDED_CONTEXTS,
+            nested: &[],
+        };
+        Self::load_embedded(&pkg, path)
+    }
+
+    /// Parity with [`Self::load_dir`] for the embedded representation (W1
+    /// §2 / decision E1): a stage id present in `pkg.nested` is this
+    /// loader's equivalent of a directory holding its own `workflow.toml` —
+    /// a positive marker detection, recursed and spliced exactly as
+    /// `load_dir` does, over whatever the embedded package representation
+    /// (a static `EmbeddedPackage` tree, since there is no build-time
+    /// directory walk for `include_str!` content) actually supports. The
+    /// built-in `software-change` workflow happens to declare no nested
+    /// entries today (`embedded()` passes `nested: &[]`), but the mechanism
+    /// itself does not assume that — see the recursion/splice tests below.
+    fn load_embedded(pkg: &EmbeddedPackage<'_>, path: String) -> Result<Self, WorkflowError> {
+        let dir_path = path
+            .strip_suffix(&format!("/{WORKFLOW_FILE}"))
+            .unwrap_or(&path)
+            .to_string();
+        let parsed = parse_descriptor(pkg.workflow_toml, &path)?;
         let ids = check_stage_ids(&parsed.workflow.stages, &path)?;
         check_stage_tables(&ids, &parsed.stages_meta, &path)?;
         let mut stages = Vec::with_capacity(ids.len());
         for id in ids {
+            // Same positive-detection rule as `load_dir`: a marker match,
+            // never "no context happened to be embedded" — an id with
+            // neither still fails closed via `MissingStage` below.
+            if let Some((_, nested_pkg)) = pkg.nested.iter().find(|(nested_id, _)| *nested_id == id)
+            {
+                let marker = format!("{dir_path}/{id}/{WORKFLOW_FILE}");
+                if pkg.contexts.iter().any(|(cid, _)| *cid == id) {
+                    let context = format!("{dir_path}/{id}/{CONTEXT_FILE}");
+                    return Err(WorkflowError::NestedPackageWithContext {
+                        path,
+                        stage: id,
+                        marker,
+                        context,
+                    });
+                }
+                if parsed.stages_meta.contains_key(&id) {
+                    return Err(WorkflowError::NestedPackageStageTable {
+                        path,
+                        stage: id,
+                        marker,
+                    });
+                }
+                let nested_path = format!("{dir_path}/{id}/{WORKFLOW_FILE}");
+                let nested = Self::load_embedded(nested_pkg, nested_path)?;
+                stages.extend(nested.stages.into_iter().map(|leaf| StageDefinition {
+                    id: format!("{id}/{}", leaf.id),
+                    ..leaf
+                }));
+                continue;
+            }
             let tag = resolve_stage_tag(&id, parsed.stages_meta.get(&id), &path)?;
-            let embedded_context = EMBEDDED_CONTEXTS
+            let embedded_context = pkg
+                .contexts
                 .iter()
                 .find(|(stage, _)| *stage == id)
                 .map(|(_, context)| (*context).to_string());
@@ -906,7 +984,7 @@ impl WorkflowDefinition {
                     return Err(WorkflowError::MissingStage {
                         path: path.clone(),
                         stage: id.clone(),
-                        missing: format!("<embedded>/{DEFAULT_WORKFLOW}/{id}/{CONTEXT_FILE}"),
+                        missing: format!("{dir_path}/{id}/{CONTEXT_FILE}"),
                     });
                 }
             };
@@ -3354,14 +3432,15 @@ mod tests {
         );
     }
 
-    /// Parity guard for the embedded loader: the built-in `software-change`
-    /// workflow is flat, and nesting is a *directory* loader concept — a
-    /// nested package can never be `SOURCE_EMBEDDED` (there is no embedded
-    /// nested descriptor to parse). Stated as a test so an embedded package
-    /// that grew a nested stage would fail here rather than silently load a
-    /// container as an actor stage with no context.
+    /// The built-in `software-change` workflow happens to be flat today
+    /// (`embedded()` passes `nested: &[]`) — this pins that current fact, not
+    /// a claim that the embedded loader is incapable of nesting. See the
+    /// `embedded_loader_*` tests below for proof the recursion/splice
+    /// mechanism itself works, exercised against a synthetic
+    /// `EmbeddedPackage` since the real built-in package has no nested entry
+    /// to exercise it against.
     #[test]
-    fn the_embedded_workflow_stays_flat() {
+    fn the_built_in_software_change_workflow_is_flat_today() {
         let def = WorkflowDefinition::embedded().expect("embedded workflow");
         for stage in &def.stages {
             assert!(
@@ -3370,6 +3449,149 @@ mod tests {
                 stage.id
             );
         }
+    }
+
+    // ---------------------------------- embedded-loader nesting parity (E1)
+
+    /// W1 §2 / E1 parity: a stage id present in an `EmbeddedPackage`'s
+    /// `nested` list recurses and splices with a composed `parent/child` id,
+    /// exactly like `load_dir`'s directory-marker recursion — proven here
+    /// against a synthetic package since the real embedded `software-change`
+    /// workflow has no nested entry today.
+    #[test]
+    fn embedded_loader_recurses_into_a_nested_package_and_composes_the_id() {
+        let leaf = EmbeddedPackage {
+            workflow_toml: "[workflow]\nname = \"10-container\"\nversion = \"1\"\nstages = [\"00-leaf\"]\n",
+            contexts: &[("00-leaf", "the nested procedure")],
+            nested: &[],
+        };
+        let root = EmbeddedPackage {
+            workflow_toml: "[workflow]\nname = \"synthetic\"\nversion = \"1\"\nstages = [\"10-container\"]\n",
+            contexts: &[],
+            nested: &[("10-container", leaf)],
+        };
+        let def = WorkflowDefinition::load_embedded(
+            &root,
+            "<embedded>/synthetic/workflow.toml".to_string(),
+        )
+        .expect("recurse into the nested embedded package");
+        assert_eq!(def.stages.len(), 1);
+        assert_eq!(def.stages[0].id, "10-container/00-leaf");
+        assert_eq!(def.stages[0].context, "the nested procedure");
+    }
+
+    /// E2 parity: the content hash folds the flattened tree for the embedded
+    /// loader too — editing a nested leaf's context changes the parent's
+    /// `content_hash`, exactly like `editing_a_nested_leafs_context_changes_the_parents_content_hash`
+    /// proves for `load_dir`.
+    #[test]
+    fn embedded_loader_folds_a_nested_leafs_content_into_the_parents_hash() {
+        const ROOT_TOML: &str =
+            "[workflow]\nname = \"synthetic\"\nversion = \"1\"\nstages = [\"10-container\"]\n";
+        const LEAF_TOML: &str =
+            "[workflow]\nname = \"10-container\"\nversion = \"1\"\nstages = [\"00-leaf\"]\n";
+
+        let original_leaf = EmbeddedPackage {
+            workflow_toml: LEAF_TOML,
+            contexts: &[("00-leaf", "original")],
+            nested: &[],
+        };
+        let original_root = EmbeddedPackage {
+            workflow_toml: ROOT_TOML,
+            contexts: &[],
+            nested: &[("10-container", original_leaf)],
+        };
+        let before = WorkflowDefinition::load_embedded(
+            &original_root,
+            "<embedded>/synthetic/workflow.toml".to_string(),
+        )
+        .expect("load");
+
+        let edited_leaf = EmbeddedPackage {
+            workflow_toml: LEAF_TOML,
+            contexts: &[("00-leaf", "edited")],
+            nested: &[],
+        };
+        let edited_root = EmbeddedPackage {
+            workflow_toml: ROOT_TOML,
+            contexts: &[],
+            nested: &[("10-container", edited_leaf)],
+        };
+        let after = WorkflowDefinition::load_embedded(
+            &edited_root,
+            "<embedded>/synthetic/workflow.toml".to_string(),
+        )
+        .expect("reload");
+
+        assert_ne!(
+            before.content_hash, after.content_hash,
+            "E2: a nested leaf's content folds into the embedded parent's identity too"
+        );
+    }
+
+    /// Parity with [`WorkflowError::NestedPackageWithContext`]: a stage id
+    /// that is both a nested embedded package and carries its own embedded
+    /// `CONTEXT.md` is refused, the same fail-closed shape `load_dir` gives a
+    /// stage directory holding both a nested `workflow.toml` and a
+    /// `CONTEXT.md`.
+    #[test]
+    fn embedded_loader_refuses_a_nested_package_that_also_carries_a_context() {
+        let leaf = EmbeddedPackage {
+            workflow_toml: "[workflow]\nname = \"10-container\"\nversion = \"1\"\nstages = [\"00-leaf\"]\n",
+            contexts: &[("00-leaf", "the nested procedure")],
+            nested: &[],
+        };
+        let root = EmbeddedPackage {
+            workflow_toml: "[workflow]\nname = \"synthetic\"\nversion = \"1\"\nstages = [\"10-container\"]\n",
+            // A context embedded for the very id that is also `nested` —
+            // the embedded equivalent of a stage directory holding both
+            // `workflow.toml` and `CONTEXT.md`.
+            contexts: &[("10-container", "should never be read")],
+            nested: &[("10-container", leaf)],
+        };
+        let err = WorkflowDefinition::load_embedded(
+            &root,
+            "<embedded>/synthetic/workflow.toml".to_string(),
+        )
+        .expect_err("a nested package with a context must be refused");
+        assert!(
+            matches!(&err, WorkflowError::NestedPackageWithContext { stage, .. } if stage == "10-container"),
+            "expected NestedPackageWithContext, got {err}"
+        );
+    }
+
+    /// Parity with [`WorkflowError::NestedPackageStageTable`]: a `[stage.*]`
+    /// table naming a nested-package stage id is refused, the same
+    /// fail-closed shape `load_dir` gives a `[stage.*]` table over a
+    /// directory that is itself a nested workflow package.
+    #[test]
+    fn embedded_loader_refuses_a_stage_table_over_a_nested_package() {
+        let leaf = EmbeddedPackage {
+            workflow_toml: "[workflow]\nname = \"10-container\"\nversion = \"1\"\nstages = [\"00-leaf\"]\n",
+            contexts: &[("00-leaf", "the nested procedure")],
+            nested: &[],
+        };
+        let root = EmbeddedPackage {
+            workflow_toml: concat!(
+                "[workflow]\n",
+                "name = \"synthetic\"\n",
+                "version = \"1\"\n",
+                "stages = [\"10-container\"]\n",
+                "[stage.\"10-container\"]\n",
+                "kind = \"actor\"\n",
+            ),
+            contexts: &[],
+            nested: &[("10-container", leaf)],
+        };
+        let err = WorkflowDefinition::load_embedded(
+            &root,
+            "<embedded>/synthetic/workflow.toml".to_string(),
+        )
+        .expect_err("a stage table over a nested package must be refused");
+        assert!(
+            matches!(&err, WorkflowError::NestedPackageStageTable { stage, .. } if stage == "10-container"),
+            "expected NestedPackageStageTable, got {err}"
+        );
     }
 
     // --------------------------------------------- T2: catalog / front matter

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -3153,6 +3153,68 @@ mod tests {
         );
     }
 
+    /// `[stage."<id>"]` tables stay per-package: a nested package's own
+    /// tables are keyed against *its* declared ids and resolve into the
+    /// leaves it contributes, carried through the splice unchanged.
+    #[test]
+    fn a_nested_packages_own_stage_table_tags_its_leaf() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "tagged-nested");
+        write_package(&wf, "tagged-nested", &["10-investigate"]);
+        let container = wf.join("10-investigate");
+        std::fs::create_dir_all(&container).expect("container dir");
+        std::fs::write(
+            container.join(WORKFLOW_FILE),
+            "[workflow]\nname = \"10-investigate\"\nversion = \"1\"\n\
+             stages = [\"00-lead\", \"10-code\"]\n\n\
+             [stage.\"00-lead\"]\nkind = \"actor\"\nharness = \"claude\"\nprofile = \"deep\"\n\
+             requires_ask = true\n",
+        )
+        .expect("nested descriptor");
+        write_stage(&container, "00-lead", "lead");
+        write_stage(&container, "10-code", "code");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("load");
+        let lead = &def.stages[0];
+        assert_eq!(lead.id, "10-investigate/00-lead");
+        assert_eq!(lead.harness.as_deref(), Some("claude"));
+        assert_eq!(lead.profile.as_deref(), Some("deep"));
+        assert!(lead.requires_ask);
+        // The untagged sibling keeps the actor default.
+        let code = &def.stages[1];
+        assert_eq!(code.id, "10-investigate/10-code");
+        assert_eq!(code.harness, None);
+        assert!(!code.requires_ask);
+    }
+
+    /// The other half of that rule: a parent's own `check_stage_tables` only
+    /// ever sees the parent's declared ids. A parent table naming a *nested*
+    /// leaf is undeclared metadata, refused as any other would be — there is
+    /// no cross-package table lookup.
+    #[test]
+    fn a_parent_may_not_declare_a_stage_table_for_a_nested_leaf() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "cross-package");
+        std::fs::create_dir_all(&wf).expect("workflow dir");
+        std::fs::write(
+            wf.join(WORKFLOW_FILE),
+            "[workflow]\nname = \"cross-package\"\nversion = \"1\"\n\
+             stages = [\"10-investigate\"]\n\n\
+             [stage.\"00-lead\"]\nharness = \"claude\"\n",
+        )
+        .expect("descriptor");
+        let container = wf.join("10-investigate");
+        write_package(&container, "10-investigate", &["00-lead"]);
+        write_stage(&container, "00-lead", "lead");
+
+        let err = WorkflowDefinition::load_dir(&wf)
+            .expect_err("a table naming a nested leaf must be refused");
+        assert!(
+            matches!(&err, WorkflowError::UndeclaredStageTable { stage, .. } if stage == "00-lead"),
+            "expected UndeclaredStageTable, got {err}"
+        );
+    }
+
     /// E15: a stage directory holding **both** `workflow.toml` and
     /// `CONTEXT.md` is a load error. A container has no actor (W1-02), so
     /// that `CONTEXT.md` could never be read — surfacing the author's

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -10,6 +10,15 @@
 //!   ...
 //! ```
 //!
+//! A stage directory may itself hold a `workflow.toml`, which makes it a
+//! *container* whose implementation is another workflow package (W1 §2).
+//! That package reuses this same grammar recursively — no `subworkflow.toml`,
+//! no DAG syntax, no second runtime. The loader flattens it: a container
+//! contributes no stage of its own, its leaves splice into the parent's one
+//! ordered stage list with `parent/child` composed ids, and everything
+//! downstream (binding, advancement, retry, replay) runs against that flat
+//! list unchanged. See [`WorkflowDefinition::load_dir`].
+//!
 //! The engine supports §12's verb set and nothing more — ordered stages,
 //! explicit entry, explicit completion, waiting, needs input, blocked, retry,
 //! failure, cancellation. It is not a DAG scheduler (§4).
@@ -245,7 +254,13 @@ pub struct ExecuteSpec {
 /// `workflow.bound` payload journaled before N3 replay cleanly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageDefinition {
-    /// Directory name, which is also the stage id (`10-implement`).
+    /// Directory name, which is also the stage id (`10-implement`) — or,
+    /// for a leaf inside a nested workflow package, the `/`-joined path of
+    /// directory names from this package's root down to it
+    /// (`10-investigate/00-lead`, W1 §3). Each component is a plain
+    /// directory name; only [`WorkflowDefinition::load_dir`] joins them, and
+    /// the composite is never itself passed back through
+    /// [`crate::domain::is_plain_name`].
     pub id: String,
     /// The stage's `CONTEXT.md`, carried verbatim.
     pub context: String,
@@ -329,7 +344,10 @@ pub struct WorkflowDefinition {
     /// Where this definition came from: [`SOURCE_EMBEDDED`] or a directory
     /// path. Recorded so a replay can tell a built-in run from a repo's own.
     pub source: String,
-    /// Stages in execution order.
+    /// Stages in execution order — **leaves only**, one flat list. A nested
+    /// workflow package's stages appear here spliced in at their container's
+    /// position with composed `parent/child` ids (W1 §2/§3, decision E1);
+    /// the container itself is never a stage (W1-02).
     pub stages: Vec<StageDefinition>,
     /// Stable content-identity hash over every execution-relevant field:
     /// descriptor (name, version), stage order, each stage's executor tag
@@ -574,6 +592,45 @@ pub enum WorkflowError {
         /// The offending name.
         name: String,
     },
+    /// A stage directory holds **both** a nested `workflow.toml` and a
+    /// `CONTEXT.md` (W1 §2 / decision E15). A container stage gets no
+    /// implicit actor execution, so nothing would ever read that
+    /// `CONTEXT.md` — refused rather than silently ignored, the same
+    /// fail-closed posture `deny_unknown_fields` gives a typo (§22.3).
+    #[error(
+        "{path} declares stage {stage:?}, whose directory holds both {marker} and {context}: a \
+         stage directory containing {marker} is a nested workflow package and runs no actor of \
+         its own, so its {context} could never be read — make it a nested package or an actor \
+         stage, not both"
+    )]
+    NestedPackageWithContext {
+        /// Path of the declaring descriptor.
+        path: String,
+        /// The offending stage id.
+        stage: String,
+        /// The nested descriptor that makes this stage a container.
+        marker: String,
+        /// The actor context that can never be read.
+        context: String,
+    },
+    /// A `[stage."<id>"]` table names a stage whose directory is a nested
+    /// workflow package. Same rule as [`WorkflowError::NestedPackageWithContext`]
+    /// applied to the other piece of authored per-stage metadata a container
+    /// can never consume: a container has no execution to pin a
+    /// kind/harness/profile for.
+    #[error(
+        "{path} declares a [stage.{stage:?}] table, but {stage:?} is a nested workflow package \
+         ({marker} exists): a container stage runs no execution of its own, so it has no \
+         harness, profile or kind to declare"
+    )]
+    NestedPackageStageTable {
+        /// Path of the declaring descriptor.
+        path: String,
+        /// The offending stage id.
+        stage: String,
+        /// The nested descriptor that makes this stage a container.
+        marker: String,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -695,6 +752,32 @@ impl WorkflowDefinition {
     }
 
     /// Load a workflow from a directory holding `workflow.toml` and its stages.
+    ///
+    /// **Nested packages (W1 §2, decision E1).** A stage directory that
+    /// itself holds a `workflow.toml` is a *container*: its implementation is
+    /// another workflow package, loaded by this same function recursively —
+    /// not a `subworkflow.toml`, not a DAG, not a second runtime. A container
+    /// contributes **no** [`StageDefinition`] of its own (W1-02: no implicit
+    /// actor execution); its leaves are spliced into this package's one flat
+    /// `stages` list, at the container's position, with `parent/child`
+    /// composed ids.
+    ///
+    /// Composition, not a widened name rule: each *component* is still the
+    /// single, `is_plain_name`-validated directory name `check_stage_ids`
+    /// already enforces at every level, and only this function ever joins
+    /// them with `/`. The composite is deliberately not a plain name — no
+    /// consumer may pass a whole stage id back through the shared
+    /// path-traversal guard (`domain::is_plain_name`), and every composed id
+    /// is unique by construction, since a `/`-free sibling can never collide
+    /// with a `/`-bearing composite.
+    ///
+    /// Everything downstream then runs unchanged against one flat, ordered
+    /// list (W1-04/W1-05): `Path::join` splits an embedded `/` into real
+    /// components, so a composed id resolves the nested directory for
+    /// context, output contracts and worktree layout alike, and the
+    /// content hash folds the whole flattened tree into one identity (E2) —
+    /// a nested leaf's edit changes the parent's `content_hash` exactly as a
+    /// top-level stage's does.
     pub fn load_dir(dir: &Path) -> Result<Self, WorkflowError> {
         let descriptor = dir.join(WORKFLOW_FILE);
         let path = descriptor.display().to_string();
@@ -718,8 +801,38 @@ impl WorkflowDefinition {
         check_stage_tables(&ids, &parsed.stages_meta, &path)?;
         let mut stages = Vec::with_capacity(ids.len());
         for id in ids {
-            let tag = resolve_stage_tag(&id, parsed.stages_meta.get(&id), &path)?;
             let stage_dir = dir.join(&id);
+            // W1 §2 / E1: a *positive* detection of the nested-package
+            // marker, never "CONTEXT.md happened to be absent" — a stage
+            // directory with neither still fails closed below.
+            let marker = stage_dir.join(WORKFLOW_FILE);
+            if marker.is_file() {
+                let context_path = stage_dir.join(CONTEXT_FILE);
+                if context_path.is_file() {
+                    return Err(WorkflowError::NestedPackageWithContext {
+                        path,
+                        stage: id,
+                        marker: marker.display().to_string(),
+                        context: context_path.display().to_string(),
+                    });
+                }
+                if parsed.stages_meta.contains_key(&id) {
+                    return Err(WorkflowError::NestedPackageStageTable {
+                        path,
+                        stage: id,
+                        marker: marker.display().to_string(),
+                    });
+                }
+                // The nested package validates itself, by its own rules, and
+                // reports failures against its own descriptor path.
+                let nested = Self::load_dir(&stage_dir)?;
+                stages.extend(nested.stages.into_iter().map(|leaf| StageDefinition {
+                    id: format!("{id}/{}", leaf.id),
+                    ..leaf
+                }));
+                continue;
+            }
+            let tag = resolve_stage_tag(&id, parsed.stages_meta.get(&id), &path)?;
             let context_path = stage_dir.join(CONTEXT_FILE);
             let context = if context_path.is_file() {
                 std::fs::read_to_string(&context_path).map_err(|source| WorkflowError::Io {
@@ -2860,6 +2973,341 @@ mod tests {
             matches!(&err, WorkflowError::DuplicateStage { stage, .. } if stage == "00-only"),
             "expected DuplicateStage naming the repeated id, got {err}"
         );
+    }
+
+    // ------------------------------------- W1 §2/§3: nested workflow packages
+
+    /// Writes one package's own `workflow.toml`, creating its directory.
+    /// The nested-package fixtures below need this at every level, not only
+    /// at the root — a nested package is an ordinary package.
+    fn write_package(dir: &Path, name: &str, stages: &[&str]) {
+        std::fs::create_dir_all(dir).expect("package dir");
+        let declared = stages
+            .iter()
+            .map(|id| format!("{id:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        std::fs::write(
+            dir.join(WORKFLOW_FILE),
+            format!("[workflow]\nname = {name:?}\nversion = \"1\"\nstages = [{declared}]\n"),
+        )
+        .expect("descriptor");
+    }
+
+    /// E1 / W1 §2: a stage directory that itself holds a `workflow.toml` is a
+    /// container. It contributes **no** `StageDefinition` of its own (W1-02:
+    /// "no implicit actor execution"); its leaves are spliced into the
+    /// parent's one flat `stages` list, in place, with `parent/child`
+    /// composed ids.
+    #[test]
+    fn a_nested_package_splices_its_leaves_into_the_parents_flat_stage_list() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "nested-two");
+        write_package(
+            &wf,
+            "nested-two",
+            &["00-orient", "10-investigate", "20-implement"],
+        );
+        write_stage(&wf, "00-orient", "orient");
+        write_stage(&wf, "20-implement", "implement");
+
+        let investigate = wf.join("10-investigate");
+        write_package(&investigate, "10-investigate", &["00-lead", "10-code"]);
+        write_stage(&investigate, "00-lead", "lead the squad");
+        write_stage(&investigate, "10-code", "read the code");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("nested package must load");
+        let ids: Vec<&str> = def.stages.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            [
+                "00-orient",
+                "10-investigate/00-lead",
+                "10-investigate/10-code",
+                "20-implement",
+            ],
+            "nested leaves splice in at the container's position, in document order"
+        );
+        assert!(
+            !def.stages.iter().any(|s| s.id == "10-investigate"),
+            "W1-02: a container stage is never itself a StageDefinition: {ids:?}"
+        );
+        assert_eq!(def.stages[1].context, "lead the squad");
+        assert_eq!(def.stages[2].context, "read the code");
+        // Every leaf is an ordinary stage — the container marker changes the
+        // id, never the executor tag.
+        assert!(def.stages.iter().all(|s| s.kind == StageKind::Actor));
+    }
+
+    /// W1 §4: "a nested package can nest again". Three levels, still one flat
+    /// list of leaves.
+    #[test]
+    fn a_nested_package_may_itself_nest() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "nested-three");
+        write_package(&wf, "nested-three", &["00-orient", "10-investigate"]);
+        write_stage(&wf, "00-orient", "orient");
+
+        let investigate = wf.join("10-investigate");
+        write_package(&investigate, "10-investigate", &["00-lead", "10-deep"]);
+        write_stage(&investigate, "00-lead", "lead");
+
+        let deep = investigate.join("10-deep");
+        write_package(&deep, "10-deep", &["00-inner", "10-inner"]);
+        write_stage(&deep, "00-inner", "inner first");
+        write_stage(&deep, "10-inner", "inner second");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("three-level package must load");
+        let ids: Vec<&str> = def.stages.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            [
+                "00-orient",
+                "10-investigate/00-lead",
+                "10-investigate/10-deep/00-inner",
+                "10-investigate/10-deep/10-inner",
+            ]
+        );
+        assert_eq!(def.stages[2].context, "inner first");
+    }
+
+    /// W1 §3 / touch point 4 of the grammar recon: every *component* of a
+    /// composed id is `is_plain_name`-valid, and the composite itself is
+    /// never a plain name — so no downstream consumer may pass the whole id
+    /// back through the shared path-traversal guard. Composed ids are also
+    /// unique by construction (a `/`-free sibling can never collide with a
+    /// `/`-bearing composite).
+    #[test]
+    fn every_component_of_a_composed_stage_id_is_a_plain_name() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "components");
+        write_package(&wf, "components", &["00-flat", "10-container"]);
+        write_stage(&wf, "00-flat", "flat");
+        let container = wf.join("10-container");
+        write_package(&container, "10-container", &["00-leaf"]);
+        write_stage(&container, "00-leaf", "leaf");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("load");
+        let mut seen = std::collections::BTreeSet::new();
+        for stage in &def.stages {
+            for component in stage.id.split('/') {
+                assert!(
+                    is_plain_name(component),
+                    "component {component:?} of {:?} must be a plain name",
+                    stage.id
+                );
+            }
+            assert!(seen.insert(stage.id.clone()), "duplicate id {:?}", stage.id);
+        }
+        assert!(
+            !is_plain_name("10-container/00-leaf"),
+            "the composite is deliberately not a plain name: only loader code joins components"
+        );
+    }
+
+    /// A nested package is validated fully, by its own rules — and its error
+    /// names the *nested* descriptor, not the parent's, so an author can find
+    /// the file that is actually wrong.
+    #[test]
+    fn a_nested_packages_own_invalid_stage_id_is_refused_naming_the_nested_descriptor() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "bad-component");
+        write_package(&wf, "bad-component", &["10-container"]);
+        let container = wf.join("10-container");
+        write_package(&container, "10-container", &["../escape"]);
+
+        let err = WorkflowDefinition::load_dir(&wf).expect_err("a bad component must be refused");
+        match err {
+            WorkflowError::InvalidStageId { path, stage } => {
+                assert_eq!(stage, "../escape");
+                assert!(
+                    path.contains("10-container"),
+                    "the error must name the nested descriptor, got {path}"
+                );
+            }
+            other => panic!("expected InvalidStageId, got {other}"),
+        }
+    }
+
+    /// A nested package's own `name` must match its stage directory, exactly
+    /// as a top-level package's must — the recursion reuses that check rather
+    /// than relaxing it.
+    #[test]
+    fn a_nested_packages_declared_name_must_match_its_stage_directory() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "nested-name");
+        write_package(&wf, "nested-name", &["10-container"]);
+        let container = wf.join("10-container");
+        write_package(&container, "something-else", &["00-leaf"]);
+        write_stage(&container, "00-leaf", "leaf");
+
+        let err =
+            WorkflowDefinition::load_dir(&wf).expect_err("a mismatched nested name is refused");
+        assert!(
+            matches!(
+                &err,
+                WorkflowError::NameMismatch { declared, directory, .. }
+                    if declared == "something-else" && directory == "10-container"
+            ),
+            "expected NameMismatch for the nested package, got {err}"
+        );
+    }
+
+    /// E15: a stage directory holding **both** `workflow.toml` and
+    /// `CONTEXT.md` is a load error. A container has no actor (W1-02), so
+    /// that `CONTEXT.md` could never be read — surfacing the author's
+    /// mistake beats silently ignoring their context.
+    #[test]
+    fn a_stage_directory_that_is_both_a_package_and_an_actor_is_refused() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "ambiguous");
+        write_package(&wf, "ambiguous", &["10-container"]);
+        let container = wf.join("10-container");
+        write_package(&container, "10-container", &["00-leaf"]);
+        write_stage(&container, "00-leaf", "leaf");
+        std::fs::write(container.join(CONTEXT_FILE), "an actor procedure").expect("context");
+
+        let err = WorkflowDefinition::load_dir(&wf)
+            .expect_err("a package that is also an actor stage must be refused");
+        match &err {
+            WorkflowError::NestedPackageWithContext { stage, .. } => {
+                assert_eq!(stage, "10-container");
+            }
+            other => panic!("expected NestedPackageWithContext, got {other}"),
+        }
+        let text = err.to_string();
+        assert!(
+            text.contains(WORKFLOW_FILE) && text.contains(CONTEXT_FILE),
+            "the error must name both files it found, got {text}"
+        );
+    }
+
+    /// The same fail-closed rule E15 states for `CONTEXT.md`, applied to the
+    /// other piece of authored per-stage metadata a container can never
+    /// consume: a `[stage."<id>"]` table naming a container declares a
+    /// harness/profile/kind for an execution that never happens.
+    #[test]
+    fn a_container_stage_may_not_carry_a_stage_table() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "tabled");
+        std::fs::create_dir_all(&wf).expect("workflow dir");
+        std::fs::write(
+            wf.join(WORKFLOW_FILE),
+            "[workflow]\nname = \"tabled\"\nversion = \"1\"\nstages = [\"10-container\"]\n\n\
+             [stage.\"10-container\"]\nharness = \"claude\"\n",
+        )
+        .expect("descriptor");
+        let container = wf.join("10-container");
+        write_package(&container, "10-container", &["00-leaf"]);
+        write_stage(&container, "00-leaf", "leaf");
+
+        let err = WorkflowDefinition::load_dir(&wf)
+            .expect_err("a stage table on a container must be refused");
+        assert!(
+            matches!(&err, WorkflowError::NestedPackageStageTable { stage, .. } if stage == "10-container"),
+            "expected NestedPackageStageTable, got {err}"
+        );
+    }
+
+    /// The nested-package branch is a *positive* detection of
+    /// `workflow.toml`, never "CONTEXT.md happened to be absent": a stage
+    /// directory with neither still fails closed exactly as it does today.
+    #[test]
+    fn a_stage_directory_with_neither_a_package_nor_a_context_is_still_missing() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "empty-stage");
+        write_package(&wf, "empty-stage", &["10-nothing"]);
+        std::fs::create_dir_all(wf.join("10-nothing")).expect("stage dir");
+
+        let err = WorkflowDefinition::load_dir(&wf).expect_err("an empty stage dir is refused");
+        assert!(
+            matches!(&err, WorkflowError::MissingStage { stage, .. } if stage == "10-nothing"),
+            "expected MissingStage, got {err}"
+        );
+    }
+
+    /// The output-contract readers join `stage_id` onto the package
+    /// directory. The grammar recon predicted `Path::join` splits an embedded
+    /// `/` into real components, so a composed id resolves the nested
+    /// directory — verified here rather than assumed, for all three readers.
+    #[test]
+    fn output_contracts_resolve_at_a_composed_stage_path() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "contracts");
+        write_package(&wf, "contracts", &["10-investigate"]);
+        let investigate = wf.join("10-investigate");
+        write_package(&investigate, "10-investigate", &["00-lead"]);
+        write_stage(&investigate, "00-lead", "lead");
+
+        let leaf_output = investigate.join("00-lead").join("output");
+        std::fs::create_dir_all(&leaf_output).expect("output dir");
+        std::fs::write(
+            leaf_output.join("README.md"),
+            "**Expected artifact:** `leads.md` — the leads.\n\n\
+             **Required columns:** `id`, `axis`\n\n\
+             **Disposition:** `promote`\n",
+        )
+        .expect("output README");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("load");
+        let leaf = &def.stages[0];
+        assert_eq!(leaf.id, "10-investigate/00-lead");
+
+        let package_dir = Path::new(&def.source);
+        assert_eq!(
+            declared_output_artifact(package_dir, &leaf.id),
+            Some("leads.md".to_string()),
+            "a composed stage id must resolve its nested output/README.md"
+        );
+        assert_eq!(
+            declared_required_columns(package_dir, &leaf.id),
+            vec!["id".to_string(), "axis".to_string()]
+        );
+        assert_eq!(
+            declared_output_disposition(package_dir, &leaf.id),
+            OutputDisposition::Promote
+        );
+    }
+
+    /// E2: the content hash folds the flattened tree — a nested leaf's
+    /// content is the parent's content. Editing a leaf's `CONTEXT.md` changes
+    /// the parent's `content_hash`, so a bound run detects drift in a nested
+    /// package exactly as it does in a top-level stage (§22.3).
+    #[test]
+    fn editing_a_nested_leafs_context_changes_the_parents_content_hash() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "folded");
+        write_package(&wf, "folded", &["10-container"]);
+        let container = wf.join("10-container");
+        write_package(&container, "10-container", &["00-leaf"]);
+        write_stage(&container, "00-leaf", "the original nested procedure");
+
+        let before = WorkflowDefinition::load_dir(&wf).expect("load");
+        write_stage(&container, "00-leaf", "an edited nested procedure");
+        let after = WorkflowDefinition::load_dir(&wf).expect("reload");
+
+        assert_ne!(
+            before.content_hash, after.content_hash,
+            "E2: a nested leaf's content folds into the parent's identity"
+        );
+    }
+
+    /// Parity guard for the embedded loader: the built-in `software-change`
+    /// workflow is flat, and nesting is a *directory* loader concept — a
+    /// nested package can never be `SOURCE_EMBEDDED` (there is no embedded
+    /// nested descriptor to parse). Stated as a test so an embedded package
+    /// that grew a nested stage would fail here rather than silently load a
+    /// container as an actor stage with no context.
+    #[test]
+    fn the_embedded_workflow_stays_flat() {
+        let def = WorkflowDefinition::embedded().expect("embedded workflow");
+        for stage in &def.stages {
+            assert!(
+                is_plain_name(&stage.id),
+                "an embedded stage id is always a single component, got {:?}",
+                stage.id
+            );
+        }
     }
 
     // --------------------------------------------- T2: catalog / front matter

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -1897,6 +1897,22 @@ fn collect_stage_output_dirs(
         }
     }
     if depth >= MAX_STAGE_SCAN_DEPTH {
+        // Fail loud, not silent (E11's own precedent, and the same posture
+        // E15 takes elsewhere in this loader): a workflow package nested
+        // past this depth is legal for `WorkflowDefinition::load_dir` (E14:
+        // "no product depth limit"), so a leaf beyond `MAX_STAGE_SCAN_DEPTH`
+        // would otherwise load and run normally while its `output/` quietly
+        // never reaches `retain_stage_outputs`/`finalize_sweep` — exactly
+        // the silent-loss shape E11 exists to close. This does not recover
+        // the output; it names the gap so an operator sees it in the logs
+        // instead of a dirty teardown quietly losing a leaf's evidence.
+        tracing::warn!(
+            directory = %dir.display(),
+            depth,
+            max_depth = MAX_STAGE_SCAN_DEPTH,
+            "stage-output scan stopped at MAX_STAGE_SCAN_DEPTH; any stage output nested deeper \
+             than this will not be retained"
+        );
         return;
     }
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -6018,6 +6034,110 @@ mod tests {
         assert!(
             !surface.root.exists(),
             "reaping the last retained artifact must let the root go too"
+        );
+    }
+
+    // ------------------------------------- stage-output scan depth (E11)
+
+    /// A `Write` sink for a captured `tracing` log, so
+    /// `stage_scan_past_max_depth_is_not_silent` can assert on what was
+    /// actually logged rather than merely on the (already-known) fact that
+    /// the deep leaf goes unretained.
+    #[derive(Clone, Default)]
+    struct CapturedLog(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CapturedLog {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("captured-log mutex")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A workflow package nested past [`MAX_STAGE_SCAN_DEPTH`] is legal for
+    /// `WorkflowDefinition::load_dir` (E14: "no product depth limit"), so a
+    /// leaf that deep would load and run normally — but `stage_output_dirs`
+    /// still cannot see its `output/`. This pins that the loss stays
+    /// *observed*: the scan logs loudly, by directory, when it stops
+    /// descending at the cap, instead of returning as if nothing were
+    /// pruned.
+    #[test]
+    fn stage_scan_past_max_depth_is_not_silent() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+
+        // Nine levels of nesting: one past MAX_STAGE_SCAN_DEPTH (8). The
+        // final level's `output/` sits beyond what the scan can reach.
+        let mut leaf = root.to_path_buf();
+        for level in 1..=9 {
+            leaf = leaf.join(format!("lvl{level}"));
+        }
+        std::fs::create_dir_all(leaf.join("output")).expect("deeply nested output dir");
+        std::fs::write(leaf.join("output").join("evidence.txt"), b"deep artifact")
+            .expect("evidence file");
+
+        let log = CapturedLog::default();
+        let make_writer = {
+            let log = log.clone();
+            move || log.clone()
+        };
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        let found = tracing::subscriber::with_default(subscriber, || stage_output_dirs(root));
+
+        // The pre-existing gap: a leaf nested this deep is still not found.
+        assert!(
+            !found.iter().any(|(id, _)| id.starts_with("lvl1")),
+            "a stage past MAX_STAGE_SCAN_DEPTH is still not retrievable: {found:?}"
+        );
+
+        // What this fix actually adds: the loss is logged, not silent.
+        let logged = String::from_utf8(log.0.lock().expect("captured-log mutex").clone())
+            .expect("log output is UTF-8");
+        assert!(
+            logged.contains("MAX_STAGE_SCAN_DEPTH") || logged.contains("stage-output scan stopped"),
+            "expected a loud warning naming the scan-depth cutoff, got: {logged:?}"
+        );
+        assert!(
+            logged.contains("lvl8"),
+            "expected the warning to name the directory where descent stopped, got: {logged:?}"
+        );
+    }
+
+    /// A tree that fits well within [`MAX_STAGE_SCAN_DEPTH`] must not trip
+    /// the same warning — it is a cutoff signal, not routine noise.
+    #[test]
+    fn stage_scan_within_max_depth_stays_quiet() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("10-stage").join("output")).expect("output dir");
+
+        let log = CapturedLog::default();
+        let make_writer = {
+            let log = log.clone();
+            move || log.clone()
+        };
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        let found = tracing::subscriber::with_default(subscriber, || stage_output_dirs(root));
+        assert_eq!(found.len(), 1);
+
+        let logged = String::from_utf8(log.0.lock().expect("captured-log mutex").clone())
+            .expect("log output is UTF-8");
+        assert!(
+            !logged.contains("MAX_STAGE_SCAN_DEPTH"),
+            "a shallow tree must not trip the depth-cutoff warning: {logged:?}"
         );
     }
 }

--- a/src/runtime/surface.rs
+++ b/src/runtime/surface.rs
@@ -1826,12 +1826,127 @@ fn retain_dirty(
     }
 }
 
+/// The `output/` directory name every stage writes its declared artifacts
+/// into (Rule 4, the ICM convention). Never itself descended into by
+/// [`stage_output_dirs`]: what is inside is artifact content, and
+/// [`copy_declared_output_artifacts`] owns walking it.
+const OUTPUT_DIR: &str = "output";
+
+/// How many directory levels below the worktree root [`stage_output_dirs`]
+/// looks for a stage directory (decision E11).
+///
+/// This is a **scan** guard, not a nesting limit W1 §4 forbids: a Work
+/// surface is a whole repository checkout, and a Work that runs a build
+/// leaves deep trees of its own in it, so the search for `<stage>/output/`
+/// must not become an unbounded walk of everything an actor happened to
+/// generate. Sized well past what a workflow author plausibly nests — W1's
+/// own illustrative package is two levels, and the acceptance battery
+/// measures three.
+const MAX_STAGE_SCAN_DEPTH: usize = 8;
+
+/// Every stage directory in a Work surface's worktree, paired with its
+/// `output/` directory: any directory below the worktree root that has an
+/// `output/` child, at any nesting depth up to [`MAX_STAGE_SCAN_DEPTH`],
+/// keyed by the `/`-joined path from the worktree root down to it.
+///
+/// E11 (W1 §2/§3): that key is exactly a composed stage id. A workflow
+/// package's nested layout is mirrored in the worktree, so a leaf at
+/// `10-investigate/00-lead` writes two levels down and a one-level scan
+/// would never see it — and because a dirty teardown force-removes the
+/// worktree, not seeing it means losing it. Both walkers below share this
+/// one function so the dirty and clean paths cannot drift apart, which is
+/// how they came to have the identical one-level limitation in the first
+/// place.
+///
+/// A container's own declared output (W1 §4) is found the same way, as a
+/// sibling of its leaves' directories — nothing here needs to know which
+/// stage ids are containers and which are leaves, and nothing here consults
+/// the workflow catalog: the worktree's own filesystem shape stays ground
+/// truth.
+///
+/// Pruned, in both cases without changing what is retained:
+/// - `.git` — never a stage directory, always large;
+/// - a directory Git itself ignores. Every file under an ignored directory
+///   is ignored, and [`copy_declared_output_artifacts`] already skips
+///   gitignored files one by one, so such a stage would have copied zero
+///   bytes and been dropped anyway (#109/R4's disk-bloat exclusion). Doing
+///   it as a subtree prune here is what keeps a build tree from costing a
+///   full walk.
+///
+/// Sorted by stage id, so the retained set and the finalize commit are
+/// deterministic rather than `read_dir` order.
+fn stage_output_dirs(worktree_root: &Path) -> Vec<(String, PathBuf)> {
+    let mut found = Vec::new();
+    collect_stage_output_dirs(worktree_root, worktree_root, 0, &mut found);
+    found.sort_by(|(a, _), (b, _)| a.cmp(b));
+    found
+}
+
+fn collect_stage_output_dirs(
+    dir: &Path,
+    worktree_root: &Path,
+    depth: usize,
+    found: &mut Vec<(String, PathBuf)>,
+) {
+    if dir != worktree_root {
+        let output_dir = dir.join(OUTPUT_DIR);
+        if output_dir.is_dir()
+            && let Some(stage_id) = composed_stage_id(dir, worktree_root)
+        {
+            found.push((stage_id, output_dir));
+        }
+    }
+    if depth >= MAX_STAGE_SCAN_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let child = entry.path();
+        if !child.is_dir() {
+            continue;
+        }
+        let Some(name) = child.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name == OUTPUT_DIR || name == ".git" {
+            continue;
+        }
+        if git_succeeds(
+            worktree_root,
+            &["check-ignore", "-q", &child.display().to_string()],
+        ) {
+            continue;
+        }
+        collect_stage_output_dirs(&child, worktree_root, depth + 1, found);
+    }
+}
+
+/// `dir`'s path relative to the worktree root, as a `/`-joined stage id —
+/// the same composition `WorkflowDefinition::load_dir` performs over
+/// package directories. `None` if `dir` is not below the root or any
+/// component is not UTF-8 (the same skip the one-level scan already made on
+/// a non-UTF-8 directory name).
+fn composed_stage_id(dir: &Path, worktree_root: &Path) -> Option<String> {
+    let relative = dir.strip_prefix(worktree_root).ok()?;
+    let mut components = Vec::new();
+    for component in relative.components() {
+        components.push(component.as_os_str().to_str()?);
+    }
+    if components.is_empty() {
+        return None;
+    }
+    Some(components.join("/"))
+}
+
 /// #240: copy each stage directory's declared `output/` artifacts out of
 /// `binding.worktree_path` before it is removed, into
 /// `<stage-dir>.output/<stage-dir>/` sibling to the worktree — the same
 /// retained-evidence area [`capture_dirty_patch`] writes its patch into.
-/// A stage directory is any top-level entry of the worktree that has an
-/// `output/` subdirectory; nothing here consults the workflow catalog
+/// A stage directory is any directory in the worktree that has an
+/// `output/` subdirectory ([`stage_output_dirs`], at any nesting depth —
+/// E11); nothing here consults the workflow catalog
 /// (Rule 4, the ICM convention (relocated: sergeant-rs-workspace knowledge/evidence/reference/icm/convention.md): "no engine collection, no artifact
 /// manifest machinery" — the worktree's own filesystem shape is ground
 /// truth, exactly as [`capture_dirty_patch`] already treats it). Returns
@@ -1856,33 +1971,21 @@ fn retain_stage_outputs(
     let Some(surface_root) = binding.worktree_path.parent() else {
         return Vec::new();
     };
-    let Ok(top_level) = std::fs::read_dir(&binding.worktree_path) else {
-        return Vec::new();
-    };
     let dest_root = surface_root.join(format!("{}.output", binding.repository));
     let mut outputs = Vec::new();
-    for entry in top_level.flatten() {
-        let stage_dir = entry.path();
-        if !stage_dir.is_dir() {
-            continue;
-        }
-        let output_dir = stage_dir.join("output");
-        if !output_dir.is_dir() {
-            continue;
-        }
-        let Some(stage_name) = stage_dir.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        let dest = dest_root.join(stage_name);
+    for (stage_id, output_dir) in stage_output_dirs(&binding.worktree_path) {
+        // A composed id nests the destination the same way it nests the
+        // source: `<repo>.output/10-investigate/00-lead/`.
+        let dest = dest_root.join(&stage_id);
         let bytes = copy_declared_output_artifacts(&output_dir, &dest, &binding.worktree_path);
         if bytes > 0 {
             let disposition = workflow_source
                 .map(|source| {
-                    crate::domain::workflow::declared_output_disposition(source, stage_name)
+                    crate::domain::workflow::declared_output_disposition(source, &stage_id)
                 })
                 .unwrap_or(crate::domain::workflow::OutputDisposition::Evidence);
             outputs.push(RetainedStageOutput {
-                stage: stage_name.to_string(),
+                stage: stage_id,
                 path: dest,
                 bytes,
                 disposition,
@@ -1890,8 +1993,12 @@ fn retain_stage_outputs(
         } else {
             // Nothing real was copied (empty dir, or only README.md) —
             // remove the now-empty destination so it never reads as
-            // retained evidence.
-            let _ = std::fs::remove_dir_all(&dest);
+            // retained evidence. Non-recursive deliberately: under nesting
+            // one stage's destination can be an *ancestor* of another's
+            // (`10-investigate` and `10-investigate/00-lead`), and a
+            // recursive removal here could take a leaf's already-copied
+            // evidence with it.
+            let _ = std::fs::remove_dir(&dest);
         }
     }
     outputs
@@ -1974,10 +2081,12 @@ fn copy_declared_output_artifacts_at(
 /// **before** [`teardown`]'s own dirty check, so a promote-class deliverable
 /// ships in the branch's history and an evidence-class `output/` never does.
 ///
-/// Walks the same top-level `<stage-id>/output/` shape [`retain_stage_outputs`]
-/// and the #260 Q3 gate already treat as ground truth for a Work's own
-/// produced artifacts (never the workflow *package*'s own tree — Rule 4's
-/// "declared locations", not a manifest). For each one that actually holds
+/// Walks the same `<stage-id>/output/` shape [`retain_stage_outputs`] and
+/// the #260 Q3 gate already treat as ground truth for a Work's own produced
+/// artifacts (never the workflow *package*'s own tree — Rule 4's "declared
+/// locations", not a manifest), through the one shared
+/// [`stage_output_dirs`] walk, so the clean path reaches a nested leaf
+/// exactly as the dirty path does (E11). For each one that actually holds
 /// real (non-`README.md`) content, [`crate::domain::workflow::
 /// declared_output_disposition`] reads that stage's authored disposition
 /// out of the *workflow package* (`workflow_source`) — `output/README.md`
@@ -2016,36 +2125,24 @@ pub fn finalize_sweep(
     let Some(surface_root) = binding.worktree_path.parent() else {
         return report;
     };
-    let Ok(top_level) = std::fs::read_dir(&binding.worktree_path) else {
-        return report;
-    };
     let dest_root = surface_root.join(format!("{}.output", binding.repository));
     let mut swept_stage_dirs = Vec::new();
-    for entry in top_level.flatten() {
-        let stage_dir = entry.path();
-        if !stage_dir.is_dir() {
-            continue;
-        }
-        let output_dir = stage_dir.join("output");
-        if !output_dir.is_dir() {
-            continue;
-        }
-        let Some(stage_name) = stage_dir.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        if crate::domain::workflow::declared_output_disposition(workflow_source, stage_name)
+    for (stage_id, output_dir) in stage_output_dirs(&binding.worktree_path) {
+        if crate::domain::workflow::declared_output_disposition(workflow_source, &stage_id)
             == crate::domain::workflow::OutputDisposition::Promote
         {
             continue;
         }
-        let dest = dest_root.join(stage_name);
+        let dest = dest_root.join(&stage_id);
         let bytes = copy_declared_output_artifacts(&output_dir, &dest, &binding.worktree_path);
         if bytes == 0 {
-            let _ = std::fs::remove_dir_all(&dest);
+            // Non-recursive: see `retain_stage_outputs`' own note — a
+            // container's destination is an ancestor of its leaves'.
+            let _ = std::fs::remove_dir(&dest);
             continue;
         }
         report.evidence.push(RetainedStageOutput {
-            stage: stage_name.to_string(),
+            stage: stage_id,
             path: dest,
             bytes,
             disposition: crate::domain::workflow::OutputDisposition::Evidence,
@@ -5476,6 +5573,178 @@ mod tests {
             std::fs::read_to_string(outputs[0].path.join("evidence").join("transcript.log"))
                 .expect("nested artifact must survive teardown at its original relative path");
         assert_eq!(retained, "nested artifact");
+    }
+
+    /// E11 (W1 §2): a nested leaf's output must be retained exactly like a
+    /// top-level stage's. The worktree mirrors the package's nested layout,
+    /// so a leaf at `10-investigate/00-lead` writes two levels down — the
+    /// one-level scan this walker used to do would silently drop it, and a
+    /// dirty teardown force-removes the worktree, so "silently dropped"
+    /// means "gone". Its declared disposition is read at the same composed
+    /// path in the workflow package.
+    #[test]
+    fn dirty_teardown_retains_a_nested_leafs_output() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01NESTEDLEAF",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+        let worktree = surface.bindings[0].worktree_path.clone();
+
+        // A top-level leaf and a nested one, side by side.
+        let orient_output = worktree.join("00-orient").join("output");
+        std::fs::create_dir_all(&orient_output).expect("orient output dir");
+        std::fs::write(orient_output.join("orientation.md"), "top-level artifact")
+            .expect("orient artifact");
+
+        let lead_output = worktree
+            .join("10-investigate")
+            .join("00-lead")
+            .join("output");
+        std::fs::create_dir_all(&lead_output).expect("lead output dir");
+        std::fs::write(lead_output.join("leads.md"), "nested artifact").expect("lead artifact");
+
+        // The nested leaf declares `promote` at its composed path in the
+        // package — the disposition read must reach it too, not just the copy.
+        let workflow_source = dir.path().join("workflow-package");
+        let declared = workflow_source
+            .join("10-investigate")
+            .join("00-lead")
+            .join("output");
+        std::fs::create_dir_all(&declared).expect("declared output dir");
+        std::fs::write(
+            declared.join("README.md"),
+            "**Expected artifact:** `leads.md` — ships with the Work.\n\n\
+             **Disposition:** `promote`\n",
+        )
+        .expect("output/README.md");
+
+        std::fs::write(worktree.join("wip.rs"), "// still working\n").expect("dirty edit");
+
+        let report = teardown(fixture_data_dir(&surface), &surface, Some(&workflow_source));
+        let BindingDisposition::RetainedDirty { outputs, .. } = &report.bindings[0].disposition
+        else {
+            panic!(
+                "expected RetainedDirty: {:?}",
+                report.bindings[0].disposition
+            );
+        };
+        assert_eq!(outputs.len(), 2, "{outputs:?}");
+
+        let lead = outputs
+            .iter()
+            .find(|o| o.stage == "10-investigate/00-lead")
+            .expect("E11: a nested leaf's output must be retained");
+        assert_eq!(
+            lead.disposition,
+            crate::domain::workflow::OutputDisposition::Promote,
+            "the composed stage id must resolve its declaration in the package: {outputs:?}"
+        );
+        assert!(
+            !worktree.exists(),
+            "the worktree is gone after a dirty teardown"
+        );
+        assert_eq!(
+            std::fs::read_to_string(lead.path.join("leads.md")).expect("nested artifact"),
+            "nested artifact"
+        );
+        assert!(
+            outputs.iter().any(|o| o.stage == "00-orient"),
+            "a top-level stage is retained exactly as before: {outputs:?}"
+        );
+    }
+
+    /// E11, clean path: `finalize_sweep` walks to the same depth. An
+    /// evidence-class nested leaf is copied out and removed from the
+    /// worktree; the container's *own* declared output — sibling to the
+    /// leaf's directory, W1 §4 — is swept in the same pass; a promote-class
+    /// nested leaf is left to ship.
+    #[test]
+    fn the_finalize_sweep_reaches_a_nested_leafs_output() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data = tempfile::TempDir::new().expect("tempdir");
+        let spec = repo(&dir.path().join("solo"));
+
+        let surface = materialize(
+            data.path(),
+            data.path(),
+            "01NESTEDSWEEP",
+            std::slice::from_ref(&spec),
+        )
+        .expect("materialize");
+        let binding = &surface.bindings[0];
+        let worktree = binding.worktree_path.clone();
+
+        let investigate = worktree.join("10-investigate");
+        // The container's own aggregate output (W1 §4), sibling to its leaves.
+        let container_output = investigate.join("output");
+        std::fs::create_dir_all(&container_output).expect("container output dir");
+        std::fs::write(container_output.join("summary.md"), "the aggregate")
+            .expect("container artifact");
+        // One evidence-class leaf, one promote-class leaf.
+        let lead_output = investigate.join("00-lead").join("output");
+        std::fs::create_dir_all(&lead_output).expect("lead output dir");
+        std::fs::write(lead_output.join("leads.md"), "working record").expect("lead artifact");
+        let code_output = investigate.join("10-code").join("output");
+        std::fs::create_dir_all(&code_output).expect("code output dir");
+        std::fs::write(code_output.join("deliverable.md"), "ships").expect("code artifact");
+
+        let workflow_source = dir.path().join("workflow-package");
+        let declared = workflow_source
+            .join("10-investigate")
+            .join("10-code")
+            .join("output");
+        std::fs::create_dir_all(&declared).expect("declared output dir");
+        std::fs::write(
+            declared.join("README.md"),
+            "**Expected artifact:** `deliverable.md`\n\n**Disposition:** `promote`\n",
+        )
+        .expect("output/README.md");
+
+        // Committed, as the ordinary "the actor already committed its own
+        // work" case — that is what gives the sweep a deletion to commit.
+        git_as_test_identity(&worktree, &["add", "-A"]);
+        git_as_test_identity(&worktree, &["commit", "-m", "seed nested stage outputs"]);
+
+        let report = finalize_sweep(binding, Some(&workflow_source));
+        let swept: Vec<&str> = report.evidence.iter().map(|e| e.stage.as_str()).collect();
+        assert!(
+            swept.contains(&"10-investigate/00-lead"),
+            "E11: the sweep must reach a nested leaf: {swept:?}"
+        );
+        assert!(
+            swept.contains(&"10-investigate"),
+            "a container's own declared output is swept too (W1 §4): {swept:?}"
+        );
+        assert!(
+            !swept.contains(&"10-investigate/10-code"),
+            "a promote-class nested leaf is left to ship: {swept:?}"
+        );
+        assert!(report.committed, "the sweep makes its one finalize commit");
+
+        assert!(
+            !lead_output.exists(),
+            "the evidence-class nested output is removed from the worktree"
+        );
+        assert!(
+            code_output.join("deliverable.md").is_file(),
+            "the promote-class nested output stays in the worktree"
+        );
+        let retained = report
+            .evidence
+            .iter()
+            .find(|e| e.stage == "10-investigate/00-lead")
+            .expect("nested evidence");
+        assert_eq!(
+            std::fs::read_to_string(retained.path.join("leads.md")).expect("copied out"),
+            "working record"
+        );
     }
 
     /// W6 (F-IN-02): `copy_declared_output_artifacts` must exclude files


### PR DESCRIPTION
Wave V1a of sprint S2 (hierarchical execution): the recursive loader — S2's most novel code. 4 implement + 2 fixer commits.

- **E1**: `load_dir` detects a nested package structurally (`<stage>/workflow.toml`), recurses through itself, and splices the child's leaves into the parent's flat `stages` with `parent/child` composed IDs — each component `is_plain_name`-validated, only loader code joins. Containers contribute no `StageDefinition` (W1-02, pinned). Three-level fixtures. No `StageKind::Container` variant (R2). Output-contract/CONTEXT resolution at composed paths verified by test, not assumed. Embedded loader has real nesting parity (panel-driven fix, not just a guard).
- **E15** + a sibling the implementer argued from E15's own rationale: both `NestedPackageWithContext` and `NestedPackageStageTable` are named load errors (a container's authored-but-unreadable metadata fails closed).
- **E2**: content-hash folds over the flattened tree — zero new code, property pinned (`editing_a_nested_leafs_context_changes_the_parents_content_hash`). Named non-goal: a nested `version:`-only bump doesn't move the parent hash (declaration vs content).
- **E11**: `retain_stage_outputs`/`finalize_sweep` share one recursive walk (they'd drifted into twin one-level bugs); container outputs ride the same walk; bounded scan (depth 8 + gitignore prune + `.git` skip — a worktree-scan bound, NOT the E14 product limit; loss-disclosure named in-code per the panel).
- **E12**: docker `pin_path` percent-encodes stage IDs (`%2F`; `__` rejected as non-injective — `b/c` vs `b__c` would share a pin file), plus a standing guard test that any new raw `stage_id` path-join fails.
- Escalated and now ruled (plan-owner): V1b adds the ~5-line canonicalize visited-set **cycle guard** in `load_dir` (a symlink cycle currently aborts via stack overflow; a cycle guard is not a depth limit, E14 stands).

Gates: TDD red-then-green per deliverable; panel → refuters → fixes (embedded parity, depth-cap disclosure); verify: **full suite green, 0 failures, 49 suites**, #231(b) guard green, tree clean.

Rungs: E1/E2/E15 J3 (plan register), R2 throughout; the two implementer judgment calls J1/J3-cited in their commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4