### PR TITLE
S2/V1b: container boundaries, cycle guard, hierarchical rendering (E3/E4/E10)

### DIFF
--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -54,13 +54,6 @@ cov_stage_begin c2-m10_harness
 cov_run cargo llvm-cov --no-report --test m10_harness --locked || cov_fail "m10_harness failed under instrumentation"
 cov_stage_end 1 "the m10 test binary must write its own profile"
 
-# S2 V1b: nested workflow packages end to end. In-process daemon, fake
-# backend, no `sgt` subprocess — so it belongs with C2's own-profile suites,
-# not with C3's spawning pair.
-cov_stage_begin c2-m11_nested_workflow
-cov_run cargo llvm-cov --no-report --test m11_nested_workflow --locked || cov_fail "m11_nested_workflow failed under instrumentation"
-cov_stage_end 1 "the m11 test binary must write its own profile"
-
 cov_stage_begin c2-estate_routes
 cov_run cargo llvm-cov --no-report --test estate_routes --locked || cov_fail "estate_routes failed under instrumentation"
 cov_stage_end 1 "the estate_routes test binary must write its own profile"

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -54,6 +54,13 @@ cov_stage_begin c2-m10_harness
 cov_run cargo llvm-cov --no-report --test m10_harness --locked || cov_fail "m10_harness failed under instrumentation"
 cov_stage_end 1 "the m10 test binary must write its own profile"
 
+# S2 V1b: nested workflow packages end to end. In-process daemon, fake
+# backend, no `sgt` subprocess — so it belongs with C2's own-profile suites,
+# not with C3's spawning pair.
+cov_stage_begin c2-m11_nested_workflow
+cov_run cargo llvm-cov --no-report --test m11_nested_workflow --locked || cov_fail "m11_nested_workflow failed under instrumentation"
+cov_stage_end 1 "the m11 test binary must write its own profile"
+
 cov_stage_begin c2-estate_routes
 cov_run cargo llvm-cov --no-report --test estate_routes --locked || cov_fail "estate_routes failed under instrumentation"
 cov_stage_end 1 "the estate_routes test binary must write its own profile"

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -49,6 +49,15 @@ cov_run cargo llvm-cov --no-report --test w5_h1_acceptance --locked || cov_fail 
 cov_stage_end 2 "w5_h1_acceptance's two-estate test spawns a real daemon via sgt run; more than \
 the test binary's own profile must arrive, or no subprocess flushed"
 
+# S2 V1b, wired at birth: m11's round-trip test spawns a real `sgt work show`
+# against the in-process daemon it started, so the CLI's own rendering of a
+# composed hierarchical stage id is measured rather than argued. Floor 2 —
+# the test binary plus that client.
+cov_stage_begin c3-m11_nested_workflow
+cov_run cargo llvm-cov --no-report --test m11_nested_workflow --locked || cov_fail "m11_nested_workflow failed under instrumentation"
+cov_stage_end 2 "m11's round-trip test spawns a real sgt work show client; more than the test \
+binary's own profile must arrive, or no subprocess flushed"
+
 # Added 2026-08-19 alongside C2's five, closing the same accounting gap: this
 # suite existed but no stage script invoked it, so backend/docker.rs's real
 # coverage never reached the report.

--- a/src/api.rs
+++ b/src/api.rs
@@ -5827,6 +5827,34 @@ mod tests {
         );
     }
 
+    /// S2 W1 / decision E10: a nested leaf's composed hierarchical id is an
+    /// ordinary string to this helper, and the position arithmetic is the
+    /// flat one it always was — `index + 1` of `of`, counting **leaves**,
+    /// because a container never occupies a stage slot (W1-02).
+    ///
+    /// The point of pinning it is that no change was needed. A coordinate
+    /// that had started parsing `/` — to show only the leaf name, say, or to
+    /// count containers as positions — would have silently disagreed with the
+    /// engine's own flat indices, which are what retry, recovery and the
+    /// analytics rows all key on.
+    #[test]
+    fn stage_label_reads_a_composed_hierarchical_id_as_one_flat_position() {
+        let nested = json!({
+            "stage_id": "10-investigate/00-lead", "index": 1, "of": 4, "status": "active",
+        });
+        assert_eq!(stage_label(&nested), "10-investigate/00-lead 2/4 · active");
+
+        let deeper = json!({
+            "stage_id": "10-investigate/10-deep/00-inner", "index": 2, "of": 4,
+            "status": "needs_input",
+        });
+        assert_eq!(
+            stage_label(&deeper),
+            "10-investigate/10-deep/00-inner 3/4 · needs_input",
+            "depth changes the id, never the position arithmetic"
+        );
+    }
+
     async fn test_state(data_dir: &std::path::Path) -> ApiState {
         let journal = Journal::open(data_dir).expect("open journal");
         let mut registry = work_registry_projection();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -363,6 +363,21 @@ impl DaemonHandle {
         }
         let _ = (&mut self.served).await;
     }
+
+    /// Abruptly terminate the daemon without giving it a chance to run its
+    /// own cooperative shutdown path — the in-process rig's analogue of
+    /// SIGKILL. m6's out-of-process rig signals a real child process; this
+    /// in-process one has no separate process to signal, so it aborts the
+    /// serving task instead. The shutdown channel is dropped unsent —
+    /// nothing here asks the daemon to stop, it is simply cut off
+    /// mid-flight. Awaiting the aborted task still lets the runtime finish
+    /// unwinding it (releasing the exclusive `daemon.lock`, closing the
+    /// listener) before a fresh daemon can bind the same data dir.
+    pub async fn kill(mut self) {
+        self.shutdown_tx.take();
+        self.served.abort();
+        let _ = (&mut self.served).await;
+    }
 }
 
 /// How a daemon instance is configured beyond its data dir.

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -334,6 +334,45 @@ pub struct StageBinding {
     pub profile: Option<crate::domain::profile::Profile>,
 }
 
+/// One container's footprint in the flattened stage list (W1 §2, decision
+/// E3; the engine recon's touch point 7).
+///
+/// A container is **not** a stage: it has no [`StageDefinition`], no
+/// [`StageBinding`], no [`StageRecord`], and the engine never enters it
+/// (W1-02). What the engine still needs to know is *when a container closes*
+/// — which flat leaf index is the last one under it — so that a container
+/// which declared its own output contract can be checked at that moment
+/// (E4). That is a side table, deliberately not a field on
+/// [`StageDefinition`].
+///
+/// It lives inside [`WorkflowDefinition`], and therefore inside the
+/// journaled `workflow.bound` payload, because recovery must be able to
+/// answer "did this leaf close a container" after a restart from the pinned
+/// definition alone — an engine-side cache would lose that fact across a
+/// daemon restart mid-park (the engine recon's Recovery item 2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContainerBoundary {
+    /// The container's hierarchical id, composed exactly the way a leaf's is
+    /// (`10-investigate`, or `10-investigate/10-deep` for a container inside
+    /// a container). This is the id an operator is shown when the
+    /// container's own output contract is unmet, and the id the gate joins
+    /// onto a package directory *and* onto a worktree — one string in both
+    /// places, so the two halves of that check can never disagree.
+    pub container_id: String,
+    /// The directory of the package that *declares* this container — the
+    /// parent package's own source, one level above the container's own
+    /// `workflow.toml`. Provenance, recorded so a journaled row says on its
+    /// own which package on disk introduced the container;
+    /// [`SOURCE_EMBEDDED`] for a container inside the embedded distro.
+    pub source: String,
+    /// Index, in [`WorkflowDefinition::stages`], of the first leaf under
+    /// this container.
+    pub first_leaf_index: usize,
+    /// Index of the last leaf under this container. Completing the leaf at
+    /// this index is what closes the container.
+    pub last_leaf_index: usize,
+}
+
 /// A resolved workflow: ordered stages plus the identity of what produced it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkflowDefinition {
@@ -349,6 +388,14 @@ pub struct WorkflowDefinition {
     /// position with composed `parent/child` ids (W1 §2/§3, decision E1);
     /// the container itself is never a stage (W1-02).
     pub stages: Vec<StageDefinition>,
+    /// Every container's leaf-index range (E3/E4), in document order,
+    /// outermost first within each subtree. Empty for a workflow with no
+    /// nested package — which is every workflow that predates W1, hence
+    /// `#[serde(default)]`: a `workflow.bound` payload journaled before this
+    /// field existed replays as "no containers", which is exactly what it
+    /// was.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub containers: Vec<ContainerBoundary>,
     /// Stable content-identity hash over every execution-relevant field:
     /// descriptor (name, version), stage order, each stage's executor tag
     /// (kind/harness/profile), and every context verbatim (§22.3). Deliberately
@@ -356,6 +403,14 @@ pub struct WorkflowDefinition {
     /// content loaded from two different paths is the same workflow.
     /// Hex-encoded BLAKE3 over a canonical JSON projection of the fields
     /// above.
+    ///
+    /// **[`Self::containers`] is deliberately not folded in** (E2/E3): the
+    /// table is *derived* from `stages` — every row's id is the common
+    /// prefix of the leaves in its range, and its range is where those
+    /// leaves sit — so it cannot vary while the flattened stage list stays
+    /// the same, and folding it would add a second copy of the same fact to
+    /// the identity. Nesting still changes the hash, because nesting changes
+    /// the composed leaf ids and the contexts, which are already folded.
     #[serde(default)]
     pub content_hash: String,
 }
@@ -872,6 +927,7 @@ impl WorkflowDefinition {
             })?,
         );
         let mut stages = Vec::with_capacity(ids.len());
+        let mut containers: Vec<ContainerBoundary> = Vec::new();
         for id in ids {
             let stage_dir = dir.join(&id);
             // W1 §2 / E1: a *positive* detection of the nested-package
@@ -913,10 +969,13 @@ impl WorkflowDefinition {
                 // The nested package validates itself, by its own rules, and
                 // reports failures against its own descriptor path.
                 let nested = Self::load_dir_within(&stage_dir, &open)?;
-                stages.extend(nested.stages.into_iter().map(|leaf| StageDefinition {
-                    id: format!("{id}/{}", leaf.id),
-                    ..leaf
-                }));
+                splice_container(
+                    &mut stages,
+                    &mut containers,
+                    &id,
+                    &dir.display().to_string(),
+                    nested,
+                );
                 continue;
             }
             let tag = resolve_stage_tag(&id, parsed.stages_meta.get(&id), &path)?;
@@ -965,6 +1024,7 @@ impl WorkflowDefinition {
             version: parsed.workflow.version,
             source: dir.display().to_string(),
             stages,
+            containers,
             content_hash,
         })
     }
@@ -999,6 +1059,7 @@ impl WorkflowDefinition {
         let ids = check_stage_ids(&parsed.workflow.stages, &path)?;
         check_stage_tables(&ids, &parsed.stages_meta, &path)?;
         let mut stages = Vec::with_capacity(ids.len());
+        let mut containers: Vec<ContainerBoundary> = Vec::new();
         for id in ids {
             // Same positive-detection rule as `load_dir`: a marker match,
             // never "no context happened to be embedded" — an id with
@@ -1024,10 +1085,7 @@ impl WorkflowDefinition {
                 }
                 let nested_path = format!("{dir_path}/{id}/{WORKFLOW_FILE}");
                 let nested = Self::load_embedded(nested_pkg, nested_path)?;
-                stages.extend(nested.stages.into_iter().map(|leaf| StageDefinition {
-                    id: format!("{id}/{}", leaf.id),
-                    ..leaf
-                }));
+                splice_container(&mut stages, &mut containers, &id, SOURCE_EMBEDDED, nested);
                 continue;
             }
             let tag = resolve_stage_tag(&id, parsed.stages_meta.get(&id), &path)?;
@@ -1069,6 +1127,7 @@ impl WorkflowDefinition {
             version: parsed.workflow.version,
             source: SOURCE_EMBEDDED.to_string(),
             stages,
+            containers,
             content_hash,
         })
     }
@@ -1077,6 +1136,74 @@ impl WorkflowDefinition {
     pub fn stage(&self, index: usize) -> Option<&StageDefinition> {
         self.stages.get(index)
     }
+
+    /// Every container that *closes* when the leaf at `index` completes,
+    /// **innermost first** (E3/E4, the engine recon's touch point 7).
+    ///
+    /// One leaf can close several containers at once — the last leaf of an
+    /// innermost package is also the last leaf of every ancestor package it
+    /// ends. Innermost-first is the narrowest range first: an inner
+    /// container's leaf range is strictly contained in its parent's, so
+    /// ordering by range width is the ancestry order, and the ids break any
+    /// tie deterministically (two containers cannot share a range, but the
+    /// sort must not depend on that to be stable).
+    pub fn containers_closing_at(&self, index: usize) -> Vec<&ContainerBoundary> {
+        let mut closing: Vec<&ContainerBoundary> = self
+            .containers
+            .iter()
+            .filter(|boundary| boundary.last_leaf_index == index)
+            .collect();
+        closing.sort_by(|a, b| {
+            (b.first_leaf_index, &a.container_id).cmp(&(a.first_leaf_index, &b.container_id))
+        });
+        closing
+    }
+}
+
+/// Splice one container's recursively-loaded package into its parent's flat
+/// stage list, and record what that splice means for the boundary table
+/// (E1 + E3). Shared by both loaders so the directory and embedded
+/// representations can never disagree about either half.
+///
+/// `id` is the container's own single-component stage id; `source` is the
+/// declaring package's directory (or [`SOURCE_EMBEDDED`]). Every id the
+/// nested definition produced — leaf and container alike — is prefixed with
+/// `id`, and every index it recorded is shifted by where the splice lands,
+/// which is what makes a container inside a container come out with a
+/// composed id and a correct range at any depth.
+fn splice_container(
+    stages: &mut Vec<StageDefinition>,
+    containers: &mut Vec<ContainerBoundary>,
+    id: &str,
+    source: &str,
+    nested: WorkflowDefinition,
+) {
+    let offset = stages.len();
+    // `check_stage_ids` refuses an empty `stages` list at every level
+    // (`NoStages`), so a package always contributes at least one leaf and
+    // this range is always non-empty.
+    let last_leaf_index = offset + nested.stages.len() - 1;
+    containers.push(ContainerBoundary {
+        container_id: id.to_string(),
+        source: source.to_string(),
+        first_leaf_index: offset,
+        last_leaf_index,
+    });
+    containers.extend(
+        nested
+            .containers
+            .into_iter()
+            .map(|inner| ContainerBoundary {
+                container_id: format!("{id}/{}", inner.container_id),
+                first_leaf_index: inner.first_leaf_index + offset,
+                last_leaf_index: inner.last_leaf_index + offset,
+                ..inner
+            }),
+    );
+    stages.extend(nested.stages.into_iter().map(|leaf| StageDefinition {
+        id: format!("{id}/{}", leaf.id),
+        ..leaf
+    }));
 }
 
 /// Authored fields from a workflow's own `index.md` front matter
@@ -3270,6 +3397,137 @@ mod tests {
         }
     }
 
+    /// E3 / touch point 7: a container contributes no `StageDefinition`, but
+    /// it does contribute one boundary row naming the flat index range of
+    /// the leaves it owns — the fact the engine needs to know a container
+    /// closed, and the only new thing `WorkflowDefinition` carries for it.
+    #[test]
+    fn a_container_records_the_flat_index_range_of_its_own_leaves() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "bounded");
+        write_package(
+            &wf,
+            "bounded",
+            &["00-orient", "10-investigate", "20-implement"],
+        );
+        write_stage(&wf, "00-orient", "orient");
+        write_stage(&wf, "20-implement", "implement");
+        let investigate = wf.join("10-investigate");
+        write_package(&investigate, "10-investigate", &["00-lead", "10-code"]);
+        write_stage(&investigate, "00-lead", "lead");
+        write_stage(&investigate, "10-code", "code");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("load");
+        assert_eq!(
+            def.containers,
+            vec![ContainerBoundary {
+                container_id: "10-investigate".to_string(),
+                source: wf.display().to_string(),
+                first_leaf_index: 1,
+                last_leaf_index: 2,
+            }],
+            "one row per container, naming the leaves it owns: {:?}",
+            def.stages.iter().map(|s| &s.id).collect::<Vec<_>>()
+        );
+        // The row's range says exactly which leaves it covers.
+        assert_eq!(def.stages[1].id, "10-investigate/00-lead");
+        assert_eq!(def.stages[2].id, "10-investigate/10-code");
+        // And the container id, joined onto the workflow's own source, is
+        // the container's package directory — the identity the container
+        // output gate depends on (one string for the declaration lookup and
+        // the worktree lookup alike).
+        assert_eq!(
+            Path::new(&def.source).join("10-investigate"),
+            investigate,
+            "workflow.source + container_id must resolve the container's own package"
+        );
+    }
+
+    /// The multi-boundary case the plan panel named: three levels, whose
+    /// deepest leaf is simultaneously the last leaf of two ancestors.
+    /// `containers_closing_at` must report both, innermost first.
+    #[test]
+    fn a_leaf_can_close_two_containers_at_once_innermost_first() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "three");
+        write_package(&wf, "three", &["00-orient", "10-investigate"]);
+        write_stage(&wf, "00-orient", "orient");
+        let investigate = wf.join("10-investigate");
+        write_package(&investigate, "10-investigate", &["00-lead", "10-deep"]);
+        write_stage(&investigate, "00-lead", "lead");
+        let deep = investigate.join("10-deep");
+        write_package(&deep, "10-deep", &["00-inner"]);
+        write_stage(&deep, "00-inner", "inner");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("load");
+        let ids: Vec<&str> = def.stages.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            [
+                "00-orient",
+                "10-investigate/00-lead",
+                "10-investigate/10-deep/00-inner"
+            ]
+        );
+        assert_eq!(
+            def.containers,
+            vec![
+                ContainerBoundary {
+                    container_id: "10-investigate".to_string(),
+                    source: wf.display().to_string(),
+                    first_leaf_index: 1,
+                    last_leaf_index: 2,
+                },
+                ContainerBoundary {
+                    container_id: "10-investigate/10-deep".to_string(),
+                    source: investigate.display().to_string(),
+                    first_leaf_index: 2,
+                    last_leaf_index: 2,
+                },
+            ],
+            "an inner container composes its id and shifts its range by the splice offset"
+        );
+
+        // Leaf 2 ends the inner package *and* the outer one.
+        let closing: Vec<&str> = def
+            .containers_closing_at(2)
+            .iter()
+            .map(|b| b.container_id.as_str())
+            .collect();
+        assert_eq!(
+            closing,
+            ["10-investigate/10-deep", "10-investigate"],
+            "innermost first, so the innermost container's own contract is checked first"
+        );
+        assert!(
+            def.containers_closing_at(1).is_empty(),
+            "a leaf that ends nothing closes nothing"
+        );
+        assert!(def.containers_closing_at(0).is_empty());
+    }
+
+    /// E2/E3: the boundary table is derived from the flattened stage list,
+    /// so it must not independently perturb content identity — the pinned
+    /// hash stays a function of the descriptor and the flattened stages
+    /// alone, exactly as it was before containers existed.
+    #[test]
+    fn the_container_table_does_not_perturb_the_content_hash() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "hashed");
+        write_package(&wf, "hashed", &["10-container"]);
+        let container = wf.join("10-container");
+        write_package(&container, "10-container", &["00-leaf"]);
+        write_stage(&container, "00-leaf", "leaf work");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("load");
+        assert!(!def.containers.is_empty(), "fixture must have a container");
+        assert_eq!(
+            def.content_hash,
+            compute_content_hash(&def.name, &def.version, &def.stages),
+            "content identity is the descriptor plus the flattened stages, and nothing else"
+        );
+    }
+
     /// The ruled cycle guard (captain ruling on PR #308, 2026-08-26): a
     /// symlink cycle in a nested package is a **named, fail-closed load
     /// error**, never a stack overflow. E14 still stands — this adds no
@@ -3608,6 +3866,18 @@ mod tests {
         assert_eq!(def.stages.len(), 1);
         assert_eq!(def.stages[0].id, "10-container/00-leaf");
         assert_eq!(def.stages[0].context, "the nested procedure");
+        // Boundary parity: the embedded loader records the same side table
+        // its directory sibling does, sourced at `<embedded>` because that
+        // is where the declaring package actually lives.
+        assert_eq!(
+            def.containers,
+            vec![ContainerBoundary {
+                container_id: "10-container".to_string(),
+                source: SOURCE_EMBEDDED.to_string(),
+                first_leaf_index: 0,
+                last_leaf_index: 0,
+            }]
+        );
     }
 
     /// E2 parity: the content hash folds the flattened tree for the embedded

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -1154,7 +1154,7 @@ impl WorkflowDefinition {
             .filter(|boundary| boundary.last_leaf_index == index)
             .collect();
         closing.sort_by(|a, b| {
-            (b.first_leaf_index, &a.container_id).cmp(&(a.first_leaf_index, &b.container_id))
+            (b.first_leaf_index, &b.container_id).cmp(&(a.first_leaf_index, &a.container_id))
         });
         closing
     }
@@ -3504,6 +3504,58 @@ mod tests {
             "a leaf that ends nothing closes nothing"
         );
         assert!(def.containers_closing_at(0).is_empty());
+    }
+
+    /// A legal, simple shape the tie-break must not get wrong: a container
+    /// whose sole stage is itself a nested container. Both boundary rows
+    /// then share the exact same `first_leaf_index` (and `last_leaf_index`)
+    /// — the only thing that still distinguishes them is that the inner
+    /// container's composed id is strictly longer than the outer's. A
+    /// comparator that mismatches its tuple sides (sorting `b`'s range
+    /// against `a`'s id, or vice versa) can pass the differing-range case
+    /// above while still reporting the outer container before the inner one
+    /// here, which is exactly the violation this test pins.
+    #[test]
+    fn a_container_whose_sole_stage_is_a_nested_container_closes_innermost_first() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "wrap");
+        write_package(&wf, "wrap", &["10-wrap"]);
+        let wrap = wf.join("10-wrap");
+        write_package(&wrap, "10-wrap", &["00-inner"]);
+        let inner = wrap.join("00-inner");
+        write_package(&inner, "00-inner", &["00-leaf"]);
+        write_stage(&inner, "00-leaf", "leaf");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("load");
+        assert_eq!(
+            def.containers,
+            vec![
+                ContainerBoundary {
+                    container_id: "10-wrap".to_string(),
+                    source: wf.display().to_string(),
+                    first_leaf_index: 0,
+                    last_leaf_index: 0,
+                },
+                ContainerBoundary {
+                    container_id: "10-wrap/00-inner".to_string(),
+                    source: wrap.display().to_string(),
+                    first_leaf_index: 0,
+                    last_leaf_index: 0,
+                },
+            ],
+            "both boundaries cover the exact same, single-leaf range"
+        );
+
+        let closing: Vec<&str> = def
+            .containers_closing_at(0)
+            .iter()
+            .map(|b| b.container_id.as_str())
+            .collect();
+        assert_eq!(
+            closing,
+            ["10-wrap/00-inner", "10-wrap"],
+            "equal-range tie must still break innermost (longer composed id) first"
+        );
     }
 
     /// E2/E3: the boundary table is derived from the flattened stage list,

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -631,6 +631,28 @@ pub enum WorkflowError {
         /// The nested descriptor that makes this stage a container.
         marker: String,
     },
+    /// A container stage's directory resolves to a package already open on
+    /// this nesting path — a symlink cycle. Recursing into it would never
+    /// terminate, so the loader refuses by name instead of overflowing the
+    /// stack (the captain's ruling on PR #308, 2026-08-26).
+    ///
+    /// This is not a depth limit (E14 stands: nesting itself is unbounded).
+    /// It is the one structural fact that makes depth unbounded *in a way no
+    /// author intended* — a package that contains itself.
+    #[error(
+        "{path} declares stage {stage:?}, whose directory resolves to {resolved}, a workflow \
+         package already open on this nesting path: a nested package may not contain itself \
+         (a symlink cycle), which would recurse without end"
+    )]
+    NestedPackageCycle {
+        /// Path of the declaring descriptor.
+        path: String,
+        /// The offending stage id.
+        stage: String,
+        /// The canonical directory the stage resolves to — already an
+        /// ancestor of itself.
+        resolved: String,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -802,7 +824,24 @@ impl WorkflowDefinition {
     /// content hash folds the whole flattened tree into one identity (E2) —
     /// a nested leaf's edit changes the parent's `content_hash` exactly as a
     /// top-level stage's does.
+    ///
+    /// **Cycle guard.** Nesting is unbounded by design (E14: no product depth
+    /// limit), so the one shape that must still be refused is a package that
+    /// *contains itself* — a symlink cycle, which is not deep nesting but
+    /// endless nesting. Each level carries the canonical paths of the
+    /// packages open above it and refuses a container that resolves to one of
+    /// them ([`WorkflowError::NestedPackageCycle`]), by name, at load time,
+    /// rather than letting the recursion overflow the stack.
     pub fn load_dir(dir: &Path) -> Result<Self, WorkflowError> {
+        Self::load_dir_within(dir, &[])
+    }
+
+    /// [`Self::load_dir`] plus the canonical paths of every package already
+    /// open above this one on the nesting path (the cycle guard's visited
+    /// set). The ancestry is a *path*, not a global set: the same package
+    /// reached twice by two different containers is finite and legal, while
+    /// the same package reached from inside itself is not.
+    fn load_dir_within(dir: &Path, ancestry: &[PathBuf]) -> Result<Self, WorkflowError> {
         let descriptor = dir.join(WORKFLOW_FILE);
         let path = descriptor.display().to_string();
         let text = std::fs::read_to_string(&descriptor).map_err(|source| WorkflowError::Io {
@@ -823,6 +862,15 @@ impl WorkflowDefinition {
         }
         let ids = check_stage_ids(&parsed.workflow.stages, &path)?;
         check_stage_tables(&ids, &parsed.stages_meta, &path)?;
+        // This package, plus everything open above it: what a container's
+        // resolved directory is checked against below.
+        let mut open = ancestry.to_vec();
+        open.push(
+            std::fs::canonicalize(dir).map_err(|source| WorkflowError::Io {
+                path: dir.display().to_string(),
+                source,
+            })?,
+        );
         let mut stages = Vec::with_capacity(ids.len());
         for id in ids {
             let stage_dir = dir.join(&id);
@@ -847,9 +895,24 @@ impl WorkflowDefinition {
                         marker: marker.display().to_string(),
                     });
                 }
+                // The cycle guard, before the recursion rather than after:
+                // a container that resolves to a package already open above
+                // it would never terminate.
+                let resolved =
+                    std::fs::canonicalize(&stage_dir).map_err(|source| WorkflowError::Io {
+                        path: stage_dir.display().to_string(),
+                        source,
+                    })?;
+                if open.contains(&resolved) {
+                    return Err(WorkflowError::NestedPackageCycle {
+                        path,
+                        stage: id,
+                        resolved: resolved.display().to_string(),
+                    });
+                }
                 // The nested package validates itself, by its own rules, and
                 // reports failures against its own descriptor path.
-                let nested = Self::load_dir(&stage_dir)?;
+                let nested = Self::load_dir_within(&stage_dir, &open)?;
                 stages.extend(nested.stages.into_iter().map(|leaf| StageDefinition {
                     id: format!("{id}/{}", leaf.id),
                     ..leaf
@@ -3205,6 +3268,73 @@ mod tests {
             }
             other => panic!("expected InvalidStageId, got {other}"),
         }
+    }
+
+    /// The ruled cycle guard (captain ruling on PR #308, 2026-08-26): a
+    /// symlink cycle in a nested package is a **named, fail-closed load
+    /// error**, never a stack overflow. E14 still stands — this adds no
+    /// depth limit, only a guard against a package that contains itself,
+    /// which is not deep nesting but unbounded nesting.
+    ///
+    /// The fixture has to satisfy the loader's own `NameMismatch` check at
+    /// every level to reach the recursion at all, so the cycle is the one
+    /// shape that can: a package whose declared stage id is its own
+    /// directory name, with that stage a symlink back to the package.
+    /// `10-inner/10-inner/10-inner/…` would otherwise recurse forever.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_cycle_in_a_nested_package_is_a_named_load_error() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "loopy");
+        write_package(&wf, "loopy", &["10-inner"]);
+        let inner = wf.join("10-inner");
+        write_package(&inner, "10-inner", &["10-inner"]);
+        std::os::unix::fs::symlink(&inner, inner.join("10-inner")).expect("cycle symlink");
+
+        let err = WorkflowDefinition::load_dir(&wf)
+            .expect_err("a package that contains itself must be refused, not recursed forever");
+        match &err {
+            WorkflowError::NestedPackageCycle { stage, path, .. } => {
+                assert_eq!(stage, "10-inner");
+                assert!(
+                    path.contains("10-inner"),
+                    "the error must name the descriptor that declared the cycling stage: {path}"
+                );
+            }
+            other => panic!("expected NestedPackageCycle, got {other}"),
+        }
+        assert!(
+            err.to_string().contains("nesting path"),
+            "the message must say what is wrong, not just that something is: {err}"
+        );
+    }
+
+    /// The guard is about a package *containing itself*, not about a package
+    /// being used twice. Two sibling containers that resolve to the same
+    /// package directory are finite, produce distinct composed ids, and must
+    /// still load — a naive global visited-set would have refused them.
+    #[cfg(unix)]
+    #[test]
+    fn the_same_nested_package_may_be_used_by_two_siblings() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let wf = workflow_dir(dir.path(), "twice");
+        write_package(&wf, "twice", &["10-shared", "20-shared"]);
+        let shared = wf.join("10-shared");
+        write_package(&shared, "10-shared", &["00-leaf"]);
+        write_stage(&shared, "00-leaf", "shared work");
+        // The second use is the same directory reached by another name; the
+        // nested package's own `name` check makes it a copy in practice, so
+        // this fixture writes the sibling as a real package with identical
+        // content and symlinks only the *leaf*, which is the shape that
+        // actually shares content on disk.
+        let second = wf.join("20-shared");
+        write_package(&second, "20-shared", &["00-leaf"]);
+        std::os::unix::fs::symlink(shared.join("00-leaf"), second.join("00-leaf"))
+            .expect("shared leaf symlink");
+
+        let def = WorkflowDefinition::load_dir(&wf).expect("sharing a package is not a cycle");
+        let ids: Vec<&str> = def.stages.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, ["10-shared/00-leaf", "20-shared/00-leaf"]);
     }
 
     /// A nested package's own `name` must match its stage directory, exactly

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -5564,6 +5564,7 @@ mod tests {
                 version: "1".to_string(),
                 source: "test".to_string(),
                 stages: Vec::new(),
+                containers: Vec::new(),
                 content_hash: String::new(),
             },
             route: Route {

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -1241,6 +1241,33 @@ pub struct Engine {
     pub intelligence_lane_cap: usize,
 }
 
+/// Whose declared output contract one [`Engine::check_output_contract`] pass
+/// is about (E4): the leaf that just completed, or a container that leaf
+/// just closed.
+///
+/// Two variants rather than a bare id, because the difference is not only
+/// which `output/` directory to read — it is what the operator is told. A
+/// container's unmet contract must not read as a complaint about the leaf,
+/// which finished cleanly.
+#[derive(Clone, Copy)]
+enum OutputContract<'a> {
+    /// The completing leaf's own contract — the only case before W1.
+    Leaf,
+    /// A container's own contract, named by its composed hierarchical id.
+    Container(&'a str),
+}
+
+impl<'a> OutputContract<'a> {
+    /// The id whose `output/` directory this contract lives in — under the
+    /// package root and under a worktree alike.
+    fn id(self, stage: &'a StageRecord) -> &'a str {
+        match self {
+            OutputContract::Leaf => &stage.stage_id,
+            OutputContract::Container(id) => id,
+        }
+    }
+}
+
 impl Engine {
     /// Build an engine over a registry and data dir. `surfaces_root`
     /// defaults to `<data_dir>/surfaces` — today's layout, nothing moves —
@@ -2908,6 +2935,19 @@ impl Engine {
                 {
                     return Ok(gated);
                 }
+                // E3/E4: the one thing nesting adds to this arm. Every leaf
+                // signal above is handled exactly as it was — nesting only
+                // asks whether completing *this* leaf also closes a
+                // container that declared its own output contract, before
+                // the run is allowed to walk past it. Checked here, ahead of
+                // `stage.completed` and `stop_execution`, for the same
+                // reason the leaf gate is: the bounded re-prompt goes to the
+                // still-live execution of the leaf that just completed.
+                if let Some(gated) =
+                    self.check_closed_container_gates(core, work_id, &run, &workflow, &stage)?
+                {
+                    return Ok(gated);
+                }
                 let mut payload = json!({"stage_id": stage.stage_id, "index": stage.index});
                 if let Some(summary) = summary {
                     payload["detail"] = Value::String(summary);
@@ -2971,10 +3011,85 @@ impl Engine {
         workflow: &WorkflowDefinition,
         stage: &StageRecord,
     ) -> Result<Option<Next>, EngineError> {
+        self.check_output_contract(core, work_id, run, workflow, OutputContract::Leaf, stage)
+    }
+
+    /// E4, the container half of the same gate: a leaf's completion may also
+    /// *close* one or more containers (W1 §4 — "the container can still
+    /// assert a mechanical aggregate/summary artifact"), and a container
+    /// that declared its own `output/README.md` must have produced it before
+    /// the run walks past the last leaf under it.
+    ///
+    /// Innermost first ([`WorkflowDefinition::containers_closing_at`]), and
+    /// the first unmet contract short-circuits — a leaf that ends three
+    /// nested packages at once produces one re-prompt/park, not three at
+    /// the same instant, and the outer contracts are re-checked on the next
+    /// `StageCompleted` for the same leaf.
+    ///
+    /// No new mechanism (E3: W1 adds no terminal vocabulary): this is
+    /// [`Self::check_output_contract`] called with the container's id
+    /// instead of the leaf's, so the bounded re-prompt, the
+    /// `stage_output_missing` reason code, and the recovery path are the
+    /// existing ones verbatim.
+    fn check_closed_container_gates(
+        &self,
+        core: &mut Core,
+        work_id: &str,
+        run: &WorkRun,
+        workflow: &WorkflowDefinition,
+        stage: &StageRecord,
+    ) -> Result<Option<Next>, EngineError> {
+        let closing: Vec<String> = workflow
+            .containers_closing_at(stage.index)
+            .into_iter()
+            .map(|boundary| boundary.container_id.clone())
+            .collect();
+        for container_id in closing {
+            if let Some(gated) = self.check_output_contract(
+                core,
+                work_id,
+                run,
+                workflow,
+                OutputContract::Container(&container_id),
+                stage,
+            )? {
+                return Ok(Some(gated));
+            }
+        }
+        Ok(None)
+    }
+
+    /// The gate body both halves share, parameterized on *whose* declared
+    /// output contract is being checked (the engine recon's touch point 5).
+    ///
+    /// `stage` is always the leaf that just signalled `StageCompleted`, in
+    /// both cases: it owns the live execution a re-prompt is sent to, and
+    /// its attempt owns the one bounded re-prompt this gate is allowed to
+    /// spend. That budget is per leaf attempt, not per contract — a leaf
+    /// that already spent its re-prompt on its own missing artifact parks
+    /// on the next unmet contract rather than re-prompting again, and a
+    /// `retry` (a fresh attempt, a fresh `StageRecord`) restores it. Bounded
+    /// is bounded: at most one SEND per attempt, whatever it was for.
+    fn check_output_contract(
+        &self,
+        core: &mut Core,
+        work_id: &str,
+        run: &WorkRun,
+        workflow: &WorkflowDefinition,
+        contract: OutputContract<'_>,
+        stage: &StageRecord,
+    ) -> Result<Option<Next>, EngineError> {
         if workflow.source == SOURCE_EMBEDDED {
             return Ok(None);
         }
-        let Some(expected) = declared_output_artifact(Path::new(&workflow.source), &stage.stage_id)
+        // One string for the declaration lookup and the worktree lookup
+        // alike, so the two halves of this check can never disagree about
+        // which `output/` directory they mean. For a container it is the
+        // composed hierarchical id (`10-investigate`, `10-investigate/
+        // 10-deep`), which `Path::join` splits into real components exactly
+        // as it does for a nested leaf's id.
+        let contract_id = contract.id(stage);
+        let Some(expected) = declared_output_artifact(Path::new(&workflow.source), contract_id)
         else {
             return Ok(None);
         };
@@ -2988,12 +3103,11 @@ impl Engine {
         // an altogether-absent one get the identical bounded-re-prompt/
         // needs_input treatment below, per Amendment 10d's own text
         // ("malformed = stage_output_missing-class refusal").
-        let required_columns =
-            declared_required_columns(Path::new(&workflow.source), &stage.stage_id);
+        let required_columns = declared_required_columns(Path::new(&workflow.source), contract_id);
         let produced = surface.bindings.iter().any(|binding| {
             let path = binding
                 .worktree_path
-                .join(&stage.stage_id)
+                .join(contract_id)
                 .join("output")
                 .join(&expected);
             let Ok(text) = std::fs::read_to_string(&path) else {
@@ -3010,22 +3124,34 @@ impl Engine {
                 // own reason; nothing more for the gate to say.
                 return Ok(Some(Next::Parked));
             }
-            self.commit(
-                core,
-                work_id,
-                KIND_STAGE_OUTPUT_MISSING,
-                json!({
-                    "stage_id": stage.stage_id,
-                    "path": expected,
-                    "attempt": stage.attempt,
-                }),
-            )?;
+            // `stage_id` is the *leaf's* throughout, in both the leaf and
+            // the container case: a container has no `StageRecord` (E3), and
+            // this is the event the reducer folds the re-prompt count onto.
+            // `container_id` rides beside it when the unmet contract is a
+            // container's, so the journal says which one without inventing a
+            // record for it.
+            let mut payload = json!({
+                "stage_id": stage.stage_id,
+                "path": expected,
+                "attempt": stage.attempt,
+            });
+            if let OutputContract::Container(container_id) = contract {
+                payload["container_id"] = Value::String(container_id.to_string());
+            }
+            self.commit(core, work_id, KIND_STAGE_OUTPUT_MISSING, payload)?;
             let execution = run.execution.clone().ok_or_else(|| EngineError::NoRun {
                 work_id: work_id.to_string(),
             })?;
             let backend = self.backend_for(work_id, &execution.backend)?;
-            let prompt =
-                format!("declared output {expected} missing — produce it or state what you need");
+            let prompt = match contract {
+                OutputContract::Leaf => format!(
+                    "declared output {expected} missing — produce it or state what you need"
+                ),
+                OutputContract::Container(container_id) => format!(
+                    "declared output {expected} for container {container_id} missing — produce it \
+                     or state what you need"
+                ),
+            };
             return Ok(Some(Next::Send(Box::new(PendingSend {
                 work_id: work_id.to_string(),
                 stage_id: stage.stage_id.clone(),
@@ -3037,33 +3163,39 @@ impl Engine {
                 resume: self.resume_request(run, work_id),
             }))));
         }
-        let detail = format!(
-            "stage {} completed without producing its declared output {expected}, even after \
-             one re-prompt",
-            stage.stage_id
-        );
-        self.commit(
-            core,
-            work_id,
-            KIND_STAGE_NEEDS_INPUT,
-            json!({
-                "stage_id": stage.stage_id,
-                "detail": detail,
-                "reason_code": REASON_STAGE_OUTPUT_MISSING,
-                "path": expected,
-            }),
-        )?;
-        self.transition(
-            core,
-            work_id,
-            KIND_WORK_NEEDS_INPUT,
-            json!({
-                "prompt": detail,
-                "stage_id": stage.stage_id,
-                "reason_code": REASON_STAGE_OUTPUT_MISSING,
-                "path": expected,
-            }),
-        )?;
+        // E4: the park names the CONTAINER when a container's contract is the
+        // unmet one — "container 10-investigate never produced its declared
+        // aggregate", not a confusing leaf-level message about a leaf that
+        // itself finished cleanly.
+        let detail = match contract {
+            OutputContract::Leaf => format!(
+                "stage {} completed without producing its declared output {expected}, even after \
+                 one re-prompt",
+                stage.stage_id
+            ),
+            OutputContract::Container(container_id) => format!(
+                "container {container_id} closed without producing its declared output \
+                 {expected}, even after one re-prompt"
+            ),
+        };
+        let mut stage_payload = json!({
+            "stage_id": stage.stage_id,
+            "detail": detail,
+            "reason_code": REASON_STAGE_OUTPUT_MISSING,
+            "path": expected,
+        });
+        let mut work_payload = json!({
+            "prompt": detail,
+            "stage_id": stage.stage_id,
+            "reason_code": REASON_STAGE_OUTPUT_MISSING,
+            "path": expected,
+        });
+        if let OutputContract::Container(container_id) = contract {
+            stage_payload["container_id"] = Value::String(container_id.to_string());
+            work_payload["container_id"] = Value::String(container_id.to_string());
+        }
+        self.commit(core, work_id, KIND_STAGE_NEEDS_INPUT, stage_payload)?;
+        self.transition(core, work_id, KIND_WORK_NEEDS_INPUT, work_payload)?;
         Ok(Some(Next::Parked))
     }
 

--- a/src/tui/geometry_matrix_tests.rs
+++ b/src/tui/geometry_matrix_tests.rs
@@ -488,6 +488,78 @@ fn geometry_workflow_tab_never_shows_a_percent_gauge() {
     }
 }
 
+/// S2 W1 / decision E10: the Workflow tab's rail gains **new persistent
+/// chrome** under nesting — an indented header row per container, with its
+/// own aggregation glyph and count — so it earns its own geometry-matrix
+/// entry, per the same rule `fleet_estate_filter` above was added under.
+fn work_nested_workflow() -> App {
+    let mut app = app_with_open_work("01NEST", "active", "which lead?");
+    app.work_screen = Some(work_view::WorkScreen::from_parts(
+        "01NEST".to_string(),
+        json!({
+            "work": {"id": "01NEST", "intent": "investigate deeply", "state": "active"},
+            "stage": {
+                "stage_id": "10-investigate/10-deep/00-inner", "index": 2, "attempt": 1,
+                "status": "active", "of": 4,
+                "executor": {"harness": "claude", "profile": {"name": "default"}},
+            },
+            "workflow": {
+                "name": "nested", "version": "1", "source": "/repo/.sergeant/workflows/nested",
+                "stages": [
+                    "00-orient",
+                    "10-investigate/00-lead",
+                    "10-investigate/10-deep/00-inner",
+                    "20-implement",
+                ],
+            },
+            "envelope": {"turn_cap": 12, "turns_spawned": 3},
+        }),
+        Vec::new(),
+        Vec::new(),
+        None,
+    ));
+    app
+}
+
+/// The rail's rows are indented, never truncated sideways, at every size —
+/// and the container header carries its aggregation without a percent
+/// (T2-50).
+///
+/// Stated rather than hidden: a container adds a *row* to the rail, so a
+/// rail that fit its pane before may now run past the bottom of the
+/// shortest size (80x24 shows through `10-deep/` here and stops). That is
+/// the Workflow pane's existing vertical behaviour for any rail longer than
+/// its height — a flat workflow with more stages truncates identically —
+/// not something nesting introduced, so this asserts the full tree only
+/// where the pane is actually tall enough to hold it.
+#[test]
+fn geometry_workflow_tab_renders_a_nested_tree_at_every_size() {
+    let mut app = work_nested_workflow();
+    app.on_key(KeyCode::Char('2')); // Workflow tab (§13.2)
+    for (w, h) in SIZES {
+        let text = text_of(&draw_at(&app, w, h));
+        assert!(
+            !text.contains('%'),
+            "{w}x{h}: Decision T2-50 holds for container rows too: {text}"
+        );
+        for needle in ["✓ 00-orient", "⠹ 10-investigate/  1/2", "  ✓ 00-lead"] {
+            assert!(
+                text.contains(needle),
+                "{w}x{h}: the tree must show {needle:?}: {text}"
+            );
+        }
+        if h >= 36 {
+            for needle in ["    ⠹ 00-inner", "· 20-implement"] {
+                assert!(
+                    text.contains(needle),
+                    "{w}x{h}: a pane this tall must show the whole rail, {needle:?} included: \
+                     {text}"
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn geometry_workflows_catalog_detail_and_error() {
     for (name, app) in [

--- a/src/tui/work_view.rs
+++ b/src/tui/work_view.rs
@@ -482,6 +482,17 @@ impl WorkScreen {
     /// earlier/later stages' pinned bindings are not part of that response,
     /// so this shows harness/profile only where the read actually supplies
     /// it, per stage.
+    ///
+    /// **Nesting (W1, decision E10).** The wire shape stays what it has
+    /// always been — one flat array of leaf ids, index/of arithmetic intact
+    /// — and hierarchy is carried inside those ids as `/`-joined path
+    /// components. This is the one place that reads it: leaves are grouped
+    /// under an indented header line per container, and each container gets
+    /// an aggregation glyph over the leaves it owns (done / running /
+    /// pending) plus a plain `done/total` count. No percent, per T2-50.
+    ///
+    /// A flat workflow has no `/` in any id, so it renders exactly as it did
+    /// before this existed: no headers, no indentation.
     fn workflow_lines(&self) -> Vec<Line<'static>> {
         let stage_ids: Vec<String> = self.work["workflow"]["stages"]
             .as_array()
@@ -508,16 +519,43 @@ impl WorkScreen {
         let attempt = self.work["stage"]["attempt"].as_u64().unwrap_or(1);
         let executor = &self.work["stage"]["executor"];
         let mut lines = vec![label, Line::default()];
-        lines.extend(stage_ids.iter().enumerate().map(|(i, id)| {
+        // The container path currently open above the leaf being rendered,
+        // deepest last. A flat list never grows it past empty.
+        let mut open: Vec<&str> = Vec::new();
+        for (i, id) in stage_ids.iter().enumerate() {
+            let mut components: Vec<&str> = id.split('/').collect();
+            // A leaf id always has a last component; `split` guarantees one.
+            let leaf = components.pop().unwrap_or(id.as_str());
+            let shared = open
+                .iter()
+                .zip(components.iter())
+                .take_while(|(a, b)| a == b)
+                .count();
+            open.truncate(shared);
+            for depth in shared..components.len() {
+                let prefix = components[..=depth].join("/");
+                let (first, last) = container_range(&stage_ids, &prefix);
+                let (glyph, style) = progress_glyph(first, last, current_index);
+                let done = current_index
+                    .map(|cur| (cur as usize).saturating_sub(first).min(last - first + 1))
+                    .unwrap_or(0);
+                lines.push(Line::from(vec![
+                    Span::raw("  ".repeat(depth)),
+                    Span::styled(format!("{glyph} "), style),
+                    Span::styled(format!("{}/", components[depth]), style),
+                    Span::styled(
+                        format!("  {done}/{}", last - first + 1),
+                        Style::default().fg(Token::Muted.rgb()),
+                    ),
+                ]));
+                open.push(components[depth]);
+            }
             let i = i as u64;
-            let (glyph, style) = match current_index {
-                Some(cur) if i < cur => ("✓", Style::default().fg(Token::Success.rgb())),
-                Some(cur) if i == cur => ("⠹", Style::default().fg(Token::Focus.rgb())),
-                _ => ("·", Style::default().fg(Token::Muted.rgb())),
-            };
+            let (glyph, style) = progress_glyph(i as usize, i as usize, current_index);
             let mut spans = vec![
+                Span::raw("  ".repeat(components.len())),
                 Span::styled(format!("{glyph} "), style),
-                Span::styled(id.clone(), style),
+                Span::styled(leaf.to_string(), style),
             ];
             if current_index == Some(i) {
                 let mut suffix = format!("  attempt {attempt}");
@@ -532,8 +570,8 @@ impl WorkScreen {
                     Style::default().fg(Token::Muted.rgb()),
                 ));
             }
-            Line::from(spans)
-        }));
+            lines.push(Line::from(spans));
+        }
         lines
     }
 
@@ -842,6 +880,44 @@ impl WorkScreen {
         )));
 
         lines
+    }
+}
+
+/// The first and last flat index of the leaves under `prefix` (W1 §3's
+/// hierarchy separator, decision E10) — the client-side reading of the same
+/// range the engine keeps in its own container-boundary table.
+///
+/// Derived from the flat list rather than requested from the API on purpose:
+/// `GET /v1/work/{id}` serves the leaf ids and nothing else about nesting,
+/// and a container's extent is exactly "the run of leaves whose id starts
+/// with `<prefix>/`", which is contiguous by construction of the loader's
+/// depth-first splice.
+fn container_range(stage_ids: &[String], prefix: &str) -> (usize, usize) {
+    let under = format!("{prefix}/");
+    let mut first = 0;
+    let mut last = 0;
+    let mut seen = false;
+    for (i, id) in stage_ids.iter().enumerate() {
+        if id.starts_with(&under) {
+            if !seen {
+                first = i;
+                seen = true;
+            }
+            last = i;
+        }
+    }
+    (first, last)
+}
+
+/// The rail's glyph for one span of leaves `[first, last]` against the
+/// current position: finished, running, or not yet reached. A leaf is the
+/// degenerate span where `first == last`, so containers and leaves cannot
+/// drift apart on what "done" looks like.
+fn progress_glyph(first: usize, last: usize, current_index: Option<u64>) -> (&'static str, Style) {
+    match current_index {
+        Some(cur) if (cur as usize) > last => ("✓", Style::default().fg(Token::Success.rgb())),
+        Some(cur) if (cur as usize) >= first => ("⠹", Style::default().fg(Token::Focus.rgb())),
+        _ => ("·", Style::default().fg(Token::Muted.rgb())),
     }
 }
 
@@ -1757,6 +1833,131 @@ mod tests {
         assert!(
             !lines.iter().any(|l| l.contains('%')),
             "Decision T2-50: never a percent bar: {lines:?}"
+        );
+    }
+
+    /// A Work whose pinned workflow nests two levels — the TUI-side fixture
+    /// that did not exist before W1 (recon-cli-api touch point 8: "today's
+    /// only fixture is flat"). `current_index` is the deepest nested leaf,
+    /// which is also the last leaf of both its container and its container's
+    /// container.
+    fn nested_work_body(current_index: u64) -> Value {
+        json!({
+            "work": {"id": "01NEST", "intent": "nest", "state": "active"},
+            "stage": {
+                "stage_id": "10-investigate/10-deep/00-inner",
+                "index": current_index,
+                "attempt": 1,
+                "status": "active",
+                "of": 4,
+                "executor": {"harness": "claude", "profile": {"name": "default"}},
+            },
+            "workflow": {
+                "name": "nested", "version": "1", "source": "/repo/.sergeant/workflows/nested",
+                "stages": [
+                    "00-orient",
+                    "10-investigate/00-lead",
+                    "10-investigate/10-deep/00-inner",
+                    "20-implement",
+                ],
+            },
+            "envelope": {"turns_spawned": 1, "turn_cap": 10},
+        })
+    }
+
+    /// E10: the flat leaf list groups by `/` into an indented tree, one
+    /// header per container, each carrying an aggregation glyph over the
+    /// leaves it owns and a plain done/total count. Order is preserved — the
+    /// rail is still the pinned order, only drawn as the tree it is.
+    #[test]
+    fn workflow_rail_groups_nested_leaves_into_an_indented_tree() {
+        let screen = WorkScreen::from_parts(
+            "01NEST".to_string(),
+            nested_work_body(2),
+            vec![],
+            vec![],
+            None,
+        );
+        let lines: Vec<String> = screen
+            .workflow_lines()
+            .iter()
+            .map(|l| l.to_string())
+            .collect();
+        // label, blank, 00-orient, 10-investigate/, 00-lead,
+        // 10-deep/, 00-inner, 20-implement.
+        assert_eq!(lines.len(), 8, "{lines:?}");
+        assert_eq!(lines[2], "✓ 00-orient", "{lines:?}");
+        assert_eq!(
+            lines[3], "⠹ 10-investigate/  1/2",
+            "the container is in progress, with one of its two leaves behind the current: {lines:?}"
+        );
+        assert_eq!(
+            lines[4], "  ✓ 00-lead",
+            "a leaf shows its own name, indented under its container: {lines:?}"
+        );
+        assert_eq!(
+            lines[5], "  ⠹ 10-deep/  0/1",
+            "an inner container indents again and aggregates only its own leaf: {lines:?}"
+        );
+        assert!(
+            lines[6].starts_with("    ⠹ 00-inner"),
+            "the current leaf is two levels deep: {lines:?}"
+        );
+        assert!(
+            lines[6].contains("attempt 1") && lines[6].contains("claude"),
+            "the current leaf still carries its executor detail: {lines:?}"
+        );
+        assert_eq!(lines[7], "· 20-implement", "{lines:?}");
+        assert!(
+            !lines.iter().any(|l| l.contains('%')),
+            "Decision T2-50 holds for containers too: {lines:?}"
+        );
+    }
+
+    /// The aggregation glyph is about the whole span, not the leaf that
+    /// happens to be current: once the run is past a container's last leaf,
+    /// the container reads done.
+    #[test]
+    fn a_container_reads_done_only_once_the_run_is_past_its_last_leaf() {
+        let screen = WorkScreen::from_parts(
+            "01NEST".to_string(),
+            nested_work_body(3),
+            vec![],
+            vec![],
+            None,
+        );
+        let lines: Vec<String> = screen
+            .workflow_lines()
+            .iter()
+            .map(|l| l.to_string())
+            .collect();
+        assert_eq!(lines[3], "✓ 10-investigate/  2/2", "{lines:?}");
+        assert_eq!(lines[5], "  ✓ 10-deep/  1/1", "{lines:?}");
+        assert!(
+            lines[7].starts_with("⠹ 20-implement"),
+            "the container's sibling is the current leaf now: {lines:?}"
+        );
+    }
+
+    /// The negative half, and the one that matters for every workflow that
+    /// does not nest: a flat stage list renders exactly as it did before the
+    /// tree existed — no headers, no indentation.
+    #[test]
+    fn a_flat_workflow_still_renders_as_a_flat_rail() {
+        let screen = screen_with("active", Vec::new());
+        let lines: Vec<String> = screen
+            .workflow_lines()
+            .iter()
+            .map(|l| l.to_string())
+            .collect();
+        assert_eq!(lines.len(), 5, "label, blank, three stages: {lines:?}");
+        assert!(
+            lines[2..].iter().all(|l| !l.starts_with(' ')),
+            "nothing is indented when nothing nests: {lines:?}"
+        );
+        assert!(
+            lines[2..].iter().all(|l| !l.contains('/')),
+            "no container headers appear: {lines:?}"
         );
     }
 

--- a/tests/m11_nested_workflow.rs
+++ b/tests/m11_nested_workflow.rs
@@ -1,0 +1,476 @@
+//! M11: nested workflow packages end to end (S2 W1 — hierarchical
+//! execution; decisions E1/E3/E4/E10/E14).
+//!
+//! The loader half (recursion, composed ids, the boundary side table) is
+//! unit-tested next to its own code in `src/domain/workflow.rs`. This suite
+//! is the other half: a *running* Work whose workflow nests, driven through
+//! the real daemon and the real engine on the fake backend, proving the
+//! claims that only a run can prove —
+//!
+//! 1. two-level recursion executes its leaves through the existing engine,
+//!    with no new execution path, and the Work completes (W1 §13 items 1-3);
+//! 2. a nested leaf's own output contract is enforced *identically* to a
+//!    non-nested leaf's (W1 §13 item 9 — split-hardening contracts are not
+//!    bypassed by nesting);
+//! 3. a container that declared its own output contract is checked when its
+//!    last leaf completes, and an unmet one parks the Work naming the
+//!    CONTAINER (E4).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend, FakeStep};
+use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
+use sergeant_rs::domain::event::Event;
+use sergeant_rs::domain::workflow::{
+    KIND_STAGE_COMPLETED, KIND_STAGE_ENTERED, KIND_STAGE_OUTPUT_MISSING,
+    REASON_STAGE_OUTPUT_MISSING,
+};
+use sergeant_rs::runtime::journal::Journal;
+
+mod support;
+
+// ---------------------------------------------------------------- helpers
+
+fn ulid() -> String {
+    ulid::Ulid::generate().to_string()
+}
+
+fn http() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .expect("client")
+}
+
+/// Write one workflow package's own `workflow.toml`, creating its directory.
+/// A nested package is an ordinary package, so every level uses this.
+fn write_package(dir: &Path, name: &str, stages: &[&str]) {
+    std::fs::create_dir_all(dir).expect("package dir");
+    let declared: Vec<String> = stages.iter().map(|id| format!("{id:?}")).collect();
+    std::fs::write(
+        dir.join("workflow.toml"),
+        format!(
+            "[workflow]\nname = {name:?}\nversion = \"1\"\nstages = [{}]\n",
+            declared.join(", ")
+        ),
+    )
+    .expect("workflow.toml");
+}
+
+/// An actor stage: a directory with a `CONTEXT.md`, which is its procedure.
+fn write_stage(package: &Path, id: &str, context: &str) {
+    let dir = package.join(id);
+    std::fs::create_dir_all(&dir).expect("stage dir");
+    std::fs::write(dir.join("CONTEXT.md"), context).expect("CONTEXT.md");
+}
+
+/// Declare an `output/README.md` contract (the ICM convention's Rule 4
+/// shape) for `id` — a leaf id or a container id alike, since a container's
+/// own `output/` sits beside its `workflow.toml` exactly as a leaf's sits
+/// beside its `CONTEXT.md`.
+fn declare_output(package: &Path, id: &str, artifact: &str) {
+    let dir = package.join(id).join("output");
+    std::fs::create_dir_all(&dir).expect("output dir");
+    std::fs::write(
+        dir.join("README.md"),
+        format!(
+            "# Output — `{id}`\n\n**Expected artifact:** `{artifact}` — proof of work.\n\n\
+             **Disposition:** `evidence`\n"
+        ),
+    )
+    .expect("output/README.md");
+}
+
+/// The two-level fixture every test below starts from:
+///
+/// ```text
+/// nested/
+///   00-orient/CONTEXT.md
+///   10-investigate/workflow.toml      <- container marker
+///     00-lead/CONTEXT.md
+///     10-code/CONTEXT.md
+///   20-implement/CONTEXT.md
+/// ```
+///
+/// Flattens to `00-orient`, `10-investigate/00-lead`,
+/// `10-investigate/10-code`, `20-implement`.
+fn write_nested_workflow(root: &Path) -> PathBuf {
+    let package = root.join(".sergeant/workflows/nested");
+    write_package(
+        &package,
+        "nested",
+        &["00-orient", "10-investigate", "20-implement"],
+    );
+    write_stage(&package, "00-orient", "orient the work");
+    write_stage(&package, "20-implement", "implement it");
+    let investigate = package.join("10-investigate");
+    write_package(&investigate, "10-investigate", &["00-lead", "10-code"]);
+    write_stage(&investigate, "00-lead", "lead the investigation");
+    write_stage(&investigate, "10-code", "read the code");
+    package
+}
+
+async fn start_fake(data_dir: &Path, script: impl IntoIterator<Item = FakeStep>) -> DaemonHandle {
+    let fake = FakeBackend::scripted(FAKE_BACKEND_NAME, script);
+    let registry = BackendRegistry::new().with(Arc::new(fake));
+    daemon::start_with(
+        data_dir,
+        DaemonConfig {
+            backends: Arc::new(registry),
+            default_backend: Some(FAKE_BACKEND_NAME.to_string()),
+            claude: None,
+            ..DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start")
+}
+
+async fn post(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    path: &str,
+    body: Value,
+) -> (reqwest::StatusCode, Value) {
+    let resp = client
+        .post(format!("{}{path}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    let value: Value = resp.json().await.expect("json body");
+    (status, value)
+}
+
+async fn submit(
+    client: &reqwest::Client,
+    handle: &DaemonHandle,
+    estate: &Path,
+    workflow: &str,
+) -> Value {
+    let (status, body) = post(
+        client,
+        handle,
+        "/v1/work",
+        json!({
+            "command_id": ulid(),
+            "intent": "run a nested workflow",
+            "workflow": workflow,
+            "estate_root": estate,
+            "origin": {"client": "cli", "cwd": estate},
+        }),
+    )
+    .await;
+    assert_eq!(status, 201, "submit must be accepted: {body}");
+    body
+}
+
+fn events_of(data_dir: &Path, work_id: &str, kind: &str) -> Vec<Event> {
+    Journal::replay_data_dir(data_dir)
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.work_id.as_deref() == Some(work_id) && e.kind == kind)
+        .collect()
+}
+
+fn stage_ids(data_dir: &Path, work_id: &str, kind: &str) -> Vec<String> {
+    events_of(data_dir, work_id, kind)
+        .into_iter()
+        .filter_map(|e| e.payload["stage_id"].as_str().map(str::to_string))
+        .collect()
+}
+
+// ------------------------------------------------------------------ tests
+
+/// W1 §13 items 1-3: a stage directory that is itself a workflow package
+/// runs its leaves through the existing engine — same backend, same
+/// surface, one flat stage order — and the Work completes. Nothing about
+/// nesting reaches the executor: the leaves are ordinary stages whose ids
+/// happen to contain `/`.
+#[tokio::test]
+async fn a_two_level_nested_workflow_runs_its_leaves_in_order_and_completes() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    support::scaffold_solo_estate(&estate, "solo");
+    write_nested_workflow(&estate);
+
+    // One completion per leaf: four leaves, four steps.
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete_with("oriented"),
+            FakeStep::complete_with("led"),
+            FakeStep::complete_with("read"),
+            FakeStep::complete_with("implemented"),
+        ],
+    )
+    .await;
+    let client = http();
+    let body = submit(&client, &handle, &estate, "nested").await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+
+    assert_eq!(
+        body["work"]["state"], "completed",
+        "a nested workflow must run to completion on the ordinary path: {body}"
+    );
+    assert_eq!(
+        stage_ids(data.path(), &work_id, KIND_STAGE_ENTERED),
+        [
+            "00-orient",
+            "10-investigate/00-lead",
+            "10-investigate/10-code",
+            "20-implement",
+        ],
+        "leaves enter in flattened document order, with composed hierarchical ids"
+    );
+    assert_eq!(
+        stage_ids(data.path(), &work_id, KIND_STAGE_COMPLETED).len(),
+        4,
+        "every leaf completes; the container itself never enters or completes"
+    );
+    // E3 / W1-02: a container is never a stage. No event anywhere names it.
+    let entered = stage_ids(data.path(), &work_id, KIND_STAGE_ENTERED);
+    assert!(
+        !entered.iter().any(|id| id == "10-investigate"),
+        "the container must never be entered as a stage: {entered:?}"
+    );
+    // E10: the wire shape stays the flat leaf list — hierarchical ids as
+    // opaque strings, with the container appearing nowhere in it.
+    let workflow = &body["workflow"];
+    assert_eq!(
+        workflow["stages"]
+            .as_array()
+            .expect("stages")
+            .iter()
+            .filter_map(|s| s.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "00-orient",
+            "10-investigate/00-lead",
+            "10-investigate/10-code",
+            "20-implement",
+        ],
+        "the wire shape stays the flat leaf list (E10): {workflow}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// W1 §13 item 9: a *leaf's* own declared output contract behaves
+/// identically nested and not. The same fixture as `m3_execution.rs`'s
+/// `t10`, one level down: the artifact is missing, the engine spends its one
+/// bounded re-prompt on that leaf, and the second miss parks the Work naming
+/// the leaf's own hierarchical id — not the container's.
+#[tokio::test]
+async fn a_nested_leafs_own_output_contract_is_enforced_exactly_as_a_flat_ones_is() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    support::scaffold_solo_estate(&estate, "solo");
+    let package = write_nested_workflow(&estate);
+    // The contract is declared on the nested leaf itself, at
+    // `10-investigate/00-lead/output/README.md`.
+    declare_output(&package.join("10-investigate"), "00-lead", "lead.md");
+
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete(), // 00-orient
+            FakeStep::complete(), // 00-lead: "done", lead.md absent
+            FakeStep::complete(), // the one bounded re-prompt: still absent
+        ],
+    )
+    .await;
+    let client = http();
+    let body = submit(&client, &handle, &estate, "nested").await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+
+    assert_eq!(
+        body["work"]["state"], "needs_input",
+        "the nested leaf's unmet contract must park the Work: {body}"
+    );
+    assert_eq!(
+        body["stage"]["stage_id"], "10-investigate/00-lead",
+        "the parked stage is the nested leaf, named by its composed id: {body}"
+    );
+    let reprompts = events_of(data.path(), &work_id, KIND_STAGE_OUTPUT_MISSING);
+    assert_eq!(reprompts.len(), 1, "exactly one bounded re-prompt");
+    assert_eq!(reprompts[0].payload["stage_id"], "10-investigate/00-lead");
+    assert_eq!(reprompts[0].payload["path"], "lead.md");
+    assert!(
+        reprompts[0].payload["container_id"].is_null(),
+        "a leaf's own contract is not a container's: {:?}",
+        reprompts[0].payload
+    );
+    let parked = events_of(data.path(), &work_id, "work.needs_input");
+    assert_eq!(
+        parked[0].payload["reason_code"],
+        REASON_STAGE_OUTPUT_MISSING
+    );
+    assert_eq!(parked[0].payload["stage_id"], "10-investigate/00-lead");
+    // Only the leaf that failed its contract is unfinished: 00-orient
+    // completed normally before it.
+    assert_eq!(
+        stage_ids(data.path(), &work_id, KIND_STAGE_COMPLETED),
+        ["00-orient"]
+    );
+
+    handle.shutdown().await;
+}
+
+/// E4: a container may declare its own output contract, checked at the
+/// moment its last leaf completes — the leaf itself having finished cleanly.
+/// The gate is the existing one verbatim (one bounded re-prompt of that
+/// leaf, then a `stage_output_missing`-class park), and what the operator is
+/// told names the **container**, so "the aggregate was never written" does
+/// not read as a complaint about a leaf that did its job.
+#[tokio::test]
+async fn a_container_that_never_produced_its_declared_output_parks_naming_the_container() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    support::scaffold_solo_estate(&estate, "solo");
+    let package = write_nested_workflow(&estate);
+    // Declared on the CONTAINER: `10-investigate/output/README.md`, sibling
+    // to `10-investigate/workflow.toml`, distinct from either leaf's own.
+    declare_output(&package, "10-investigate", "findings.md");
+
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete(), // 00-orient
+            FakeStep::complete(), // 10-investigate/00-lead
+            FakeStep::complete(), // 10-investigate/10-code — closes the container
+            FakeStep::complete(), // the container gate's one bounded re-prompt
+        ],
+    )
+    .await;
+    let client = http();
+    let body = submit(&client, &handle, &estate, "nested").await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+
+    assert_eq!(
+        body["work"]["state"], "needs_input",
+        "a closed container with an unmet contract must park the Work: {body}"
+    );
+    // The parked stage is still the leaf — a container has no StageRecord
+    // (E3) — but everything the operator reads names the container.
+    assert_eq!(body["stage"]["stage_id"], "10-investigate/10-code");
+    let reprompts = events_of(data.path(), &work_id, KIND_STAGE_OUTPUT_MISSING);
+    assert_eq!(
+        reprompts.len(),
+        1,
+        "the container gate reuses the same bounded re-prompt, not a new mechanism"
+    );
+    assert_eq!(reprompts[0].payload["container_id"], "10-investigate");
+    assert_eq!(reprompts[0].payload["stage_id"], "10-investigate/10-code");
+    assert_eq!(reprompts[0].payload["path"], "findings.md");
+    let parked = events_of(data.path(), &work_id, "work.needs_input");
+    assert_eq!(parked.len(), 1);
+    assert_eq!(
+        parked[0].payload["reason_code"],
+        REASON_STAGE_OUTPUT_MISSING
+    );
+    assert_eq!(parked[0].payload["container_id"], "10-investigate");
+    let prompt = parked[0].payload["prompt"].as_str().expect("prompt");
+    assert!(
+        prompt.contains("container 10-investigate") && prompt.contains("findings.md"),
+        "the operator must be told which container never produced what: {prompt}"
+    );
+    // The run never walked past the container: 20-implement never entered.
+    let entered = stage_ids(data.path(), &work_id, KIND_STAGE_ENTERED);
+    assert!(
+        !entered.iter().any(|id| id == "20-implement"),
+        "an unmet container contract must hold the run at its boundary: {entered:?}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// The other half of E4, which is the one that must not regress: a container
+/// whose declared output *is* present closes silently. No new event kind, no
+/// container-level record — the next leaf entering is the only evidence the
+/// container completed, exactly as it is for a top-level stage today.
+#[tokio::test]
+async fn a_container_whose_declared_output_is_present_closes_silently() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    support::scaffold_solo_estate(&estate, "solo");
+    let package = write_nested_workflow(&estate);
+    declare_output(&package, "10-investigate", "findings.md");
+
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete(),
+            FakeStep::complete(),
+            FakeStep::complete(),
+            FakeStep::complete(),
+        ],
+    )
+    .await;
+    let client = http();
+    let body = submit(&client, &handle, &estate, "nested").await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    let worktree = PathBuf::from(
+        body["surface"]["bindings"][0]["worktree_path"]
+            .as_str()
+            .expect("worktree"),
+    );
+
+    // The fake actor writes nothing, so the container's aggregate is
+    // missing on the first pass and the Work parks — the same gate the test
+    // above pins. Produce it and answer: the container closes, the run
+    // walks on to the container's next sibling, and the Work completes.
+    assert_eq!(body["work"]["state"], "needs_input", "{body}");
+    std::fs::create_dir_all(worktree.join("10-investigate/output")).expect("output dir");
+    std::fs::write(
+        worktree.join("10-investigate/output/findings.md"),
+        "what we found\n",
+    )
+    .expect("write the container's aggregate");
+
+    let (status, body) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/input"),
+        json!({"command_id": ulid(), "input": "there, the aggregate is written"}),
+    )
+    .await;
+    assert_eq!(status, 200, "input rejected: {body}");
+    assert_eq!(
+        body["work"]["state"], "completed",
+        "with the container's artifact present the run must walk past the boundary: {body}"
+    );
+    // No new vocabulary: the container's completion is evidenced only by
+    // the next leaf entering.
+    let entered = stage_ids(data.path(), &work_id, KIND_STAGE_ENTERED);
+    assert_eq!(
+        entered,
+        [
+            "00-orient",
+            "10-investigate/00-lead",
+            "10-investigate/10-code",
+            "20-implement",
+        ]
+    );
+    assert!(
+        Journal::replay_data_dir(data.path())
+            .expect("replay")
+            .map(|e| e.expect("event"))
+            .filter(|e| e.work_id.as_deref() == Some(&work_id))
+            .all(|e| !e.kind.starts_with("container.")),
+        "W1 adds no new event kind for a container"
+    );
+
+    handle.shutdown().await;
+}

--- a/tests/m11_nested_workflow.rs
+++ b/tests/m11_nested_workflow.rs
@@ -616,10 +616,12 @@ async fn a_composed_stage_id_round_trips_through_events_analytics_and_work_show(
 /// Nothing reconstructs a tree to do it. The pinned `workflow.bound` carries
 /// the already-flattened stage list, the journal carries whatever stage id
 /// was current, and "the deepest incomplete path" is simply the last
-/// `StageRecord` — whose id *is* that path by construction. This test kills
-/// the daemon while a nested leaf is the failed, current stage and asserts
-/// both halves: the restarted daemon names that leaf, and `retry` re-enters
-/// that leaf rather than an ancestor or the container's first child.
+/// `StageRecord` — whose id *is* that path by construction. This test
+/// genuinely kills the daemon (`DaemonHandle::kill`, an abrupt task-abort
+/// with no cooperative shutdown — see its doc comment) while a nested leaf
+/// is the failed, current stage, and asserts both halves: the restarted
+/// daemon names that leaf, and `retry` re-enters that leaf rather than an
+/// ancestor or the container's first child.
 #[tokio::test]
 async fn a_restarted_daemon_reconstructs_the_deepest_incomplete_path_and_retry_re_enters_it() {
     let repos = TempDir::new().expect("tempdir");
@@ -646,7 +648,7 @@ async fn a_restarted_daemon_reconstructs_the_deepest_incomplete_path_and_retry_r
         ["10-investigate/10-code"],
         "the failure event names the nested leaf, which IS the container-scoped failure report"
     );
-    handle.shutdown().await;
+    handle.kill().await;
 
     // A fresh daemon over the same journal, which re-reads nothing from the
     // repository. Its remaining script picks up where the dead one left off.

--- a/tests/m11_nested_workflow.rs
+++ b/tests/m11_nested_workflow.rs
@@ -17,6 +17,7 @@
 //!    CONTAINER (E4).
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 
 use serde_json::{Value, json};
@@ -27,12 +28,15 @@ use sergeant_rs::backend::fake::{FAKE_BACKEND_NAME, FakeBackend, FakeStep};
 use sergeant_rs::daemon::{self, DaemonConfig, DaemonHandle};
 use sergeant_rs::domain::event::Event;
 use sergeant_rs::domain::workflow::{
-    KIND_STAGE_COMPLETED, KIND_STAGE_ENTERED, KIND_STAGE_OUTPUT_MISSING,
+    KIND_STAGE_COMPLETED, KIND_STAGE_ENTERED, KIND_STAGE_FAILED, KIND_STAGE_OUTPUT_MISSING,
     REASON_STAGE_OUTPUT_MISSING,
 };
+use sergeant_rs::runtime::analytics::Analytics;
 use sergeant_rs::runtime::journal::Journal;
 
 mod support;
+
+const SGT: &str = env!("CARGO_BIN_EXE_sgt");
 
 // ---------------------------------------------------------------- helpers
 
@@ -147,6 +151,18 @@ async fn post(
     let status = resp.status();
     let value: Value = resp.json().await.expect("json body");
     (status, value)
+}
+
+async fn get(client: &reqwest::Client, handle: &DaemonHandle, path: &str) -> Value {
+    client
+        .get(format!("{}{path}", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .send()
+        .await
+        .expect("request")
+        .json()
+        .await
+        .expect("json body")
 }
 
 async fn submit(
@@ -471,6 +487,213 @@ async fn a_container_whose_declared_output_is_present_closes_silently() {
             .all(|e| !e.kind.starts_with("container.")),
         "W1 adds no new event kind for a container"
     );
+
+    handle.shutdown().await;
+}
+
+/// W1 §13 item 4: a composed hierarchical id is an opaque string everywhere
+/// downstream of the loader, and this proves it at each of the four places
+/// that could have parsed it and did not have to — the journal's own events,
+/// the analytics `stages` rows folded from them, the read surface `sgt work
+/// show` prints, and (below) a restarted daemon's reconstruction of the
+/// deepest incomplete path.
+///
+/// The claim is deliberately negative: **nothing new was needed**. The
+/// reducer, the fold and the read model never parsed a stage id's structure,
+/// so a `/` in one changes nothing for them — which is the whole reason
+/// hierarchy was encoded in the existing string id (W1-04) rather than in a
+/// parallel tree.
+#[tokio::test]
+async fn a_composed_stage_id_round_trips_through_events_analytics_and_work_show() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    support::scaffold_solo_estate(&estate, "solo");
+    write_nested_workflow(&estate);
+
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete(),                       // 00-orient
+            FakeStep::needs_input("which lead first?"), // 10-investigate/00-lead parks here
+        ],
+    )
+    .await;
+    let client = http();
+    let body = submit(&client, &handle, &estate, "nested").await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    assert_eq!(body["work"]["state"], "needs_input", "{body}");
+
+    // 1. Events. Every stage event for the nested leaf carries the composed
+    //    id verbatim — no escaping, no splitting, no parent field.
+    assert_eq!(
+        stage_ids(data.path(), &work_id, KIND_STAGE_ENTERED),
+        ["00-orient", "10-investigate/00-lead"]
+    );
+    assert_eq!(
+        stage_ids(data.path(), &work_id, "stage.needs_input"),
+        ["10-investigate/00-lead"]
+    );
+
+    // 2. Analytics. The `stages` table is folded from those events by a pure
+    //    reducer; the composed id lands in its `stage_id` column unchanged,
+    //    keyed and indexed like any other.
+    let events: Vec<Result<Event, _>> = Journal::replay_data_dir(data.path())
+        .expect("replay")
+        .collect();
+    let mut analytics = Analytics::in_memory(events).expect("fold the journal");
+    let stages = analytics.table_rows("stages").expect("stages table");
+    let stage_id_column = stages
+        .columns
+        .iter()
+        .position(|c| c == "stage_id")
+        .expect("stage_id column");
+    let idx_column = stages
+        .columns
+        .iter()
+        .position(|c| c == "idx")
+        .expect("idx column");
+    let nested_row = stages
+        .rows
+        .iter()
+        .find(|row| row[stage_id_column] == json!("10-investigate/00-lead"))
+        .unwrap_or_else(|| panic!("no analytics row for the nested leaf: {:?}", stages.rows));
+    assert_eq!(
+        nested_row[idx_column],
+        json!(1),
+        "the analytics row keeps the leaf's flat index: {nested_row:?}"
+    );
+
+    // 3. The read surface. `sgt work show` prints the same record the API
+    //    serves, so this spawns the real binary rather than asserting the
+    //    API body twice.
+    //
+    //    `spawn_blocking`, not a bare `Command::output()`: this daemon lives
+    //    on the test's own current-thread runtime, so blocking that thread
+    //    on a child process that is trying to reach it would deadlock the
+    //    server it is calling.
+    let (data_dir, cwd, id) = (data.path().to_path_buf(), estate.clone(), work_id.clone());
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(SGT)
+            .arg("--data-dir")
+            .arg(&data_dir)
+            .args(["work", "show", &id])
+            .current_dir(&cwd)
+            .stdin(std::process::Stdio::null())
+            .output()
+            .expect("run sgt work show")
+    })
+    .await
+    .expect("join the spawned CLI");
+    assert!(
+        output.status.success(),
+        "sgt work show failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let shown: Value =
+        serde_json::from_slice(&output.stdout).expect("work show prints one JSON record");
+    assert_eq!(
+        shown["stage"]["stage_id"], "10-investigate/00-lead",
+        "work show must name the leaf by its composed id: {shown}"
+    );
+    assert_eq!(
+        shown["workflow"]["stages"][1], "10-investigate/00-lead",
+        "and carry the flat leaf list E10 settled: {shown}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// W1 §9 / §13 item 4's recovery half: a daemon that dies mid-nest comes
+/// back knowing exactly which leaf was in flight, *from the journal alone*.
+///
+/// Nothing reconstructs a tree to do it. The pinned `workflow.bound` carries
+/// the already-flattened stage list, the journal carries whatever stage id
+/// was current, and "the deepest incomplete path" is simply the last
+/// `StageRecord` — whose id *is* that path by construction. This test kills
+/// the daemon while a nested leaf is the failed, current stage and asserts
+/// both halves: the restarted daemon names that leaf, and `retry` re-enters
+/// that leaf rather than an ancestor or the container's first child.
+#[tokio::test]
+async fn a_restarted_daemon_reconstructs_the_deepest_incomplete_path_and_retry_re_enters_it() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    support::scaffold_solo_estate(&estate, "solo");
+    write_nested_workflow(&estate);
+
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete(),                      // 00-orient
+            FakeStep::complete(),                      // 10-investigate/00-lead
+            FakeStep::fail("the nested leaf gave up"), // 10-investigate/10-code
+        ],
+    )
+    .await;
+    let client = http();
+    let body = submit(&client, &handle, &estate, "nested").await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    assert_eq!(body["work"]["state"], "failed", "{body}");
+    assert_eq!(
+        stage_ids(data.path(), &work_id, KIND_STAGE_FAILED),
+        ["10-investigate/10-code"],
+        "the failure event names the nested leaf, which IS the container-scoped failure report"
+    );
+    handle.shutdown().await;
+
+    // A fresh daemon over the same journal, which re-reads nothing from the
+    // repository. Its remaining script picks up where the dead one left off.
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete(), // the retried 10-investigate/10-code
+            FakeStep::complete(), // 20-implement
+        ],
+    )
+    .await;
+    let view = get(&client, &handle, &format!("/v1/work/{work_id}")).await;
+    assert_eq!(
+        view["stage"]["stage_id"], "10-investigate/10-code",
+        "the restarted daemon's current stage is the deepest incomplete path: {view}"
+    );
+    assert_eq!(view["stage"]["index"], 2, "at its flat index: {view}");
+    assert_eq!(
+        view["stage"]["of"], 4,
+        "of the flattened leaf count: {view}"
+    );
+
+    let (status, body) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/retry"),
+        json!({"command_id": ulid()}),
+    )
+    .await;
+    assert_eq!(status, 200, "retry rejected: {body}");
+    assert_eq!(
+        body["work"]["state"], "completed",
+        "the retried nested leaf and the container's sibling must finish the run: {body}"
+    );
+    let entered = stage_ids(data.path(), &work_id, KIND_STAGE_ENTERED);
+    assert_eq!(
+        entered,
+        [
+            "00-orient",
+            "10-investigate/00-lead",
+            "10-investigate/10-code",
+            "10-investigate/10-code", // the retry: same leaf, attempt 2
+            "20-implement",
+        ],
+        "retry re-entered exactly the leaf that failed — never an ancestor container, \
+         never the container's first child"
+    );
+    let retried: Vec<u64> = events_of(data.path(), &work_id, KIND_STAGE_ENTERED)
+        .iter()
+        .filter(|e| e.payload["stage_id"] == "10-investigate/10-code")
+        .map(|e| e.payload["attempt"].as_u64().unwrap_or(1))
+        .collect();
+    assert_eq!(retried, [1, 2], "attempts 1 and 2 of the same nested leaf");
 
     handle.shutdown().await;
 }

--- a/tests/m11_nested_workflow.rs
+++ b/tests/m11_nested_workflow.rs
@@ -14,7 +14,13 @@
 //!    bypassed by nesting);
 //! 3. a container that declared its own output contract is checked when its
 //!    last leaf completes, and an unmet one parks the Work naming the
-//!    CONTAINER (E4).
+//!    CONTAINER (E4);
+//! 4. a composed id round-trips through the journal, the analytics fold and
+//!    `sgt work show`, and a restarted daemon reconstructs the deepest
+//!    incomplete path from the journal alone (W1 §13 item 4);
+//! 5. the multi-boundary case the plan panel named — a three-level fixture
+//!    whose deepest leaf is simultaneously the last leaf of two ancestor
+//!    containers, gated innermost first.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -694,6 +700,187 @@ async fn a_restarted_daemon_reconstructs_the_deepest_incomplete_path_and_retry_r
         .map(|e| e.payload["attempt"].as_u64().unwrap_or(1))
         .collect();
     assert_eq!(retried, [1, 2], "attempts 1 and 2 of the same nested leaf");
+
+    handle.shutdown().await;
+}
+
+/// The three-level fixture the plan panel named as the recon's sharpest
+/// risk:
+///
+/// ```text
+/// deep/
+///   00-orient/CONTEXT.md
+///   10-investigate/workflow.toml
+///     00-lead/CONTEXT.md
+///     10-deep/workflow.toml
+///       00-inner/CONTEXT.md
+///   20-implement/CONTEXT.md
+/// ```
+///
+/// Its third leaf, `10-investigate/10-deep/00-inner`, is simultaneously the
+/// last leaf of `10-investigate/10-deep` **and** of `10-investigate` — one
+/// `StageCompleted` closing two container boundaries at once.
+fn write_three_level_workflow(root: &Path) -> PathBuf {
+    let package = root.join(".sergeant/workflows/deep");
+    write_package(
+        &package,
+        "deep",
+        &["00-orient", "10-investigate", "20-implement"],
+    );
+    write_stage(&package, "00-orient", "orient");
+    write_stage(&package, "20-implement", "implement");
+    let investigate = package.join("10-investigate");
+    write_package(&investigate, "10-investigate", &["00-lead", "10-deep"]);
+    write_stage(&investigate, "00-lead", "lead");
+    let deep = investigate.join("10-deep");
+    write_package(&deep, "10-deep", &["00-inner"]);
+    write_stage(&deep, "00-inner", "the innermost procedure");
+    package
+}
+
+/// E4's multi-boundary case, end to end: when one leaf closes two
+/// containers that both declared an output contract, the boundaries are
+/// evaluated **innermost first**, one at a time, and the run walks on only
+/// once every one of them is satisfied.
+///
+/// The sequencing is the assertion. The inner container's unmet contract is
+/// what the operator hears about first; only after it is satisfied does the
+/// outer one become the thing holding the run. Neither is skipped, and
+/// neither is reported at the same instant as the other — a leaf that ends
+/// three packages must not produce three simultaneous parks.
+///
+/// It also pins the re-prompt budget's shape: bounded per leaf *attempt*,
+/// not per contract. The one SEND this attempt is allowed goes to the first
+/// unmet contract; every later one on the same attempt parks straight away
+/// rather than re-prompting again.
+#[tokio::test]
+async fn a_leaf_that_closes_two_containers_at_once_gates_them_innermost_first() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    support::scaffold_solo_estate(&estate, "solo");
+    let package = write_three_level_workflow(&estate);
+    declare_output(&package, "10-investigate", "findings.md");
+    declare_output(&package.join("10-investigate"), "10-deep", "inner.md");
+
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete(), // 00-orient
+            FakeStep::complete(), // 10-investigate/00-lead
+            FakeStep::complete(), // 00-inner: closes both containers, neither satisfied
+            FakeStep::complete(), // the one bounded re-prompt (the INNER contract)
+            FakeStep::complete(), // after the answer: inner satisfied, outer is not
+            FakeStep::complete(), // after the second answer: both satisfied
+            FakeStep::complete(), // 20-implement
+        ],
+    )
+    .await;
+    let client = http();
+    let body = submit(&client, &handle, &estate, "deep").await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+    let worktree = PathBuf::from(
+        body["surface"]["bindings"][0]["worktree_path"]
+            .as_str()
+            .expect("worktree"),
+    );
+
+    // Innermost first: the inner container is the one that re-prompted and
+    // then parked. The outer one has said nothing yet.
+    assert_eq!(body["work"]["state"], "needs_input", "{body}");
+    assert_eq!(body["stage"]["stage_id"], "10-investigate/10-deep/00-inner");
+    let reprompts = events_of(data.path(), &work_id, KIND_STAGE_OUTPUT_MISSING);
+    assert_eq!(
+        reprompts.len(),
+        1,
+        "one bounded re-prompt, not one per boundary"
+    );
+    assert_eq!(
+        reprompts[0].payload["container_id"], "10-investigate/10-deep",
+        "the innermost unmet contract is the one that gets the attempt's one SEND"
+    );
+    let parked = events_of(data.path(), &work_id, "work.needs_input");
+    assert_eq!(parked.len(), 1);
+    assert_eq!(parked[0].payload["container_id"], "10-investigate/10-deep");
+    assert_eq!(parked[0].payload["path"], "inner.md");
+
+    // Satisfy the inner contract and answer. Same leaf, same attempt — so
+    // the budget is spent, and the *outer* container now parks the run
+    // immediately rather than re-prompting a second time.
+    std::fs::create_dir_all(worktree.join("10-investigate/10-deep/output")).expect("output dir");
+    std::fs::write(
+        worktree.join("10-investigate/10-deep/output/inner.md"),
+        "the inner aggregate\n",
+    )
+    .expect("write inner.md");
+    let (status, body) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/input"),
+        json!({"command_id": ulid(), "input": "inner aggregate written"}),
+    )
+    .await;
+    assert_eq!(status, 200, "input rejected: {body}");
+    assert_eq!(
+        body["work"]["state"], "needs_input",
+        "the outer container's contract is still unmet, so the run must still be held: {body}"
+    );
+    let parked = events_of(data.path(), &work_id, "work.needs_input");
+    assert_eq!(parked.len(), 2, "the outer boundary parks in its own turn");
+    assert_eq!(
+        parked[1].payload["container_id"], "10-investigate",
+        "and it is the OUTER container that is named now: {:?}",
+        parked[1].payload
+    );
+    assert_eq!(parked[1].payload["path"], "findings.md");
+    assert_eq!(
+        events_of(data.path(), &work_id, KIND_STAGE_OUTPUT_MISSING).len(),
+        1,
+        "still exactly one re-prompt across this attempt, whatever it was for"
+    );
+    // Neither park ever let the run past the boundary.
+    assert!(
+        !stage_ids(data.path(), &work_id, KIND_STAGE_ENTERED)
+            .iter()
+            .any(|id| id == "20-implement"),
+        "the run must be held at the leaf that closes both containers"
+    );
+
+    // Satisfy the outer contract too: both boundaries close and the run
+    // walks on to the container's sibling and finishes.
+    std::fs::create_dir_all(worktree.join("10-investigate/output")).expect("output dir");
+    std::fs::write(
+        worktree.join("10-investigate/output/findings.md"),
+        "the outer aggregate\n",
+    )
+    .expect("write findings.md");
+    let (status, body) = post(
+        &client,
+        &handle,
+        &format!("/v1/work/{work_id}/input"),
+        json!({"command_id": ulid(), "input": "outer aggregate written"}),
+    )
+    .await;
+    assert_eq!(status, 200, "input rejected: {body}");
+    assert_eq!(
+        body["work"]["state"], "completed",
+        "with both contracts satisfied the run must complete: {body}"
+    );
+    assert_eq!(
+        stage_ids(data.path(), &work_id, KIND_STAGE_ENTERED),
+        [
+            "00-orient",
+            "10-investigate/00-lead",
+            "10-investigate/10-deep/00-inner",
+            "20-implement",
+        ],
+        "one entry per leaf: closing two containers never re-enters or duplicates a stage"
+    );
+    assert_eq!(
+        stage_ids(data.path(), &work_id, KIND_STAGE_COMPLETED).len(),
+        4,
+        "and each leaf completes exactly once"
+    );
 
     handle.shutdown().await;
 }

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -750,6 +750,123 @@ async fn t1c_extend_reaches_the_real_api_with_the_typed_turn_count() {
     handle.shutdown().await;
 }
 
+/// A two-level nested workflow package (S2 W1 / decision E1) in the estate:
+/// `10-investigate` is a stage directory that holds its own `workflow.toml`,
+/// so it is a container and its leaves flatten to composed ids.
+fn write_nested_workflow(root: &Path) {
+    let dir = root.join(".sergeant/workflows/nested");
+    std::fs::create_dir_all(&dir).expect("workflow dir");
+    std::fs::write(
+        dir.join("workflow.toml"),
+        "[workflow]\nname = \"nested\"\nversion = \"1\"\n\
+         stages = [\"00-orient\", \"10-investigate\", \"20-implement\"]\n",
+    )
+    .expect("workflow.toml");
+    for stage in ["00-orient", "20-implement"] {
+        std::fs::create_dir_all(dir.join(stage)).expect("stage dir");
+        std::fs::write(dir.join(stage).join("CONTEXT.md"), "context").expect("CONTEXT.md");
+    }
+    let investigate = dir.join("10-investigate");
+    std::fs::create_dir_all(&investigate).expect("container dir");
+    std::fs::write(
+        investigate.join("workflow.toml"),
+        "[workflow]\nname = \"10-investigate\"\nversion = \"1\"\n\
+         stages = [\"00-lead\", \"10-code\"]\n",
+    )
+    .expect("nested workflow.toml");
+    for stage in ["00-lead", "10-code"] {
+        std::fs::create_dir_all(investigate.join(stage)).expect("nested stage dir");
+        std::fs::write(investigate.join(stage).join("CONTEXT.md"), "context").expect("CONTEXT.md");
+    }
+}
+
+/// S2 W1 / decision E10, end to end against a live daemon: a Work bound to a
+/// nested workflow renders its rail as a **tree** — one indented header per
+/// container, leaves under it — while the header's stage coordinate names
+/// the current leaf by its full composed id.
+///
+/// Both halves are deliberately asserted here rather than only in
+/// `work_view.rs`'s own unit tests. The wire shape stayed flat
+/// (`workflow.stages` is still one array of leaf ids, and `stage_label`
+/// still does `index + 1` of `of`), so the tree exists only in the render —
+/// which means a rig that unit-tested `workflow_lines` alone could not tell
+/// whether the API actually serves ids with `/` in them at all.
+#[tokio::test]
+async fn t1e_a_nested_workflow_renders_as_an_indented_tree_over_the_live_api() {
+    let data = TempDir::new().expect("tempdir");
+    let (estate, mount) = solo_estate("svc");
+    write_nested_workflow(estate.path());
+
+    let (handle, _fake) = start_fake(
+        data.path(),
+        estate.path(),
+        [
+            FakeStep::complete(),                 // 00-orient
+            FakeStep::needs_input("which lead?"), // 10-investigate/00-lead parks here
+        ],
+    )
+    .await;
+    let client = client_for(&handle, estate.path());
+    let work = submit(
+        &handle,
+        estate.path(),
+        &mount,
+        "investigate deeply",
+        "nested",
+    )
+    .await;
+
+    let mut app = App::new();
+    app.refresh(&client).await.expect("first read");
+    let action = Action::OpenWork(work.clone());
+    assert_eq!(app.execute(&client, action).await, Action::None);
+
+    // The header coordinate: `stage_label` renders a composed id as-is,
+    // with the flat position arithmetic E10 preserved.
+    let terminal = render(&app);
+    assert_shows(
+        &terminal,
+        "10-investigate/00-lead",
+        "the current stage's composed id",
+    );
+
+    // The Workflow tab (§13.4's rail), now a tree. `Tab` rather than `2`,
+    // the same way t1 above reaches it: Home's own form still owns the digit
+    // keys here, and leaving it would close the open Work.
+    app.on_key(ratatui::crossterm::event::KeyCode::Tab);
+    let terminal = render(&app);
+    // Asserted as whole-line substrings (the rail's rows sit inside a
+    // bordered pane, so a row never *begins* at column 0): the container
+    // header carries its own glyph and a plain done/total over the leaves it
+    // owns, each of those leaves is indented one level under it, and the
+    // container's sibling stays at the top level.
+    for row in [
+        "✓ 00-orient",
+        "⠹ 10-investigate/  0/2",
+        "  ⠹ 00-lead",
+        "  · 10-code",
+        "· 20-implement",
+    ] {
+        assert_shows(&terminal, row, "a row of the nested rail");
+    }
+    let lines = screen_lines(&terminal);
+    let leaf = lines
+        .iter()
+        .find(|line| line.contains("⠹ 00-lead"))
+        .expect("the current leaf's row");
+    assert!(
+        !leaf.contains("10-investigate/00-lead"),
+        "a nested leaf shows its own name under its container header, not the composed id \
+         again: {leaf:?}"
+    );
+    assert!(
+        !screen_text(&terminal).contains('%'),
+        "never a percent bar, containers included (Decision T2-50)"
+    );
+
+    handle.shutdown().await;
+}
+
 /// §12.1 end to end: the Add-repo form's real `POST /v1/estate/repos` —
 /// kicked off the render loop rather than awaited inline (the spinner/
 /// elapsed rule), per T3's own routes over `crate::domain::manifest::


### PR DESCRIPTION
Wave V1b of sprint S2: the nested-package half completes. 6 implement + 2 fixer commits.

- **Cycle guard**: ancestry-based visited set (the same package reached via two different containers still loads with distinct composed IDs; only self-containment is a cycle) — named fail-closed `NestedPackageCycle`, no depth cap (E14 stands), both halves pinned.
- **E3**: journaled `ContainerBoundary` side-table on `WorkflowDefinition` built at V1a's splice site; deliberately NOT folded into content-hash (derived from the flat list — folding would double-count; pinned by test). Containers still have no StageRecord.
- **E3/E4**: the `StageCompleted` arm checks each closing container's declared contract with the existing gate mechanics — bounded re-prompt of the closing leaf, then `stage_output_missing`-class needs_input carrying a new `container_id` field (leaf `stage_id` retained so the reducer's park-fold keeps working; the operator-visible text names the container). Multi-boundary closes innermost-first — **panel caught a real HIGH here**: the tie-break comparator mismatched sides on equal ranges; fixed with a proper compound key + a sole-stage-container regression fixture.
- **W1 §13.4**: composed IDs pinned round-tripping through events, analytics rows, `work show`, and recovery — whose test now genuinely kills the daemon (new in-process `DaemonHandle::kill()`, the analogue of m6's SIGKILL rig; fixer-driven upgrade from graceful shutdown).
- **E10**: the TUI rail renders the flat leaf list as an indented tree with per-container aggregation; `stage_label` needed nothing (R1, pinned); geometry entry names the pre-existing tall-rail pane limit honestly.
- `m11_nested_workflow.rs` (7 tests, coverage stage C3 — its round-trip spawns a real `sgt work show`): two-level e2e, leaf contracts identical nested/flat, container-gate needs_input, multi-boundary, recovery-mid-nest.

Gates: TDD per deliverable; panel → refuters → 2 confirmed fixed (comparator HIGH, kill-honesty MEDIUM); verify: **full suite green, 0 failures, 1063 lib + all integration suites**, #231(b) green, tree clean.

Rungs: E3/E4/E10 J3 (plan register + the recon's outcome table), R2/R3 throughout; implementer judgment calls J1-cited per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4