### PR TITLE
V1d: probe children die with their probe and their daemon (#310)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,5 +22,11 @@
 <!-- Tick what applies; the ledger is append-only.
 - [ ] No deviation from the proposal, or the deviation is registered in the workspace knowledge library's deviation register (D-row)
 - [ ] Deferred findings landed as backlog rows or GitHub issues, not silence
-- [ ] After the suites, both orphan-check patterns find nothing: `pgrep -f "debug/sgt [-]-data-dir"` (a test's own built binary — `release/sgt` too, if the change touched a release-profile path) and `pgrep -af "cargo/bin/[s]gt"` (an installed binary this session's own `sgt init`/`install-service` work may have started — the host daemon now outlives any one estate, so it does not stop merely because the test that spawned it exited)
+- [ ] After the suites, all four orphan-check patterns find nothing:
+  - `pgrep -f "debug/sgt [-]-data-dir"` — a test's own built binary (`release/sgt` too, if the change touched a release-profile path)
+  - `pgrep -af "cargo/bin/[s]gt"` — an installed binary this session's own `sgt init`/`install-service` work may have started; the host daemon outlives any one estate, so it does not stop merely because the test that spawned it exited
+  - `pgrep -x opencode` — a probe-spawned `opencode serve` (#310)
+  - `pgrep -f 'codex.*app[-]server'` — a probe-spawned `codex app-server` (#310)
+
+  The last two exist because the first two are both `sgt`-shaped and the species that actually accumulated is not. Dozens of ~265 MB `opencode serve` children sat on PID 1 for a working day while every orphan check reported clean, and four OOM-driven session and host deaths sat on top of that. A non-empty result from any of these is a failure to fix, never a note to file.
 -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2923,6 +2923,7 @@ dependencies = [
  "duckdb",
  "http-body-util",
  "include_dir",
+ "libc",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,17 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3"
 ulid = "3.0.0"
 
+# #310: `prctl(PR_SET_PDEATHSIG, SIGKILL)` on a probe child, and nothing else.
+# R3/R4 fail — neither the standard library nor any process API this crate
+# already uses can couple a child's death to its parent's; only the kernel can,
+# and only through this call. R5 rather than R7: libc is already in this
+# crate's dependency graph (transitively, via tokio/reqwest/duckdb), so
+# declaring it directly adds a line here and no crate to the build. `nix` was
+# the alternative and would be a genuinely new graph edge for one constant and
+# one call. Unix-gated because that is the only place it is referenced.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 # M5 Unknown #1 — "the duckdb crate's bundled-build cost in this container
 # (compile time and disk) — measure first". Measured here, dev profile, before
 # this override: libduckdb.a 2.08 GB, liblibduckdb_sys.rlib 2.0 GB, and every

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -73,3 +73,16 @@ cov_stage_begin c3-m7_docker_executor
 cov_run cargo llvm-cov --no-report --test m7_docker_executor --locked || cov_fail "m7_docker_executor failed under instrumentation"
 cov_stage_end 1 "the m7 test binary must write its own profile; container subprocesses are not \
 required because the suite self-skips where Docker is unreachable"
+
+# S2 V1d, wired at birth (#310): four of this suite's six tests spawn real
+# processes — a bare `sgt daemon` it SIGKILLs mid-probe-walk, and this test
+# binary re-executed as a parent whose hardened child has to die with it.
+# Belongs beside m2/m6, not in C2's no-daemon-of-its-own bucket. Floor 2: the
+# test binary plus at least one spawned daemon. Note that the SIGKILLed
+# daemons flush nothing at exit by construction — the profiles that arrive
+# here come from the suite's politely-reaped daemons, which is why the floor
+# is 2 and not the number of processes it starts.
+cov_stage_begin c3-v1d_probe_child_lifecycle
+cov_run cargo llvm-cov --no-report --test v1d_probe_child_lifecycle --locked || cov_fail "v1d_probe_child_lifecycle failed under instrumentation"
+cov_stage_end 2 "v1d spawns real sgt daemons and re-executes its own test binary; more than the \
+test binary's own profile must arrive, or no subprocess flushed"

--- a/src/backend/agy.rs
+++ b/src/backend/agy.rs
@@ -236,6 +236,7 @@ use super::{
     ExecutionHandle, NativeEvent, NativeState, Observation, PreparedExecution, ProbeReport,
     ResumeRequest, RuntimeScope, StartRequest,
 };
+use crate::backend::child;
 use crate::domain::event::{EventDraft, EventSource};
 use crate::domain::profile::Profile;
 use crate::runtime::blob::BlobStore;
@@ -3086,6 +3087,10 @@ impl AgyBackend {
             &self.config.env,
             self.config.settings_home.as_deref(),
         );
+        // #310: `output()` waits, so this child cannot outlive *this call* —
+        // but it can outlive a daemon SIGKILLed during the call, and a
+        // `--help` that never returns is exactly how one gets stuck there.
+        child::harden_probe_child(&mut command);
         let out = command.output().map_err(|e| {
             format!(
                 "capability probe: cannot run {exe:?} {}: {e} (kind: {:?})",
@@ -3117,10 +3122,25 @@ impl AgyBackend {
             &self.config.env,
             self.config.settings_home.as_deref(),
         );
-        let Ok(mut child) = command.spawn() else {
+        // #310: this is a *full* `agy` invocation, not a `--help`, so it can
+        // spawn children of its own and it can block indefinitely on an
+        // interactive login prompt. Hardened and group-led so the kill below
+        // reaches whatever it started, and so a daemon SIGKILLed while this
+        // is in flight takes it with it instead of reparenting it to init.
+        child::harden_probe_child(&mut command);
+        let Ok(mut spawned) = command.spawn() else {
             return ConfigProbe::default();
         };
-        let Some(mut stdout) = child.stdout.take() else {
+        let stdout = spawned.stdout.take();
+        let stderr = spawned.stderr.take();
+        // Owns the child from here on. Every exit from this function below —
+        // the early return, the budget expiry, the ordinary answer, a panic
+        // in the parse — goes through this guard's `Drop`, which is the only
+        // cleanup an early return cannot skip. Before #310 the `stdout.take()`
+        // arm returned with the child still running and nothing at all
+        // holding it.
+        let probe_child = ConfigProbeChild::adopt(spawned);
+        let Some(mut stdout) = stdout else {
             return ConfigProbe::default();
         };
         // Piped but deliberately unread here: a probe that never touches this
@@ -3128,31 +3148,28 @@ impl AgyBackend {
         // its own thread purely so a child that writes to it does not block on
         // (or SIGPIPE from) a closed pipe while this call is still waiting on
         // stdout.
-        if let Some(mut stderr) = child.stderr.take() {
+        if let Some(mut stderr) = stderr {
             std::thread::spawn(move || {
                 let mut sink = Vec::new();
                 let _ = stderr.read_to_end(&mut sink);
             });
         }
-        let child = Arc::new(Mutex::new(child));
         let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(1);
         std::thread::spawn(move || {
             let mut buf = Vec::new();
             let _ = stdout.read_to_end(&mut buf);
             let _ = tx.send(buf);
         });
-        let stdout_bytes = match rx.recv_timeout(CONFIG_PROBE_BUDGET) {
-            Ok(buf) => buf,
-            Err(_) => {
-                // Most likely cause, per the measurement in `CONFIG_PROBE_BUDGET`'s
-                // doc: an unauthenticated `agy` blocked this call on an
-                // interactive login prompt. Killed and treated as any other
-                // probe failure — never propagated as a hang.
-                let _ = child.lock().expect("agy config-probe child lock").kill();
-                Vec::new()
-            }
-        };
-        let _ = child.lock().expect("agy config-probe child lock").wait();
+        // An expired budget yields no bytes at all. Most likely cause, per the
+        // measurement in `CONFIG_PROBE_BUDGET`'s doc: an unauthenticated `agy`
+        // blocked this call on an interactive login prompt. Killed by the
+        // guard below and treated as any other probe failure — never
+        // propagated as a hang.
+        let stdout_bytes = rx.recv_timeout(CONFIG_PROBE_BUDGET).unwrap_or_default();
+        // Explicit, at the completion point, rather than left to scope end:
+        // the measurement is finished, so the child has no further reason to
+        // exist and the parse below must not run while it does.
+        drop(probe_child);
         serde_json::from_slice::<Value>(&stdout_bytes)
             .map(|value| decode_config_probe(&value))
             .unwrap_or_default()
@@ -3167,6 +3184,7 @@ impl AgyBackend {
             &self.config.env,
             self.config.settings_home.as_deref(),
         );
+        child::harden_probe_child(&mut version_command);
         let version_out = match version_command.output() {
             Ok(out) => out,
             Err(e) => {
@@ -4134,37 +4152,54 @@ impl AgyBackend {
 
 // ------------------------------------------------------------ turn reader
 
-/// Send `SIGKILL` to a whole process group.
+/// One `agy -p /config` probe child, killed group-first and reaped when this
+/// guard drops (#310 requirement 2: a probe's child dies when the probe
+/// completes, with a `Drop` backstop covering every path that is not the
+/// ordinary one — an early return, an expired budget, a panic in the parse).
 ///
-/// Nothing gates this on the leader being alive, and that is the point: the
-/// group can outlive its leader (opencode probe 11), so the group id is
-/// signalled unconditionally and `ESRCH` (an already-empty group) is success,
-/// not an error to report.
-fn kill_process_group(pgid: Option<u32>) {
-    let Some(pgid) = pgid else { return };
-    #[cfg(unix)]
-    {
-        if let Err(e) = Command::new("/bin/sh")
-            .arg("-c")
-            .arg(format!("kill -KILL -{pgid}"))
-            .output()
-        {
-            tracing::warn!(
-                pgid,
-                error = %e,
-                "could not run the process-group kill; the turn's direct child is all that \
-                 INTERRUPT reached — any commands it spawned may still be running"
-            );
+/// The group goes first for the reason [`kill_process_group`] documents: this
+/// is a whole agent invocation, not a `--help`, so it may have started
+/// commands of its own, and a group routinely outlives its leader.
+struct ConfigProbeChild {
+    child: Child,
+    pgid: u32,
+    /// Deregisters this pgid from the owning probe walk's live set. Held,
+    /// never read.
+    _registration: child::ProbeChildRegistration,
+}
+
+impl ConfigProbeChild {
+    fn adopt(spawned: Child) -> Self {
+        let pgid = spawned.id();
+        Self {
+            child: spawned,
+            pgid,
+            _registration: child::register_probe_child(pgid),
         }
     }
-    #[cfg(not(unix))]
-    {
-        tracing::warn!(
-            pgid,
-            "no process-group signal mechanism on this platform; killing only the direct child \
-             — any commands it spawned may still be running"
-        );
+}
+
+impl Drop for ConfigProbeChild {
+    fn drop(&mut self) {
+        kill_process_group(Some(self.pgid));
+        let _ = self.child.kill();
+        // Reaped, not merely signalled: an un-`wait`ed child becomes a zombie
+        // the instant it exits, and a zombie still answers `kill(pid, 0)` as
+        // alive — which is exactly what an orphan check would then report.
+        let _ = self.child.wait();
     }
+}
+
+/// Kill a turn's whole process group, by the pgid recorded at spawn.
+///
+/// One line, because #310 moved the implementation to
+/// [`crate::backend::child::kill_process_group`] — three adapters carried a
+/// byte-identical private copy of it and the probe path needed a fourth (R2).
+/// The behaviour and every reason for it are documented there; this alias
+/// stays so the call sites in this module keep reading as adapter-local
+/// vocabulary.
+fn kill_process_group(pgid: Option<u32>) {
+    crate::backend::child::kill_process_group(pgid);
 }
 
 /// The group kill above plus `Child::kill()` on the direct child as a belt, for

--- a/src/backend/child.rs
+++ b/src/backend/child.rs
@@ -181,7 +181,10 @@ pub fn harden_probe_child(command: &mut Command) {
             });
         }
     }
-    #[cfg(not(any(unix, target_os = "linux")))]
+    // `target_os = "linux"` implies `unix`, so this is simply the non-unix
+    // case: no process groups, no parent-death signal, nothing to arm. Named
+    // rather than omitted so a Windows build compiles and the gap is visible.
+    #[cfg(not(unix))]
     {
         let _ = command;
     }

--- a/src/backend/child.rs
+++ b/src/backend/child.rs
@@ -1,0 +1,482 @@
+//! Child-process lifecycle shared by every adapter (#310).
+//!
+//! ## The measurement this module exists for
+//!
+//! Diagnosed on Cerberus 2026-08-26 after four OOM-driven session and host
+//! deaths: `daemon::start_with` probes every registered backend, the opencode
+//! probe runs a real `opencode serve --port 0` and the codex probe a real
+//! `codex app-server --listen stdio://`, and the suites start daemons by the
+//! hundred and kill them abruptly. A daemon killed while a probe child is
+//! live leaves that child reparented to init, where it stays — measured at
+//! ~265-342 MB RSS each, ages up to many hours, one killed at 74 GB total-vm.
+//! Reproduced against this tree before the fix: ten `sgt daemon` starts
+//! SIGKILLed at staggered delays left three `opencode serve --port 0
+//! --hostname 127.0.0.1` processes at PPID 1.
+//!
+//! Neither doctrinal orphan-check pattern matched them (both are `sgt`-shaped;
+//! the leaked species is named `opencode` and `codex`), so every wave's
+//! hygiene check was honest and blind.
+//!
+//! ## The three mechanisms, and why all three
+//!
+//! 1. **Explicit kill and reap when the probe completes.** The gate functions
+//!    already do this on every return path; it is the ordinary case and it is
+//!    not what failed.
+//! 2. **A `Drop` backstop on the owning handle.** Covers an adapter dropped
+//!    without an explicit stop — a path that is not supported lifecycle, but
+//!    must still not orphan a process.
+//! 3. **[`harden_probe_child`], which is the one that closes #310.** Neither
+//!    of the first two runs when the daemon dies by `SIGKILL`: no destructor
+//!    of any kind executes for a killed process. Only the kernel can couple
+//!    the child's death to the parent's, and on Linux
+//!    `prctl(PR_SET_PDEATHSIG, SIGKILL)` is that coupling.
+//!
+//! ## Why a probe child keeps its *own* process group
+//!
+//! #310's requirement 3 names "the daemon's process group". This module puts
+//! each probe child in a **new** group instead (`process_group(0)`), which is
+//! what `opencode_serve` and `codex_appserver` already did for their launch
+//! children and what [`kill_process_group`] is built to signal. The reason is
+//! that the two goals want opposite things: sharing the daemon's group makes
+//! `kill -KILL -<pgid>` unusable (it would take the daemon with it), so the
+//! probe's own cleanup could then reach only the direct child and would leak
+//! any grandchild it spawned. An own group plus `PR_SET_PDEATHSIG` gets both
+//! halves — a precise subtree kill on completion *and* kernel-guaranteed
+//! death when the daemon dies — so it is strictly stronger than the literal
+//! wording, and it is what is implemented. J1: local, reversible, changes no
+//! contract; the requirement's stated goal ("daemon death must take probe
+//! children with it") is met, not narrowed.
+//!
+//! **Where the guarantee stops, stated rather than hidden.** `PR_SET_PDEATHSIG`
+//! is Linux-only; macOS has no equivalent, so on macOS a probe child outlives
+//! a `SIGKILL`ed daemon exactly as before. What covers macOS is the *reaper*
+//! half of the fix — `platform::process::descendants` captured before the
+//! kill (`tests/support`'s `DataDir` guard) — not this function.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+/// Kill a whole process group by the pgid recorded at spawn — `SIGKILL` to
+/// the negated group id, through a shell rather than a `libc`/`nix` call for
+/// one signal (R5). Through `/bin/sh -c` specifically, not by spawning `kill`
+/// as a program: `kill` is a shell builtin every POSIX shell has, while
+/// `kill(1)` as an executable on `PATH` is a package a host need not install,
+/// and `Command::new("kill")` fails with `ENOENT` on such a host — a silent
+/// no-op if the caller drops the result.
+///
+/// Nothing gates this on the leader being alive, and that is the whole point:
+/// the group routinely outlives its leader (a command a turn started in the
+/// background survives the agent process once it has exited and been reaped —
+/// opencode probe 11's finding), so the group id is signalled unconditionally
+/// and `ESRCH` (an already-empty group) is success, not an error to report.
+/// Idempotent for the same reason.
+///
+/// **One copy, not four (R2).** `codex.rs`, `opencode.rs` and `agy.rs` each
+/// carried a byte-identical private version of this, and #310 needed a fourth
+/// for the probe path. They now all delegate here.
+pub(crate) fn kill_process_group(pgid: Option<u32>) {
+    let Some(pgid) = pgid else { return };
+    #[cfg(unix)]
+    {
+        if let Err(e) = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(format!("kill -KILL -{pgid}"))
+            .output()
+        {
+            tracing::warn!(
+                pgid,
+                error = %e,
+                "could not run the process-group kill; the direct child is all that was \
+                 reached — any commands it spawned may still be running"
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        tracing::warn!(
+            pgid,
+            "no process-group signal mechanism on this platform; killing only the direct \
+             child — any commands it spawned may still be running"
+        );
+    }
+}
+
+/// Whether a spawned child is bounded by the call that spawns it, or owned
+/// across a whole execution.
+///
+/// The distinction is load-bearing and must stay explicit at every call site,
+/// because [`harden_probe_child`]'s hardening is only ever *correct* for the
+/// first kind.
+///
+/// **What the parent-death signal is actually coupled to, measured here
+/// rather than taken from the man page (Cerberus, Linux 7.0.0, 2026-08-26).**
+/// `prctl(2)` documents the "parent" as *the thread that created the process*,
+/// which would make a hardened child die when its spawning thread returned.
+/// Measured on this kernel it does **not**: a C reproduction whose spawning
+/// `pthread` exits leaves the child running, while `SIGKILL`ing the whole
+/// parent process kills it immediately. So on this kernel it is process
+/// death, not thread death, that fires it.
+///
+/// The split is kept anyway, and is not decoration: the man page's wording is
+/// the portable contract, this crate's `rust-version` floor says nothing about
+/// which kernel it runs on, and a build that *does* couple to thread death
+/// would kill a live agent the moment its spawning worker returned to the
+/// blocking pool. A probe child is spawned and killed inside one function on
+/// one thread, so it is safe under either reading; an execution child is not,
+/// so it never gets the hardening. `tests/v1d_probe_child_lifecycle.rs` pins
+/// the process-death half, which is the half #310 depends on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChildLifetime {
+    /// Killed before the call that spawned it returns (a probe gate).
+    Probe,
+    /// Owned across an execution, killed by the adapter's own lifecycle.
+    Execution,
+}
+
+/// Put `command`'s child in its own process group and, on Linux, arrange for
+/// the kernel to `SIGKILL` it if its parent dies first.
+///
+/// Call this only for [`ChildLifetime::Probe`] children — see that variant's
+/// doc for why an execution child must not get it.
+///
+/// `pub` rather than `pub(crate)` so `tests/v1d_probe_child_lifecycle.rs` can
+/// evidence the parent-death coupling from a real, separately-spawned
+/// process: a unit test inside this crate's own test binary cannot be killed
+/// to prove it, and the mechanism is exactly the one #310 turns on.
+pub fn harden_probe_child(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // A new group, not the daemon's: see the module doc.
+        command.process_group(0);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::process::CommandExt;
+        let parent = std::process::id();
+        // SAFETY (`pre_exec`'s own contract): this closure runs in the child
+        // between `fork` and `exec`, in a process that has one thread and may
+        // hold locks the parent's other threads were mid-way through. It may
+        // therefore call only async-signal-safe functions and must allocate
+        // nothing. All three calls below are on POSIX's async-signal-safe
+        // list (`prctl` is Linux's own, documented signal-safe), none
+        // allocates, and the captured `parent` is a plain `u32` copied into
+        // the closure before the fork.
+        unsafe {
+            command.pre_exec(move || {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                // The fork/prctl race: if the parent died between `fork` and
+                // the `prctl` above, the death signal it would have triggered
+                // has already been and gone, and this child would live
+                // forever — which is precisely #310's failure. Re-reading the
+                // parent after arming is the standard close: a mismatch means
+                // the parent is already gone, so leave rather than exec.
+                if libc::getppid() != parent as libc::pid_t {
+                    libc::_exit(0);
+                }
+                Ok(())
+            });
+        }
+    }
+    #[cfg(not(any(unix, target_os = "linux")))]
+    {
+        let _ = command;
+    }
+}
+
+/// The probe children one daemon's probe walk has live right now.
+///
+/// **Why ownership is per-walk rather than global.** `cargo test` runs many
+/// tests in one process, so several in-process daemons can be probing at
+/// once; a global set would let one daemon's `kill` take another's live probe
+/// child down and turn its probe into a spurious refusal. The walk installs
+/// its own set on the thread it calls `Backend::probe` from
+/// ([`owned_by`]), and every hardened probe child spawned under that call
+/// records itself into whichever set it finds there — exact attribution with
+/// no change to the `Backend` trait, which has no daemon-shaped parameter to
+/// carry one.
+#[derive(Debug, Default)]
+pub struct ProbeChildren {
+    live: Mutex<BTreeSet<u32>>,
+}
+
+impl ProbeChildren {
+    /// An empty set, ready to be installed by a probe walk.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// The process groups this walk currently has live, sorted.
+    pub fn live(&self) -> Vec<u32> {
+        self.live
+            .lock()
+            .expect("probe children lock")
+            .iter()
+            .copied()
+            .collect()
+    }
+
+    /// `SIGKILL` every live probe child's whole group, returning the pgids
+    /// signalled. Idempotent, and safe to call on a walk that never spawned
+    /// anything.
+    ///
+    /// The set is drained under the lock *before* any signal goes out, so a
+    /// concurrent caller cannot signal the same group twice and a probe that
+    /// finishes mid-kill deregisters into an empty set rather than blocking
+    /// on one held across a subprocess.
+    pub fn kill_all(&self) -> Vec<u32> {
+        let killed: Vec<u32> = std::mem::take(&mut *self.live.lock().expect("probe children lock"))
+            .into_iter()
+            .collect();
+        for pgid in &killed {
+            kill_process_group(Some(*pgid));
+        }
+        killed
+    }
+
+    fn record(&self, pgid: u32) {
+        self.live.lock().expect("probe children lock").insert(pgid);
+    }
+
+    fn forget(&self, pgid: u32) {
+        self.live.lock().expect("probe children lock").remove(&pgid);
+    }
+}
+
+thread_local! {
+    /// The set probe children spawned on this thread record themselves into.
+    static OWNER: std::cell::RefCell<Option<Arc<ProbeChildren>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Run `f` with `owner` installed as the probe-child owner for this thread,
+/// restoring whatever was there before.
+///
+/// Restoring rather than clearing matters because the blocking pool reuses
+/// threads: a walk that left `None` behind would be indistinguishable from a
+/// thread that never had an owner, and the *next* walk scheduled onto that
+/// thread would install its own anyway — but a nested call (a probe that
+/// itself drives a probe) must not silently disown the outer one.
+pub fn owned_by<R>(owner: Arc<ProbeChildren>, f: impl FnOnce() -> R) -> R {
+    let previous = OWNER.with(|slot| slot.borrow_mut().replace(owner));
+    let result = f();
+    OWNER.with(|slot| *slot.borrow_mut() = previous);
+    result
+}
+
+/// The probe-child owner installed on this thread, if any.
+///
+/// Public to the crate so an adapter that isolates a probe on a helper thread
+/// (`opencode`'s serve gate runs its whole reqwest-touching body on a freshly
+/// spawned OS thread) can carry the owner across that boundary — a
+/// thread-local does not cross a `thread::spawn` on its own.
+pub(crate) fn owner() -> Option<Arc<ProbeChildren>> {
+    OWNER.with(|slot| slot.borrow().clone())
+}
+
+/// Deregisters one probe child from the walk that owns it.
+///
+/// Deliberately does **not** kill on drop: the handle that owns the child
+/// (`ServeChild`, `AppServerChild`, `ConfigProbeChild`) already kills its
+/// group in its own `Drop`, and two kills of one group is one wasted
+/// subprocess per probe on the ordinary path.
+#[derive(Debug)]
+pub(crate) struct ProbeChildRegistration {
+    owner: Option<Arc<ProbeChildren>>,
+    pgid: u32,
+}
+
+impl Drop for ProbeChildRegistration {
+    fn drop(&mut self) {
+        if let Some(owner) = &self.owner {
+            owner.forget(self.pgid);
+        }
+    }
+}
+
+/// Record a just-spawned probe child against whichever walk owns this thread.
+///
+/// A child spawned outside a walk (a unit test, a direct `probe()` call)
+/// registers against nothing and is still hardened — the registration is what
+/// makes a *live* child reachable by [`ProbeChildren::kill_all`], not what
+/// makes it die.
+pub(crate) fn register_probe_child(pgid: u32) -> ProbeChildRegistration {
+    let owner = owner();
+    if let Some(owner) = &owner {
+        owner.record(pgid);
+    }
+    ProbeChildRegistration { owner, pgid }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+
+    fn alive(pid: u32) -> bool {
+        crate::platform::process::process_alive(pid)
+    }
+
+    fn wait_until_gone(pid: u32, budget: Duration) -> bool {
+        let deadline = Instant::now() + budget;
+        loop {
+            if !alive(pid) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    fn sleeper(harden: bool) -> std::process::Child {
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("sleep 300")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        if harden {
+            harden_probe_child(&mut command);
+        }
+        command.spawn().expect("spawn a sleeper")
+    }
+
+    /// The parent-death coupling `harden_probe_child` arms is *not*
+    /// observable from inside this test binary — measured on this kernel
+    /// (Cerberus, Linux 7.0.0, 2026-08-26) it fires on the parent
+    /// **process**'s death, not the spawning thread's, so evidencing it means
+    /// killing a process, which a unit test cannot do to itself.
+    /// `tests/v1d_probe_child_lifecycle.rs` owns that assertion, against a
+    /// separately spawned parent and against a real `SIGKILL`ed daemon. What
+    /// stays here is everything a live process *can* prove about a hardened
+    /// child: which process group it leads, and how the walk that owns it
+    /// finds it again.
+    ///
+    /// Pinned as an explicit negative so nobody re-adds a thread-death
+    /// assertion here and watches it fail for the right reason.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parent_death_coupling_is_not_thread_death_on_this_kernel() {
+        let mut child = std::thread::spawn(|| sleeper(true))
+            .join()
+            .expect("spawner thread");
+        let pid = child.id();
+        let died_with_the_thread = wait_until_gone(pid, Duration::from_secs(2));
+        kill_process_group(Some(pid));
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(
+            !died_with_the_thread,
+            "PR_SET_PDEATHSIG now fires on the spawning thread's death on this kernel. That \
+             is the portable reading of prctl(2) and it makes `ChildLifetime::Execution` \
+             load-bearing rather than merely defensive — re-read that enum's doc before \
+             changing anything here."
+        );
+    }
+
+    /// `/proc/<pid>/stat`'s process-group id (field 5). The `comm` field
+    /// before it is parenthesised and unescaped, so the positional fields
+    /// after it are found by splitting at the **last** `)`, never the first.
+    #[cfg(target_os = "linux")]
+    fn pgid_of(pid: u32) -> Option<u32> {
+        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        let after_comm = stat.rsplit_once(") ")?.1;
+        // After `) ` the fields are state, ppid, pgrp, ... — pgrp is index 2.
+        after_comm.split_whitespace().nth(2)?.parse::<u32>().ok()
+    }
+
+    /// Its own group means the pgid *is* the child's pid, which is what every
+    /// caller records at spawn. Had the child instead inherited this
+    /// process's group, `kill -KILL -<pgid>` would signal the test runner
+    /// itself — which is why the module deliberately does not put probe
+    /// children in the daemon's group.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_hardened_child_leads_its_own_process_group_so_the_group_kill_is_precise() {
+        let mut child = sleeper(true);
+        let pid = child.id();
+        let pgid = pgid_of(pid);
+        kill_process_group(Some(pid));
+        let _ = child.wait();
+        assert_eq!(
+            pgid,
+            Some(pid),
+            "a hardened probe child must lead its own process group"
+        );
+    }
+
+    #[test]
+    fn probe_children_are_recorded_against_the_walk_that_owns_the_thread() {
+        let owner = ProbeChildren::new();
+        let recorded = owned_by(owner.clone(), || {
+            let child = sleeper(true);
+            let registration = register_probe_child(child.id());
+            let seen = owner.live();
+            drop(registration);
+            let mut child = child;
+            kill_process_group(Some(child.id()));
+            let _ = child.wait();
+            seen
+        });
+        assert_eq!(
+            recorded.len(),
+            1,
+            "the child was not recorded: {recorded:?}"
+        );
+        assert!(
+            owner.live().is_empty(),
+            "dropping the registration must deregister: {:?}",
+            owner.live()
+        );
+    }
+
+    #[test]
+    fn a_child_spawned_outside_a_walk_records_against_nothing() {
+        let mut child = sleeper(true);
+        let registration = register_probe_child(child.id());
+        drop(registration);
+        kill_process_group(Some(child.id()));
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn kill_all_reaps_every_live_probe_child_of_that_walk_and_no_other() {
+        let mine = ProbeChildren::new();
+        let theirs = ProbeChildren::new();
+        let (mut my_child, my_registration) = owned_by(mine.clone(), || {
+            let child = sleeper(true);
+            let registration = register_probe_child(child.id());
+            (child, registration)
+        });
+        let (mut their_child, their_registration) = owned_by(theirs.clone(), || {
+            let child = sleeper(true);
+            let registration = register_probe_child(child.id());
+            (child, registration)
+        });
+        let (my_pid, their_pid) = (my_child.id(), their_child.id());
+
+        assert_eq!(mine.kill_all(), vec![my_pid]);
+        let _ = my_child.wait();
+        assert!(
+            wait_until_gone(my_pid, Duration::from_secs(10)),
+            "kill_all left this walk's own probe child {my_pid} alive"
+        );
+        assert!(
+            alive(their_pid),
+            "kill_all reached another walk's probe child {their_pid} — a global set would \
+             turn a sibling daemon's probe into a spurious refusal"
+        );
+
+        assert_eq!(theirs.kill_all(), vec![their_pid]);
+        let _ = their_child.wait();
+        assert!(wait_until_gone(their_pid, Duration::from_secs(10)));
+        drop((my_registration, their_registration));
+    }
+}

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -3049,6 +3049,7 @@ mod tests {
         let session = "11111111-2222-4333-8444-555555555555";
         let turn = ProcessArgv {
             pid: 42,
+            ppid: None,
             argv: vec![
                 "claude".to_string(),
                 "-p".to_string(),

--- a/src/backend/claude.rs
+++ b/src/backend/claude.rs
@@ -129,6 +129,7 @@ use super::{
     ExecutionHandle, NativeEvent, NativeState, Observation, PreparedExecution, ProbeReport,
     ResumeRequest, RuntimeScope, StartRequest,
 };
+use crate::backend::child;
 use crate::domain::estate::InstructionPolicy;
 use crate::domain::event::{Event, EventDraft, EventSource};
 use crate::domain::profile::Profile;
@@ -876,6 +877,25 @@ impl std::fmt::Debug for ClaudeBackend {
     }
 }
 
+/// One bounded probe invocation, hardened per #310.
+///
+/// `output()` waits, so the child cannot outlive *this call* — but it can
+/// outlive a daemon `SIGKILL`ed during it, and a `--version` that never
+/// returns is exactly how one gets stuck there. Both of this adapter's probe
+/// invocations go through here so neither can forget the hardening.
+///
+/// Audited for #310 alongside the other four adapters: this adapter's probe
+/// spawns **nothing persistent** — two token-free one-shots that exit on
+/// their own — so it was never a source of the leak. It is hardened anyway
+/// because the cost is one line and the failure mode it guards against is a
+/// process nobody counts.
+fn probe_output(exe: &Path, args: &[&str]) -> std::io::Result<std::process::Output> {
+    let mut command = Command::new(exe);
+    command.args(args);
+    child::harden_probe_child(&mut command);
+    command.output()
+}
+
 impl ClaudeBackend {
     /// Build the adapter. Probing is lazy (first PROBE/START), so
     /// constructing one costs nothing on daemons that never route to it.
@@ -1014,7 +1034,7 @@ impl ClaudeBackend {
 
     fn run_probe(&self) -> ProbeOutcome {
         let exe = &self.config.executable;
-        let version_out = match Command::new(exe).arg("--version").output() {
+        let version_out = match probe_output(exe, &["--version"]) {
             Ok(out) => out,
             Err(e) => {
                 return ProbeOutcome {
@@ -1070,7 +1090,7 @@ impl ClaudeBackend {
                 version: Some(canonical_version),
             };
         }
-        let help_out = match Command::new(exe).arg("--help").output() {
+        let help_out = match probe_output(exe, &["--help"]) {
             Ok(out) => out,
             Err(e) => {
                 return ProbeOutcome {

--- a/src/backend/codex.rs
+++ b/src/backend/codex.rs
@@ -124,6 +124,7 @@ use super::{
     ExecutionHandle, NativeEvent, NativeState, Observation, PreparedExecution, ProbeReport,
     ResumeRequest, RuntimeScope, StartRequest,
 };
+use crate::backend::child;
 use crate::domain::event::{EventDraft, EventSource};
 use crate::domain::profile::Profile;
 use crate::platform::process::ProcessArgv;
@@ -2823,7 +2824,7 @@ impl CodexBackend {
 
     fn run_probe(&self) -> ProbeOutcome {
         let exe = &self.config.executable;
-        let version_out = match Command::new(exe).arg("--version").output() {
+        let version_out = match probe_output(exe, &["--version"]) {
             Ok(out) => out,
             Err(e) => {
                 return ProbeOutcome {
@@ -2860,7 +2861,7 @@ impl CodexBackend {
             VersionProvenance::BelowFloor
         };
 
-        let exec_help = match Command::new(exe).args(["exec", "--help"]).output() {
+        let exec_help = match probe_output(exe, &["exec", "--help"]) {
             Ok(out) => String::from_utf8_lossy(&out.stdout).to_string(),
             Err(e) => {
                 return ProbeOutcome {
@@ -2875,10 +2876,7 @@ impl CodexBackend {
                 };
             }
         };
-        let resume_help = match Command::new(exe)
-            .args(["exec", "resume", "--help"])
-            .output()
-        {
+        let resume_help = match probe_output(exe, &["exec", "resume", "--help"]) {
             Ok(out) => String::from_utf8_lossy(&out.stdout).to_string(),
             Err(e) => {
                 return ProbeOutcome {
@@ -2995,10 +2993,7 @@ impl CodexBackend {
     }
 
     fn run_auth_probe(&self) -> AuthState {
-        match Command::new(&self.config.executable)
-            .args(["login", "status"])
-            .output()
-        {
+        match probe_output(&self.config.executable, &["login", "status"]) {
             // Re-measured while wiring the live suite (this is *not* what an
             // interactive shell shows): `codex login status` writes its
             // answer to **stderr**, not stdout, when it is not attached to a
@@ -3058,9 +3053,7 @@ impl CodexBackend {
     /// `stdio://`. Token-free.
     fn gate_g1_help(&self) -> Result<(), String> {
         let exe = &self.config.executable;
-        let out = Command::new(exe)
-            .args(["app-server", "--help"])
-            .output()
+        let out = probe_output(exe, &["app-server", "--help"])
             .map_err(|e| format!("G1: cannot run {exe:?} app-server --help: {e}"))?;
         if !out.status.success() {
             return Err(format!(
@@ -3085,10 +3078,13 @@ impl CodexBackend {
         let exe = &self.config.executable;
         let scratch = self.config.data_dir.join(".codex-appserver-schema-probe");
         let _ = std::fs::remove_dir_all(&scratch);
-        let out = Command::new(exe)
+        let mut command = Command::new(exe);
+        command
             .args(["app-server", "generate-json-schema", "--out"])
             .arg(&scratch)
-            .arg("--experimental")
+            .arg("--experimental");
+        child::harden_probe_child(&mut command);
+        let out = command
             .output()
             .map_err(|e| format!("G2: cannot run {exe:?} app-server generate-json-schema: {e}"))?;
         if !out.status.success() {
@@ -3126,6 +3122,9 @@ impl CodexBackend {
             &self.config.data_dir,
             &self.config.env,
             self.config.codex_home.as_deref(),
+            // #310: this child exists only for the `initialize` round trip
+            // below, and must not survive a daemon that dies during it.
+            child::ChildLifetime::Probe,
             |_handle, _line| {},
         )
         .map_err(|e| format!("G4: {e}"))?;
@@ -3757,6 +3756,10 @@ impl CodexBackend {
             &request.cwd,
             &env,
             codex_home.as_deref(),
+            // Owned for the whole execution, so deliberately *not* hardened:
+            // `PR_SET_PDEATHSIG` fires on the spawning thread's death, and
+            // this thread returns long before the turn ends.
+            child::ChildLifetime::Execution,
             move |handle, line| appserver_on_line(&ctx, &cb_cell, handle, line),
         )
         .map_err(|e| self.err_failed(format!("cannot spawn app-server child: {e}")))?;
@@ -4121,61 +4124,31 @@ impl CodexBackend {
     }
 }
 
-/// Kill a turn's whole process group (§5.5): `SIGKILL` to the negated group
-/// id recorded at spawn, through a shell rather than a `libc`/`nix`
-/// dependency for one signal — the reason `tests/support/mod.rs` gives (R5).
+/// One bounded probe invocation, hardened per #310.
 ///
-/// Through `/bin/sh -c` specifically, and not by spawning `kill` as a program.
-/// `kill` is a **shell builtin** that every POSIX shell is required to have,
-/// while `kill(1)` as an executable on `PATH` is a package that a host need
-/// not install — and `Command::new("kill")` fails with `ENOENT` on such a
-/// host, which is a silent no-op when the caller drops the result. That is
-/// not hypothetical: it is measured, and it is why this call reports a spawn
-/// failure instead of discarding it. `/bin/sh` is an absolute path for the
-/// same reason, so a `PATH` this process never chose cannot decide whether
-/// INTERRUPT works.
+/// Every gate in this adapter that is a plain "run it and read the text" call
+/// goes through here rather than building its own `Command`, so none of them
+/// can forget [`child::harden_probe_child`]. `output()` waits, so the child
+/// cannot outlive *this call* — but it can outlive a daemon `SIGKILL`ed
+/// during it, and a `--help` or a `login status` that never returns is
+/// exactly how one gets stuck there.
+fn probe_output(exe: &Path, args: &[&str]) -> std::io::Result<std::process::Output> {
+    let mut command = Command::new(exe);
+    command.args(args);
+    child::harden_probe_child(&mut command);
+    command.output()
+}
+
+/// Kill a turn's whole process group, by the pgid recorded at spawn (§5.5).
 ///
-/// **Nothing gates this on the leader being alive**, and that is the whole
-/// point. The group is what INTERRUPT promises to kill, and the group
-/// routinely outlives its leader: a command the turn started in the
-/// background survives the codex process, and once that process has exited
-/// and the reader has reaped it, every liveness test one could run — the
-/// turn's `TurnState`, `try_wait`, the child handle at all — says "nothing to
-/// kill" about a group that is still very much running. So the group id is
-/// signalled unconditionally and `ESRCH` (an already-empty group) is success,
-/// not an error to report: the shell's *exit status* is deliberately not
-/// consulted, because "no such group" and "killed the group" are the same
-/// outcome here. Failing to run the kill at all is not — that one is logged.
-///
-/// Signalling a recorded id after its leader is gone is safe as well as
-/// necessary: Linux keeps a pid number allocated for as long as any process
-/// still uses it as a process-group id, so while there is anything in this
-/// group to kill, this id cannot have come to mean another one.
+/// One line, because #310 moved the implementation to
+/// [`crate::backend::child::kill_process_group`] — three adapters carried a
+/// byte-identical private copy of it and the probe path needed a fourth (R2).
+/// The behaviour and every reason for it are documented there; this alias
+/// stays so the call sites in this module keep reading as adapter-local
+/// vocabulary.
 fn kill_process_group(pgid: Option<u32>) {
-    let Some(pgid) = pgid else { return };
-    #[cfg(unix)]
-    {
-        if let Err(e) = Command::new("/bin/sh")
-            .arg("-c")
-            .arg(format!("kill -KILL -{pgid}"))
-            .output()
-        {
-            tracing::warn!(
-                pgid,
-                error = %e,
-                "could not run the process-group kill; the turn's direct child is all that \
-                 INTERRUPT reached — any commands it spawned may still be running"
-            );
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        tracing::warn!(
-            pgid,
-            "no process-group signal mechanism on this platform; killing only the direct \
-             child — any commands it spawned may still be running"
-        );
-    }
+    crate::backend::child::kill_process_group(pgid);
 }
 
 /// The group kill above plus `Child::kill()` on the direct child as a belt,

--- a/src/backend/codex.rs
+++ b/src/backend/codex.rs
@@ -5474,10 +5474,12 @@ mod tests {
         let processes = vec![
             ProcessArgv {
                 pid: 10,
+                ppid: None,
                 argv: vec!["exec".to_string(), "-C".to_string(), "/work".to_string()],
             },
             ProcessArgv {
                 pid: 20,
+                ppid: None,
                 argv: vec!["exec".to_string(), "resume".to_string(), "t1".to_string()],
             },
         ];
@@ -5496,6 +5498,7 @@ mod tests {
     fn turn_liveness_among_reports_surface_ambiguous_for_a_first_turn_process() {
         let processes = vec![ProcessArgv {
             pid: 30,
+            ppid: None,
             argv: vec!["exec".to_string(), "-C".to_string(), "/work".to_string()],
         }];
         let liveness = turn_liveness_among("t1", Some(Path::new("/work")), 999, Some(processes));
@@ -5512,6 +5515,7 @@ mod tests {
     fn turn_liveness_among_is_dead_with_no_matching_process() {
         let processes = vec![ProcessArgv {
             pid: 1,
+            ppid: None,
             argv: vec!["other-program".to_string()],
         }];
         assert_eq!(
@@ -5524,6 +5528,7 @@ mod tests {
     fn turn_liveness_among_skips_the_callers_own_pid() {
         let processes = vec![ProcessArgv {
             pid: 42,
+            ppid: None,
             argv: vec!["exec".to_string(), "resume".to_string(), "t1".to_string()],
         }];
         assert_eq!(

--- a/src/backend/codex_appserver.rs
+++ b/src/backend/codex_appserver.rs
@@ -776,14 +776,22 @@ impl AppServerChild {
         // reachable by `ProbeChildren::kill_all`.
         let registration =
             matches!(lifetime, ChildLifetime::Probe).then(|| child::register_probe_child(pgid));
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| "child stdin was not piped".to_string())?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| "child stdout was not piped".to_string())?;
+        // #310: an early return here used to drop `child` without signalling
+        // it, leaving a live `codex app-server` with nothing holding it. The
+        // arms are "cannot happen" — stdio was piped four lines above — which
+        // is precisely the kind of path this issue is about.
+        let reap_and_fail = |child: &mut Child, reason: &str| -> String {
+            super::kill_process_group(Some(pgid));
+            let _ = child.kill();
+            let _ = child.wait();
+            reason.to_string()
+        };
+        let Some(stdin) = child.stdin.take() else {
+            return Err(reap_and_fail(&mut child, "child stdin was not piped"));
+        };
+        let Some(stdout) = child.stdout.take() else {
+            return Err(reap_and_fail(&mut child, "child stdout was not piped"));
+        };
         // Stderr is drained on its own thread into a bounded ring. Draining
         // is what keeps the pipe from filling and blocking the child;
         // *retaining* the tail is what makes a child that died mid-turn
@@ -955,13 +963,21 @@ impl AppServerChild {
 
 impl Drop for AppServerChild {
     fn drop(&mut self) {
-        // Best-effort: a caller that wants the join should call `kill`
-        // itself. This exists so a `CodexExecution` dropped without an
+        // Best-effort: a caller that wants the reader joined should call
+        // `kill` itself. This exists so a `CodexExecution` dropped without an
         // explicit STOP does not leave the child running past the adapter's
         // own memory of it (mirrors exec's own posture: adapter state
         // dropping is not a supported lifecycle path, but it should not
         // orphan a process either).
+        //
+        // #310: killed *and reaped*. A killed child nobody reaps stays in the
+        // process table answering `kill(pid, 0)` as alive and matching
+        // `pgrep -f 'codex.*app-server'` — indistinguishable, to an orphan
+        // check, from the leak itself.
         super::kill_process_group(Some(self.pgid));
+        let mut child = self.child.lock().expect("child lock");
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }
 

--- a/src/backend/codex_appserver.rs
+++ b/src/backend/codex_appserver.rs
@@ -28,6 +28,7 @@ use std::time::Duration;
 use serde_json::{Value, json};
 
 use super::{ItemKind, ItemView, KIND_TURN_HARNESS_ERROR, NativeEvent, Terminal, TurnAccumulator};
+use crate::backend::child::{self, ChildLifetime};
 
 // -------------------------------------------------------------- fingerprint
 
@@ -636,6 +637,10 @@ pub(super) struct AppServerChild {
     stderr_tail: Arc<Mutex<Vec<u8>>>,
     pgid: u32,
     reader: Option<std::thread::JoinHandle<()>>,
+    /// `Some` only for a [`ChildLifetime::Probe`] child (#310): deregisters
+    /// this pgid from the owning probe walk's live set when this handle
+    /// drops. Held, never read.
+    _registration: Option<child::ProbeChildRegistration>,
 }
 
 /// How much of the child's stderr is retained for evidence (a ring: the tail
@@ -717,11 +722,20 @@ impl AppServerChild {
     /// holds — so `on_line` can answer a server request inline, without a
     /// second round trip through this struct. The caller must not block long
     /// in `on_line`, the same rule exec's `TurnReader` follows.
+    ///
+    /// `lifetime` is #310's fix and must be stated by every caller: a
+    /// [`ChildLifetime::Probe`] child is additionally hardened
+    /// ([`child::harden_probe_child`]) so a `SIGKILL`ed daemon takes it with
+    /// it, and recorded against the probe walk that owns the calling thread.
+    /// `gate_g4_handshake` is that caller; the launch path's child is
+    /// [`ChildLifetime::Execution`] and must never be hardened — see that
+    /// enum's own doc for why.
     pub(super) fn spawn(
         executable: &Path,
         cwd: &Path,
         env: &BTreeMap<String, String>,
         codex_home: Option<&Path>,
+        lifetime: ChildLifetime,
         on_line: impl Fn(&AppServerHandle, InboundLine) + Send + 'static,
     ) -> Result<Self, String> {
         let mut command = Command::new(executable);
@@ -739,17 +753,29 @@ impl AppServerChild {
         }
         // §1.5.5: reused, not copied — the app-server child spawns
         // grandchildren (shell commands) exactly as `codex exec` does, so
-        // the same grandchild-survives-the-kill hazard applies unchanged.
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
-            command.process_group(0);
+        // the same grandchild-survives-the-kill hazard applies unchanged. A
+        // probe child gets that group from `harden_probe_child`, plus
+        // `PR_SET_PDEATHSIG` (#310); an execution child gets the group and
+        // nothing else.
+        match lifetime {
+            ChildLifetime::Probe => child::harden_probe_child(&mut command),
+            ChildLifetime::Execution => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::CommandExt;
+                    command.process_group(0);
+                }
+            }
         }
 
         let mut child = command
             .spawn()
             .map_err(|e| format!("cannot spawn {executable:?} app-server: {e}"))?;
         let pgid = child.id();
+        // Recorded before anything below can fail: from here on this pgid is
+        // reachable by `ProbeChildren::kill_all`.
+        let registration =
+            matches!(lifetime, ChildLifetime::Probe).then(|| child::register_probe_child(pgid));
         let stdin = child
             .stdin
             .take()
@@ -859,6 +885,7 @@ impl AppServerChild {
             stderr_tail,
             pgid,
             reader: Some(reader),
+            _registration: registration,
         })
     }
 

--- a/src/backend/docker.rs
+++ b/src/backend/docker.rs
@@ -909,6 +909,20 @@ impl Backend for DockerBackend {
     /// every submission that touches an execute stage, so it stays a single
     /// `docker version` round trip rather than the full lifecycle probe
     /// `sgt doctor` runs (`lifecycle_probe`).
+    ///
+    /// **Audited for #310 and deliberately left alone.** The other four
+    /// adapters' probes now go through `backend::child::harden_probe_child`,
+    /// which puts a probe child in its own process group and arms
+    /// `PR_SET_PDEATHSIG`. This one does not, for two reasons. It spawns
+    /// nothing persistent: `docker version` is a bounded client round trip
+    /// against a daemon that owns every container, so there is no long-lived
+    /// child to orphan and an orphaned client exits by itself. And the only
+    /// seam it could be applied at is [`DockerBackend::cmd`], which every
+    /// *execution* verb in this adapter shares — including `capture`'s
+    /// `docker logs`, whose output is read on threads that outlive the
+    /// spawning one. Hardening there would be applying a probe-shaped
+    /// lifetime to execution-shaped children, which is exactly the mistake
+    /// `ChildLifetime` exists to keep visible.
     fn probe(&self) -> ProbeReport {
         match self.run(&["version", "--format", "{{.Server.Version}}"]) {
             Ok(version) => ProbeReport {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -38,6 +38,11 @@
 /// Registered in `daemon.rs` (the agy-adapter sprint's W2) and reachable via
 /// `sgt agy` and `--backend agy`.
 pub mod agy;
+/// Child-process lifecycle shared by every adapter (#310): the one
+/// process-group kill, the probe-child hardening that makes a `SIGKILL`ed
+/// daemon take its probe children with it, and the per-walk registry a
+/// daemon's own `kill` reaps through.
+pub mod child;
 pub mod claude;
 /// The `codex exec` adapter (W1 of the *Sergeant speaks Codex* sprint,
 /// `knowledge/evidence/resources/h-series/w1-spec.md`, closing deviation D6

--- a/src/backend/opencode.rs
+++ b/src/backend/opencode.rs
@@ -5589,10 +5589,12 @@ mod tests {
         let processes = vec![
             ProcessArgv {
                 pid: 1,
+                ppid: None,
                 argv: vec!["run".to_string(), "-s".to_string(), "ses_abc".to_string()],
             },
             ProcessArgv {
                 pid: 2,
+                ppid: None,
                 argv: vec!["run".to_string(), "-s".to_string(), "ses_abc".to_string()],
             },
         ];

--- a/src/backend/opencode.rs
+++ b/src/backend/opencode.rs
@@ -187,6 +187,7 @@ use super::{
     ExecutionHandle, NativeEvent, NativeState, Observation, PreparedExecution, ProbeReport,
     ResumeRequest, RuntimeScope, StartRequest,
 };
+use crate::backend::child;
 use crate::domain::event::{EventDraft, EventSource};
 use crate::domain::profile::Profile;
 use crate::platform::process::ProcessArgv;
@@ -2225,6 +2226,10 @@ impl OpencodeBackend {
         let mut command = Command::new(exe);
         command.args(args).stdin(Stdio::null());
         apply_env(&mut command, &self.config.env, None);
+        // #310: `output()` waits, so this child cannot outlive *this call* —
+        // but it can outlive a daemon SIGKILLed during the call, and a
+        // `--help` that never returns is exactly how one gets stuck there.
+        child::harden_probe_child(&mut command);
         let out = command.output().map_err(|e| {
             format!(
                 "capability probe: cannot run {exe:?} {}: {e} (kind: {:?})",
@@ -2244,6 +2249,7 @@ impl OpencodeBackend {
         let mut version_command = Command::new(exe);
         version_command.arg("--version").stdin(Stdio::null());
         apply_env(&mut version_command, &self.config.env, None);
+        child::harden_probe_child(&mut version_command);
         let version_out = match version_command.output() {
             Ok(out) => out,
             Err(e) => {
@@ -2397,9 +2403,20 @@ impl OpencodeBackend {
     /// (`OnceLock`) means this runs at most once per backend either way, so
     /// the extra thread costs nothing that matters.
     fn run_serve_gates(&self) -> ServeGates {
+        // #310: a thread-local does not cross `thread::spawn`, and the probe
+        // walk installs its probe-child owner on the thread it calls
+        // `probe()` from — so the owner is carried across this isolation
+        // boundary by hand. Without this the serve gate's child would still
+        // be hardened (it is spawned through `harden_probe_child` either
+        // way) but invisible to `ProbeChildren::kill_all`, and the daemon's
+        // own `kill` could not reach it.
+        let owner = child::owner();
         std::thread::scope(|scope| {
             scope
-                .spawn(|| self.run_serve_gates_inner())
+                .spawn(move || match owner {
+                    Some(owner) => child::owned_by(owner, || self.run_serve_gates_inner()),
+                    None => self.run_serve_gates_inner(),
+                })
                 .join()
                 .unwrap_or_else(|panic| ServeGates {
                     result: Err(format!(
@@ -2465,6 +2482,9 @@ impl OpencodeBackend {
             self.config.config_content.as_deref(),
             &password,
             readiness,
+            // #310: this child exists only until the fingerprint below is
+            // computed, and must not survive a daemon that dies before then.
+            child::ChildLifetime::Probe,
         );
         let (mut child, base_url) = match spawn {
             Ok(pair) => pair,
@@ -3078,6 +3098,10 @@ impl OpencodeBackend {
             config_content.as_deref(),
             &password,
             budgets.readiness,
+            // Owned for the whole execution (§3.1), so deliberately *not*
+            // hardened: `PR_SET_PDEATHSIG` fires on the spawning thread's
+            // death, and this thread returns long before the turn ends.
+            child::ChildLifetime::Execution,
         )
         .map_err(|e| self.err_failed(format!("serve launch refused (phase: spawn): {e}")))?;
 
@@ -3543,46 +3567,16 @@ fn observe_serve(runtime: &ServeRuntime) -> Observation {
     }
 }
 
-/// Kill a turn's whole process group (mirrors `codex.rs::kill_process_group`,
-/// §5.5): `SIGKILL` to the negated group id recorded at spawn, through a
-/// shell rather than a `libc`/`nix` dependency for one signal (R5). Through
-/// `/bin/sh -c` specifically, not by spawning `kill` as a program: `kill` is
-/// a shell builtin every POSIX shell has, while `kill(1)` as an executable on
-/// `PATH` is a package a host need not install, and `Command::new("kill")`
-/// fails with `ENOENT` on such a host — a silent no-op if the caller drops
-/// the result.
+/// Kill a turn's whole process group, by the pgid recorded at spawn (§5.5).
 ///
-/// Nothing gates this on the leader being alive, and that is the whole
-/// point: the group routinely outlives its leader (a command the turn
-/// started in the background survives the opencode process once it has
-/// exited and been reaped — exactly probe 11's finding), so the group id is
-/// signalled unconditionally and `ESRCH` (an already-empty group) is
-/// success, not an error to report.
+/// One line, because #310 moved the implementation to
+/// [`crate::backend::child::kill_process_group`] — three adapters carried a
+/// byte-identical private copy of it and the probe path needed a fourth (R2).
+/// The behaviour and every reason for it are documented there; this alias
+/// stays so the call sites in this module keep reading as adapter-local
+/// vocabulary.
 fn kill_process_group(pgid: Option<u32>) {
-    let Some(pgid) = pgid else { return };
-    #[cfg(unix)]
-    {
-        if let Err(e) = Command::new("/bin/sh")
-            .arg("-c")
-            .arg(format!("kill -KILL -{pgid}"))
-            .output()
-        {
-            tracing::warn!(
-                pgid,
-                error = %e,
-                "could not run the process-group kill; the turn's direct child is all that \
-                 INTERRUPT reached — any commands it spawned may still be running"
-            );
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        tracing::warn!(
-            pgid,
-            "no process-group signal mechanism on this platform; killing only the direct \
-             child — any commands it spawned may still be running"
-        );
-    }
+    crate::backend::child::kill_process_group(pgid);
 }
 
 /// The group kill above plus `Child::kill()` on the direct child as a belt,

--- a/src/backend/opencode_serve.rs
+++ b/src/backend/opencode_serve.rs
@@ -627,10 +627,16 @@ impl ServeChild {
         // kills the group leaves nothing behind either way.
         let registration =
             matches!(lifetime, ChildLifetime::Probe).then(|| child::register_probe_child(pgid));
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| "serve child stdout was not piped".to_string())?;
+        // #310: an early return here used to drop `child` without signalling
+        // it, leaving a live `opencode serve` with nothing holding it. The arm
+        // is "cannot happen" — stdout was piped a dozen lines above — which is
+        // precisely the kind of path this issue is about.
+        let Some(stdout) = child.stdout.take() else {
+            super::kill_process_group(Some(pgid));
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("serve child stdout was not piped".to_string());
+        };
 
         let stderr_tail = Arc::new(Mutex::new(Vec::<u8>::new()));
         if let Some(mut stderr) = child.stderr.take() {
@@ -674,11 +680,20 @@ impl ServeChild {
 
         let base_url = match rx.recv_timeout(port_budget) {
             Ok(Some(url)) => url,
+            // #310: both failure arms below kill *and reap*. Killing alone
+            // leaves a zombie — the pid is still in the process table, still
+            // answers `kill(pid, 0)` as alive, and still shows up under
+            // `pgrep -x opencode`, so an orphan check cannot tell it from a
+            // live 265 MB server. Measured: this is the arm that fired when
+            // `DaemonHandle::kill` reaped a live gate child out from under a
+            // spawn still waiting for its listening line.
             Ok(None) => {
                 let tail =
                     String::from_utf8_lossy(&stderr_tail.lock().expect("serve stderr tail lock"))
                         .into_owned();
+                super::kill_process_group(Some(pgid));
                 let _ = child.kill();
+                let _ = child.wait();
                 return Err(format!(
                     "serve child's stdout reached EOF before a listening line arrived; stderr: {tail}"
                 ));
@@ -689,6 +704,7 @@ impl ServeChild {
                         .into_owned();
                 super::kill_process_group(Some(pgid));
                 let _ = child.kill();
+                let _ = child.wait();
                 return Err(format!(
                     "serve child emitted no listening line within {port_budget:?}; stderr: {tail}"
                 ));
@@ -756,9 +772,15 @@ impl ServeChild {
 impl Drop for ServeChild {
     /// Best-effort (§3.7, mirrors `AppServerChild::drop`): adapter state
     /// dropping is not a supported lifecycle path, but it must not orphan a
-    /// process.
+    /// process — nor leave a zombie, which is #310's addition here. A killed
+    /// child nobody reaps stays in the process table answering `kill(pid, 0)`
+    /// as alive and matching `pgrep -x opencode`, which is exactly the shape
+    /// an orphan check cannot distinguish from the leak.
     fn drop(&mut self) {
         super::kill_process_group(Some(self.pgid));
+        let mut child = self.child.lock().expect("serve child lock");
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }
 

--- a/src/backend/opencode_serve.rs
+++ b/src/backend/opencode_serve.rs
@@ -30,6 +30,8 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 
+use crate::backend::child::{self, ChildLifetime};
+
 // ------------------------------------------------------------------- consts
 
 /// `OPENCODE_SERVER_PASSWORD`'s required username (§3.4, C6): the *literal*
@@ -549,6 +551,10 @@ pub(super) struct ServeChild {
     exit_status: Arc<Mutex<Option<ExitStatus>>>,
     stderr_tail: Arc<Mutex<Vec<u8>>>,
     pgid: u32,
+    /// `Some` only for a [`ChildLifetime::Probe`] child (#310): deregisters
+    /// this pgid from the owning probe walk's live set when this handle
+    /// drops. Held, never read.
+    _registration: Option<child::ProbeChildRegistration>,
 }
 
 impl ServeChild {
@@ -564,6 +570,14 @@ impl ServeChild {
     /// not a correctness hazard because the port is *learned*, never
     /// assumed, from this stdout line — but a reader must not conclude "port
     /// 0 means never 4096".
+    ///
+    /// `lifetime` is #310's fix and must be stated by every caller: a
+    /// [`ChildLifetime::Probe`] child is additionally hardened
+    /// ([`child::harden_probe_child`]) so a `SIGKILL`ed daemon takes it with
+    /// it, and recorded against the probe walk that owns the calling thread.
+    /// The `ServeOnly`/`Auto` gate is that caller; `launch_serve`'s child is
+    /// [`ChildLifetime::Execution`] and must never be hardened — see that
+    /// enum's own doc for why.
     pub(super) fn spawn(
         executable: &Path,
         cwd: &Path,
@@ -571,6 +585,7 @@ impl ServeChild {
         config_content: Option<&str>,
         password: &str,
         port_budget: Duration,
+        lifetime: ChildLifetime,
     ) -> Result<(Self, String), String> {
         let mut command = Command::new(executable);
         command
@@ -589,17 +604,29 @@ impl ServeChild {
         // §3.7: a serve child's tool subprocesses are its grandchildren, so
         // the identical probe-11 orphaning hazard applies — process_group(0)
         // is what makes the recorded-pgid kill (never by name/pattern) reach
-        // the whole tree.
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
-            command.process_group(0);
+        // the whole tree. A probe child gets that from `harden_probe_child`
+        // (plus `PR_SET_PDEATHSIG`, #310); an execution child gets the group
+        // and nothing else.
+        match lifetime {
+            ChildLifetime::Probe => child::harden_probe_child(&mut command),
+            ChildLifetime::Execution => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::CommandExt;
+                    command.process_group(0);
+                }
+            }
         }
 
         let mut child = command
             .spawn()
             .map_err(|e| format!("cannot spawn {executable:?} serve: {e}"))?;
         let pgid = child.id();
+        // Recorded before anything below can fail: from here on this pgid is
+        // reachable by `ProbeChildren::kill_all`, so an early return that
+        // kills the group leaves nothing behind either way.
+        let registration =
+            matches!(lifetime, ChildLifetime::Probe).then(|| child::register_probe_child(pgid));
         let stdout = child
             .stdout
             .take()
@@ -674,6 +701,7 @@ impl ServeChild {
                 exit_status: Arc::new(Mutex::new(None)),
                 stderr_tail,
                 pgid,
+                _registration: registration,
             },
             base_url,
         ))

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -90,6 +90,7 @@ use crate::api::{
     drive_completions, router,
 };
 use crate::backend::agy::{AGY_BACKEND_NAME, AgyBackend, AgyConfig};
+use crate::backend::child::{self, ProbeChildren};
 use crate::backend::claude::{CLAUDE_BACKEND_NAME, ClaudeBackend, ClaudeConfig};
 use crate::backend::codex::{CODEX_BACKEND_NAME, CodexBackend, CodexConfig};
 use crate::backend::docker::{DOCKER_BACKEND_NAME, DockerBackend, DockerConfig};
@@ -353,6 +354,11 @@ pub struct DaemonHandle {
     pub token: String,
     shutdown_tx: Option<oneshot::Sender<()>>,
     served: tokio::task::JoinHandle<()>,
+    /// The probe children *this* daemon's walk has live (#310). Per-daemon,
+    /// never global: `cargo test` runs many in-process daemons at once, and a
+    /// global set would let one daemon's `kill` take a sibling's live probe
+    /// child down and turn its probe into a spurious refusal.
+    probe_children: Arc<ProbeChildren>,
 }
 
 impl DaemonHandle {
@@ -377,6 +383,21 @@ impl DaemonHandle {
         self.shutdown_tx.take();
         self.served.abort();
         let _ = (&mut self.served).await;
+        // #310: aborting the serve task does not reach the probe walk, and a
+        // probe child is a *process* — a real `opencode serve` at ~265 MB —
+        // that nothing in this process's memory owns once the handle is
+        // gone. Reaped by recorded pgid, so the kill reaches whatever the
+        // probe child itself spawned and nothing that belongs to anyone
+        // else. This is the in-process analogue of the `PR_SET_PDEATHSIG`
+        // that covers the out-of-process daemon; both exist because
+        // destructors do not run for a killed process.
+        let killed = self.probe_children.kill_all();
+        if !killed.is_empty() {
+            tracing::debug!(
+                ?killed,
+                "killed probe children still live when the daemon was killed"
+            );
+        }
     }
 }
 
@@ -1134,11 +1155,15 @@ pub async fn start_with(
     // that already knows what evidence is outstanding.
     probe_gate.expect(probe_backends.names());
     let probe_lanes = Arc::new(tokio::sync::Semaphore::new(PROBE_WALK_LANES));
+    // #310: the set every probe child this walk spawns records itself into,
+    // and the set `DaemonHandle::kill` reaps. Created here, one per daemon.
+    let probe_children = ProbeChildren::new();
     let probes = tokio::spawn(probe_walk(
         state.core.clone(),
         probe_backends,
         probe_gate.clone(),
         probe_lanes.clone(),
+        probe_children.clone(),
     ));
 
     let app = router(state.clone());
@@ -1261,6 +1286,7 @@ pub async fn start_with(
         token,
         shutdown_tx: Some(shutdown_tx),
         served,
+        probe_children,
     })
 }
 
@@ -1307,11 +1333,13 @@ async fn probe_walk(
     backends: Arc<BackendRegistry>,
     gate: Arc<ProbeGate>,
     lanes: Arc<tokio::sync::Semaphore>,
+    probe_children: Arc<ProbeChildren>,
 ) {
     let mut walking = tokio::task::JoinSet::new();
     for name in backends.names() {
         let backends = backends.clone();
         let lanes = lanes.clone();
+        let probe_children = probe_children.clone();
         walking.spawn(async move {
             // The lane permit is held across the blocking probe and released
             // when it returns — see `PROBE_WALK_LANES` for why the fan-out is
@@ -1325,7 +1353,15 @@ async fn probe_walk(
                 let Some(backend) = backends.get(&name) else {
                     return (name, None);
                 };
-                let report = backend.probe();
+                // #310: everything a probe spawns is recorded against this
+                // walk for as long as this closure runs, which is exactly the
+                // window in which a probe child is live. The owner is
+                // installed around `capabilities()` too, because for the
+                // opencode and agy adapters that call *is* a subprocess gate.
+                let (report, capabilities) = child::owned_by(probe_children, || {
+                    let report = backend.probe();
+                    (report, backend.capabilities())
+                });
                 // `capabilities()` is read here, inside the blocking task,
                 // and not on the runtime: for the opencode and agy adapters
                 // it resolves the transport, which is itself a subprocess
@@ -1335,7 +1371,7 @@ async fn probe_walk(
                     "backend": name,
                     "available": report.available,
                     "detail": report.detail,
-                    "capabilities": backend.capabilities(),
+                    "capabilities": capabilities,
                     // §17: the adapter's declared runtime scope, recorded
                     // with the probe because it is a claim about the adapter,
                     // and the core is forbidden from assuming one.

--- a/src/platform/process.rs
+++ b/src/platform/process.rs
@@ -25,14 +25,23 @@
 //! duplicate copies of that same scan were found and fixed to reuse this
 //! module during the same trip). Closes #18.
 
-/// One running process a liveness scan can see: its pid, and — wherever the
-/// platform can produce it — its argv, already tokenized into separate
-/// arguments (never a single joined command line: see
+/// One running process a liveness scan can see: its pid, its parent's pid,
+/// and — wherever the platform can produce it — its argv, already tokenized
+/// into separate arguments (never a single joined command line: see
 /// `backend::claude::cmdline_names_session`'s doc for why a joined line is
 /// exactly the false-positive shape this fact must not produce).
 #[derive(Debug, Clone)]
 pub struct ProcessArgv {
     pub pid: u32,
+    /// The parent this process had **at the moment of the scan**. `None`
+    /// where the platform arm could not read it (a process that exited
+    /// between being listed and being read, a `ps` line missing the column).
+    ///
+    /// Deliberately not cached anywhere: a parent that dies reparents its
+    /// children to init, so this fact is only ever true of the instant it was
+    /// gathered. [`descendants`] exists precisely so a caller captures the
+    /// tree *before* it kills the root, rather than looking for it after.
+    pub ppid: Option<u32>,
     pub argv: Vec<String>,
 }
 
@@ -56,6 +65,54 @@ pub fn process_alive(pid: u32) -> bool {
     raw_process_alive(pid)
 }
 
+/// Every process currently descended from `root`, breadth-first, `root`
+/// itself excluded.
+///
+/// **Why this exists (#310).** A daemon's probe children are its *children*
+/// only while it is alive: the instant it is SIGKILLed they reparent to init
+/// and no ancestry query can find them again. So a reaper that wants to take
+/// a whole tree down has to enumerate the tree first and signal the recorded
+/// pids afterwards — "kill the daemon, then look for its children" is the
+/// shape that let ~265 MB `opencode serve` probe children accumulate for a
+/// working day while every orphan check reported clean.
+///
+/// One scan, then a pure walk over it: re-scanning per level would let a
+/// process appear under two different parents across scans and be visited
+/// twice (or missed entirely). A cycle is impossible in a real process table,
+/// but the walk carries a `seen` set anyway — this reads a live kernel
+/// surface, and a torn read must not become an infinite loop in a `Drop`.
+///
+/// Returns empty where [`running_processes`] cannot answer at all: the
+/// fail-closed direction for a *reaper* is to signal nothing rather than
+/// guess at pids it cannot evidence.
+pub fn descendants(root: u32) -> Vec<u32> {
+    let Some(processes) = running_processes() else {
+        return Vec::new();
+    };
+    let mut children: std::collections::BTreeMap<u32, Vec<u32>> = std::collections::BTreeMap::new();
+    for process in processes {
+        if let Some(ppid) = process.ppid {
+            children.entry(ppid).or_default().push(process.pid);
+        }
+    }
+    let mut seen: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
+    let mut found = Vec::new();
+    let mut queue = std::collections::VecDeque::from([root]);
+    seen.insert(root);
+    while let Some(pid) = queue.pop_front() {
+        let Some(kids) = children.get(&pid) else {
+            continue;
+        };
+        for &kid in kids {
+            if seen.insert(kid) {
+                found.push(kid);
+                queue.push_back(kid);
+            }
+        }
+    }
+    found
+}
+
 #[cfg(target_os = "linux")]
 fn raw_running_processes() -> Option<Vec<ProcessArgv>> {
     let entries = std::fs::read_dir("/proc").ok()?;
@@ -76,9 +133,28 @@ fn raw_running_processes() -> Option<Vec<ProcessArgv>> {
             .filter(|arg| !arg.is_empty())
             .map(|arg| String::from_utf8_lossy(arg).into_owned())
             .collect();
-        processes.push(ProcessArgv { pid, argv });
+        let ppid = std::fs::read_to_string(entry.path().join("status"))
+            .ok()
+            .as_deref()
+            .and_then(parse_proc_status_ppid);
+        processes.push(ProcessArgv { pid, ppid, argv });
     }
     Some(processes)
+}
+
+/// The `PPid:` line of `/proc/<pid>/status`.
+///
+/// `status` rather than `stat`: `stat`'s parent is field 4, *after* a `comm`
+/// field the kernel writes in parentheses without escaping — a process named
+/// `foo) 1 (bar` shifts every positional field after it, and a reaper that
+/// mis-parses one line signals the wrong pid. `status` is line-oriented and
+/// has no such hazard.
+#[cfg(any(test, target_os = "linux"))]
+fn parse_proc_status_ppid(status: &str) -> Option<u32> {
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix("PPid:"))
+        .and_then(|value| value.trim().parse::<u32>().ok())
 }
 
 #[cfg(target_os = "linux")]
@@ -86,8 +162,9 @@ fn raw_process_alive(pid: u32) -> bool {
     std::path::Path::new(&format!("/proc/{pid}")).exists()
 }
 
-/// `ps -axo pid=,command=` output, one process per line: pid then its full
-/// command line, tokenized here on whitespace. That tokenization is the one
+/// `ps -axo pid=,ppid=,command=` output, one process per line: pid, parent
+/// pid, then its full command line, tokenized here on whitespace. That
+/// tokenization is the one
 /// place this arm is weaker than Linux's byte-exact NUL-split argv: a quoted
 /// argument containing a space would defeat it. The launch grammar this fact
 /// is actually matched against — `--session-id <uuid>` / `--resume <uuid>`,
@@ -115,8 +192,16 @@ fn parse_ps_output(stdout: &str) -> Vec<ProcessArgv> {
         let Some(pid) = tokens.next().and_then(|token| token.parse::<u32>().ok()) else {
             continue;
         };
+        // The parent column is required by the invocation above, so a line
+        // whose second token is not a bare number is a line this parser does
+        // not understand — dropped whole rather than turned into an entry
+        // whose argv silently starts one token late.
+        let Some(ppid) = tokens.next().and_then(|token| token.parse::<u32>().ok()) else {
+            continue;
+        };
         processes.push(ProcessArgv {
             pid,
+            ppid: Some(ppid),
             argv: tokens.map(str::to_string).collect(),
         });
     }
@@ -130,7 +215,7 @@ fn parse_ps_output(stdout: &str) -> Vec<ProcessArgv> {
 #[cfg(target_os = "macos")]
 fn raw_running_processes() -> Option<Vec<ProcessArgv>> {
     let output = std::process::Command::new("ps")
-        .args(["-axo", "pid=,command="])
+        .args(["-axo", "pid=,ppid=,command="])
         .output()
         .ok()?;
     if !output.status.success() {
@@ -168,27 +253,113 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ordinary_shape_parses_pid_and_argv() {
-        let stdout = "1234 /usr/bin/claude --session-id abc-123\n";
+    fn ordinary_shape_parses_pid_ppid_and_argv() {
+        let stdout = "1234 1 /usr/bin/claude --session-id abc-123\n";
         let processes = parse_ps_output(stdout);
         assert_eq!(processes.len(), 1);
         assert_eq!(processes[0].pid, 1234);
+        assert_eq!(processes[0].ppid, Some(1));
         assert_eq!(
             processes[0].argv,
             vec!["/usr/bin/claude", "--session-id", "abc-123"]
         );
     }
 
-    /// A header row (should `ps -axo pid=,command=` ever regain one) or a
-    /// torn read's partial first line both have a non-numeric or missing
+    /// A header row (should `ps -axo pid=,ppid=,command=` ever regain one) or
+    /// a torn read's partial first line both have a non-numeric or missing
     /// leading token — neither may become a bogus pid entry the liveness
     /// scan then reasons about.
     #[test]
     fn line_without_a_leading_pid_is_dropped_not_a_bogus_entry() {
-        let stdout = "  PID COMMAND\n5678 /usr/bin/claude --resume def-456\n";
+        let stdout = "  PID  PPID COMMAND\n5678 4321 /usr/bin/claude --resume def-456\n";
         let processes = parse_ps_output(stdout);
         assert_eq!(processes.len(), 1);
         assert_eq!(processes[0].pid, 5678);
+        assert_eq!(processes[0].ppid, Some(4321));
+    }
+
+    /// #310: the parent column is what [`descendants`] walks. A line missing
+    /// it must not silently become an entry whose argv begins one token late
+    /// — `[/usr/bin/claude, --resume, def]` read from a two-column line would
+    /// be a *different process's* command line as far as every argv matcher
+    /// in this crate is concerned.
+    #[test]
+    fn line_without_a_parent_column_is_dropped_not_shifted() {
+        assert!(parse_ps_output("5678 /usr/bin/claude --resume def-456\n").is_empty());
+    }
+
+    #[test]
+    fn proc_status_ppid_is_read_from_its_own_line() {
+        let status = "Name:\tsgt\nUmask:\t0022\nState:\tS (sleeping)\nTgid:\t42\nPid:\t42\n\
+                      PPid:\t7\nTracerPid:\t0\n";
+        assert_eq!(parse_proc_status_ppid(status), Some(7));
+    }
+
+    /// `Pid:` precedes `PPid:` in the real file and shares its prefix in the
+    /// other direction; a matcher looking for `Pid:` anywhere in the line
+    /// would answer with the process's own id. Pinned because getting this
+    /// backwards makes every process its own parent, and [`descendants`]
+    /// would then return nothing at all — a reaper that silently reaps
+    /// nothing is the exact failure #310 is about.
+    #[test]
+    fn proc_status_ppid_is_not_confused_with_the_pid_line() {
+        let status = "Pid:\t42\nPPid:\t7\n";
+        assert_eq!(parse_proc_status_ppid(status), Some(7));
+        let no_parent = "Name:\tinit\nPid:\t1\n";
+        assert_eq!(parse_proc_status_ppid(no_parent), None);
+    }
+
+    /// A real tree, walked from a real root: this process's own children are
+    /// whatever it spawns, and a grandchild must come back too — the probe
+    /// children #310 is about are grandchildren of the test process whenever
+    /// an adapter isolates its spawn on a helper thread.
+    #[test]
+    fn descendants_reaches_a_grandchild_not_just_a_child() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("/bin/sh -c 'sleep 30' & sleep 30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn a two-level tree");
+        let child_pid = child.id();
+        // The grandchild is forked by the child, so it exists only after the
+        // child has run — poll rather than sleep on a guessed duration.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let found = loop {
+            let found = descendants(std::process::id());
+            if found.len() >= 2 && found.contains(&child_pid) {
+                break found;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the spawned tree never appeared under this process: {found:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        };
+        let _ = child.kill();
+        let _ = child.wait();
+        for &pid in &found {
+            if pid != child_pid {
+                let _ = std::process::Command::new("kill")
+                    .args(["-KILL", &pid.to_string()])
+                    .status();
+            }
+        }
+        assert!(
+            found.contains(&child_pid),
+            "the direct child {child_pid} was not in {found:?}"
+        );
+        assert!(
+            found.len() >= 2,
+            "only the direct child came back, so the walk never went a second level: {found:?}"
+        );
+    }
+
+    #[test]
+    fn descendants_never_includes_the_root_itself() {
+        assert!(!descendants(std::process::id()).contains(&std::process::id()));
     }
 
     #[test]
@@ -209,7 +380,7 @@ mod tests {
     /// fail the moment someone tries to rely on quoting surviving here.
     #[test]
     fn quoted_argument_with_a_space_is_split_current_known_weakness() {
-        let stdout = "1234 /usr/bin/claude --session-id \"abc def\"\n";
+        let stdout = "1234 1 /usr/bin/claude --session-id \"abc def\"\n";
         let processes = parse_ps_output(stdout);
         assert_eq!(processes.len(), 1);
         assert_eq!(

--- a/tests/codex_backend.rs
+++ b/tests/codex_backend.rs
@@ -1746,20 +1746,37 @@ fn the_group_kill_never_depends_on_a_kill_executable_being_installed() {
     // `kill_process_group` names the very construct being banned, in order to
     // explain why it is banned, and a check that cannot tell code from the
     // comment documenting it would forbid saying so.
-    let source: String = include_str!("../src/backend/codex.rs")
-        .lines()
-        .filter(|line| !line.trim_start().starts_with("//"))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let strip = |source: &str| -> String {
+        source
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    // #310 moved the one implementation to `backend/child.rs` — three
+    // adapters carried a byte-identical private copy and the probe path
+    // needed a fourth. The ban still binds this adapter (it must not grow a
+    // local copy that spawns `kill`), and the positive assertion now names
+    // the file the behaviour actually lives in.
+    let adapter = strip(include_str!("../src/backend/codex.rs"));
+    let shared = strip(include_str!("../src/backend/child.rs"));
+    for (file, source) in [("codex.rs", &adapter), ("child.rs", &shared)] {
+        assert!(
+            !source.contains("Command::new(\"kill\")"),
+            "{file}: the process-group kill must not spawn a bare `kill` executable: it is a \
+             package a host need not install, and `Command` reports its absence as an ENOENT \
+             that a dropped result silently turns into 'INTERRUPT killed nothing'. Go through \
+             a shell builtin."
+        );
+    }
     assert!(
-        !source.contains("Command::new(\"kill\")"),
-        "the process-group kill must not spawn a bare `kill` executable: it is a package a \
-         host need not install, and `Command` reports its absence as an ENOENT that a dropped \
-         result silently turns into 'INTERRUPT killed nothing'. Go through a shell builtin."
+        shared.contains("kill -KILL -{pgid}"),
+        "the process-group kill must still SIGKILL the negated group id (§5.5)"
     );
     assert!(
-        source.contains("kill -KILL -{pgid}"),
-        "the process-group kill must still SIGKILL the negated group id (§5.5)"
+        adapter.contains("crate::backend::child::kill_process_group"),
+        "this adapter must reach the group kill through the one shared implementation, not a \
+         reinstated local copy"
     );
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -339,7 +339,8 @@ pub fn daemon_pids(data_dir: &Path) -> Vec<u32> {
     pids
 }
 
-/// SIGTERM every daemon on `data_dir`, then SIGKILL whatever is left.
+/// SIGTERM every daemon on `data_dir`, then SIGKILL whatever is left — and
+/// then everything those daemons had descended from them.
 ///
 /// Returns what was signalled and with what, so a test can assert the rig
 /// did something rather than trusting it silently — and so the escalation
@@ -348,11 +349,30 @@ pub fn daemon_pids(data_dir: &Path) -> Vec<u32> {
 /// coverage profile that never arrived. A `Kill` in this report is therefore
 /// also announced on stderr, because `Drop` throws the value away and the
 /// escalation is exactly the thing a discarded return value must not hide.
+///
+/// **#310: the descendant sweep, and why its order is the whole point.** A
+/// daemon's children are its children only while it is alive; the instant it
+/// is signalled they reparent to init and no ancestry query can find them
+/// again. That is how dozens of ~265 MB `opencode serve` probe children
+/// accumulated over a working day while every orphan check reported clean —
+/// both doctrinal patterns are `sgt`-shaped and the leaked species is named
+/// `opencode`. So the tree is enumerated **before** the daemon is signalled,
+/// and the recorded pids are signalled afterwards.
+///
+/// This is belt to the product's own braces (`backend::child`'s
+/// `PR_SET_PDEATHSIG`, which is what actually closes the leak). It is the
+/// half that still works on a platform with no parent-death signal, and the
+/// half that reaches a child something other than a hardened probe spawned.
 pub fn reap_daemons(data_dir: &Path) -> Vec<ReapedDaemon> {
     let pids = daemon_pids(data_dir);
     if pids.is_empty() {
         return Vec::new();
     }
+    let descendants: Vec<u32> = pids
+        .iter()
+        .flat_map(|&pid| sergeant_rs::platform::process::descendants(pid))
+        .filter(|pid| !pids.contains(pid))
+        .collect();
     // Built from the escalation branch this call actually took, never from
     // "it went away, so TERM must have done it": that inference would report
     // `Term` for a reaper that had been changed to open with SIGKILL.
@@ -382,6 +402,34 @@ pub fn reap_daemons(data_dir: &Path) -> Vec<ReapedDaemon> {
                 TERM_GRACE.as_secs()
             );
         }
+    }
+    // The recorded tree, now that the daemons are gone. `kill -KILL -<pid>`
+    // rather than `kill -KILL <pid>`: a hardened probe child leads its own
+    // process group (`backend::child`), so the negated form reaches whatever
+    // *it* spawned, and an already-empty group is `ESRCH` — success, not an
+    // error worth reporting. Both forms are sent, because a descendant that
+    // is not a group leader is reached only by the plain one.
+    let survivors: Vec<u32> = descendants
+        .into_iter()
+        .filter(|&pid| sergeant_rs::platform::process::process_alive(pid))
+        .collect();
+    if !survivors.is_empty() {
+        for pid in &survivors {
+            let _ = std::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg(format!(
+                    "kill -KILL -{pid} 2>/dev/null; kill -KILL {pid} 2>/dev/null"
+                ))
+                .status();
+        }
+        eprintln!(
+            "support::reap_daemons: {} process(es) descended from the daemon(s) on {:?} \
+             outlived them and were killed by recorded pid: {survivors:?}. #310: a probe \
+             child that reaches this line is one the product's own PR_SET_PDEATHSIG should \
+             already have taken.",
+            survivors.len(),
+            data_dir,
+        );
     }
     reaped
 }

--- a/tests/v1d_probe_child_lifecycle.rs
+++ b/tests/v1d_probe_child_lifecycle.rs
@@ -1,0 +1,504 @@
+//! #310: a probe's child never outlives the probe, and never outlives the
+//! daemon — not even a daemon that dies by `SIGKILL`.
+//!
+//! ## What this suite is evidence of
+//!
+//! Every `daemon::start_with` probes every registered backend. The opencode
+//! probe runs a real `opencode serve --port 0` and the codex probe a real
+//! `codex app-server --listen stdio://`; the suites in this directory start
+//! daemons by the hundred and kill them abruptly. A daemon killed while a
+//! probe child was live left that child reparented to init forever —
+//! diagnosed on Cerberus 2026-08-26 after four OOM-driven session and host
+//! deaths, at ~265-342 MB RSS per orphan, one killed at 74 GB total-vm.
+//! Neither doctrinal orphan-check pattern matched them (both are `sgt`-shaped,
+//! and the leaked species is named `opencode`), so every wave's hygiene check
+//! was honest and blind.
+//!
+//! Two independent facts are pinned here, because the fix has two halves and
+//! either one alone would leave the hole open:
+//!
+//! 1. **The kernel coupling** — `backend::child::harden_probe_child` arms
+//!    `prctl(PR_SET_PDEATHSIG, SIGKILL)`, so a hardened child dies when its
+//!    parent process is killed. Evidenced against a real, separately spawned
+//!    parent (this binary re-executed in a role), with an unhardened control
+//!    beside it so a passing assertion cannot mean "the child was going to
+//!    exit anyway". Runs on any Linux host, CI included — no CLI needed.
+//! 2. **The whole thing, end to end** — a real daemon with real adapters
+//!    registered, `SIGKILL`ed mid-probe-walk, leaving **zero** survivors
+//!    among the descendant pids captured before the kill. Asserted by exact
+//!    pid, never by name-grep: a name-grep would pass on a host where the
+//!    operator's own editor happens not to be running opencode, and fail on
+//!    one where it is.
+//!
+//! ## Environment gate
+//!
+//! Test 2 needs the real third-party CLIs, because a probe that spawns
+//! nothing proves nothing about a probe child. It skips loudly
+//! (`SKIPPED-ENV`) where they are absent, per this repo's environment-fixture
+//! rule — but on a host that has them (Cerberus does) it runs for real, and a
+//! survivor is a failure, never a note.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use sergeant_rs::platform::process::{descendants, process_alive, running_processes};
+
+mod support;
+use support::DataDir;
+
+const SGT: &str = env!("CARGO_BIN_EXE_sgt");
+
+/// Selects the re-executed role this binary plays for test 1. Unset in an
+/// ordinary run, which is why [`v1d_role_helper`] is a no-op then.
+const ROLE_ENV: &str = "SGT_V1D_ROLE";
+/// Where the role helper writes the pid of the child it spawned.
+const ROLE_PIDFILE_ENV: &str = "SGT_V1D_PIDFILE";
+
+/// How long any poll in this suite waits before calling it a hang. A
+/// deadline guard, not a latency pin: nothing here asserts anything was
+/// *fast*, only that it happened at all.
+const DEADLINE: Duration = Duration::from_secs(30);
+
+// --------------------------------------------------------------- role helper
+
+/// A no-op in an ordinary run; the parent half of test 1 when re-executed
+/// with [`ROLE_ENV`] set.
+///
+/// The re-exec exists because the fact under test is not observable from
+/// inside a live process. Measured on this kernel (Cerberus, Linux 7.0.0,
+/// 2026-08-26), `PR_SET_PDEATHSIG` fires on the parent **process**'s death,
+/// not the spawning thread's — so evidencing it means killing a process, and
+/// a unit test cannot do that to itself. Re-executing this test binary under
+/// `--exact` gives a real parent to kill that runs the real production
+/// `harden_probe_child`, with no stand-in and no second implementation.
+// The child is deliberately never `wait()`ed: this process is about to be
+// SIGKILLed, and whether the child outlives that is the entire measurement.
+#[allow(clippy::zombie_processes)]
+#[test]
+fn v1d_role_helper() {
+    let Ok(role) = std::env::var(ROLE_ENV) else {
+        return;
+    };
+    let harden = match role.as_str() {
+        "hardened" => true,
+        "bare" => false,
+        other => panic!("unknown {ROLE_ENV} role {other:?}"),
+    };
+    let pidfile = PathBuf::from(std::env::var(ROLE_PIDFILE_ENV).expect("role pidfile"));
+
+    let mut command = Command::new("/bin/sh");
+    // `exec` so the surviving process is `sleep` itself and the pid written
+    // below is the one that has to die — an intermediate shell would make
+    // "the child is gone" ambiguous about which child.
+    command
+        .arg("-c")
+        .arg("exec sleep 300")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if harden {
+        sergeant_rs::backend::child::harden_probe_child(&mut command);
+    }
+    let child = command
+        .spawn()
+        .expect("role helper could not spawn its child");
+
+    // Written-then-renamed so the parent never reads a half-written pid.
+    let staging = pidfile.with_extension("staging");
+    std::fs::write(&staging, child.id().to_string()).expect("write role pidfile");
+    std::fs::rename(&staging, &pidfile).expect("publish role pidfile");
+
+    // Block forever. The parent kills this process; that is the event under
+    // test, so returning normally here would defeat the whole fixture.
+    loop {
+        std::thread::sleep(Duration::from_secs(3600));
+    }
+}
+
+/// Start the role helper and return `(the helper process, the pid of the
+/// child it spawned)`.
+///
+/// The `Child` is handed back rather than waited on here — every caller kills
+/// it and then reaps it, which is what the lint below cannot see across a
+/// return.
+#[allow(clippy::zombie_processes)]
+fn start_role(role: &str, pidfile: &Path) -> (std::process::Child, u32) {
+    let helper = Command::new(std::env::current_exe().expect("current exe"))
+        .args([
+            "--exact",
+            "v1d_role_helper",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(ROLE_ENV, role)
+        .env(ROLE_PIDFILE_ENV, pidfile)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn the role helper");
+    let deadline = Instant::now() + DEADLINE;
+    loop {
+        if let Ok(text) = std::fs::read_to_string(pidfile)
+            && let Ok(pid) = text.trim().parse::<u32>()
+        {
+            return (helper, pid);
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the {role:?} role helper never published a child pid"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_until_gone(pid: u32, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    loop {
+        if !process_alive(pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn hard_kill(pid: u32) {
+    let _ = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(format!(
+            "kill -KILL -{pid} 2>/dev/null; kill -KILL {pid} 2>/dev/null"
+        ))
+        .status();
+}
+
+// ------------------------------------------------------ 1. the kernel coupling
+
+/// A hardened probe child dies when the process that spawned it is
+/// `SIGKILL`ed. This is the one mechanism that survives a killed parent —
+/// nothing else can, because no destructor of any kind runs for one.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_hardened_probe_child_dies_when_its_parent_process_is_sigkilled() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (mut helper, child_pid) = start_role("hardened", &dir.path().join("pid"));
+    let helper_pid = helper.id();
+
+    hard_kill(helper_pid);
+    let _ = helper.wait();
+
+    let gone = wait_until_gone(child_pid, DEADLINE);
+    if !gone {
+        hard_kill(child_pid);
+    }
+    assert!(
+        gone,
+        "hardened child {child_pid} outlived its SIGKILLed parent {helper_pid} — \
+         PR_SET_PDEATHSIG is not armed, which is exactly the #310 leak"
+    );
+}
+
+/// The control that makes the assertion above mean something: the identical
+/// child, spawned without the hardening, survives the identical kill. This is
+/// the behaviour every adapter probe had before #310 was fixed, and it is
+/// what put dozens of `opencode serve` processes on PID 1.
+#[cfg(target_os = "linux")]
+#[test]
+fn an_unhardened_child_survives_the_same_kill() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (mut helper, child_pid) = start_role("bare", &dir.path().join("pid"));
+
+    hard_kill(helper.id());
+    let _ = helper.wait();
+
+    // Two seconds is not a latency claim: an orphaned `sleep 300` either dies
+    // in the kernel's own reparenting (immediately) or lives for five
+    // minutes. There is nothing in between for this budget to be wrong about.
+    let survived = !wait_until_gone(child_pid, Duration::from_secs(2));
+    hard_kill(child_pid);
+    assert!(
+        survived,
+        "the unhardened control child died on its own, so the hardened assertion beside \
+         this one proves nothing about PR_SET_PDEATHSIG"
+    );
+}
+
+// ------------------------------------------------- 2. the whole thing, for real
+
+/// Why this host cannot run the end-to-end assertion, or `None` if it can.
+///
+/// Both CLIs are named because they are the two probes that spawn a
+/// *persistent* child (`opencode serve`, `codex app-server`); a host with
+/// neither has no probe child to leak and would pass this test for the wrong
+/// reason.
+fn missing_probe_clis() -> Option<String> {
+    let missing: Vec<&str> = ["opencode", "codex"]
+        .into_iter()
+        .filter(|cli| {
+            !Command::new("/bin/sh")
+                .arg("-c")
+                .arg(format!("command -v {cli}"))
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .is_ok_and(|status| status.success())
+        })
+        .collect();
+    (!missing.is_empty()).then(|| missing.join(", "))
+}
+
+/// The argv of a live process, or `None` if it is gone.
+fn argv_of(pid: u32) -> Option<Vec<String>> {
+    running_processes()?
+        .into_iter()
+        .find(|process| process.pid == pid)
+        .map(|process| process.argv)
+}
+
+/// Whether an argv is one of the two persistent probe children #310 names.
+fn is_persistent_probe_child(argv: &[String]) -> bool {
+    let joined = argv.join(" ");
+    is_opencode_serve_child(argv) || joined.contains("app-server --listen")
+}
+
+/// The `opencode serve --port 0` child specifically — the species that
+/// actually accumulated on PID 1.
+///
+/// Told apart from `codex app-server` deliberately, because the two do not
+/// leak alike and a test that stopped at whichever appeared first would pass
+/// for the wrong reason. An app-server child reads JSON-RPC from a stdin pipe
+/// the dying daemon closes, so it sees EOF and exits on its own; a serve
+/// child listens on a socket and writes to nobody, so nothing tells it its
+/// parent is gone. That difference is why `PR_SET_PDEATHSIG` — not pipe
+/// closure — is the mechanism this suite is really about, and why the capture
+/// loop below waits for a serve child rather than settling for the first
+/// persistent one it sees.
+fn is_opencode_serve_child(argv: &[String]) -> bool {
+    argv.join(" ").contains("serve --port")
+}
+
+/// Spawn a bare `sgt daemon` on `dir` and hand back its process.
+///
+/// Not through auto-spawn: this test has to hold the daemon's own pid to kill
+/// it at a chosen instant, and auto-spawn deliberately detaches.
+#[allow(clippy::zombie_processes)]
+fn spawn_daemon(dir: &DataDir) -> std::process::Child {
+    Command::new(SGT)
+        .current_dir(dir.path())
+        .arg("--data-dir")
+        .arg(dir.path())
+        .arg("daemon")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sgt daemon")
+}
+
+/// **#310's centrepiece.** A real daemon, real adapters, `SIGKILL`ed the
+/// moment a persistent probe child appears — and then not one of the pids
+/// captured before the kill is still alive.
+///
+/// Asserted by exact captured pid, never by name-grep. A name-grep would pass
+/// on a host where the operator's own editor happens not to be running
+/// `opencode` and fail on one where it is, which is the opposite of a
+/// regression test. Every descendant seen at any point during the walk is
+/// accumulated, not just the persistent ones, so a `--help` child that got
+/// stuck would be caught by the same assertion.
+#[test]
+fn a_hard_killed_daemon_leaves_no_probe_descendant_alive() {
+    if let Some(missing) = missing_probe_clis() {
+        eprintln!(
+            "SKIPPED-ENV: #310's end-to-end probe-child assertion needs the real CLIs whose \
+             probes spawn a persistent child; not on this host: {missing}. The kernel-coupling \
+             half of the fix is still asserted by the two tests above, which need no CLI."
+        );
+        return;
+    }
+
+    let dir = DataDir::new();
+    support::scaffold_estate(dir.path(), "v1d", &["solo"]);
+    let mut daemon = spawn_daemon(&dir);
+    let daemon_pid = daemon.id();
+
+    // Accumulate every descendant this daemon ever shows, and stop the
+    // instant one of them is a persistent probe child — that is the window
+    // the leak lived in, and waiting for the walk to finish would close it.
+    let mut captured: Vec<u32> = Vec::new();
+    let mut caught_persistent: Vec<(u32, String)> = Vec::new();
+    let mut caught_the_leaker = false;
+    let deadline = Instant::now() + DEADLINE;
+    while Instant::now() < deadline && !caught_the_leaker {
+        for pid in descendants(daemon_pid) {
+            if !captured.contains(&pid) {
+                captured.push(pid);
+            }
+            let Some(argv) = argv_of(pid) else { continue };
+            if is_persistent_probe_child(&argv)
+                && !caught_persistent.iter().any(|(seen, _)| *seen == pid)
+            {
+                caught_persistent.push((pid, argv.join(" ")));
+            }
+            caught_the_leaker |= is_opencode_serve_child(&argv);
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    hard_kill(daemon_pid);
+    let _ = daemon.wait();
+
+    assert!(
+        caught_the_leaker,
+        "the probe walk never showed an `opencode serve --port 0` child under daemon \
+         {daemon_pid} within {DEADLINE:?} (persistent children seen: {caught_persistent:?}; \
+         all descendants seen: {captured:?}). That child is the species #310 is about, and \
+         a run that never saw one cannot evidence the fix — so this fails rather than \
+         passing vacuously. Check that the opencode adapter is still registered at daemon \
+         start and still resolves its transport through the serve gate."
+    );
+
+    // Poll rather than sleep-then-check: the kernel delivers the death signal
+    // asynchronously, and a fixed sleep would either be flaky or slow.
+    let gone_by = Instant::now() + DEADLINE;
+    let survivors: Vec<u32> = loop {
+        let alive: Vec<u32> = captured
+            .iter()
+            .copied()
+            .filter(|&pid| process_alive(pid))
+            .collect();
+        if alive.is_empty() || Instant::now() >= gone_by {
+            break alive;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+
+    let described: Vec<String> = survivors
+        .iter()
+        .map(|&pid| match argv_of(pid) {
+            Some(argv) => format!("{pid}: {}", argv.join(" ")),
+            None => format!("{pid}: <exited between the check and this line>"),
+        })
+        .collect();
+    for &pid in &survivors {
+        hard_kill(pid);
+    }
+    assert!(
+        survivors.is_empty(),
+        "#310 regression: {} process(es) descended from daemon {daemon_pid} survived its \
+         SIGKILL. Caught mid-walk: {caught_persistent:?}. Survivors: {described:?}",
+        survivors.len(),
+    );
+}
+
+/// The ordinary path, which is the one that runs hundreds of times a suite: a
+/// probe walk that completes normally leaves nothing of its own behind.
+///
+/// Separate from the assertion above because it fails for a different reason.
+/// That one catches "a killed daemon orphans its probe child"; this one
+/// catches "a probe forgot to kill and reap its child when it finished", the
+/// requirement that holds even when nothing ever kills the daemon.
+#[test]
+fn a_completed_probe_walk_leaves_no_child_of_its_own_behind() {
+    if let Some(missing) = missing_probe_clis() {
+        eprintln!("SKIPPED-ENV: no probe on this host spawns a child to leave behind: {missing}");
+        return;
+    }
+
+    let dir = DataDir::new();
+    support::scaffold_estate(dir.path(), "v1d", &["solo"]);
+    let mut daemon = spawn_daemon(&dir);
+    let daemon_pid = daemon.id();
+
+    // The walk is finished when the daemon has been idle of children for a
+    // while — asserted as a settled state rather than read from the journal,
+    // because what this test is about is processes, not events.
+    let deadline = Instant::now() + DEADLINE;
+    let mut quiet_since: Option<Instant> = None;
+    let mut saw_a_child = false;
+    while Instant::now() < deadline {
+        let live = descendants(daemon_pid);
+        saw_a_child |= !live.is_empty();
+        match (live.is_empty(), quiet_since) {
+            (true, None) => quiet_since = Some(Instant::now()),
+            (true, Some(since)) if since.elapsed() >= Duration::from_secs(3) => break,
+            (true, Some(_)) => {}
+            (false, _) => quiet_since = None,
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let leftover: Vec<u32> = descendants(daemon_pid);
+    let described: Vec<String> = leftover
+        .iter()
+        .map(|&pid| match argv_of(pid) {
+            Some(argv) => format!("{pid}: {}", argv.join(" ")),
+            None => format!("{pid}: <exited>"),
+        })
+        .collect();
+
+    // The daemon goes the polite way here; the rig's own guard is what
+    // asserts nothing survived it.
+    hard_kill(daemon_pid);
+    let _ = daemon.wait();
+
+    assert!(
+        saw_a_child,
+        "the daemon never spawned a probe child at all, so this test proves nothing"
+    );
+    assert!(
+        leftover.is_empty(),
+        "#310 requirement 2: a completed probe walk left {} child process(es) running \
+         under daemon {daemon_pid}: {described:?}",
+        leftover.len()
+    );
+}
+
+/// #310 requirement 3, from the rig's side: after the `DataDir` guard has
+/// reaped, nothing that was ever a descendant of its daemons is still alive.
+///
+/// The guard captures the tree *before* it signals, which is the only order
+/// that can work — a signalled daemon's children reparent to init and no
+/// ancestry query finds them again. That ordering is exactly what made every
+/// wave's orphan check honest and blind for a working day.
+#[test]
+fn the_data_dir_guard_leaves_no_descendant_of_its_daemons_alive() {
+    let dir = DataDir::new();
+    support::scaffold_estate(dir.path(), "v1d", &["solo"]);
+    let mut daemon = spawn_daemon(&dir);
+    let daemon_pid = daemon.id();
+
+    let mut captured: Vec<u32> = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        for pid in descendants(daemon_pid) {
+            if !captured.contains(&pid) {
+                captured.push(pid);
+            }
+        }
+        if !captured.is_empty() && Instant::now() > deadline - Duration::from_secs(7) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    dir.reap();
+    let _ = daemon.wait();
+
+    let survivors: Vec<u32> = captured
+        .iter()
+        .copied()
+        .filter(|&pid| process_alive(pid))
+        .collect();
+    for &pid in &survivors {
+        hard_kill(pid);
+    }
+    assert!(
+        survivors.is_empty(),
+        "the DataDir guard reaped daemon {daemon_pid} but left {} of its descendants \
+         alive: {survivors:?}",
+        survivors.len()
+    );
+}

--- a/tests/v1d_probe_child_lifecycle.rs
+++ b/tests/v1d_probe_child_lifecycle.rs
@@ -502,3 +502,130 @@ fn the_data_dir_guard_leaves_no_descendant_of_its_daemons_alive() {
         survivors.len()
     );
 }
+
+// ------------------------------- 3. the in-process daemon's own descendant reap
+
+/// The kernel's one-letter state for `pid` (`R`, `S`, `Z`, ...), or a
+/// description of why it could not be read.
+///
+/// Read from `/proc/<pid>/stat` by splitting at the **last** `)`: the `comm`
+/// field before it is parenthesised and unescaped, so a positional split from
+/// the left is wrong for any process whose name contains a bracket.
+fn proc_state(pid: u32) -> String {
+    #[cfg(target_os = "linux")]
+    {
+        match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+            Ok(stat) => stat
+                .rsplit_once(") ")
+                .and_then(|(_, tail)| tail.split_whitespace().next().map(str::to_string))
+                .unwrap_or_else(|| "<unparseable /proc stat>".to_string()),
+            Err(e) => format!("<{e}>"),
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = pid;
+        "<no /proc on this platform>".to_string()
+    }
+}
+
+/// The probe children spawned **directly by this test process**, which is
+/// what an in-process daemon's probe children are.
+///
+/// Attribution by parent pid, not by a descendant walk: the other tests in
+/// this file spawn real `sgt daemon` children of this same process, and
+/// *their* serve children are descendants of this process too. Only the
+/// in-process daemon's are its direct children, so that is the filter.
+fn direct_serve_children() -> Vec<u32> {
+    let me = std::process::id();
+    running_processes()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|process| process.ppid == Some(me) && is_opencode_serve_child(&process.argv))
+        .map(|process| process.pid)
+        .collect()
+}
+
+/// #310 requirement 3, from the daemon's own side: `DaemonHandle::kill` — the
+/// in-process rig's analogue of `SIGKILL` — reaps the probe children its walk
+/// still has live.
+///
+/// Aborting the serve task does not reach the probe walk, and a probe child is
+/// a *process*: a real `opencode serve` at ~265 MB that nothing in this
+/// process's memory owns once the handle is gone. `PR_SET_PDEATHSIG` covers
+/// the out-of-process daemon because that daemon's death is a process death;
+/// an in-process daemon's is not, so the same guarantee has to come from the
+/// per-daemon `ProbeChildren` set the walk records into.
+///
+/// `await_probe_walk: false` is what makes the window observable at all: the
+/// default hands the handle back only after the walk has finished, by which
+/// time every probe has already killed its own child.
+#[tokio::test]
+async fn daemon_handle_kill_reaps_a_probe_child_its_walk_still_has_live() {
+    if let Some(missing) = missing_probe_clis() {
+        eprintln!(
+            "SKIPPED-ENV: no probe on this host spawns a persistent child for \
+             DaemonHandle::kill to reap: {missing}"
+        );
+        return;
+    }
+
+    let dir = DataDir::new();
+    support::scaffold_estate(dir.path(), "v1d", &["solo"]);
+    let handle = sergeant_rs::daemon::start_with(
+        dir.path(),
+        sergeant_rs::daemon::DaemonConfig {
+            await_probe_walk: false,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("start the in-process daemon");
+
+    let deadline = Instant::now() + DEADLINE;
+    let live = loop {
+        let live = direct_serve_children();
+        if !live.is_empty() {
+            break live;
+        }
+        if Instant::now() >= deadline {
+            break Vec::new();
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    };
+
+    handle.kill().await;
+
+    let survivors: Vec<u32> = live
+        .iter()
+        .copied()
+        .filter(|&pid| {
+            // Poll each one: the group kill is a subprocess, so "gone" is not
+            // instantaneous even though it is prompt.
+            !wait_until_gone(pid, Duration::from_secs(10))
+        })
+        .collect();
+    for &pid in &survivors {
+        hard_kill(pid);
+    }
+
+    assert!(
+        !live.is_empty(),
+        "the in-process daemon's walk never showed a live `opencode serve` child within \
+         {DEADLINE:?}, so this test cannot evidence the reap — it fails rather than passing \
+         vacuously"
+    );
+    // The kernel's own state letter for each survivor, because the two ways
+    // to fail here need different fixes and the pid alone does not say which:
+    // `R`/`S` means the kill never reached it, `Z` means it was killed and
+    // nobody reaped it — and a zombie is not a harmless bookkeeping detail
+    // here, it still answers `kill(pid, 0)` as alive and still matches
+    // `pgrep -x opencode`, so an orphan check cannot tell it from the leak.
+    let states: Vec<String> = survivors.iter().map(|&pid| proc_state(pid)).collect();
+    assert!(
+        survivors.is_empty(),
+        "DaemonHandle::kill left {} probe child(ren) of its own walk behind: {survivors:?} \
+         (states {states:?})",
+        survivors.len()
+    );
+}


### PR DESCRIPTION
The root cause of every OOM, session death, and reboot across S1–S2: backend probes launch real servers (`opencode serve`, `codex app-server`, and — found in this wave's audit — agy's full-agent config probe), and a hard-killed daemon orphaned them to PID 1 at ~265–340 MB each, forever. Test suites hard-kill daemons by the hundred. 6 commits.

- **Reproduced before fixing**: 10 staggered-SIGKILL daemon starts → 3 orphaned `opencode serve` at PPID 1. Same script after: zero.
- **All five adapters audited**: opencode (confirmed leaker — serve child + four one-shots), codex (leaker by class — its accidental stdin-EOF exit was luck, not a guarantee), **agy (previously unknown, worst-shaped: full agent invocation, no group, a drop-with-live-process early return)**, claude (clean, hardened anyway), docker (clean; deliberately untouched — the shared `cmd()` seam serves execution-lifetime children; recorded in its probe doc).
- **Layered kill mechanisms**: explicit kill+reap on probe completion; Drop backstops that now *reap* (a second bug class found: killed-but-unreaped zombies fool `kill(pid,0)` and pgrep alike); own process group + `PR_SET_PDEATHSIG(SIGKILL)` with the fork race closed by `getppid` re-read (out-of-process SIGKILL — the case nothing else can cover); per-daemon `ProbeChildren` registry for in-process daemons (per-daemon, never global — parallel test daemons must not kill siblings' probes); the test rig captures descendant PIDs **before** signalling (after, reparenting makes them unfindable — exactly why every prior orphan check was honest and blind).
- **`prctl(2)`'s man page measured wrong on this kernel** (parent-death signal is process-coupled, not thread-coupled as documented) — recorded on the `ChildLifetime` enum, pinned by a negative test, and the Probe/Execution split kept as portability defense.
- macOS gap stated, not hidden: no PDEATHSIG there; the rig's descendant sweep is the macOS cover.
- Regression bites both ways: with PDEATHSIG disarmed, the test fails naming the exact survivor (`(30783, "opencode serve --por…")`).

Gates: panel — **zero findings**. Verify: full suite 1864 passed / 0 failed; leak counts **0 → 0 → 0** (baseline / post-full-suite / post-3× hard-kill regression). Orphan-check doctrine gains the bracketed backend patterns.

Rungs: #310 J3; R3 (libc/prctl), R2 (existing Drop/guard shapes); the two argued departures from #310's literal wording J1-cited in-code.

Fixes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4