### PR TITLE
S3 X1 — Atlas substrate: module tree, one owner per database, named schemas + ops rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,34 @@ release.
     above. Recorded here per the brief's own honesty requirement rather
     than silently discarded as a bad take.
 
+### Atlas substrate (S3)
+
+- Atlas — the world-intelligence store — gets its own module tree
+  (`src/runtime/atlas/`) and its own database file, `<data-dir>/atlas/
+  atlas.duckdb`, deliberately outside the disposable `projections/`
+  directory. `runtime/atlas/db.rs` is its single owning file: it is the
+  only module in that tree that reaches the database driver, and it hands
+  no live connection out. Two independent structural tests now hold two
+  independent one-owner invariants — M5's keeps naming `runtime/
+  analytics.rs` as the operations projection's sole owner, and a new suite
+  (`tests/x1_atlas_substrate.rs`) names `runtime/atlas/db.rs` as Atlas's.
+  They are never merged into one "either of these files may open a
+  database" rule.
+- Atlas declares the `meta`, `source`, `git` and `context` schema
+  namespaces; no table yet. Every table lands in the change that lands its
+  writer, the same empty-table refusal doctrine the operations projection
+  already applies.
+- The two stores do not share a rebuild discipline, and both module docs
+  say so: the operations projection is deleted and re-folded from the
+  journal on every daemon start, while Atlas's `source.*`, `git.*` and
+  `meta.coverage` persist across restarts — they are derived from source
+  bytes plus extractor identity, keyed by source generation, and a
+  generation is evicted only when those bytes change.
+- The ten operations tables moved into an `ops` schema inside
+  `sergeant.duckdb`. Physical requalification only: every table name the
+  daemon reports (`/v1/analytics`, `sgt analytics`) and every answer it
+  gives is unchanged, and the existing projection suite passes as-is.
+
 ## [0.2.4] - 2026-08-25
 
 sergeant-rs narrows to a product-documents-only repo, codex actors gain

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -137,3 +137,13 @@ cov_stage_end 1 "the c2_light test binary must write its own profile"
 cov_stage_begin c2-v4_w1_acceptance
 cov_run cargo llvm-cov --no-report --test v4_w1_acceptance --locked || cov_fail "v4_w1_acceptance failed under instrumentation"
 cov_stage_end 1 "the v4_w1_acceptance test binary must write its own profile"
+
+# S3 X1: the Atlas substrate's structural suite — the second one-owner
+# invariant (`runtime/atlas/db.rs`, held separately from M5's assertion about
+# `runtime/analytics.rs`), the module-doc persistence contract, and the schema
+# namespaces read back out of a real database file. Source scanning plus one
+# tempdir; no daemon, no estate, no backend, so it sits in C2 rather than C3.
+# Floor 1.
+cov_stage_begin c2-x1_atlas_substrate
+cov_run cargo llvm-cov --no-report --test x1_atlas_substrate --locked || cov_fail "x1_atlas_substrate failed under instrumentation"
+cov_stage_end 1 "the x1_atlas_substrate test binary must write its own profile"

--- a/src/runtime/analytics.rs
+++ b/src/runtime/analytics.rs
@@ -25,6 +25,15 @@
 //! adapter emits `filesystem.changed` or `git.changed`), so they are absent
 //! rather than declared empty — a table that can only ever answer "zero rows"
 //! is a false promise, not completeness.
+//!
+//! **They live in the [`OPS_SCHEMA`] namespace** (S3 F3, A1 §5's
+//! meta/ops/source/git/context split). That is a physical requalification and
+//! nothing more: the names this module answers with — [`Analytics::table_counts`],
+//! [`Analytics::table_rows`], the API's `tables` list — are still the bare
+//! table names, because the namespace says which database family a table
+//! belongs to, not what it is called. The other families named by §5 belong
+//! to a different file with a different rebuild discipline
+//! ([`crate::runtime::atlas`]); nothing in §5's list implies one database.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -105,10 +114,27 @@ pub enum AnalyticsError {
 /// re-planned mid-rebuild.
 const STATEMENT_CACHE: usize = 64;
 
-/// The §22 schema. Written on every rebuild; there is no migration path and
-/// there does not need to be one — the file is derived.
+/// The schema every operations table lives in (S3 F3, A1 §5).
+///
+/// Physical qualification only — nothing this module reports changes name
+/// because of it. See the module doc.
+const OPS_SCHEMA: &str = "ops";
+
+/// One operations table, qualified and quoted for SQL.
+///
+/// The quoting is what keeps `usage` (a reserved word) addressable; the
+/// qualification is what stops a bare name from resolving against DuckDB's
+/// default `main` schema, which this database deliberately leaves empty.
+fn ops(table: &str) -> String {
+    format!("{OPS_SCHEMA}.\"{table}\"")
+}
+
+/// The §22 schema, in the [`OPS_SCHEMA`] namespace. Written on every rebuild;
+/// there is no migration path and there does not need to be one — the file is
+/// derived.
 const SCHEMA: &str = r#"
-CREATE TABLE events (
+CREATE SCHEMA ops;
+CREATE TABLE ops.events (
     seq            BIGINT PRIMARY KEY,
     event_id       VARCHAR NOT NULL,
     timestamp      VARCHAR NOT NULL,
@@ -123,8 +149,8 @@ CREATE TABLE events (
     kind           VARCHAR NOT NULL,
     payload        VARCHAR NOT NULL
 );
-CREATE INDEX idx_events_kind_work ON events(kind, work_id);
-CREATE TABLE work (
+CREATE INDEX idx_events_kind_work ON ops.events(kind, work_id);
+CREATE TABLE ops.work (
     work_id       VARCHAR PRIMARY KEY,
     intent        VARCHAR,
     estate        VARCHAR,
@@ -143,7 +169,7 @@ CREATE TABLE work (
     submitted_seq BIGINT,
     submitted_ms  BIGINT
 );
-CREATE TABLE stages (
+CREATE TABLE ops.stages (
     work_id     VARCHAR,
     stage_id    VARCHAR,
     attempt     BIGINT,
@@ -156,7 +182,7 @@ CREATE TABLE stages (
     ended_ms    BIGINT,
     PRIMARY KEY (work_id, stage_id, attempt)
 );
-CREATE TABLE executions (
+CREATE TABLE ops.executions (
     execution_id          VARCHAR PRIMARY KEY,
     work_id               VARCHAR,
     backend               VARCHAR,
@@ -170,7 +196,7 @@ CREATE TABLE executions (
     stop_requested        BOOLEAN,
     reconcile_disposition VARCHAR
 );
-CREATE TABLE messages (
+CREATE TABLE ops.messages (
     seq          BIGINT PRIMARY KEY,
     work_id      VARCHAR,
     execution_id VARCHAR,
@@ -178,7 +204,7 @@ CREATE TABLE messages (
     text         VARCHAR,
     ts_ms        BIGINT
 );
-CREATE TABLE tool_calls (
+CREATE TABLE ops.tool_calls (
     execution_id  VARCHAR,
     tool_use_id   VARCHAR,
     work_id       VARCHAR,
@@ -190,7 +216,7 @@ CREATE TABLE tool_calls (
     is_error      BOOLEAN,
     PRIMARY KEY (execution_id, tool_use_id)
 );
-CREATE TABLE "usage" (
+CREATE TABLE ops."usage" (
     seq                   BIGINT PRIMARY KEY,
     work_id               VARCHAR,
     execution_id          VARCHAR,
@@ -204,7 +230,7 @@ CREATE TABLE "usage" (
     model_pin             VARCHAR,
     is_error              BOOLEAN
 );
-CREATE TABLE repositories (
+CREATE TABLE ops.repositories (
     work_id          VARCHAR,
     repository       VARCHAR,
     source_path      VARCHAR,
@@ -218,14 +244,14 @@ CREATE TABLE repositories (
     disposition      VARCHAR,
     PRIMARY KEY (work_id, repository)
 );
-CREATE TABLE graph_nodes (
+CREATE TABLE ops.graph_nodes (
     node_id    VARCHAR PRIMARY KEY,
     kind       VARCHAR NOT NULL,
     label      VARCHAR,
     work_id    VARCHAR,
     source_seq BIGINT NOT NULL
 );
-CREATE TABLE graph_edges (
+CREATE TABLE ops.graph_edges (
     edge_id    VARCHAR PRIMARY KEY,
     relation   VARCHAR NOT NULL,
     from_node  VARCHAR NOT NULL,
@@ -264,14 +290,14 @@ pub const CANNED_QUERIES: &[CannedQuery] = &[
             WITH spans AS (\
                 SELECT work_id, kind, ts_ms, \
                        lead(ts_ms) OVER (PARTITION BY work_id ORDER BY seq) AS next_ms \
-                FROM events \
+                FROM ops.events \
                 WHERE work_id IS NOT NULL AND kind LIKE 'work.%' \
             ) \
             SELECT w.work_id, w.state, \
                    COALESCE(SUM(CASE WHEN spans.kind = 'work.blocked' AND spans.next_ms IS NOT NULL \
                                      THEN spans.next_ms - spans.ts_ms END), 0) AS blocked_ms, \
                    COUNT(CASE WHEN spans.kind = 'work.blocked' THEN 1 END) AS blocked_episodes \
-            FROM work w LEFT JOIN spans ON spans.work_id = w.work_id \
+            FROM ops.work w LEFT JOIN spans ON spans.work_id = w.work_id \
             GROUP BY w.work_id, w.state ORDER BY blocked_ms DESC, w.work_id",
     },
     CannedQuery {
@@ -285,7 +311,7 @@ pub const CANNED_QUERIES: &[CannedQuery] = &[
                    COUNT(*) FILTER (WHERE s.attempt > 1) AS retries, \
                    COUNT(*) AS stage_attempts, \
                    COUNT(DISTINCT s.work_id) AS works \
-            FROM stages s JOIN work w ON w.work_id = s.work_id \
+            FROM ops.stages s JOIN ops.work w ON w.work_id = s.work_id \
             GROUP BY 1 ORDER BY retries DESC, backend",
     },
     CannedQuery {
@@ -296,12 +322,12 @@ pub const CANNED_QUERIES: &[CannedQuery] = &[
                    COALESCE(r.repositories, 0) AS repositories, \
                    COALESCE(t.tool_calls, 0) AS tool_calls, \
                    COALESCE(m.messages, 0) AS messages \
-            FROM executions e \
-            LEFT JOIN (SELECT work_id, COUNT(*) AS repositories FROM repositories GROUP BY 1) r \
+            FROM ops.executions e \
+            LEFT JOIN (SELECT work_id, COUNT(*) AS repositories FROM ops.repositories GROUP BY 1) r \
                    ON r.work_id = e.work_id \
-            LEFT JOIN (SELECT execution_id, COUNT(*) AS tool_calls FROM tool_calls GROUP BY 1) t \
+            LEFT JOIN (SELECT execution_id, COUNT(*) AS tool_calls FROM ops.tool_calls GROUP BY 1) t \
                    ON t.execution_id = e.execution_id \
-            LEFT JOIN (SELECT execution_id, COUNT(*) AS messages FROM messages GROUP BY 1) m \
+            LEFT JOIN (SELECT execution_id, COUNT(*) AS messages FROM ops.messages GROUP BY 1) m \
                    ON m.execution_id = e.execution_id \
             ORDER BY e.started_seq",
     },
@@ -315,16 +341,16 @@ pub const CANNED_QUERIES: &[CannedQuery] = &[
         sql: "\
             WITH failure AS (\
                 SELECT work_id, MIN(seq) AS failed_seq \
-                FROM events \
+                FROM ops.events \
                 WHERE work_id IS NOT NULL \
                   AND kind IN ('work.failed', 'work.blocked', 'stage.failed', 'stage.blocked') \
                 GROUP BY work_id \
             ) \
             SELECT f.work_id, f.failed_seq, \
-                   (SELECT kind FROM events WHERE seq = f.failed_seq) AS failure_kind, \
+                   (SELECT kind FROM ops.events WHERE seq = f.failed_seq) AS failure_kind, \
                    COUNT(t.tool_use_id) AS tool_calls_before \
             FROM failure f \
-            LEFT JOIN tool_calls t \
+            LEFT JOIN ops.tool_calls t \
                    ON t.work_id = f.work_id AND t.requested_seq < f.failed_seq \
             GROUP BY f.work_id, f.failed_seq ORDER BY tool_calls_before DESC, f.work_id",
     },
@@ -338,7 +364,7 @@ pub const CANNED_QUERIES: &[CannedQuery] = &[
                    COALESCE(SUM(output_tokens), 0) AS output_tokens, \
                    COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens, \
                    COALESCE(SUM(total_cost_usd), 0) AS total_cost_usd \
-            FROM \"usage\" GROUP BY work_id ORDER BY work_id",
+            FROM ops.\"usage\" GROUP BY work_id ORDER BY work_id",
     },
 ];
 
@@ -853,7 +879,7 @@ impl Analytics {
     fn reset(&mut self) -> Result<(), AnalyticsError> {
         for table in TABLES {
             self.conn
-                .execute_batch(&format!("DELETE FROM \"{table}\""))?;
+                .execute_batch(&format!("DELETE FROM {}", ops(table)))?;
         }
         self.rows = Rows::default();
         self.graph = GraphContext::default();
@@ -893,7 +919,7 @@ impl Analytics {
         }
         for table in MUTABLE_TABLES {
             self.conn
-                .execute_batch(&format!("DELETE FROM \"{table}\""))?;
+                .execute_batch(&format!("DELETE FROM {}", ops(table)))?;
         }
         append_all(
             &self.conn,
@@ -1335,7 +1361,7 @@ impl Analytics {
         for table in TABLES {
             let mut statement = self
                 .conn
-                .prepare(&format!("SELECT COUNT(*) FROM \"{table}\""))?;
+                .prepare(&format!("SELECT COUNT(*) FROM {}", ops(table)))?;
             let count: i64 = statement.query_row(duckdb::params![], |row| row.get(0))?;
             counts.push(((*table).to_string(), count));
         }
@@ -1365,7 +1391,7 @@ impl Analytics {
                 name: table.to_string(),
             })?;
         self.materialize()?;
-        let sql = format!("SELECT * FROM \"{table}\"");
+        let sql = format!("SELECT * FROM {}", ops(table));
         let (columns, rows) = self.select(&sql, duckdb::params![])?;
         Ok(QueryResult {
             name: (*table).to_string(),
@@ -1385,15 +1411,15 @@ impl Analytics {
     pub fn graph_neighborhood(&mut self, work_id: &str) -> Result<GraphView, AnalyticsError> {
         self.materialize()?;
         let (node_columns, node_rows) = self.select(
-            "SELECT node_id, kind, label, work_id, source_seq FROM graph_nodes \
+            "SELECT node_id, kind, label, work_id, source_seq FROM ops.graph_nodes \
              WHERE work_id = ?1 \
-                OR node_id IN (SELECT from_node FROM graph_edges WHERE work_id = ?1) \
-                OR node_id IN (SELECT to_node FROM graph_edges WHERE work_id = ?1) \
+                OR node_id IN (SELECT from_node FROM ops.graph_edges WHERE work_id = ?1) \
+                OR node_id IN (SELECT to_node FROM ops.graph_edges WHERE work_id = ?1) \
              ORDER BY source_seq, node_id",
             duckdb::params![work_id],
         )?;
         let (edge_columns, edge_rows) = self.select(
-            "SELECT edge_id, relation, from_node, to_node, source_seq FROM graph_edges \
+            "SELECT edge_id, relation, from_node, to_node, source_seq FROM ops.graph_edges \
              WHERE work_id = ?1 ORDER BY source_seq, edge_id",
             duckdb::params![work_id],
         )?;
@@ -1511,7 +1537,7 @@ fn append_all(conn: &Connection, table: &str, rows: Vec<Vec<Duck>>) -> Result<()
     if rows.is_empty() {
         return Ok(());
     }
-    let mut appender = conn.appender(table)?;
+    let mut appender = conn.appender_to_db(table, OPS_SCHEMA)?;
     for values in rows {
         appender.append_row(duckdb::appender_params_from_iter(values))?;
     }
@@ -1629,6 +1655,39 @@ mod tests {
         assert!(counts.iter().all(|(_, count)| *count == 0));
     }
 
+    /// S3 F3. The requalification is physical, not cosmetic: every table this
+    /// module creates lives in the `ops` namespace and DuckDB's default
+    /// `main` schema holds nothing at all. Read back out of the catalog, so a
+    /// table added later without a namespace fails here rather than quietly
+    /// landing in `main` and still answering queries.
+    #[test]
+    fn every_table_lives_in_the_ops_schema_and_main_holds_nothing() {
+        let analytics = Analytics::in_memory(Vec::new()).expect("projection");
+        let (columns, rows) = analytics
+            .select(
+                "SELECT schema_name, table_name FROM duckdb_tables() \
+                 WHERE database_name = current_database() ORDER BY table_name",
+                duckdb::params![],
+            )
+            .expect("select");
+        assert_eq!(columns, vec!["schema_name", "table_name"]);
+        let mut expected: Vec<&str> = TABLES.to_vec();
+        expected.sort_unstable();
+        let found: Vec<String> = rows
+            .iter()
+            .map(|row| {
+                assert_eq!(
+                    row[0],
+                    json!(OPS_SCHEMA),
+                    "{:?} is not in the ops namespace",
+                    row[1]
+                );
+                row[1].as_str().expect("table name").to_string()
+            })
+            .collect();
+        assert_eq!(found, expected);
+    }
+
     #[test]
     fn folding_is_idempotent_over_a_replayed_prefix() {
         // `catch_up` skipping the covered prefix is what lets the daemon hand
@@ -1663,7 +1722,7 @@ mod tests {
         analytics.materialize().expect("materialize");
         let (columns, rows) = analytics
             .select(
-                "SELECT work_id, estate_root FROM work ORDER BY work_id",
+                "SELECT work_id, estate_root FROM ops.work ORDER BY work_id",
                 duckdb::params![],
             )
             .expect("select");
@@ -1690,7 +1749,7 @@ mod tests {
         let mut analytics = Analytics::in_memory(Vec::new()).expect("projection");
         analytics
             .conn
-            .execute_batch("DROP TABLE events")
+            .execute_batch("DROP TABLE ops.events")
             .expect("drop the events table to force the next append to fail");
 
         let mut fold = analytics.fold().expect("fold");
@@ -1717,7 +1776,7 @@ mod tests {
         let mut analytics = Analytics::in_memory(events(vec![odd])).expect("projection");
         analytics.materialize().expect("materialize");
         let (_, rows) = analytics
-            .select("SELECT ts_ms FROM events", duckdb::params![])
+            .select("SELECT ts_ms FROM ops.events", duckdb::params![])
             .expect("select");
         assert_eq!(rows, vec![vec![Value::Null]]);
     }
@@ -1865,7 +1924,7 @@ mod tests {
         analytics.materialize().expect("materialize");
         let (_, rows) = analytics
             .select(
-                "SELECT reconcile_disposition FROM executions WHERE execution_id = 'e1'",
+                "SELECT reconcile_disposition FROM ops.executions WHERE execution_id = 'e1'",
                 duckdb::params![],
             )
             .expect("select");

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -1,0 +1,243 @@
+//! The one owner of Atlas's database file (F2).
+//!
+//! ```text
+//! <data-dir>/atlas/atlas.duckdb
+//! ```
+//!
+//! This file is the only place under `runtime/atlas/` that names the `duckdb`
+//! crate, and the [`Connection`] it holds is a private field with no
+//! accessor — exactly the shape [`crate::runtime::analytics`] holds for the
+//! operations projection, held independently for this database.
+//! `tests/x1_atlas_substrate.rs` pins it structurally; that test is a
+//! separate assertion from M5's, over a separate tree, because two databases
+//! with one owner each is a different (and stronger) property than two files
+//! sharing permission to open any database.
+//!
+//! # This file is not a projection (F1)
+//!
+//! [`crate::runtime::analytics`] opens its file by deleting it: the
+//! operations tables are a pure fold of the journal, so the rebuild path and
+//! the startup path are the same path, and losing the file loses nothing.
+//!
+//! **None of that is true here.** [`AtlasDb::open`] opens the existing file
+//! and keeps it, because `source.*`, `git.*` and `meta.coverage` PERSIST
+//! across restarts. They are derived from source bytes plus extractor
+//! identity, keyed by SourceGeneration; no
+//! journal replay reproduces them. A generation is evicted only when the
+//! source bytes it was derived from changed, and the eviction is reported as
+//! a coverage row rather than a silent gap (ruling §4). The journal carries
+//! one compact `source.scanned` summary per completed scan so the
+//! authoritative trail stays journal-side while the unit-level detail stays
+//! here.
+//!
+//! Two consequences bind any later wave:
+//!
+//! * Nothing may delete this file to "fix" it the way a projection may be
+//!   deleted, and no cleanup path may treat it as disposable state.
+//! * The DDL below is `IF NOT EXISTS` because reopening an existing file is
+//!   the normal path, not a recovery path.
+//!
+//! # Why the file is not under `projections/`
+//!
+//! The operations projection lives in `<data-dir>/projections/`, whose whole
+//! documented contract is that deleting the directory loses nothing — an
+//! acceptance test deletes it wholesale and asserts exactly that. A database
+//! that must survive restarts cannot live inside a directory that is
+//! advertised as disposable, so Atlas gets its own directory beside the
+//! journal and the blobs, at the same level as `projections/`.
+//!
+//! # Scope today
+//!
+//! Schema namespaces only — no table. Every table lands in the wave that
+//! lands its writer (the empty-table refusal doctrine); a declared-but-never
+//! populated table is a false promise, not completeness.
+
+use std::path::{Path, PathBuf};
+
+use duckdb::Connection;
+
+use crate::runtime::fsutil::create_dir_all_durable;
+
+/// Directory under the data dir holding Atlas's durable store.
+///
+/// Deliberately not [`crate::runtime::analytics::PROJECTIONS_DIR`]: that
+/// directory is disposable by contract and this one is not.
+pub const ATLAS_DIR: &str = "atlas";
+
+/// Atlas's database file name inside [`ATLAS_DIR`].
+pub const ATLAS_DB_FILE: &str = "atlas.duckdb";
+
+/// The schema namespaces Atlas declares (A1 §5, F3).
+///
+/// `meta` holds Atlas's own bookkeeping (coverage above all); `source` holds
+/// what was derived from source bytes; `git` holds what was derived from Git
+/// objects; `context` holds the retrieval-facing units assembled from the
+/// other two. Sorted, because [`AtlasDb::schema_names`] answers sorted and
+/// the two are compared directly.
+pub const SCHEMAS: &[&str] = &["context", "git", "meta", "source"];
+
+/// Prepared statements the connection keeps planned.
+const STATEMENT_CACHE: usize = 64;
+
+/// Atlas's durable directory for a data dir.
+pub fn atlas_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join(ATLAS_DIR)
+}
+
+/// Atlas's database file for a data dir.
+pub fn atlas_db_path(data_dir: &Path) -> PathBuf {
+    atlas_dir(data_dir).join(ATLAS_DB_FILE)
+}
+
+/// Failures of the Atlas store.
+#[derive(Debug, thiserror::Error)]
+pub enum AtlasError {
+    /// DuckDB refused a statement or could not open the database.
+    #[error("atlas duckdb error: {0}")]
+    Duck(#[from] duckdb::Error),
+    /// Filesystem failure around Atlas's directory.
+    #[error("atlas io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// The schema-namespace DDL, applied on every open.
+///
+/// `IF NOT EXISTS` throughout: unlike the operations projection, opening an
+/// existing file is this store's normal path, so the DDL has to be
+/// idempotent rather than run exactly once against a fresh file.
+const SCHEMA_DDL: &str = "\
+CREATE SCHEMA IF NOT EXISTS meta;\n\
+CREATE SCHEMA IF NOT EXISTS source;\n\
+CREATE SCHEMA IF NOT EXISTS git;\n\
+CREATE SCHEMA IF NOT EXISTS context;\n";
+
+/// Atlas's database over one data dir.
+///
+/// Owns its connection privately; nothing hands a [`Connection`] out. Values
+/// cross this boundary as plain Rust, the same rule the operations
+/// projection holds for its own file.
+pub struct AtlasDb {
+    conn: Connection,
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for AtlasDb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AtlasDb")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AtlasDb {
+    /// Open (creating if absent) Atlas's database under `data_dir` and
+    /// ensure its schema namespaces exist.
+    ///
+    /// Existing contents are kept. That is the F1 contract, not an
+    /// optimization: what this file holds cannot be re-folded from the
+    /// journal.
+    pub fn open(data_dir: &Path) -> Result<Self, AtlasError> {
+        create_dir_all_durable(&atlas_dir(data_dir))?;
+        let path = atlas_db_path(data_dir);
+        let conn = Connection::open(&path)?;
+        Self::over(conn, path)
+    }
+
+    /// An in-memory Atlas database, for callers that want the namespaces
+    /// without a file (tests, and any read-only rendering).
+    pub fn open_in_memory() -> Result<Self, AtlasError> {
+        let conn = Connection::open_in_memory()?;
+        Self::over(conn, PathBuf::from(":memory:"))
+    }
+
+    fn over(conn: Connection, path: PathBuf) -> Result<Self, AtlasError> {
+        conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
+        conn.execute_batch(SCHEMA_DDL)?;
+        Ok(Self { conn, path })
+    }
+
+    /// Where this database lives (`:memory:` for [`AtlasDb::open_in_memory`]).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Every non-internal schema this database actually holds, sorted.
+    ///
+    /// Read back out of the catalog rather than echoed from [`SCHEMAS`], so
+    /// a test comparing the two is checking the database and not the
+    /// constant. DuckDB reports its own default `main` (and
+    /// `information_schema`/`pg_catalog`) as internal, so what comes back is
+    /// exactly what Atlas declared — no filtering of our own, which is what
+    /// keeps a stray namespace visible here instead of quietly excluded.
+    pub fn schema_names(&self) -> Result<Vec<String>, AtlasError> {
+        let mut statement = self.conn.prepare(
+            "SELECT schema_name FROM duckdb_schemas() \
+             WHERE database_name = current_database() AND NOT internal \
+             ORDER BY schema_name",
+        )?;
+        let mut rows = statement.query([])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push(row.get::<usize, String>(0)?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// F3: exactly the four namespaces are created — no more, no fewer.
+    ///
+    /// DuckDB's own default `main` does not appear because DuckDB itself
+    /// marks it internal, not because this module filters it out; Atlas
+    /// simply never puts anything in it (a table with no namespace has no
+    /// owner).
+    #[test]
+    fn open_declares_exactly_the_atlas_schema_namespaces() {
+        let atlas = AtlasDb::open_in_memory().expect("atlas");
+        assert_eq!(atlas.schema_names().expect("schemas"), SCHEMAS);
+    }
+
+    /// The DDL is idempotent, because reopening the file is the normal path.
+    ///
+    /// This is **not** F1's restart-persistence regression test — that one
+    /// proves derived *facts* survive a daemon restart and lands with the
+    /// first writer that can produce a fact to lose. This asserts only that
+    /// applying the namespace DDL to a database that already has the
+    /// namespaces neither fails nor duplicates them.
+    #[test]
+    fn reopening_an_existing_file_neither_fails_nor_duplicates_a_schema() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first = AtlasDb::open(dir.path()).expect("open");
+        let names = first.schema_names().expect("schemas");
+        assert_eq!(first.path(), atlas_db_path(dir.path()));
+        drop(first);
+
+        let second = AtlasDb::open(dir.path()).expect("reopen");
+        assert_eq!(second.schema_names().expect("schemas"), names);
+    }
+
+    /// The store must not land inside the directory whose contract is that
+    /// deleting it loses nothing.
+    #[test]
+    fn the_store_lives_outside_the_disposable_projections_directory() {
+        let data = Path::new("/data");
+        let path = atlas_db_path(data);
+        assert!(
+            !path.starts_with(crate::runtime::analytics::projections_dir(data)),
+            "{} must not live under the disposable projections directory",
+            path.display()
+        );
+        assert_eq!(path, data.join(ATLAS_DIR).join(ATLAS_DB_FILE));
+    }
+
+    #[test]
+    fn debug_names_the_path_and_never_the_connection() {
+        let atlas = AtlasDb::open_in_memory().expect("atlas");
+        let debug = format!("{atlas:?}");
+        assert!(debug.contains(":memory:"), "{debug}");
+        assert!(!debug.contains("Connection"), "{debug}");
+    }
+}

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -1,0 +1,60 @@
+//! Atlas — the daemon-owned world-intelligence store (A1 §1–§8).
+//!
+//! A second analytical database, in its own file, sitting beside the
+//! journal-derived operations projection ([`crate::runtime::analytics`]) and
+//! deliberately **not** inside it. This module tree is the whole of Atlas;
+//! [`db`] is the whole of its database access.
+//!
+//! # One owner, per database — two invariants, never one (F2)
+//!
+//! The operations projection has exactly one owning file
+//! ([`crate::runtime::analytics`]) and Atlas has exactly one owning file
+//! ([`db`]). Those are two separate invariants over two separate database
+//! files, and they are enforced by two separate structural tests
+//! (`tests/m5_projections.rs`'s `t2_the_duckdb_file_has_exactly_one_owner`
+//! and `tests/x1_atlas_substrate.rs`'s `atlas_database_has_exactly_one_owner`).
+//! They are never collapsed into one "these two files may both touch a
+//! database driver" union rule: a union rule would let either owner drift
+//! into the other's file and still pass.
+//!
+//! Every sibling module under `runtime/atlas/` is therefore plain Rust —
+//! structs, parsing, pure functions over bytes and rows — and hands [`db`]
+//! owned values to write. No sibling names the database driver crate, and
+//! [`db`] hands no live connection back out.
+//!
+//! # The two rebuild disciplines (F1) — read this before adding a table
+//!
+//! Atlas and the operations projection do **not** share a rebuild story, and
+//! the most likely way to break Atlas is to assume they do.
+//!
+//! * **Operations tables (`ops.*`, in the other file)** are disposable.
+//!   The daemon deletes that file and re-folds it from the journal on every
+//!   start; "delete the file and restart" and "restart" are the same
+//!   operation. Nothing may come to depend on state that only lives there.
+//!
+//! * **Atlas's `source.*`, `git.*` and `meta.coverage` tables PERSIST
+//!   across restarts.** They are not a function of the journal — no replay
+//!   reproduces them. They are derived from source bytes plus the identity
+//!   of the extractor that read those bytes, keyed by SourceGeneration. A
+//!   generation is evicted only when the underlying source bytes changed,
+//!   and an eviction is reported: it leaves an explicit "generation evicted"
+//!   coverage row rather than a silent gap (ruling §4, contract §15–§16).
+//!   The journal still carries the authoritative trail as one compact
+//!   `source.scanned` summary per completed scan; the unit-level detail
+//!   lives here.
+//!
+//! So: deleting Atlas's file is not free and is not a no-op. It is
+//! re-derivable by re-scanning every declared source, which costs what the
+//! sources cost, and coverage will say the derived evidence was lost. Do not
+//! write code — or a test, or a cleanup path — that treats this file the way
+//! the operations projection's file may be treated.
+//!
+//! # Scope of what exists here today
+//!
+//! Schema namespaces only. `meta`, `source`, `git` and `context` are created
+//! by [`db`]; no table is declared yet. That is the same empty-table refusal
+//! doctrine the operations projection states: a table that can only ever
+//! answer "zero rows" is a false promise, not completeness, so every table
+//! lands in the wave that lands its writer.
+
+pub mod db;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,7 +1,8 @@
-//! Runtime: journal, projections, git, surfaces, integrity, repository
+//! Runtime: journal, projections, atlas, git, surfaces, integrity, repository
 //! locking, git admission preflight, routing, engine, recovery, sweep.
 
 pub mod analytics;
+pub mod atlas;
 pub mod blob;
 pub mod engine;
 pub mod estates;

--- a/tests/m5_projections.rs
+++ b/tests/m5_projections.rs
@@ -645,12 +645,25 @@ fn journal_segment(data_dir: &Path) -> PathBuf {
 
 // ------------------------------------------------------ 2. one owner
 
-/// Acceptance 2. Only the daemon's own projection module opens DuckDB.
+/// Acceptance 2. Only the daemon's own projection module opens
+/// `sergeant.duckdb`.
 ///
 /// Enforced structurally and checked mechanically: the `duckdb` crate is
 /// named in exactly one source file, that file hands out no connection, and
 /// the dependency is a normal one (a client binary that wanted its own copy
 /// would have to change this test first).
+///
+/// **Scope (S3 X1).** This assertion is about the operations projection's
+/// database and stays that. Atlas (`src/runtime/atlas/`) is a *second,
+/// separate* database with its own single owning file, pinned by its own
+/// test — `tests/x1_atlas_substrate.rs`'s
+/// `atlas_database_has_exactly_one_owner`. The scan below therefore skips
+/// that tree rather than growing an allowed-owners list: a union rule
+/// ("either of these files may open a database") would pass just as happily
+/// once one owner had grown into the other's database, which is exactly the
+/// drift a one-owner acceptance exists to catch. Every `.rs` file outside
+/// those two trees is still scanned here, so the two tests together leave no
+/// source unscanned.
 #[test]
 fn t2_the_duckdb_file_has_exactly_one_owner() {
     let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
@@ -663,8 +676,12 @@ fn t2_the_duckdb_file_has_exactly_one_owner() {
         text.split(|c: char| !(c.is_alphanumeric() || c == '_'))
             .any(|token| token == "duckdb")
     };
+    // Atlas's own tree is out of this test's scope, not exempt from having an
+    // owner: `tests/x1_atlas_substrate.rs` scans it, with the same token scan
+    // and the same positive half, against `runtime/atlas/db.rs`.
+    let atlas_tree = src.join("runtime").join("atlas");
     for file in rust_sources(&src) {
-        if file.ends_with("runtime/analytics.rs") {
+        if file.ends_with("runtime/analytics.rs") || file.starts_with(&atlas_tree) {
             continue;
         }
         let text = std::fs::read_to_string(&file).expect("read source");
@@ -674,6 +691,12 @@ fn t2_the_duckdb_file_has_exactly_one_owner() {
             file.strip_prefix(&src).expect("under src").display()
         );
     }
+    assert!(
+        atlas_tree.join("db.rs").is_file(),
+        "the skip above is only honest while {} exists to carry the second \
+         one-owner assertion",
+        atlas_tree.join("db.rs").display()
+    );
 
     // The positive half of "exactly one owner". Without it the loop above is
     // satisfied by a build that stopped using the crate altogether — and R5

--- a/tests/x1_atlas_substrate.rs
+++ b/tests/x1_atlas_substrate.rs
@@ -1,0 +1,158 @@
+//! S3 X1 — Atlas substrate: the second one-owner invariant, and the schema
+//! namespaces Atlas declares.
+//!
+//! This suite is deliberately independent of `tests/m5_projections.rs`'s
+//! `t2_the_duckdb_file_has_exactly_one_owner`. There are two databases, and
+//! each has exactly one owning file: M5 owns the assertion about the
+//! operations projection's file, this suite owns the assertion about Atlas's.
+//! Neither is a union rule ("either of these two files may open a database"),
+//! because a union rule passes just as happily when one owner has quietly
+//! grown into the other's territory. Two databases, two invariants, two
+//! tests.
+//!
+//! Non-spawning and filesystem-light: no daemon, no estate, no backend.
+
+use std::path::{Path, PathBuf};
+
+use sergeant_rs::runtime::atlas::db::{ATLAS_DB_FILE, ATLAS_DIR, AtlasDb, SCHEMAS, atlas_db_path};
+
+/// The Atlas module tree.
+fn atlas_src() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/runtime/atlas")
+}
+
+/// Every `.rs` file under `dir`, recursively.
+fn rust_sources(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir).expect("read dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            out.extend(rust_sources(&path));
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+    out
+}
+
+/// A token scan, not a fixed-pattern grep: however the import is spelled
+/// (`use duckdb::...`, `duckdb::Connection`, a re-export), the crate's own
+/// lowercase name has to appear as a bare identifier somewhere in the file.
+/// Prose that mentions the product ("DuckDB") is capitalized and does not
+/// collide.
+fn names_the_crate(text: &str) -> bool {
+    text.split(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .any(|token| token == "duckdb")
+}
+
+/// F2. Inside the Atlas tree, `db.rs` is the only file that may reach the
+/// database driver, and it hands no connection back out.
+#[test]
+fn atlas_database_has_exactly_one_owner() {
+    let src = atlas_src();
+    let owner = src.join("db.rs");
+    let files = rust_sources(&src);
+    assert!(
+        files.len() > 1,
+        "the scan must actually cover a tree, not just its owner: {files:?}"
+    );
+
+    // The negative half: every sibling is plain Rust.
+    for file in &files {
+        if *file == owner {
+            continue;
+        }
+        let text = std::fs::read_to_string(file).expect("read source");
+        assert!(
+            !names_the_crate(&text),
+            "{} names the duckdb crate; only runtime/atlas/db.rs may",
+            file.strip_prefix(&src)
+                .expect("under the atlas tree")
+                .display()
+        );
+    }
+
+    // The positive half: without it the loop above is satisfied by an Atlas
+    // that stopped using the database altogether, which is exactly the drift
+    // a one-owner assertion exists to catch.
+    let db = std::fs::read_to_string(&owner).expect("read runtime/atlas/db.rs");
+    assert!(
+        names_the_crate(&db),
+        "runtime/atlas/db.rs must be the one module in this tree that uses the duckdb crate"
+    );
+
+    // And it must not leak the connection. Private-by-default does not cover
+    // this: `AtlasDb` is a public struct in a public module, so a `pub conn`
+    // would compile and be reachable estate-wide — and a consumer written
+    // against it names the lowercase crate token nowhere, so the scan above
+    // would not see it either. The field declaration is pinned directly.
+    assert!(
+        db.contains("\n    conn: Connection,"),
+        "the Atlas connection must stay a private field"
+    );
+    assert!(
+        !db.contains("pub fn conn") && !db.contains("-> &Connection"),
+        "no accessor may hand a live connection outside the Atlas owner"
+    );
+}
+
+/// F1. The persistence split is a module-doc contract, not folklore: both
+/// the tree's entry point and its database owner have to say, in the file a
+/// contributor opens first, that these tables are not disposable the way the
+/// operations projection's tables are.
+#[test]
+fn the_atlas_module_docs_carry_the_persistence_contract() {
+    for (name, path) in [
+        ("mod.rs", atlas_src().join("mod.rs")),
+        ("db.rs", atlas_src().join("db.rs")),
+    ] {
+        let text = std::fs::read_to_string(&path).expect("read source");
+        let doc: String = text
+            .lines()
+            .take_while(|line| line.starts_with("//!") || line.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+        for required in ["PERSIST", "SourceGeneration", "coverage", "journal"] {
+            assert!(
+                doc.contains(required),
+                "runtime/atlas/{name}'s module doc must state the persistence \
+                 contract; it never mentions {required:?}"
+            );
+        }
+    }
+}
+
+/// F3. The namespaces are created in the database, read back out of its own
+/// catalog rather than echoed from the constant.
+#[test]
+fn opening_atlas_declares_the_four_schema_namespaces() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let atlas = AtlasDb::open(dir.path()).expect("open atlas");
+    assert_eq!(
+        atlas.schema_names().expect("schema names"),
+        SCHEMAS,
+        "atlas declares exactly its own namespaces — no more, no fewer"
+    );
+    assert_eq!(
+        SCHEMAS,
+        ["context", "git", "meta", "source"],
+        "A1 §5 names exactly these four Atlas namespaces"
+    );
+}
+
+/// The file is real, and it is not inside the directory whose whole contract
+/// is that deleting it loses nothing.
+#[test]
+fn the_atlas_file_is_created_outside_the_disposable_projections_directory() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let atlas = AtlasDb::open(dir.path()).expect("open atlas");
+    let path = atlas_db_path(dir.path());
+    assert_eq!(atlas.path(), path);
+    drop(atlas);
+    assert!(path.is_file(), "{} must exist", path.display());
+    assert_eq!(path, dir.path().join(ATLAS_DIR).join(ATLAS_DB_FILE));
+    assert!(
+        !dir.path().join("projections").exists(),
+        "opening atlas must not touch the disposable projections directory"
+    );
+}


### PR DESCRIPTION
Wave X1 of S3 (Atlas core, A1a) under the Host+Atlas program. Plan: workspace `host-atlas-s3-series/sprint-plan-2026-08-27.md` (as amended by the plan panel).

- **F2**: new `src/runtime/atlas/` tree; `db.rs` is the sole owner of the `duckdb` token and the private `Connection` for `atlas.duckdb`. Two INDEPENDENT one-owner structural tests: `m5_projections::t2` keeps `analytics.rs` as sergeant.duckdb's owner (narrowed to skip the atlas tree, guarded); new `x1_atlas_substrate::atlas_database_has_exactly_one_owner` pins `atlas/db.rs`.
- **F3**: atlas declares schemas `meta`/`source`/`git`/`context` (CREATE SCHEMA only — per-table DDL lands with each writer wave); existing analytics tables requalified into an `ops` schema, physical-only, zero behavior change (fold suite unchanged is the gate).
- **F1**: persistence-split module-doc contract (ops.* disposable refold vs source.*/git.*/meta.coverage persist) pinned by test.

Gates: wave workflow wf_fd5a105e — 3 panel findings, all refuted; verify gate green (fmt/clippy clean, nextest 1942/1942); aria seat SOUND, no material findings. Rung citations in commit bodies (J3 plan register; R2/R6 throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4