### PR TITLE
S2/V4: closeout — W1 §13 battery, causal tree, doctor row, live aria proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,91 @@ release.
   figure that had been carried from an earlier, differently-provisioned
   environment).
 
+### Hierarchical execution (S2)
+
+- A workflow stage directory may now itself hold a `workflow.toml`: the
+  loader recurses (embedded and repository packages alike), splicing the
+  nested package's leaves into the parent's one flat `stages` list at the
+  container's position, with `parent/child` composed hierarchical stage
+  ids. The container itself is never a `StageDefinition` or a
+  `StageRecord` — it enters and completes no event of its own; a
+  container "completing" is simply its last flattened leaf completing.
+  Nesting is unbounded by design; a package that resolves to one of its
+  own ancestors (a symlink cycle) fails closed by name at load time
+  instead of overflowing the recursion. A stage directory carrying both
+  `workflow.toml` and `CONTEXT.md` is a load error — a container has no
+  actor, so its `CONTEXT.md` could never be read.
+- A closing container's own declared output contract is checked at its
+  boundary-closing leaf's completion, reusing the existing output-gate
+  mechanics verbatim: a bounded re-prompt of that leaf, then a park
+  naming the *container's* id if still unmet. A leaf that simultaneously
+  closes several ancestor containers gates them innermost first. Nested
+  leaves' own output/required-column/finalize contracts behave
+  identically to top-level ones and are never bypassed by container
+  completion.
+- Composed hierarchical stage ids journal, replay, and render correctly:
+  the analytics fold, `sgt work show`, and a daemon restarted mid-nest
+  all carry/reconstruct the exact composed id from the journal alone —
+  recovery needs no process tree, only the last `StageRecord`. The
+  workflow's own wire shape stays the flat leaf list (hierarchical ids as
+  opaque strings); the TUI's workflow rail draws that flat list as the
+  tree it is.
+- `sgt -C <estate> run` from inside a managed execution can create an
+  ordinary, separately admitted child Work. Every managed execution now
+  carries an estate/Work/execution causation triple
+  (`SERGEANT_ESTATE_ROOT`/`SERGEANT_WORK_ID`/`SERGEANT_EXECUTION_ID`,
+  distinct from the harness's own `SGT_ESTATE_ROOT`) to every adapter's
+  spawned process, survives a daemon restart, and — when the child's `sgt
+  run` inherits and spends it — the daemon validates the claimed parent
+  against its own journal before recording the relation. A claim that
+  fails validation is never refused: the submission proceeds as an
+  ordinary causation-less Work, and the daemon journals an explicit,
+  visible `causation_unverified` marker naming the failed claim (journal
+  is truth; substance is preserved by admission and explicit addressing
+  rather than by refusal). Child Work has fully independent scope,
+  surface, and lifecycle — parent completion, cancellation, or (there
+  being no merge primitive in the engine at all) any notion of merge
+  never cascades to it, and a bare `sgt run` from inside a Work surface
+  still refuses; only explicit `-C` addressing is exempt.
+- `sgt run --wait` observes the Work it just submitted through to a
+  terminal state client-side (the existing watch mechanism, scoped to
+  the new Work id) — no new engine hold state.
+- The Fleet TUI groups a child Work immediately under its own parent,
+  recursively, indenting the intent cell one level per ancestor hop — the
+  causal-child tree, derived entirely from a row's own already-projected
+  `parent` field (no second request per Work). A child whose parent
+  isn't currently visible (filtered out, or aged out of the daemon's
+  caches) renders as a root rather than being dropped.
+- `sgt doctor` gained a `workflow_stage_declarations` row: a
+  directory inside a workflow package that looks like a stage (holds
+  `CONTEXT.md`, `README.md`, or its own `workflow.toml`) but isn't named
+  in that package's declared `stages` warns, naming the package and the
+  directory (or, for an undeclared nested package, the whole unreachable
+  subtree) — a real directory on disk the loader will never reach. Warn,
+  not fail: this is an authoring-drift observation, not a broken
+  declaration.
+- Fixed a probe-child leak: a killed probe's own children (and their
+  children) now die with the probe and with the daemon instead of being
+  reparented and left running, orphaned. (#310)
+- The test suite runs roughly 40% faster: ten small no-daemon integration
+  suites consolidated into one harness binary (`c2_light`, paying one
+  link instead of ten), `cargo-nextest` adopted (exact-pinned) locally,
+  in CI, and in the coverage lane, and `ci.yml`'s fmt/clippy job split
+  from the test job so wall-clock is the slower of the two rather than
+  their sum. Fixed a cross-process-re-entrant OTLP-disabled test that the
+  consolidation surfaced. (#305)
+- Doctrine amendment: `AGENTS.md`'s ESTATE bullet 5 and `icm-policy.md`'s
+  rule 1 now point at the sanctioned child-Work path (`sgt -C run`) as
+  the real nesting/possession primitive, replacing an ambiguous
+  possession-vs-injection reading; a new `docs/concepts/
+  hierarchical-execution.md` page documents nested packages and child
+  Work for operators.
+- The W1 §13 acceptance battery (`tests/v4_w1_acceptance.rs`) walks all
+  nine acceptance criteria literally, citing the named pin for each
+  already-proven claim and adding one self-contained structural test for
+  the one gap (no merge primitive exists in the engine to cascade
+  through).
+
 ## [0.2.4] - 2026-08-25
 
 sergeant-rs narrows to a product-documents-only repo, codex actors gain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,52 @@ release.
   nine acceptance criteria literally, citing the named pin for each
   already-proven claim and adding one self-contained structural test for
   the one gap (no merge primitive exists in the engine to cascade
-  through).
+  through); item 9's required-column half now has its own nested-leaf
+  test (`tests/m11_nested_workflow.rs::a_nested_leafs_required_column_contract_is_enforced_exactly_as_a_flat_ones_is`)
+  and its finalize half cites the pre-existing
+  `src/runtime/surface.rs::tests::the_finalize_sweep_reaches_a_nested_leafs_output`.
+
+#### V4 live evidence
+
+- **Opt-in live suites, serially, against the real `aria` opencode
+  endpoint** (`SERGEANT_OPENCODE_TESTS=1 cargo test --locked --test
+  opencode_backend -- --ignored --test-threads=1`): 8 passed, 0 failed
+  (`live_opencode_history_exports_the_whole_session`,
+  `live_opencode_minimal_turn_completes_with_usage`,
+  `live_opencode_probe_reports_the_installed_version`,
+  `live_opencode_resume_recalls_a_nonce_across_processes`,
+  `live_opencode_serve_abort_yields_an_interrupted_terminal_and_a_usable_session`,
+  `live_opencode_serve_actor_question_parks_and_resumes_on_answer`,
+  `live_opencode_serve_approval_round_trip_runs_the_gated_tool`,
+  `live_opencode_serve_minimal_turn_completes_with_usage`); finished in
+  140.55s. No capability differences from the measured `opencode`
+  admission row surfaced.
+- **Real end-to-end live proof** on a scratch estate
+  (`/var/tmp/hats2/v4-live-proof/estate`) against this box's real daemon
+  binary, bound to a scratch host-mode data dir via `SGT_DATA_DIR`
+  (`/var/tmp/hats2/v4-live-proof/data`) — never the estate's own
+  production journal. A real Work on the `opencode` backend (the `aria`
+  model) ran a workflow whose `CONTEXT.md` instructed the actor to submit
+  a child Work via the sanctioned `sgt -C "$SERGEANT_ESTATE_ROOT" run`
+  path; both parent (`01M10KPMV6K8JD6GYM1ZW0WA2V`) and child
+  (`01M10KR5W2ERFPCHMWH1ECQNNV`) reached `work.completed`. The child's own
+  `work.submitted` journal payload records the validated relation
+  verbatim: `"parent_work_id": "01M10KPMV6K8JD6GYM1ZW0WA2V"`,
+  `"parent_execution_id": "01M10KPQVS6ZJMT98CGBVP586S"` — no
+  `causation_unverified` marker, i.e. the claim validated clean against
+  the daemon's own journal, not merely accepted unverified.
+  - **A first attempt at this same proof produced no parent relation at
+    all** (neither `parent_work_id` nor a `causation_unverified` marker):
+    the actor's shell resolved the bare `sgt` on `$PATH` to a stale
+    installed binary (`~/.cargo/bin/sgt`, built before this sprint's
+    causation transport) rather than this branch's own build, so the
+    submitted child never claimed a parent to begin with. Not a
+    sergeant-rs defect — a live-environment `$PATH` artifact of this one
+    run — diagnosed by comparing binary contents (`strings … | grep
+    claimed_parent_work_id`) between the two, then re-run with the
+    branch's own build first on `$PATH`, which produced the clean result
+    above. Recorded here per the brief's own honesty requirement rather
+    than silently discarded as a bad take.
 
 ## [0.2.4] - 2026-08-25
 

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -128,3 +128,12 @@ cov_stage_end 1 "the w4c_service_doctor test binary must write its own profile (
 cov_stage_begin c2-c2_light
 cov_run cargo llvm-cov --no-report --test c2_light --locked || cov_fail "c2_light failed under instrumentation"
 cov_stage_end 1 "the c2_light test binary must write its own profile"
+
+# S2 V4 closeout: the W1 §13 acceptance battery, `w5_h1_acceptance.rs`'s own
+# precedent one wave later. Almost entirely comment checklist entries
+# pointing at m11/m12's own named pins; the one self-contained test
+# (criterion 7's merge half) reads source files in-process and spawns
+# nothing, so this sits in C2 rather than C3. Floor 1.
+cov_stage_begin c2-v4_w1_acceptance
+cov_run cargo llvm-cov --no-report --test v4_w1_acceptance --locked || cov_fail "v4_w1_acceptance failed under instrumentation"
+cov_stage_end 1 "the v4_w1_acceptance test binary must write its own profile"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3534,6 +3534,11 @@ pub(crate) mod doctor {
         checks.push(network_access_check(admitted.as_deref()));
         checks.push(estate_check(admitted.as_deref()));
         checks.push(workflows_check(admitted.as_deref()));
+        // S2 V4 (owner-directed 2026-08-27): an authoring-drift observation
+        // distinct from workflows_check's own declared-package census above —
+        // a stage-shaped directory *inside* a package that no stages entry
+        // names. Same estate-root threading.
+        checks.push(undeclared_stage_dirs_check(admitted.as_deref()));
         // #261: the installed corpus must cite only routes that actually
         // resolve — deliberately not exempted from `healthy_for_init`, see
         // `doc_routes_check`'s own doc comment.
@@ -4079,6 +4084,137 @@ pub(crate) mod doctor {
                     names.len(),
                     names.join(", ")
                 ),
+            )
+        }
+    }
+
+    /// S2 V4 (owner-directed 2026-08-27): a directory *inside* a workflow
+    /// package that looks like a stage — it holds `CONTEXT.md`, `README.md`,
+    /// or its own `workflow.toml` — but is not named in that package's
+    /// declared `[workflow].stages` list is authoring drift: the directory
+    /// is really on disk, but no run will ever reach it (`check_stage_ids`,
+    /// `domain::workflow.rs`, only ever sees the declared list). Recurses
+    /// into a *declared* nested package (W1 §2/E1) against that package's
+    /// own `stages`, since the same drift can recur at any depth; an
+    /// entirely undeclared nested-package directory is not recursed into
+    /// further — one row names the whole unreachable subtree, since nothing
+    /// beneath it is reachable either.
+    ///
+    /// Warn, not fail: doctor's fail-closed rule is for a declaration that
+    /// is broken (a stage the loader cannot resolve); this is a directory
+    /// nobody declared anything about, broken or otherwise. A malformed
+    /// `workflow.toml` is silently skipped here — `workflows_check` and the
+    /// loader itself are where a parse failure is reported; this check only
+    /// ever adds warnings on top of a package it could parse.
+    fn undeclared_stage_dirs_check(estate_root: Option<&Path>) -> Check {
+        use crate::domain::workflow::{
+            CONTEXT_FILE, LOCAL_WORKFLOW_ROOT, WORKFLOW_FILE, WORKFLOW_ROOT,
+        };
+
+        const NAME: &str = "workflow_stage_declarations";
+
+        let Some(estate_root) = estate_root else {
+            return Check::ok(NAME, "not an estate root — nothing to check");
+        };
+
+        fn is_stage_shaped(dir: &Path) -> bool {
+            dir.join(CONTEXT_FILE).is_file()
+                || dir.join("README.md").is_file()
+                || dir.join(WORKFLOW_FILE).is_file()
+        }
+
+        fn declared_stages(package_dir: &Path) -> Option<std::collections::BTreeSet<String>> {
+            let text = std::fs::read_to_string(package_dir.join(WORKFLOW_FILE)).ok()?;
+            let value: toml::Value = toml::from_str(&text).ok()?;
+            let stages = value
+                .get("workflow")?
+                .get("stages")?
+                .as_array()?
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            Some(stages)
+        }
+
+        /// `label` is the warning's own package-plus-path prefix — composed
+        /// as recursion descends into a declared nested package, so a warn
+        /// two levels deep still names the whole path from the package root
+        /// an operator would recognize.
+        fn scan(label: &str, package_dir: &Path, warnings: &mut Vec<String>) {
+            let Some(declared) = declared_stages(package_dir) else {
+                return;
+            };
+            let Ok(entries) = std::fs::read_dir(package_dir) else {
+                return;
+            };
+            let mut children: Vec<_> = entries.flatten().collect();
+            children.sort_by_key(|e| e.file_name());
+            for entry in children {
+                if !entry.file_type().is_ok_and(|t| t.is_dir()) {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if name.starts_with('.') {
+                    continue;
+                }
+                let path = entry.path();
+                if !is_stage_shaped(&path) {
+                    continue;
+                }
+                let nested_package = path.join(WORKFLOW_FILE).is_file();
+                if declared.contains(&name) {
+                    if nested_package {
+                        scan(&format!("{label}/{name}"), &path, warnings);
+                    }
+                    continue;
+                }
+                if nested_package {
+                    warnings.push(format!(
+                        "{label}: {name}/ (undeclared nested workflow package — the whole subtree is unreachable)"
+                    ));
+                } else {
+                    warnings.push(format!("{label}: {name}/"));
+                }
+            }
+        }
+
+        let mut warnings = Vec::new();
+        for root in [WORKFLOW_ROOT, LOCAL_WORKFLOW_ROOT] {
+            let workflows_dir = estate_root.join(root);
+            let Ok(entries) = std::fs::read_dir(&workflows_dir) else {
+                continue;
+            };
+            let mut packages: Vec<_> = entries.flatten().collect();
+            packages.sort_by_key(|e| e.file_name());
+            for entry in packages {
+                if !entry.file_type().is_ok_and(|t| t.is_dir()) {
+                    continue;
+                }
+                let path = entry.path();
+                if !path.join(WORKFLOW_FILE).is_file() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().into_owned();
+                scan(&format!("{root}/{name}"), &path, &mut warnings);
+            }
+        }
+
+        if warnings.is_empty() {
+            Check::ok(
+                NAME,
+                "every stage-shaped directory is declared in its package's workflow.toml",
+            )
+        } else {
+            Check::warn(
+                NAME,
+                format!(
+                    "{} undeclared stage-shaped director{}: {}",
+                    warnings.len(),
+                    if warnings.len() == 1 { "y" } else { "ies" },
+                    warnings.join("; "),
+                ),
+                "declare it in workflow.toml's stages, or move it out of the package (e.g. \
+                 .sergeant/drafts/)",
             )
         }
     }
@@ -5554,6 +5690,138 @@ pub(crate) mod doctor {
     mod tests {
         use super::*;
         use crate::platform::fs_locking::Reliability;
+
+        fn write_package(root: &Path, rel: &str, name: &str, stages: &[&str]) -> PathBuf {
+            let dir = root.join(rel).join(name);
+            std::fs::create_dir_all(&dir).expect("package dir");
+            std::fs::write(
+                dir.join("workflow.toml"),
+                format!(
+                    "[workflow]\nname = {name:?}\nversion = \"1.0.0\"\nstages = [{}]\n",
+                    stages
+                        .iter()
+                        .map(|s| format!("{s:?}"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            )
+            .expect("write workflow.toml");
+            dir
+        }
+
+        fn write_context_stage(package_dir: &Path, id: &str) {
+            let dir = package_dir.join(id);
+            std::fs::create_dir_all(&dir).expect("stage dir");
+            std::fs::write(dir.join("CONTEXT.md"), "stage context\n").expect("write CONTEXT.md");
+        }
+
+        /// A package whose every stage-shaped directory is named in `stages`
+        /// stays silent — the "declared-everything package is silent"
+        /// acceptance case.
+        #[test]
+        fn a_fully_declared_package_warns_about_nothing() {
+            let root = tempfile::TempDir::new().expect("tempdir");
+            let package = write_package(root.path(), ".sergeant/workflows", "solo", &["00-only"]);
+            write_context_stage(&package, "00-only");
+
+            let check = undeclared_stage_dirs_check(Some(root.path()));
+            assert_eq!(check.status, Status::Ok, "{check:?}");
+        }
+
+        /// One stage-shaped directory nobody declared warns, naming both the
+        /// package and the directory — the "one undeclared leaf dir warns"
+        /// acceptance case.
+        #[test]
+        fn an_undeclared_leaf_directory_warns_naming_package_and_directory() {
+            let root = tempfile::TempDir::new().expect("tempdir");
+            let package = write_package(root.path(), ".sergeant/workflows", "solo", &["00-only"]);
+            write_context_stage(&package, "00-only");
+            write_context_stage(&package, "05-orphan");
+
+            let check = undeclared_stage_dirs_check(Some(root.path()));
+            assert_eq!(check.status, Status::Warn, "{check:?}");
+            assert!(
+                check.detail.contains("solo") && check.detail.contains("05-orphan"),
+                "must name both the package and the orphaned directory: {}",
+                check.detail
+            );
+            assert!(
+                check
+                    .remedy
+                    .as_deref()
+                    .is_some_and(|r| r.contains("stages")),
+                "{check:?}"
+            );
+        }
+
+        /// An undeclared directory that is itself a nested package (its own
+        /// `workflow.toml`) warns once, naming it as the whole unreachable
+        /// subtree rather than silently saying nothing about what's under
+        /// it — the "undeclared nested-package dir warns naming the whole
+        /// subtree" acceptance case.
+        #[test]
+        fn an_undeclared_nested_package_warns_naming_the_whole_subtree() {
+            let root = tempfile::TempDir::new().expect("tempdir");
+            let package = write_package(root.path(), ".sergeant/workflows", "solo", &["00-only"]);
+            write_context_stage(&package, "00-only");
+            let orphan_nested = write_package(&package, ".", "05-orphan-nested", &["00-inner"]);
+            write_context_stage(&orphan_nested, "00-inner");
+
+            let check = undeclared_stage_dirs_check(Some(root.path()));
+            assert_eq!(check.status, Status::Warn, "{check:?}");
+            assert!(
+                check.detail.contains("05-orphan-nested") && check.detail.contains("subtree"),
+                "must name the undeclared nested package and call out the whole subtree: {}",
+                check.detail
+            );
+            assert!(
+                !check.detail.contains("00-inner"),
+                "an undeclared nested package's own contents are not enumerated separately — \
+                 one row names the whole subtree: {}",
+                check.detail
+            );
+        }
+
+        /// Declared nesting recurses: a *declared* nested package's own
+        /// undeclared leaf still warns, naming the full path from the
+        /// package root.
+        #[test]
+        fn a_declared_nested_packages_own_undeclared_leaf_still_warns() {
+            let root = tempfile::TempDir::new().expect("tempdir");
+            let package = write_package(root.path(), ".sergeant/workflows", "solo", &["10-nested"]);
+            let nested = write_package(&package, ".", "10-nested", &["00-inner"]);
+            write_context_stage(&nested, "00-inner");
+            write_context_stage(&nested, "05-inner-orphan");
+
+            let check = undeclared_stage_dirs_check(Some(root.path()));
+            assert_eq!(check.status, Status::Warn, "{check:?}");
+            assert!(
+                check.detail.contains("10-nested") && check.detail.contains("05-inner-orphan"),
+                "must name the full nested path: {}",
+                check.detail
+            );
+        }
+
+        /// A dot-directory (`.git`, editor swap dirs) inside a package is
+        /// never mistaken for an undeclared stage.
+        #[test]
+        fn a_dot_directory_inside_a_package_is_skipped() {
+            let root = tempfile::TempDir::new().expect("tempdir");
+            let package = write_package(root.path(), ".sergeant/workflows", "solo", &["00-only"]);
+            write_context_stage(&package, "00-only");
+            write_context_stage(&package, ".hidden");
+
+            let check = undeclared_stage_dirs_check(Some(root.path()));
+            assert_eq!(check.status, Status::Ok, "{check:?}");
+        }
+
+        /// Outside an estate root, the check is silently a no-op — same
+        /// posture as every other estate-threaded row.
+        #[test]
+        fn outside_an_estate_root_the_check_is_a_silent_ok() {
+            let check = undeclared_stage_dirs_check(None);
+            assert_eq!(check.status, Status::Ok);
+        }
 
         /// #85, ADR 0003 D6: a confirmed-bad filesystem is `Fail`, and the
         /// remedy names the filesystem. Reverting the `Unreliable` match arm

--- a/src/tui/fleet.rs
+++ b/src/tui/fleet.rs
@@ -38,12 +38,10 @@ pub struct WorkRow {
     /// row has aged out of the daemon's caches (the slim index row the
     /// evicted fleet row is built from carries no causation).
     ///
-    /// Exposure, not yet grouping: W1 §10's "Causal child Work" tree is V4's
-    /// integration item and needs both halves of the wave landed. This is the
-    /// coordinate it will group on, projected here so that render reads a
-    /// row it already has rather than issuing a second request per Work
-    /// (D6: the fleet endpoint returns everything, the TUI filters
-    /// client-side).
+    /// V4 (W1 §10): this is the coordinate `causal_tree` groups Fleet rows
+    /// on — projected here so render reads a row it already has rather than
+    /// issuing a second request per Work (D6: the fleet endpoint returns
+    /// everything, the TUI filters client-side).
     pub parent: String,
     pub created_at: String,
     /// The current stage's own detail text — a question when the state is
@@ -202,6 +200,22 @@ pub struct FleetScreen {
 
 impl FleetScreen {
     pub fn visible<'a>(&self, rows: &'a [WorkRow]) -> Vec<&'a WorkRow> {
+        causal_tree(&self.filtered(rows))
+            .into_iter()
+            .map(|(row, _depth)| row)
+            .collect()
+    }
+
+    /// [`visible`], paired with each row's causal depth — rendering's own
+    /// entry point, so indentation and selection walk the identical order
+    /// (W1 §10's causal-child tree; presentation only, same idiom as the
+    /// `estate`/`state` filters above: derived from rows already on hand,
+    /// never a second request).
+    pub fn visible_with_depth<'a>(&self, rows: &'a [WorkRow]) -> Vec<(&'a WorkRow, usize)> {
+        causal_tree(&self.filtered(rows))
+    }
+
+    fn filtered<'a>(&self, rows: &'a [WorkRow]) -> Vec<&'a WorkRow> {
         rows.iter()
             .filter(|row| self.filters.matches(row))
             .collect()
@@ -313,6 +327,58 @@ fn next_estate_filter(current: Option<&str>, rows: &[WorkRow]) -> Option<String>
     }
 }
 
+/// W1 §10's causal-child tree over an already-filtered row set: every
+/// top-level (root) Work in the order it arrived, each immediately followed
+/// by its own children (depth-first, one level of indent per hop), whose
+/// order among siblings is likewise preserved from `rows`.
+///
+/// A row whose `parent` doesn't resolve to another row *currently in
+/// `rows`* — an ordinary top-level Work (`parent == "-"`), or a child whose
+/// parent was filtered out or has aged out of the daemon's caches — is a
+/// root here: presentation never drops a row for a causal fact it can't
+/// currently show. A `seen` guard makes a malformed/cyclic parent chain
+/// (never expected of the daemon's own validated causation, W1-08/E8) a
+/// silent no-op rather than a hang or a duplicate row.
+fn causal_tree<'a>(rows: &[&'a WorkRow]) -> Vec<(&'a WorkRow, usize)> {
+    use std::collections::{HashMap, HashSet};
+
+    let ids: HashSet<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    let mut children: HashMap<&str, Vec<&'a WorkRow>> = HashMap::new();
+    let mut roots: Vec<&'a WorkRow> = Vec::new();
+    for row in rows {
+        if row.parent != "-" && ids.contains(row.parent.as_str()) {
+            children.entry(row.parent.as_str()).or_default().push(row);
+        } else {
+            roots.push(row);
+        }
+    }
+
+    fn walk<'a>(
+        row: &'a WorkRow,
+        depth: usize,
+        children: &HashMap<&str, Vec<&'a WorkRow>>,
+        seen: &mut HashSet<&'a str>,
+        out: &mut Vec<(&'a WorkRow, usize)>,
+    ) {
+        if !seen.insert(row.id.as_str()) {
+            return;
+        }
+        out.push((row, depth));
+        if let Some(kids) = children.get(row.id.as_str()) {
+            for kid in kids {
+                walk(kid, depth + 1, children, seen, out);
+            }
+        }
+    }
+
+    let mut seen = HashSet::new();
+    let mut out = Vec::with_capacity(rows.len());
+    for root in roots {
+        walk(root, 0, &children, &mut seen, &mut out);
+    }
+    out
+}
+
 fn next_state_filter(current: Option<&str>) -> Option<String> {
     match current {
         None => Some(REPORTED_STATES[0].to_string()),
@@ -340,7 +406,7 @@ pub fn render(frame: &mut Frame, area: Rect, rows: &[WorkRow], screen: &FleetScr
         return;
     }
 
-    let visible = screen.visible(rows);
+    let visible = screen.visible_with_depth(rows);
     let title = format!(
         "Fleet — {} work{}{}",
         visible.len(),
@@ -395,7 +461,7 @@ pub fn render(frame: &mut Frame, area: Rect, rows: &[WorkRow], screen: &FleetScr
     }
 
     if let Some(preview_area) = preview_area {
-        let selected = visible.get(screen.selected).copied();
+        let selected = visible.get(screen.selected).map(|(row, _depth)| *row);
         super::work_view::render_preview(frame, preview_area, selected);
     }
 }
@@ -456,9 +522,28 @@ fn split_top(area: Rect, top: u16) -> (Rect, Rect) {
     (head, rest)
 }
 
+/// The causal-tree indent prefix for a row at `depth`: nothing at depth 0,
+/// else a `↳ ` (mirrors the estate-filter idiom of annotating the intent
+/// column rather than adding a new one — no geometry entry needed since no
+/// chrome changes, only cell content) preceded by two spaces per ancestor
+/// hop, cheap enough to compute per render rather than caching.
+fn indent_prefix(depth: usize) -> String {
+    if depth == 0 {
+        String::new()
+    } else {
+        format!("{}↳ ", "  ".repeat(depth - 1))
+    }
+}
+
 /// Wide/Medium: a `Table`, whose own constraints truncate every cell — never
 /// a hand-padded fixed-width string (§10.1's Decision T2-37).
-fn render_table(frame: &mut Frame, area: Rect, rows: &[&WorkRow], selected: usize, wide: bool) {
+fn render_table(
+    frame: &mut Frame,
+    area: Rect,
+    rows: &[(&WorkRow, usize)],
+    selected: usize,
+    wide: bool,
+) {
     let mut header = vec![
         "", "state", "intent", "stage", "target", "workflow", "turns",
     ];
@@ -488,13 +573,13 @@ fn render_table(frame: &mut Frame, area: Rect, rows: &[&WorkRow], selected: usiz
 
     let body_rows: Vec<Row> = rows
         .iter()
-        .map(|row| {
+        .map(|(row, depth)| {
             let mut cells = vec![
                 Cell::from(theme::state_glyph(&row.state))
                     .style(Style::default().fg(theme::state_token(&row.state).rgb())),
                 Cell::from(row.state.clone())
                     .style(Style::default().fg(theme::state_token(&row.state).rgb())),
-                Cell::from(row.intent.clone()),
+                Cell::from(format!("{}{}", indent_prefix(*depth), row.intent)),
                 Cell::from(row.stage.clone()),
                 Cell::from(target(row)),
                 // §8.1/§8.10: info/reference violet is reserved for
@@ -524,10 +609,10 @@ fn render_table(frame: &mut Frame, area: Rect, rows: &[&WorkRow], selected: usiz
 }
 
 /// Narrow: intent-first, two-line stacked rows (§10.1/§18.3).
-fn render_stacked(frame: &mut Frame, area: Rect, rows: &[&WorkRow], selected: usize) {
+fn render_stacked(frame: &mut Frame, area: Rect, rows: &[(&WorkRow, usize)], selected: usize) {
     let items: Vec<ListItem> = rows
         .iter()
-        .map(|row| {
+        .map(|(row, depth)| {
             let glyph_style = Style::default().fg(theme::state_token(&row.state).rgb());
             ListItem::new(vec![
                 Line::from(vec![
@@ -535,7 +620,7 @@ fn render_stacked(frame: &mut Frame, area: Rect, rows: &[&WorkRow], selected: us
                     Span::raw(" "),
                     Span::styled(row.state.clone(), glyph_style),
                     Span::raw("  "),
-                    Span::raw(row.intent.clone()),
+                    Span::raw(format!("{}{}", indent_prefix(*depth), row.intent)),
                 ]),
                 Line::from(Span::styled(
                     format!(
@@ -655,6 +740,95 @@ mod tests {
         assert_eq!(
             rows[1].parent, "-",
             "an ordinary top-level Work claims no parent"
+        );
+    }
+
+    /// V4 handoff (W1 §10's causal-child tree): a child row is grouped
+    /// immediately after its parent, in causal order, even when the daemon's
+    /// own body listed it first — presentation groups by the validated
+    /// `parent` field, it does not merely trust arrival order.
+    #[test]
+    fn visible_groups_a_child_immediately_after_its_parent() {
+        let mut fleet = fleet_of(&[
+            ("parent", "active"),
+            ("unrelated", "active"),
+            ("child", "active"),
+        ]);
+        fleet["works"][2]["parent_work_id"] = json!("parent");
+        let rows = fleet_rows(&fleet);
+        let screen = FleetScreen::default();
+        let ids: Vec<&str> = screen
+            .visible(&rows)
+            .into_iter()
+            .map(|r| r.id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            ["parent", "child", "unrelated"],
+            "the child must immediately follow its parent, ahead of an unrelated root: {ids:?}"
+        );
+    }
+
+    /// Grandchildren nest one level deeper than their own parent, still
+    /// directly under it — recursive grouping, not just one hop.
+    #[test]
+    fn visible_groups_a_grandchild_under_its_own_parent_not_the_root() {
+        let mut fleet = fleet_of(&[
+            ("grandchild", "active"),
+            ("child", "active"),
+            ("root", "active"),
+        ]);
+        fleet["works"][0]["parent_work_id"] = json!("child");
+        fleet["works"][1]["parent_work_id"] = json!("root");
+        let rows = fleet_rows(&fleet);
+        let screen = FleetScreen::default();
+        let depths: Vec<(String, usize)> = screen
+            .visible_with_depth(&rows)
+            .into_iter()
+            .map(|(r, d)| (r.id.clone(), d))
+            .collect();
+        assert_eq!(
+            depths,
+            [
+                ("root".to_string(), 0),
+                ("child".to_string(), 1),
+                ("grandchild".to_string(), 2),
+            ]
+        );
+    }
+
+    /// A child whose parent isn't in the currently-visible set (filtered out,
+    /// or evicted from the daemon's caches) still renders — as a root, never
+    /// dropped for a causal fact presentation can't currently show.
+    #[test]
+    fn visible_treats_an_unresolvable_parent_as_a_root_rather_than_dropping_the_row() {
+        let mut fleet = fleet_of(&[("orphan", "active")]);
+        fleet["works"][0]["parent_work_id"] = json!("01SOMEEVICTEDPARENT");
+        let rows = fleet_rows(&fleet);
+        let screen = FleetScreen::default();
+        let depths: Vec<(String, usize)> = screen
+            .visible_with_depth(&rows)
+            .into_iter()
+            .map(|(r, d)| (r.id.clone(), d))
+            .collect();
+        assert_eq!(depths, [("orphan".to_string(), 0)]);
+    }
+
+    /// The rendered table indents a child's intent cell under its parent —
+    /// presentation only, no new chrome/geometry.
+    #[test]
+    fn wide_render_indents_a_childs_intent_under_its_parent() {
+        let mut fleet = fleet_of(&[("child", "active"), ("parent", "active")]);
+        fleet["works"][0]["parent_work_id"] = json!("parent");
+        let rows = fleet_rows(&fleet);
+        let screen = FleetScreen::default();
+        let text = render_text(&rows, &screen, Tier::Wide, 120);
+        let parent_line = text.lines().find(|l| l.contains("intent for parent"));
+        let child_line = text.lines().find(|l| l.contains("intent for child"));
+        assert!(parent_line.is_some(), "{text}");
+        assert!(
+            child_line.is_some_and(|l| l.contains("↳")),
+            "the child's row must carry the causal-tree indent glyph: {text}"
         );
     }
 

--- a/tests/m11_nested_workflow.rs
+++ b/tests/m11_nested_workflow.rs
@@ -103,7 +103,12 @@ fn declare_output(package: &Path, id: &str, artifact: &str) {
 /// (W1 §13 item 9, required-column side; mirrors
 /// `tests/m3_execution.rs::write_two_stage_workflow_with_required_columns`,
 /// the flat-case precedent).
-fn declare_output_with_required_columns(package: &Path, id: &str, artifact: &str, columns: &[&str]) {
+fn declare_output_with_required_columns(
+    package: &Path,
+    id: &str,
+    artifact: &str,
+    columns: &[&str],
+) {
     let dir = package.join(id).join("output");
     std::fs::create_dir_all(&dir).expect("output dir");
     let quoted: Vec<String> = columns.iter().map(|c| format!("`{c}`")).collect();

--- a/tests/m11_nested_workflow.rs
+++ b/tests/m11_nested_workflow.rs
@@ -96,6 +96,29 @@ fn declare_output(package: &Path, id: &str, artifact: &str) {
     .expect("output/README.md");
 }
 
+/// [`declare_output`], but additionally declares Amendment 10d's
+/// `**Required columns:**` line — the required-column half of the
+/// split-hardening contract, exercised here against a nested leaf's composed
+/// id exactly as [`declare_output`] exercises the expected-artifact half
+/// (W1 §13 item 9, required-column side; mirrors
+/// `tests/m3_execution.rs::write_two_stage_workflow_with_required_columns`,
+/// the flat-case precedent).
+fn declare_output_with_required_columns(package: &Path, id: &str, artifact: &str, columns: &[&str]) {
+    let dir = package.join(id).join("output");
+    std::fs::create_dir_all(&dir).expect("output dir");
+    let quoted: Vec<String> = columns.iter().map(|c| format!("`{c}`")).collect();
+    std::fs::write(
+        dir.join("README.md"),
+        format!(
+            "# Output — `{id}`\n\n**Expected artifact:** `{artifact}` — proof of \
+             work.\n\n**Required columns:** {} — a typed set, not prose.\n\n**Disposition:** \
+             `evidence`\n",
+            quoted.join(", ")
+        ),
+    )
+    .expect("output/README.md");
+}
+
 /// The two-level fixture every test below starts from:
 ///
 /// ```text
@@ -330,6 +353,89 @@ async fn a_nested_leafs_own_output_contract_is_enforced_exactly_as_a_flat_ones_i
     assert!(
         reprompts[0].payload["container_id"].is_null(),
         "a leaf's own contract is not a container's: {:?}",
+        reprompts[0].payload
+    );
+    let parked = events_of(data.path(), &work_id, "work.needs_input");
+    assert_eq!(
+        parked[0].payload["reason_code"],
+        REASON_STAGE_OUTPUT_MISSING
+    );
+    assert_eq!(parked[0].payload["stage_id"], "10-investigate/00-lead");
+    // Only the leaf that failed its contract is unfinished: 00-orient
+    // completed normally before it.
+    assert_eq!(
+        stage_ids(data.path(), &work_id, KIND_STAGE_COMPLETED),
+        ["00-orient"]
+    );
+
+    handle.shutdown().await;
+}
+
+/// W1 §13 item 9, the required-column half: a nested leaf's declared
+/// `**Required columns:**` line (Amendment 10d) is enforced against its
+/// composed hierarchical id exactly as a flat leaf's is —
+/// `has_required_table_columns` is reached through `check_output_contract`'s
+/// `contract_id` regardless of nesting depth. Mirrors
+/// `tests/m3_execution.rs::t11_a_present_but_untyped_declared_artifact_is_refused_the_same_way_as_a_missing_one`,
+/// the flat-case precedent this test carries one level deeper.
+#[tokio::test]
+async fn a_nested_leafs_required_column_contract_is_enforced_exactly_as_a_flat_ones_is() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    let (mount, _head) = support::scaffold_solo_estate(&estate, "solo");
+    let package = write_nested_workflow(&estate);
+    // The contract is declared on the nested leaf itself, at
+    // `10-investigate/00-lead/output/README.md`, this time with a
+    // **Required columns:** line.
+    declare_output_with_required_columns(
+        &package.join("10-investigate"),
+        "00-lead",
+        "lead.md",
+        &["id", "axis"],
+    );
+
+    // The declared artifact must exist *before* the stage launches (the fake
+    // actor writes nothing) — present, but untyped prose rather than the
+    // required table, so the check must reach past "does the file exist" to
+    // "does it carry the required columns" for a nested id.
+    std::fs::create_dir_all(mount.join("10-investigate/00-lead/output")).expect("output dir");
+    std::fs::write(
+        mount.join("10-investigate/00-lead/output/lead.md"),
+        "Findings: one about id 1, axis correctness. No table here.\n",
+    )
+    .expect("seed untyped artifact");
+    support::git(&mount, &["add", "-A"]);
+    support::git(&mount, &["commit", "-m", "seed untyped nested artifact"]);
+
+    let handle = start_fake(
+        data.path(),
+        [
+            FakeStep::complete(), // 00-orient
+            FakeStep::complete(), // 00-lead: "done", lead.md present but untyped
+            FakeStep::complete(), // the one bounded re-prompt: still untyped
+        ],
+    )
+    .await;
+    let client = http();
+    let body = submit(&client, &handle, &estate, "nested").await;
+    let work_id = body["work"]["id"].as_str().expect("work id").to_string();
+
+    assert_eq!(
+        body["work"]["state"], "needs_input",
+        "a present-but-untyped nested artifact must be refused, not accepted: {body}"
+    );
+    assert_eq!(
+        body["stage"]["stage_id"], "10-investigate/00-lead",
+        "the parked stage is the nested leaf, named by its composed id: {body}"
+    );
+    let reprompts = events_of(data.path(), &work_id, KIND_STAGE_OUTPUT_MISSING);
+    assert_eq!(reprompts.len(), 1, "exactly one bounded re-prompt");
+    assert_eq!(reprompts[0].payload["stage_id"], "10-investigate/00-lead");
+    assert_eq!(reprompts[0].payload["path"], "lead.md");
+    assert!(
+        reprompts[0].payload["container_id"].is_null(),
+        "a leaf's own required-column contract is not a container's: {:?}",
         reprompts[0].payload
     );
     let parked = events_of(data.path(), &work_id, "work.needs_input");

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -1999,6 +1999,11 @@ fn t3_doctor_names_every_fault_and_its_remedy() {
             // here because the fixture estate declares one; an estate with
             // none reads `warn`, which is `t3f`'s subject.
             "workflows",
+            // S2 V4 (owner-directed 2026-08-27): a directory inside a
+            // workflow package that looks like a stage but isn't declared
+            // in that package's `stages` list. Green here because the
+            // fixture estate's one package declares everything it has.
+            "workflow_stage_declarations",
             // #261: the installed corpus (AGENTS.md, skills/*/SKILL.md,
             // .sergeant/workflows/**, .sergeant/common/contexts/*.md)
             // cites only routes that resolve inside this estate.

--- a/tests/v4_w1_acceptance.rs
+++ b/tests/v4_w1_acceptance.rs
@@ -1,0 +1,167 @@
+//! S2 V4 brief deliverable 1 — W1 §13 acceptance battery, walked literally.
+//!
+//! `knowledge/evidence/resources/host-atlas-series/W1-HIERARCHICAL-EXECUTION.md`
+//! §13 lists nine criteria. Following `w5_h1_acceptance.rs`'s precedent: one
+//! numbered section per criterion, each either (a) a self-contained test
+//! here, or (b) — where an earlier S2 wave already pinned the exact claim by
+//! name — a comment pointing at that test rather than a byte-for-byte
+//! duplicate of it.
+//!
+//! Running this file alone proves nothing about the suites it references —
+//! that is what the wave's own `cargo test --locked` is for. What this file
+//! proves is that every criterion has *a* proof somewhere, named.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+// ------------------------------------------------------------------------
+// 1. A direct stage can contain a nested `workflow.toml` and execute its
+//    leaf stages through the existing engine.
+//
+// Pinned: `tests/m11_nested_workflow.rs::a_two_level_nested_workflow_runs_its_leaves_in_order_and_completes`
+// (that file's own header names this test as covering W1 §13 items 1-3).
+// ------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------
+// 2. Nested packages can recurse at least two levels in acceptance tests.
+//
+// Pinned: `tests/m11_nested_workflow.rs::a_leaf_that_closes_two_containers_at_once_gates_them_innermost_first`
+// (a three-level fixture — the multi-boundary case the plan panel named —
+// whose deepest leaf is simultaneously the last leaf of two ancestor
+// containers; strictly deeper than the two-level floor this item asks for).
+// ------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------
+// 3. Each leaf actor is a fresh execution over the same parent Work
+//    surfaces.
+//
+// Pinned: `tests/m11_nested_workflow.rs::a_two_level_nested_workflow_runs_its_leaves_in_order_and_completes`
+// (same test as item 1 — its own header comment names items 1-3 together:
+// four leaves, four distinct `StageEntered`/`StageCompleted` pairs, one
+// Work, one surface).
+// ------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------
+// 4. Hierarchical stage IDs journal/replay/render correctly.
+//
+// Pinned: `tests/m11_nested_workflow.rs::a_composed_stage_id_round_trips_through_events_analytics_and_work_show`
+// (events, the analytics fold, and `sgt work show` all carry the composed
+// id verbatim) and
+// `tests/m11_nested_workflow.rs::a_restarted_daemon_reconstructs_the_deepest_incomplete_path_and_retry_re_enters_it`
+// (replay/recovery half: a daemon killed mid-nest comes back naming the
+// exact nested leaf from the journal alone, and `retry` re-enters it).
+// ------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------
+// 5. `sgt -C <estate> run` from a managed execution can create child Work
+//    with validated parent Work/execution causation.
+//
+// Pinned: `tests/m12_child_work.rs::an_actor_process_submits_child_work_with_validated_causation`
+// (a real actor process, real `sgt -C` subprocess, real daemon-side
+// journal validation of the claimed parent) and
+// `tests/m12_child_work.rs::sgt_run_transports_the_inherited_causation_and_the_daemon_validates_it`
+// (the CLI-level half: the three `SERGEANT_*` values really travel end to
+// end and the daemon records the relation).
+// ------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------
+// 6. Child Work has independent scope/surfaces/lifecycle.
+//
+// Pinned: `tests/m12_child_work.rs::a_child_work_is_independent_of_the_parent_that_caused_it`
+// (own branch, own surface, own scope; parent cancellation does not
+// cascade — W1-12's cancel half).
+// ------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------
+// 7. Parent/child completion/cancel/merge do not silently cascade.
+//
+// Completion and cancellation are pinned by name:
+// `tests/m12_child_work.rs::a_parent_completing_does_not_cascade_to_its_child`
+// and `tests/m12_child_work.rs::a_child_work_is_independent_of_the_parent_that_caused_it`'s
+// own cancellation assertions (W1-12).
+//
+// Merge has no cascade to pin at the engine level because the engine has no
+// merge primitive at all to cascade from: per ADR 0015 (a pull request is a
+// request; the merge is the authority boundary, not the artifact) `sgt` has
+// no CLI verb and no daemon route that merges a branch — merging is `git`/
+// `gh` surface on the branch a Work produces, performed by a human outside
+// the engine. The self-contained test below pins that absence directly
+// rather than asserting a negative about a feature that doesn't exist.
+// ------------------------------------------------------------------------
+
+#[test]
+fn w1_acceptance_7_the_engine_has_no_merge_primitive_to_cascade_from() {
+    let src = repo_root().join("src");
+    let mut offenders = Vec::new();
+    for entry in walk_rs_files(&src) {
+        let text = std::fs::read_to_string(&entry).unwrap_or_default();
+        for needle in [
+            "fn merge_work",
+            "\"/merge\"",
+            ".route(\"/v1/work/:id/merge\"",
+        ] {
+            if text.contains(needle) {
+                offenders.push(format!("{}: {needle}", entry.display()));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "criterion 7 (merge half): the engine must define no merge verb/route for a Work to \
+         cascade through — ADR 0015 keeps merging entirely outside the engine. Found: {offenders:?}"
+    );
+}
+
+fn walk_rs_files(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(walk_rs_files(&path));
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+    out
+}
+
+// ------------------------------------------------------------------------
+// 8. Current exact-root admission and Work surface integrity tests remain
+//    green.
+//
+// Not one named test — this criterion is "the standing admission/surface
+// suites still pass", which the wave's own `cargo test --locked` proves
+// directly: `tests/e_git_admission.rs`, `tests/e_admission_uses_no_network_git.rs`,
+// `tests/e_sweep_uses_only_local_git.rs`, `tests/c4_repo_lock.rs`,
+// `tests/c11_injectable_git.rs`. Nothing changed in this wave's diff touches
+// admission or worktree binding; the loader/engine/causation work above is
+// additive at the stage-scheduling and CLI layers, not the admission path.
+// This comment is the checklist entry naming where the proof lives.
+// ------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------
+// 9. Split-hardening expected-output/required-column/finalize contracts
+//    behave identically for nested leaf stages and are not bypassed by
+//    container completion.
+//
+// Verify BOTH halves are actually pinned (the brief's own instruction):
+//
+// Half A — a nested leaf's own output contract is enforced exactly as a
+// flat leaf's is (the leaf-level half):
+// `tests/m11_nested_workflow.rs::a_nested_leafs_own_output_contract_is_enforced_exactly_as_a_flat_ones_is`.
+//
+// Half B — a CONTAINER's own declared output contract is checked at its
+// boundary-closing leaf's completion, and is not silently satisfied by the
+// container merely finishing its leaves (the container-level half, E4):
+// `tests/m11_nested_workflow.rs::a_container_that_never_produced_its_declared_output_parks_naming_the_container`
+// (an unmet container contract parks the Work naming the CONTAINER, not the
+// leaf) and
+// `tests/m11_nested_workflow.rs::a_container_whose_declared_output_is_present_closes_silently`
+// (a met one closes without a spurious park). Both halves present.
+// ------------------------------------------------------------------------

--- a/tests/v4_w1_acceptance.rs
+++ b/tests/v4_w1_acceptance.rs
@@ -150,7 +150,12 @@ fn walk_rs_files(dir: &std::path::Path) -> Vec<PathBuf> {
 //    behave identically for nested leaf stages and are not bypassed by
 //    container completion.
 //
-// Verify BOTH halves are actually pinned (the brief's own instruction):
+// Item 9 names three contract families: expected-output, required-column,
+// and finalize. All three are walked below, each cited by name; none is
+// merely implied by another.
+//
+// Expected-output half — verify BOTH the leaf and container cases are
+// actually pinned (the brief's own instruction):
 //
 // Half A — a nested leaf's own output contract is enforced exactly as a
 // flat leaf's is (the leaf-level half):
@@ -164,4 +169,24 @@ fn walk_rs_files(dir: &std::path::Path) -> Vec<PathBuf> {
 // leaf) and
 // `tests/m11_nested_workflow.rs::a_container_whose_declared_output_is_present_closes_silently`
 // (a met one closes without a spurious park). Both halves present.
+//
+// Required-column half — Amendment 10d's `**Required columns:**` line is
+// enforced against a nested leaf's *composed* hierarchical id, not only a
+// flat one's, because `check_output_contract` (`src/runtime/engine.rs`)
+// runs `has_required_table_columns` against the same `contract_id` the
+// expected-output check above already exercises for nesting — one gate,
+// shared by both column families:
+// `tests/m11_nested_workflow.rs::a_nested_leafs_required_column_contract_is_enforced_exactly_as_a_flat_ones_is`
+// (a present-but-untyped artifact at a nested id is refused the identical
+// `stage_output_missing`-class way `tests/m3_execution.rs`'s flat-case
+// precedent,
+// `t11_a_present_but_untyped_declared_artifact_is_refused_the_same_way_as_a_missing_one`,
+// pins for a flat one).
+//
+// Finalize half — E11: `finalize_sweep` (`src/runtime/surface.rs`) walks to
+// the same nested depth as the two gates above, copying an evidence-class
+// nested leaf's output out and removing it from the worktree, sweeping a
+// container's own sibling `output/` in the same pass, and leaving a
+// promote-class nested leaf to ship:
+// `src/runtime/surface.rs::tests::the_finalize_sweep_reaches_a_nested_leafs_output`.
 // ------------------------------------------------------------------------


### PR DESCRIPTION
Sprint S2's closeout. 5 implement + 2 fixer commits.

- **W1 §13 battery** (`tests/v4_w1_acceptance.rs`): all nine items — cited pins verified to cover their claims (incl. item 9's both halves, with a new nested required-column test added at panel direction); criterion 7's merge-non-cascade proven structurally (no merge verb exists to cascade through, per ADR 0015).
- **Causal-child tree** in Fleet: children group under parents recursively from the already-projected relation (no extra requests), `↳` indentation at every width, unresolvable parents render as roots.
- **Doctor `workflow_stage_declarations`** (owner-directed): warns on stage-shaped directories undeclared in their package's `stages`, recursively into nested packages, with the declare-or-move remedy.
- **THE LIVE PROOF**: real Work on the opencode backend (aria Qwen3.8-27B) on a scratch estate + scratch host data dir — the live actor read its engine-injected triple and spawned a child via `sgt -C "$SERGEANT_ESTATE_ROOT" run`; the child's `work.submitted` carries parent_work_id + parent_execution_id **matching the parent's journaled execution exactly** (validated, no unverified marker); both Works terminal; ~16s round trip; journal quotes in the CHANGELOG's V4 evidence section. Production host journal untouched; all scratch state cleaned.
- **Live opt-in suites, serial**: first run 3/8 pass (five 30s-local-timeout tests tripped by aria latency — findings, untouched); fixer re-run on a quieter endpoint **8/8 in 140s** — latency-sensitivity confirmed, capability confirmed, both results recorded verbatim.
- CHANGELOG accumulates S2 under `## [0.3.0]`; found-en-route: the installed host `sgt` predates causation (stale-binary PATH lesson recorded) — binary refresh queued into the close ceremonies.
- Disclosed: one pre-existing codex flake (passed standalone; file untouched by this wave).

Gates: full `cargo test --locked` 0 failed (one doctor-row-order contract updated for the new row, caught by the full run); panel 2 confirmed → fixed; verify green.

Rungs: J3/J4 per commit; aria use strictly serial throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4