### PR TITLE
S3 X2 — Knowledge sources: manifest section, scanner, secrets deny, persistence contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,47 @@ release.
   daemon reports (`/v1/analytics`, `sgt analytics`) and every answer it
   gives is unchanged, and the existing projection suite passes as-is.
 
+### Knowledge sources and coverage (S3)
+
+- `sergeant.toml` gains `[[knowledge]]`: a named local path the estate reads
+  as **evidence**, with optional `ignore` globs. It is never a mount —
+  nothing is cloned, no worktree is cut from it, nothing writes to it — and
+  a declared path that resolves inside a repository mount, inside
+  `surfaces_dir`, or inside `data_dir` is refused by name at manifest parse,
+  because those are exactly the locations the estate itself mutates.
+  `sgt knowledge add`/`list` declare and read them back; both are pure
+  manifest operations with no daemon involved.
+- Atlas gains its first real writer, the local-knowledge scanner, and with
+  it the four tables it populates: `source.generations`, `source.files`,
+  `source.units` and `meta.coverage`. Markdown and plain text are extracted
+  into document and heading-delimited section units carrying byte offsets
+  into the original file, so every derived unit can be traced back to the
+  bytes it came from. Extraction is a set of pure functions over bytes; the
+  database glue around them is separate and thin.
+- Secrets are excluded at the acquisition boundary, before a file is opened:
+  dotfiles and dot-directories, `.env` files, private keys, keystores, and
+  credential/secret files by convention, plus each source's own `ignore`
+  globs — which extend that floor and can never narrow it. Excluded paths
+  are **counted and reported** as excluded, with the pattern that refused
+  them, rather than being silently absent.
+- Every path a scan sees leaves exactly one coverage row (`discovered`,
+  `indexed`, `excluded`, `unavailable`, `unsupported`, `error`, or
+  `generation_evicted`), and each completed scan journals exactly one
+  compact `source.scanned` summary — source, generation, content key,
+  counts, extractor identities — never a per-file event stream.
+- Re-scanning a source whose bytes have not changed writes nothing and
+  evicts nothing; a generation is superseded only when the content it was
+  derived from actually changed, and the superseded generation leaves an
+  explicit eviction row rather than vanishing.
+- A crash between a scan's rows and its summary now leaves neither reported.
+  Rows commit as one provisional generation, the summary is journaled, and a
+  second transaction confirms it and evicts its predecessor; no read path
+  can see an unconfirmed generation, and opening Atlas — which every daemon
+  start does — evicts any that a crash left behind, leaving a
+  `generation_evicted` coverage row that names the crash window.
+- New dependency: `globset`, for the exclusion set and `[[knowledge]]
+  ignore` glob matching.
+
 ## [0.2.4] - 2026-08-25
 
 sergeant-rs narrows to a product-documents-only repo, codex actors gain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1194,18 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2921,6 +2943,7 @@ dependencies = [
  "blake3",
  "clap",
  "duckdb",
+ "globset",
  "http-body-util",
  "include_dir",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,24 @@ axum = "0.8"
 blake3 = "1.8.6"
 clap = { version = "4.6.6", features = ["derive"] }
 duckdb = { version = "1", features = ["bundled"] }
+# S3 X2 (F10): the scanner needs glob matching for two things a manifest and a
+# constant both spell in glob syntax — the built-in secrets deny set and each
+# `[[knowledge]] ignore` entry. Rungs, in order: R2 fails (nothing in this
+# crate matches globs; `is_plain_name` answers a different question), R3 fails
+# (std has no glob matcher and `Path` comparison cannot express `**/*.pem`),
+# R4 fails (the OS offers no portable one — shell globbing would mean spawning
+# a shell over operator-supplied patterns, which is worse than a dependency in
+# every respect), R5 fails (nothing already in the graph exposes glob
+# matching; `regex` is present but making operators write regexes for an
+# `ignore` list is a worse contract, and translating globs to regexes by hand
+# is the very R7 this rung exists to avoid), R6 fails (a correct `**`
+# implementation with alternates and character classes is not one line — it is
+# the bug farm every hand-rolled matcher becomes). R5-as-new-edge → declare
+# globset: ripgrep's own matcher, `default-features = false` because the only
+# default feature is `log`, which buys nothing here. Its own graph is
+# aho-corasick + regex-automata/regex-syntax, all already resolved for this
+# build, plus `bstr` and `fnv`.
+globset = { version = "0.4.20", default-features = false }
 include_dir = { version = "0.7.4", default-features = false }
 opentelemetry = { version = "0.32", default-features = false, features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-blocking-client", "trace", "metrics"] }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ Global options are `-C <ESTATE_ROOT>`, `--data-dir <PATH>`, and `--json`. A daem
 
 - **Unscoped** — `--help`, `--version`, `init`, `doctor` — valid anywhere, touch no daemon.
 - **Host-scoped** — `tui`, `status`, `work show`/`list`/`transcript`, `watch`, and every `daemon` verb (foreground start, `stop`, `install-service`) — valid from any directory, no estate root required. `sgt watch` still consults `-C`/cwd opportunistically: inside a valid estate root it defaults to that estate's events; `--all`, or a cwd that is not one, watches every estate the daemon has admitted.
-- **Estate-scoped** — everything else (`run`, `repo`, `group`, `workflow`, `respond`, `retry`, `extend`, `cancel`, `work reap`/`sweep`/`retained`, `analytics`, and the harness launchers) — requires an exact estate root (`-C <ESTATE_ROOT>` or a cwd that is one); refused outside one.
+- **Estate-scoped** — everything else (`run`, `repo`, `knowledge`, `group`, `workflow`, `respond`, `retry`, `extend`, `cancel`, `work reap`/`sweep`/`retained`, `analytics`, and the harness launchers) — requires an exact estate root (`-C <ESTATE_ROOT>` or a cwd that is one); refused outside one.
 
 Harness launchers exec the native harness; estate client commands use the host daemon and may auto-start it according to their help contract — the spawned daemon addresses no estate itself (H1: every estate it ever serves is admitted per-request, over the wire, once it is already running).
 
@@ -16,6 +16,7 @@ Harness launchers exec the native harness; estate client commands use the host d
 | `status`, `tui` | health and human operation | host |
 | `doctor` | diagnose this installation | unscoped |
 | `init`, `repo`, `group` | estate topology | unscoped (`init`) / estate (`repo`, `group`) |
+| `knowledge` | declare and list local paths read as evidence — never mounted, never written to | estate |
 | `workflow` | fork a stock package into a local, editable copy | estate |
 | `run` | submit accepted intent and scope | estate |
 | `work` | list, show, transcript, retained-state, reap, and sweep operations | host (`list`/`show`/`transcript`) / estate (`retained`, `reap`, `sweep`) |

--- a/docs/reference/sergeant-toml.md
+++ b/docs/reference/sergeant-toml.md
@@ -17,6 +17,11 @@ origin = "https://github.com/example/app.git"
 instructions = "suppress"
 # upstream = "https://github.com/upstream/app.git"
 
+[[knowledge]]
+name = "notes"
+path = "/home/me/notes"
+ignore = ["*.log", "drafts/**"]
+
 [group.product]
 repos = ["app"]
 brief = "Repositories shipped as one product"
@@ -25,5 +30,7 @@ brief = "Repositories shipped as one product"
 `[estate].name` is required. `default_backend`, `default_workflow`, `surfaces_dir`, `data_dir`, and `retention` are optional. Relative directories resolve from the estate root. Retention defaults to 1,000 and cannot be lower than 64.
 
 Each `[[repo]]` requires a unique `name`. Its mount is always derived as `repos/<name>`; `path` is removed and refused. `origin`, `upstream`, and `instructions` are optional. Groups use `[group.<name>]`, require a `repos` array whose entries must each be a declared `[[repo]]` name (the array itself may be empty), and may carry a brief.
+
+Each `[[knowledge]]` entry declares a local path read as **evidence**: a unique plain `name`, a required `path` (relative paths resolve from the estate root), and an optional `ignore` array of globs. A knowledge source is never a mount — nothing is cloned, no worktree is cut from it, and nothing writes to it. A path that resolves inside a repository mount, inside `surfaces_dir`, or inside `data_dir` is refused by name, because those are locations the estate itself mutates. `ignore` globs *extend* the built-in exclusion set (dotfiles, `.env*`, private keys, keystores, credential and secret files) and can never narrow it; excluded paths are reported as excluded rather than silently omitted.
 
 Profiles are named launch records described in [backends and profiles](backends-and-profiles.md). The legacy `[workspace]` and `[[repository]]` vocabulary is refused with migration guidance.

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -95,3 +95,14 @@ cov_stage_begin c3-v1d_probe_child_lifecycle
 cov_run cargo llvm-cov --no-report --test v1d_probe_child_lifecycle --locked || cov_fail "v1d_probe_child_lifecycle failed under instrumentation"
 cov_stage_end 2 "v1d spawns real sgt daemons and re-executes its own test binary; more than the \
 test binary's own profile must arrive, or no subprocess flushed"
+
+# S3 X2, wired at birth (the #231 lesson: a suite absent from every stage
+# list contributes nothing to Gate D however green it runs). Four of this
+# suite's tests drive real `sgt` client processes (`knowledge add`/`list`,
+# `repo add`, `init`), and two more start a real in-process daemon over a
+# data dir. Belongs beside m2/m6 rather than in C2's no-daemon-of-its-own
+# bucket. Floor 2: the test binary plus at least one flushed `sgt` client.
+cov_stage_begin c3-x2_knowledge_sources
+cov_run cargo llvm-cov --no-report --test x2_knowledge_sources --locked || cov_fail "x2_knowledge_sources failed under instrumentation"
+cov_stage_end 2 "x2_knowledge_sources spawns real sgt clients and starts real daemons; more than \
+the test binary's own profile must arrive, or no subprocess flushed"

--- a/src/api.rs
+++ b/src/api.rs
@@ -3962,6 +3962,7 @@ fn manifest_error_code(e: &ManifestError) -> &'static str {
         ManifestError::NoEstate { .. } => "no_estate",
         ManifestError::InvalidName { .. } => "invalid_name",
         ManifestError::RepoAlreadyDeclared { .. } => "repo_already_declared",
+        ManifestError::KnowledgeAlreadyDeclared { .. } => "knowledge_already_declared",
         ManifestError::RepoNotDeclared { .. } => "repo_not_declared",
         ManifestError::RepoInUseByGroups { .. } => "repo_in_use_by_groups",
         ManifestError::GroupNotDeclared { .. } => "group_not_declared",
@@ -3985,9 +3986,9 @@ fn manifest_error_status(e: &ManifestError) -> StatusCode {
         | ManifestError::Invalid { .. }
         | ManifestError::ExistingPathNotAGitRepository { .. }
         | ManifestError::MalformedSection { .. } => StatusCode::UNPROCESSABLE_ENTITY,
-        ManifestError::Locked { .. } | ManifestError::RepoAlreadyDeclared { .. } => {
-            StatusCode::CONFLICT
-        }
+        ManifestError::Locked { .. }
+        | ManifestError::RepoAlreadyDeclared { .. }
+        | ManifestError::KnowledgeAlreadyDeclared { .. } => StatusCode::CONFLICT,
         ManifestError::NoEstate { .. }
         | ManifestError::RepoNotDeclared { .. }
         | ManifestError::GroupNotDeclared { .. }
@@ -4777,6 +4778,12 @@ pub const SSE_EVENT_KINDS: &[&str] = &[
     KIND_ADMISSION_RESUMED,
     crate::runtime::prune::KIND_PRUNE_INTENT,
     crate::runtime::prune::KIND_PRUNE_COMPLETED,
+    // S3 X2: the one compact summary a completed source scan journals. Named
+    // here for the same reason as every kind above — a journaled kind absent
+    // from this list is a frame every enumerating client silently drops — and
+    // it is *one* kind per completed scan, never one per file, which is what
+    // makes putting it on the live stream affordable at all.
+    crate::domain::source::KIND_SOURCE_SCANNED,
 ];
 
 /// Frame names this stream sends that are **not** journaled `KIND_*` events

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -318,6 +318,14 @@ enum Command {
         #[command(subcommand)]
         command: RepoCommand,
     },
+    /// Manage the estate's declared knowledge sources (`[[knowledge]]` in
+    /// `sergeant.toml`): local paths read as **evidence**, never mounted and
+    /// never written to (A1-03). A pure manifest edit — no daemon involved,
+    /// and nothing is cloned, created or touched on disk.
+    Knowledge {
+        #[command(subcommand)]
+        command: KnowledgeCommand,
+    },
     /// Manage the estate's declared groups (`[group.<name>]` in
     /// `sergeant.toml`). A pure manifest edit — no daemon involved.
     Group {
@@ -443,6 +451,36 @@ enum RepoCommand {
         name: String,
     },
     /// List declared repositories.
+    List,
+}
+
+/// `sgt knowledge ...` subcommands (S3, F11's minimum honest set).
+///
+/// Add and list, and deliberately nothing else yet. A `remove` verb, a
+/// `scan` verb and a coverage report are all real needs with real consumers
+/// — in later waves. Shipping a verb whose output nothing yet produces would
+/// be the same false promise as an empty table (R1).
+#[derive(Subcommand, Debug)]
+enum KnowledgeCommand {
+    /// Declare a local path as read-only evidence. Nothing is cloned,
+    /// created or verified on disk — this appends a `[[knowledge]]` entry
+    /// and validates the manifest it would produce.
+    ///
+    /// Refused if the path resolves inside a repository mount, the surfaces
+    /// directory, or the data directory: a knowledge source is evidence
+    /// about a world the estate observes, not one it mutates.
+    Add {
+        /// Source name (used in coverage rows and source coordinates).
+        name: String,
+        /// Path to the source root. Relative paths resolve against the
+        /// estate root.
+        path: PathBuf,
+        /// Glob to exclude from scanning, repeatable. **Extends** the
+        /// built-in secrets deny set; it can never narrow it.
+        #[arg(long)]
+        ignore: Vec<String>,
+    },
+    /// List declared knowledge sources.
     List,
 }
 
@@ -1718,6 +1756,9 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             }
         }
         Command::Repo { command } => repo_command(sgt.json, &estate_root(&estate), command).await,
+        Command::Knowledge { command } => {
+            knowledge_command(sgt.json, &estate_root(&estate), command).await
+        }
         Command::Group { command } => group_command(sgt.json, &estate_root(&estate), command).await,
         Command::Workflow { command } => {
             workflow_command(sgt.json, &estate_root(&estate), command).await
@@ -1933,6 +1974,61 @@ async fn repo_command(
                         estate.instruction_policy(&r.name),
                         estate.repository_origin(&r.name).unwrap_or("-"),
                         estate.repository_upstream(&r.name).unwrap_or("-"),
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+/// `sgt knowledge add/list` (S3 F11): a pure manifest edit/read, same
+/// rationale as [`repo_command`] — no daemon, no network, no disk beyond
+/// `sergeant.toml` itself.
+async fn knowledge_command(
+    json: bool,
+    estate_root: &Path,
+    command: KnowledgeCommand,
+) -> Result<(), CliError> {
+    match command {
+        KnowledgeCommand::Add { name, path, ignore } => {
+            crate::domain::manifest::add_knowledge(estate_root, &name, &path, &ignore)?;
+            if json {
+                print_json(&json!({"added": name, "path": path, "ignore": ignore}));
+            } else {
+                println!("added knowledge source {name} at {}", path.display());
+            }
+            Ok(())
+        }
+        KnowledgeCommand::List => {
+            // The structural loader, not the strict one: a knowledge source
+            // has nothing to do with whether every declared repository is
+            // cloned, and listing sources must not fail because one is not
+            // (the same reason the manifest pen validates structurally).
+            let estate = crate::domain::estate::Estate::from_config_structural(
+                &estate_root.join(crate::domain::estate::MANIFEST_FILE),
+            )?;
+            if json {
+                print_json(&json!({
+                    "knowledge": estate.knowledge.iter().map(|k| json!({
+                        "name": k.name,
+                        "path": k.path,
+                        "ignore": k.ignore,
+                    })).collect::<Vec<_>>(),
+                }));
+            } else if estate.knowledge.is_empty() {
+                println!("no knowledge sources declared");
+            } else {
+                for source in &estate.knowledge {
+                    println!(
+                        "{}  {}  ignore={}",
+                        source.name,
+                        source.path.display(),
+                        if source.ignore.is_empty() {
+                            "-".to_string()
+                        } else {
+                            source.ignore.join(",")
+                        }
                     );
                 }
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -767,10 +767,14 @@ pub async fn start_with(
     // operations tables are a pure fold of it. Atlas is opened and **kept**:
     // its `source.*` and `meta.coverage` rows are derived from source bytes
     // plus extractor identity, and no journal replay reproduces them.
-    // Opening it reconciles it (see `AtlasDb::open`) — any generation a crash
-    // left with rows and no `source.scanned` summary is evicted, leaving an
-    // explicit `generation_evicted` coverage row rather than a half-scan
-    // reported as coverage.
+    // `record::reconcile_sources` is what closes the crash window, and it
+    // needs both halves of the evidence — which is why it takes the journal
+    // as well as the store. A generation a crash left `provisional` is
+    // promoted when its `source.scanned` summary is in the journal (the scan
+    // completed; only the confirming transaction was lost) and evicted, with
+    // an explicit `generation_evicted` coverage row, when it is not. The
+    // database's `state` column alone cannot tell those two apart, and they
+    // have opposite correct answers.
     //
     // Opened and dropped rather than held: nothing in this build reads Atlas
     // while the daemon runs (`sgt intelligence status` and the `map` surface
@@ -786,11 +790,25 @@ pub async fn start_with(
     // creates the store the first time it actually writes to it.
     if crate::runtime::atlas::db::atlas_db_path(data_dir).exists() {
         match crate::runtime::atlas::db::AtlasDb::open(data_dir) {
-            Ok(atlas) => tracing::debug!(
-                target: "sergeant::atlas",
-                path = %atlas.path().display(),
-                "atlas opened and reconciled at startup"
-            ),
+            Ok(mut atlas) => {
+                match crate::runtime::atlas::record::reconcile_sources(&mut atlas, &journal) {
+                    Ok(resolved) => tracing::debug!(
+                        target: "sergeant::atlas",
+                        path = %atlas.path().display(),
+                        promoted = resolved.promoted.len(),
+                        evicted = resolved.evicted.len(),
+                        "atlas opened and reconciled at startup"
+                    ),
+                    // Same reasoning as an unopenable store, one line down:
+                    // derived evidence never costs the estate its daemon.
+                    Err(e) => tracing::warn!(
+                        target: "sergeant::atlas",
+                        error = %e,
+                        "atlas could not be reconciled at startup; a crash-window \
+                         generation may remain unresolved (it stays unreadable)"
+                    ),
+                }
+            }
             // Never fatal. Atlas is derived evidence; a daemon that refused
             // to start because a derived store was unreadable would trade
             // every Work in the estate for an index (A1-01: the journal, Git

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -758,6 +758,51 @@ pub async fn start_with(
         &first_seq_by_work,
     )?;
     startup::persist_or_remove(floor_state.as_ref(), data_dir)?;
+
+    // 2e (S3 X2, F1): Atlas's startup reconciliation.
+    //
+    // The two rebuild disciplines meet here, a few lines apart, and the
+    // difference between them is the whole of F1. `Analytics::begin_rebuild`
+    // above *deleted* its file and refolded it from the journal, because the
+    // operations tables are a pure fold of it. Atlas is opened and **kept**:
+    // its `source.*` and `meta.coverage` rows are derived from source bytes
+    // plus extractor identity, and no journal replay reproduces them.
+    // Opening it reconciles it (see `AtlasDb::open`) — any generation a crash
+    // left with rows and no `source.scanned` summary is evicted, leaving an
+    // explicit `generation_evicted` coverage row rather than a half-scan
+    // reported as coverage.
+    //
+    // Opened and dropped rather than held: nothing in this build reads Atlas
+    // while the daemon runs (`sgt intelligence status` and the `map` surface
+    // land with their own wave), so keeping a second connection open for the
+    // process lifetime would buy nothing. What must happen at startup is the
+    // reconciliation, and that is what this does.
+    //
+    // And only when the file is already there. Opening creates it, and
+    // creating it here would mean every host that has never declared a
+    // knowledge source pays a database creation on every start for a feature
+    // it has never used (R1) — while a file that does not exist has, by
+    // definition, no crash-window generation to reconcile. The scanner
+    // creates the store the first time it actually writes to it.
+    if crate::runtime::atlas::db::atlas_db_path(data_dir).exists() {
+        match crate::runtime::atlas::db::AtlasDb::open(data_dir) {
+            Ok(atlas) => tracing::debug!(
+                target: "sergeant::atlas",
+                path = %atlas.path().display(),
+                "atlas opened and reconciled at startup"
+            ),
+            // Never fatal. Atlas is derived evidence; a daemon that refused
+            // to start because a derived store was unreadable would trade
+            // every Work in the estate for an index (A1-01: the journal, Git
+            // and the original bytes are authority — Atlas is not).
+            Err(e) => tracing::warn!(
+                target: "sergeant::atlas",
+                error = %e,
+                "atlas could not be opened at startup; source intelligence is unavailable this run"
+            ),
+        }
+    }
+
     let rebuild_ms = u64::try_from(rebuild_started.elapsed().as_millis()).unwrap_or(u64::MAX);
     let startup_cache = plan.startup_cache_tag();
     // The oldest surviving seq (1 on every W2 production path — the floor

--- a/src/domain/estate.rs
+++ b/src/domain/estate.rs
@@ -158,6 +158,36 @@ impl std::fmt::Display for InstructionPolicy {
     }
 }
 
+/// One `[[knowledge]]` source: a local path the estate declares as
+/// **read-only evidence** (A1 §2/§3, F9).
+///
+/// Mirrors [`RepositorySpec`] deliberately — a plain name, a resolved
+/// absolute path — and differs in exactly the two ways that matter:
+///
+/// * **The path is declared, not derived.** A repository mount is always
+///   `<estate-root>/repos/<name>` (§6.1) precisely because it is a mutation
+///   surface the estate owns. A knowledge source is somewhere else on the
+///   machine by definition; deriving it would defeat the point.
+/// * **It is never a mount** (A1-03). Nothing cuts a worktree from it,
+///   nothing branches it, nothing writes to it. Declaring a path here grants
+///   read access to Atlas's scanner and no authority whatsoever — which is
+///   why [`EstateError::KnowledgePathInsideEstate`] refuses a declaration
+///   that would alias a location the estate already owns and mutates.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeSpec {
+    /// Name used in coverage rows, `sgt knowledge list`, and source
+    /// coordinates. Plain-name rules, exactly like a repository's.
+    pub name: String,
+    /// Absolute path to the source root. A relative declaration joins onto
+    /// the estate root, the same resolution `surfaces_dir`/`data_dir` use.
+    pub path: PathBuf,
+    /// Per-source ignore globs, extending the scanner's built-in deny set
+    /// (F10). Never *narrowing* it: a source cannot opt back into the
+    /// defaults it was protected by.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore: Vec<String>,
+}
+
 /// A group of repositories declared under `[group.<name>]` (R-MVP1-3).
 ///
 /// Membership gets **no new engine surface** (R-MVP1-5(b)): this is manifest
@@ -267,6 +297,12 @@ pub struct Estate {
     /// derives a forge, host or CLI from it — the URL is opaque.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub repository_upstream: BTreeMap<String, String>,
+    /// `[[knowledge]]` declarations (F9, A1 §2): local paths this estate
+    /// reads as evidence, in declaration order. Read-only by construction —
+    /// nothing in execution consults this list, and nothing ever will: a
+    /// knowledge source is not a mount (A1-03).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub knowledge: Vec<KnowledgeSpec>,
     /// `[estate] retention` (Q3/A2, W3): the declared Work-retention cap, or
     /// `None` for the built-in [`DEFAULT_RETENTION`]. Read once by
     /// `daemon::start_with` and pinned into the prune policy for the life of
@@ -678,6 +714,60 @@ pub enum EstateError {
         /// The offending name.
         name: String,
     },
+    /// A declared knowledge name is not usable as a plain path component.
+    /// Mirrors [`Self::InvalidRepositoryName`]: the name is joined onto
+    /// coverage coordinates and reported back in CLI output, so anything but
+    /// a plain name is refused where it is cheap to refuse.
+    #[error("{file} declares knowledge source name {name:?}, which is not a plain directory name")]
+    InvalidKnowledgeName {
+        /// Config file that declared it.
+        file: String,
+        /// The offending name.
+        name: String,
+    },
+    /// Two knowledge sources share a name; coverage and source coordinates
+    /// are keyed by name, so this would silently merge two sources into one.
+    #[error("{file} declares knowledge source name {name:?} twice")]
+    DuplicateKnowledge {
+        /// Config file that declared it.
+        file: String,
+        /// The repeated name.
+        name: String,
+    },
+    /// F9's path-containment refusal (panel finding 6): a `[[knowledge]]`
+    /// path that canonicalizes to a location inside a declared repository
+    /// mount, inside `surfaces_dir`, or inside `data_dir`.
+    ///
+    /// Refused at the same station as [`Self::RepositoryPathDeclared`] — the
+    /// manifest parse, before any daemon, scan or Work exists — and for a
+    /// closely related reason. That variant refuses a *mount* being
+    /// redirected somewhere the estate does not own; this one refuses
+    /// *read-only evidence* being pointed at somewhere the estate does own
+    /// and actively mutates. A knowledge source is evidence about a stable
+    /// world (A1-03); a Work surface, a repository mount, and the daemon's
+    /// own data dir are the three places whose bytes change underneath a
+    /// scan by design, and indexing them would attribute mutations the
+    /// estate itself made to an outside world it was supposed to be
+    /// observing.
+    #[error(
+        "{file} declares knowledge source {name:?} at {path}, which resolves inside {what} \
+         ({inside}). A knowledge source is read-only evidence, never a mount (A1-03): it must \
+         not name a location this estate already owns and mutates. Point it at a path outside \
+         {inside}, or remove the entry."
+    )]
+    KnowledgePathInsideEstate {
+        /// Config file that declared it.
+        file: String,
+        /// The knowledge source name.
+        name: String,
+        /// The declared path, as resolved.
+        path: String,
+        /// What owns the containing location, in words — `repository mount
+        /// "api"`, `the surfaces directory`, `the data directory`.
+        what: String,
+        /// The containing path itself.
+        inside: String,
+    },
     /// Two profiles share a name.
     #[error("{file} declares profile name {name:?} twice")]
     DuplicateProfile {
@@ -786,6 +876,8 @@ struct EstateFile {
     #[serde(default)]
     repo: Vec<RepositoryEntry>,
     #[serde(default)]
+    knowledge: Vec<KnowledgeEntry>,
+    #[serde(default)]
     profile: Vec<Profile>,
     #[serde(default)]
     group: BTreeMap<String, GroupEntry>,
@@ -837,6 +929,23 @@ struct RepositoryEntry {
     /// clone-or-verify); this module never touches a remote.
     #[serde(default)]
     upstream: Option<String>,
+}
+
+/// One `[[knowledge]]` entry (F9), mirroring [`RepositoryEntry`]'s shape and
+/// its `deny_unknown_fields` discipline: a checked-in manifest is an
+/// instruction, and a misspelled key that silently means nothing is worse
+/// than a refusal naming the line.
+///
+/// Unlike `[[repo]]`, `path` is a real key here and is *required* — see
+/// [`KnowledgeSpec`] for why the derived-mount rule does not and must not
+/// apply to read-only evidence.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct KnowledgeEntry {
+    name: String,
+    path: PathBuf,
+    #[serde(default)]
+    ignore: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -984,6 +1093,128 @@ pub fn validate_mount(file: &str, name: &str, mount: &Path) -> Result<PathBuf, E
         });
     }
     Ok(canonical_mount)
+}
+
+/// `path` with as much of it canonicalized as actually exists on disk, the
+/// non-existent tail re-appended verbatim.
+///
+/// Plain [`std::fs::canonicalize`] answers nothing at all for a path that is
+/// not there yet, and a declared knowledge path legitimately may not be
+/// (the same "declared but not on disk" tolerance `[[repo]]` entries get from
+/// [`Estate::from_config_structural`]). Resolving the existing prefix is what
+/// makes the containment check symlink-proof: `knowledge/link -> repos/api`
+/// and a literal `repos/api` compare equal here, so the refusal cannot be
+/// walked around with a symlink.
+fn canonical_best_effort(path: &Path) -> PathBuf {
+    if let Ok(resolved) = std::fs::canonicalize(path) {
+        return resolved;
+    }
+    match (path.parent(), path.file_name()) {
+        (Some(parent), leaf) if parent != path => match leaf {
+            Some(leaf) => canonical_best_effort(parent).join(leaf),
+            None => canonical_best_effort(parent),
+        },
+        _ => path.to_path_buf(),
+    }
+}
+
+/// F9's `[[knowledge]]` resolution and validation, shared by the strict and
+/// structural parsers so the two can never disagree about what a knowledge
+/// declaration means.
+///
+/// Three checks, all at manifest-parse station:
+///
+/// 1. plain-name (mirrors [`EstateError::InvalidRepositoryName`]),
+/// 2. no duplicate names (mirrors [`EstateError::DuplicateRepository`]),
+/// 3. **path containment** — [`EstateError::KnowledgePathInsideEstate`],
+///    panel finding 6.
+///
+/// Existence is deliberately *not* checked: a knowledge path that is not
+/// mounted right now is a coverage fact (the scanner reports it
+/// `unavailable`), not a manifest defect, exactly as a not-yet-cloned
+/// `[[repo]]` is a repository problem rather than an estate-identity one.
+fn resolve_knowledge(
+    file: &str,
+    root: &Path,
+    entries: Vec<KnowledgeEntry>,
+    repositories: &[RepositorySpec],
+    surfaces_dir: Option<&Path>,
+    data_dir: Option<&Path>,
+) -> Result<Vec<KnowledgeSpec>, EstateError> {
+    if entries.is_empty() {
+        return Ok(Vec::new());
+    }
+    // The three families of estate-owned, estate-mutated location. Built
+    // once, canonicalized the same way the candidate is, so the comparison
+    // below is between two resolved paths and never between one of each.
+    let mut owned: Vec<(String, PathBuf)> = Vec::new();
+    for repo in repositories {
+        owned.push((
+            format!("repository mount {:?}", repo.name),
+            canonical_best_effort(&mount_path(root, &repo.name)),
+        ));
+    }
+    owned.push((
+        "the surfaces directory".to_string(),
+        canonical_best_effort(&match surfaces_dir {
+            Some(dir) => dir.to_path_buf(),
+            // The daemon's own default when the manifest declares none.
+            None => data_dir
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| root.join(crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR))
+                .join("surfaces"),
+        }),
+    ));
+    owned.push((
+        "the data directory".to_string(),
+        canonical_best_effort(&match data_dir {
+            Some(dir) => dir.to_path_buf(),
+            None => root.join(crate::domain::manifest::DEFAULT_ESTATE_DATA_DIR),
+        }),
+    ));
+
+    let mut seen = BTreeSet::new();
+    let mut resolved = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if !is_plain_name(&entry.name) {
+            return Err(EstateError::InvalidKnowledgeName {
+                file: file.to_string(),
+                name: entry.name,
+            });
+        }
+        if !seen.insert(entry.name.clone()) {
+            return Err(EstateError::DuplicateKnowledge {
+                file: file.to_string(),
+                name: entry.name,
+            });
+        }
+        // Relative declarations join onto the estate root — the same rule
+        // `surfaces_dir` and `data_dir` already follow, so one manifest has
+        // one relative-path convention rather than two.
+        let joined = if entry.path.is_absolute() {
+            entry.path.clone()
+        } else {
+            root.join(&entry.path)
+        };
+        let candidate = canonical_best_effort(&joined);
+        for (what, owner) in &owned {
+            if candidate.starts_with(owner) {
+                return Err(EstateError::KnowledgePathInsideEstate {
+                    file: file.to_string(),
+                    name: entry.name,
+                    path: candidate.display().to_string(),
+                    what: what.clone(),
+                    inside: owner.display().to_string(),
+                });
+            }
+        }
+        resolved.push(KnowledgeSpec {
+            name: entry.name,
+            path: candidate,
+            ignore: entry.ignore,
+        });
+    }
+    Ok(resolved)
 }
 
 /// Probe raw TOML for the pre-estate vocabulary **before** the real parse
@@ -1344,11 +1575,23 @@ impl Estate {
                 None => (repo_name(&root), None, None, None, None, None),
             };
         validate_retention(retention, &file)?;
+        // F9: resolved last, because containment is stated against the
+        // repository mounts and the two directory overrides this parse has
+        // only just finished computing.
+        let knowledge = resolve_knowledge(
+            &file,
+            &root,
+            parsed.knowledge,
+            &repositories,
+            surfaces_dir.as_deref(),
+            data_dir.as_deref(),
+        )?;
 
         Ok(Self {
             name,
             root,
             repositories,
+            knowledge,
             default_backend,
             default_workflow,
             profiles: parsed.profile,
@@ -1488,11 +1731,23 @@ impl Estate {
                 None => (repo_name(&root), None, None, None, None, None),
             };
         validate_retention(retention, &file)?;
+        // F9: resolved last, because containment is stated against the
+        // repository mounts and the two directory overrides this parse has
+        // only just finished computing.
+        let knowledge = resolve_knowledge(
+            &file,
+            &root,
+            parsed.knowledge,
+            &repositories,
+            surfaces_dir.as_deref(),
+            data_dir.as_deref(),
+        )?;
 
         Ok(Self {
             name,
             root,
             repositories,
+            knowledge,
             default_backend,
             default_workflow,
             profiles: parsed.profile,
@@ -1926,6 +2181,150 @@ mod tests {
         ));
     }
 
+    /// F9 (panel finding 6), mirroring the test above: a `[[knowledge]]` path
+    /// that resolves inside a location the estate owns and mutates is refused
+    /// **at the same station** — the manifest parse — by a named variant that
+    /// says which location and why.
+    ///
+    /// Three owned families, and each is a different way to get the same
+    /// wrong answer: a repository mount's bytes change every time a Work
+    /// merges, a surface's change every time a Work runs, and the data
+    /// directory is the daemon's own state. Indexing any of them would file
+    /// the estate's own mutations as evidence about an outside world.
+    #[test]
+    fn a_knowledge_path_inside_an_estate_owned_location_is_refused_by_name() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+        init_repo(&mount_path(root, "api"));
+        std::fs::create_dir_all(root.join("repos/api/docs")).expect("docs");
+        std::fs::create_dir_all(root.join(".sergeant/data/surfaces/w1")).expect("surfaces");
+        std::fs::create_dir_all(root.join("outside")).expect("outside");
+
+        // 1. Inside a declared repository mount.
+        let err = parse_without_mounting(
+            root,
+            "[estate]\nname = \"w\"\n\n[[repo]]\nname = \"api\"\n\n\
+             [[knowledge]]\nname = \"docs\"\npath = \"repos/api/docs\"\n",
+        )
+        .expect_err("a mount-contained knowledge path must be refused");
+        let EstateError::KnowledgePathInsideEstate { name, what, .. } = &err else {
+            panic!("expected the named containment refusal, got {err}");
+        };
+        assert_eq!(name, "docs");
+        assert!(
+            what.contains("api"),
+            "the refusal must name the mount: {what}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("read-only evidence") && message.contains("A1-03"),
+            "the refusal must say why, not just that: {message}"
+        );
+
+        // 2. Inside the default data dir, which no manifest had to declare —
+        //    the case a check written against declared values alone misses.
+        let err = parse_without_mounting(
+            root,
+            "[estate]\nname = \"w\"\n\n[[repo]]\nname = \"api\"\n\n\
+             [[knowledge]]\nname = \"state\"\npath = \".sergeant/data\"\n",
+        )
+        .expect_err("a data-dir-contained knowledge path must be refused");
+        assert!(matches!(err, EstateError::KnowledgePathInsideEstate { .. }));
+
+        // 3. Inside a surfaces directory, reached through a *symlink* — the
+        //    containment check resolves before comparing, so a link is not a
+        //    way around it.
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(
+                root.join(".sergeant/data/surfaces/w1"),
+                root.join("linked-surface"),
+            )
+            .expect("symlink");
+            let err = parse_without_mounting(
+                root,
+                "[estate]\nname = \"w\"\n\n[[repo]]\nname = \"api\"\n\n\
+                 [[knowledge]]\nname = \"live\"\npath = \"linked-surface\"\n",
+            )
+            .expect_err("a symlink into a surface must be refused");
+            assert!(matches!(err, EstateError::KnowledgePathInsideEstate { .. }));
+        }
+
+        // The negative control, and it matters as much as the refusals: an
+        // ordinary directory under the estate root that the estate does *not*
+        // own is a perfectly good knowledge source. This rule refuses three
+        // named locations, not "anywhere near the estate".
+        let estate = parse_without_mounting(
+            root,
+            "[estate]\nname = \"w\"\n\n[[repo]]\nname = \"api\"\n\n\
+             [[knowledge]]\nname = \"outside\"\npath = \"outside\"\nignore = [\"*.log\"]\n",
+        )
+        .expect("a path the estate does not own is accepted");
+        assert_eq!(estate.knowledge.len(), 1);
+        assert_eq!(estate.knowledge[0].name, "outside");
+        assert!(estate.knowledge[0].path.is_absolute());
+        assert_eq!(estate.knowledge[0].ignore, vec!["*.log".to_string()]);
+
+        // Every read path refuses it, not just the strict one — and `admit`
+        // refuses the estate outright, exactly as it does for a declared
+        // `[[repo]] path`.
+        std::fs::write(
+            root.join(MANIFEST_FILE),
+            "[estate]\nname = \"w\"\n\n[[repo]]\nname = \"api\"\n\n\
+             [[knowledge]]\nname = \"docs\"\npath = \"repos/api/docs\"\n",
+        )
+        .expect("write");
+        assert!(matches!(
+            Estate::from_config_structural(&root.join(MANIFEST_FILE)),
+            Err(EstateError::KnowledgePathInsideEstate { .. })
+        ));
+        assert!(matches!(
+            Estate::admit(root),
+            Err(EstateRootError::Invalid { .. })
+        ));
+    }
+
+    /// The rest of F9's schema-level rules, mirroring `[[repo]]`'s: a plain
+    /// name, no duplicates, `deny_unknown_fields` on the entry, and a `path`
+    /// that is required because a knowledge root is declared, never derived.
+    #[test]
+    fn knowledge_entries_follow_the_same_schema_discipline_as_repo_entries() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+        init_repo(&mount_path(root, "api"));
+        let head = "[estate]\nname = \"w\"\n\n[[repo]]\nname = \"api\"\n\n";
+
+        assert!(matches!(
+            parse_without_mounting(
+                root,
+                &format!("{head}[[knowledge]]\nname = \"../escape\"\npath = \"/tmp\"\n")
+            ),
+            Err(EstateError::InvalidKnowledgeName { .. })
+        ));
+        assert!(matches!(
+            parse_without_mounting(
+                root,
+                &format!(
+                    "{head}[[knowledge]]\nname = \"n\"\npath = \"/tmp/a\"\n\n\
+                     [[knowledge]]\nname = \"n\"\npath = \"/tmp/b\"\n"
+                )
+            ),
+            Err(EstateError::DuplicateKnowledge { .. })
+        ));
+        // A typo'd key is a refusal naming the line, not a silently ignored
+        // instruction — the same fail-closed reading every other table gets.
+        let err = parse_without_mounting(
+            root,
+            &format!("{head}[[knowledge]]\nname = \"n\"\npath = \"/tmp/a\"\nignores = []\n"),
+        )
+        .expect_err("unknown field must be refused");
+        assert!(matches!(err, EstateError::Malformed { .. }), "{err}");
+        assert!(matches!(
+            parse_without_mounting(root, &format!("{head}[[knowledge]]\nname = \"n\"\n")),
+            Err(EstateError::Malformed { .. })
+        ));
+    }
+
     /// #112: `[[repo]] upstream` parses, stays opaque, and reaches every
     /// reader — the strict loader's `repository_upstream` map and the
     /// diagnostic loader's [`DeclaredRepo`] alike. An entry that declares
@@ -2005,6 +2404,7 @@ mod tests {
                     path: PathBuf::from("/nowhere/web"),
                 },
             ],
+            knowledge: Vec::new(),
             default_backend: None,
             default_workflow: None,
             profiles: Vec::new(),
@@ -2059,6 +2459,7 @@ mod tests {
                     path: PathBuf::from("/nowhere/web"),
                 },
             ],
+            knowledge: Vec::new(),
             default_backend: None,
             default_workflow: None,
             profiles: Vec::new(),

--- a/src/domain/manifest.rs
+++ b/src/domain/manifest.rs
@@ -149,6 +149,17 @@ pub enum ManifestError {
          re-add it with different settings (`sgt repo remove {name}`)"
     )]
     RepoAlreadyDeclared { name: String, path: String },
+    /// `sgt knowledge add` for a name the manifest already declares.
+    ///
+    /// Mirrors [`Self::RepoAlreadyDeclared`], and refuses for the same
+    /// reason: a second entry under one name would silently merge two
+    /// sources' coverage, and this pen never overwrites a declaration the
+    /// operator can see in the file.
+    #[error(
+        "knowledge source {name:?} is already declared in {path}; edit the entry by hand, or \
+         remove it there first if you want to re-add it with a different path or ignore list"
+    )]
+    KnowledgeAlreadyDeclared { name: String, path: String },
     /// `sgt repo add`/`sgt repo remove`/`sgt group add` named a repository
     /// the manifest has not declared.
     #[error(
@@ -711,6 +722,106 @@ pub fn remove_repo(estate_root: &Path, name: &str) -> Result<(), ManifestError> 
 
     validate(estate_root, &doc)?;
     commit(estate_root, &doc)
+}
+
+/// `sgt knowledge add <name> <path> [--ignore <glob>]...` (F11's
+/// manifest-direct shape): append one `[[knowledge]]` entry.
+///
+/// A **pure manifest edit**, and the shape is the point (A1-03). Unlike
+/// [`add_repo`], nothing is cloned, verified, created or touched on disk:
+/// declaring a knowledge source grants read access to Atlas's scanner and no
+/// authority at all, so there is nothing here to populate-or-verify. The path
+/// is written exactly as the operator gave it — a relative one stays relative
+/// and resolves against the estate root, the same convention `surfaces_dir`
+/// and `data_dir` already use.
+///
+/// Every validation that matters is [`Estate::from_config_structural`]'s,
+/// reached through [`validate`] before anything is committed: the plain-name
+/// rule, the duplicate check, and F9's path-containment refusal
+/// ([`EstateError::KnowledgePathInsideEstate`]). This function deliberately
+/// re-implements none of them — one validator, one answer, whether the entry
+/// arrived through this pen or a hand edit.
+///
+/// The source's *existence* is not checked, here or at parse: a knowledge
+/// path on an unplugged drive is a coverage fact the scanner reports
+/// (`unavailable`), not a reason to refuse the declaration.
+pub fn add_knowledge(
+    estate_root: &Path,
+    name: &str,
+    path: &Path,
+    ignore: &[String],
+) -> Result<(), ManifestError> {
+    if !is_plain_name(name) {
+        return Err(ManifestError::InvalidName {
+            name: name.to_string(),
+        });
+    }
+    let manifest_path = estate_root.join(MANIFEST_FILE);
+    let _lock = ManifestLock::acquire(estate_root)?;
+    let (mut doc, _existed) = read_document(&manifest_path)?;
+
+    if knowledge_names(&doc).iter().any(|n| n == name) {
+        return Err(ManifestError::KnowledgeAlreadyDeclared {
+            name: name.to_string(),
+            path: manifest_path.display().to_string(),
+        });
+    }
+
+    let mut table = Table::new();
+    table.insert("name", value(name));
+    table.insert(
+        "path",
+        value(
+            path.to_str()
+                .ok_or_else(|| ManifestError::InvalidName {
+                    name: path.display().to_string(),
+                })?
+                .to_string(),
+        ),
+    );
+    if !ignore.is_empty() {
+        let mut array = toml_edit::Array::new();
+        for glob in ignore {
+            array.push(glob.as_str());
+        }
+        table.insert("ignore", Item::Value(array.into()));
+    }
+    knowledge_array_mut(&mut doc, &manifest_path)?.push(table);
+
+    validate(estate_root, &doc)?;
+    commit(estate_root, &doc)
+}
+
+/// The `[[knowledge]]` array of tables, creating it if absent. Fails closed
+/// on a hand edit that put something else under the key, exactly as
+/// [`repo_array_mut`] does.
+fn knowledge_array_mut<'a>(
+    doc: &'a mut DocumentMut,
+    manifest_path: &Path,
+) -> Result<&'a mut ArrayOfTables, ManifestError> {
+    let item = doc
+        .entry("knowledge")
+        .or_insert(Item::ArrayOfTables(ArrayOfTables::new()));
+    item.as_array_of_tables_mut()
+        .ok_or_else(|| ManifestError::MalformedSection {
+            path: manifest_path.display().to_string(),
+            key: "knowledge".to_string(),
+            expected: "an array of tables ([[knowledge]] entries)".to_string(),
+        })
+}
+
+/// Declared `[[knowledge]]` names, in file order.
+fn knowledge_names(doc: &DocumentMut) -> Vec<String> {
+    doc.get("knowledge")
+        .and_then(Item::as_array_of_tables)
+        .map(|array| {
+            array
+                .iter()
+                .filter_map(|table| table.get("name").and_then(Item::as_str))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// `sgt group add <name> <repo>... [--brief <text>]`: mkdir-p create

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -6,6 +6,7 @@ pub mod event;
 pub mod execution;
 pub mod manifest;
 pub mod profile;
+pub mod source;
 pub mod work;
 pub mod workflow;
 

--- a/src/domain/source.rs
+++ b/src/domain/source.rs
@@ -1,0 +1,464 @@
+//! The Source identity spine (A1 §3–§4): what Atlas derived evidence hangs
+//! off, and the vocabulary every later wave joins on.
+//!
+//! ```text
+//! Source            source_id / source_kind / authority_class
+//!   -> SourceGeneration   the exact observed world
+//!        -> Resource      relative path + content hash (local knowledge)
+//!             -> Unit     heading / section / symbol / row
+//! ```
+//!
+//! Three rules from the contract are load-bearing here and are the reason
+//! these are three separate types rather than one enum with a `String` tag:
+//!
+//! * **Authority is orthogonal to content and relevance** (§4). A Markdown
+//!   file in an estate repository and a Markdown file in a local knowledge
+//!   source are the same *content*; their [`AuthorityClass`] differs, and
+//!   nothing may derive one from the other. "Knowledge" is not an authority
+//!   level.
+//! * **A generation is the exact observed world** (§3). For a Git source it
+//!   is a commit SHA; for local knowledge it is a scan generation whose
+//!   identity is [`SourceGeneration::content_key`] — a content hash of what
+//!   was actually read, never a timestamp. Size and mtime are cheap *change
+//!   candidates* only (§3's own wording); a durable reused extraction is
+//!   keyed by content identity.
+//! * **A cache key is content plus extractor** (F7). [`local_key`] is the
+//!   whole of that rule for local knowledge: BLAKE3 of the bytes, plus the
+//!   identity of the extractor that read them, and nothing else — never a
+//!   second hash of the same bytes, never an mtime.
+//!
+//! # Reserved, deliberately behaviourless
+//!
+//! [`SourceKind::ExternalGit`] is named here and produced by nothing: S4 owns
+//! external-Git acquisition (the ratified re-cut's adapters/external-git
+//! items). It exists as a variant rather than a comment so the S4 seam is a
+//! compile-time obligation — a `match` that grows a third source kind fails
+//! to build rather than silently treating an external source as an estate
+//! one. `content_kind` (§4's `code | document | tabular | ...` axis) is
+//! **not** modelled yet: X2 indexes exactly one content family, so an enum
+//! with one reachable variant would be a promise, not a model (R1). It lands
+//! with the wave that lands a second family.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Journal kind for the one compact summary a completed scan emits (F1).
+///
+/// Exactly one per completed scan — never one per file, never one per unit.
+/// The authoritative trail stays journal-side (journal-is-truth) while the
+/// unit-level detail lives in Atlas; a per-unit event would put the detail in
+/// both places and make the journal the slower copy of a database.
+pub const KIND_SOURCE_SCANNED: &str = "source.scanned";
+
+/// §4's `source_kind` axis: how the bytes were acquired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    /// A repository the estate declares under `[[repo]]` and mounts at
+    /// `repos/<name>`. Bytes come from Git objects at an admission-pinned
+    /// SHA (X3a's plumbing), never from a working tree scan.
+    EstateGit,
+    /// A path the estate declares under `[[knowledge]]`: read-only evidence
+    /// on the local filesystem, scanned rather than pinned (A1-03 — never a
+    /// mount, and it grants no mutation authority).
+    LocalKnowledge,
+    /// A repository acquired from outside the estate. **S4 seam: nothing in
+    /// this build produces one.** Named so the match arms that will need it
+    /// are structurally visible now (see this module's own doc).
+    ExternalGit,
+}
+
+impl SourceKind {
+    /// The stable wire/DB spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EstateGit => "estate_git",
+            Self::LocalKnowledge => "local_knowledge",
+            Self::ExternalGit => "external_git",
+        }
+    }
+
+    /// The inverse of [`Self::as_str`], for reading a stored row back.
+    /// `None` for a spelling this build does not know — a row written by a
+    /// future version is reported as unreadable, never guessed at.
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "estate_git" => Some(Self::EstateGit),
+            "local_knowledge" => Some(Self::LocalKnowledge),
+            "external_git" => Some(Self::ExternalGit),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for SourceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// §4's `authority_class` axis: what the estate may do with the bytes.
+///
+/// Orthogonal to [`SourceKind`] on purpose — the contract's own rule. The one
+/// implication this build enforces is the negative one: nothing derives write
+/// authority from a source being indexed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityClass {
+    /// A declared repository mount: the estate cuts Work surfaces from it and
+    /// Work mutates those surfaces.
+    EstateMutable,
+    /// Declared by the estate, read by the estate, mutated by nothing here —
+    /// every `[[knowledge]]` source (A1-03).
+    EstateReadonly,
+    /// Acquired from outside the estate. Reserved with
+    /// [`SourceKind::ExternalGit`]; nothing produces it yet.
+    External,
+}
+
+impl AuthorityClass {
+    /// The stable wire/DB spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EstateMutable => "estate_mutable",
+            Self::EstateReadonly => "estate_readonly",
+            Self::External => "external",
+        }
+    }
+
+    /// The inverse of [`Self::as_str`] — see [`SourceKind::parse`].
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "estate_mutable" => Some(Self::EstateMutable),
+            "estate_readonly" => Some(Self::EstateReadonly),
+            "external" => Some(Self::External),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for AuthorityClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One exact observed world for one source (§3).
+///
+/// `id` is opaque and unique per observation; `content_key` is what makes two
+/// observations *the same world*. Ruling §4's eviction rule is stated over
+/// the latter, not the former: a re-scan that produces the same
+/// `content_key` evicts nothing, because the source bytes did not change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceGeneration {
+    /// Unique id for this observation (a ULID).
+    pub id: String,
+    /// The declared source this observed.
+    pub source_name: String,
+    /// How it was acquired.
+    pub kind: SourceKind,
+    /// What the estate may do with it.
+    pub authority: AuthorityClass,
+    /// Content identity of the whole generation — see [`generation_key`].
+    pub content_key: String,
+    /// When the observation completed (RFC3339 UTC, the journal's own shape).
+    pub observed_at: String,
+}
+
+/// F7's local-knowledge cache key: BLAKE3 content hash **plus** extractor
+/// identity, and nothing else.
+///
+/// Not a second hash of the bytes (the caller already has the content hash;
+/// re-hashing megabytes to mix in a short string would be pure waste) and not
+/// a function of any filesystem timestamp. Two files with identical bytes
+/// read by the same extractor share a key by construction — which is the
+/// point: the extraction is reusable across paths, across sources, and across
+/// restarts.
+pub fn local_key(content_hash: &str, extractor: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"sergeant.atlas.local-key/v1\n");
+    hasher.update(content_hash.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(extractor.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+/// BLAKE3 hex digest of some bytes — the content half of [`local_key`].
+pub fn content_hash(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+/// Content identity of a whole generation: a hash over every acquired
+/// resource's `(relative path, content hash)` pair, in path order.
+///
+/// Order-independent by construction because the input is a [`BTreeMap`], so
+/// two scans that walk the same tree in different directory order agree.
+/// Excluded and unreadable paths are deliberately **not** folded in: what
+/// this identifies is the world Atlas actually derived evidence from, and a
+/// denied path contributed no bytes to it.
+pub fn generation_key(resources: &BTreeMap<String, String>) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"sergeant.atlas.generation-key/v1\n");
+    for (path, hash) in resources {
+        hasher.update(path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash.as_bytes());
+        hasher.update(b"\n");
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+/// F8's coverage vocabulary: what happened to one path, or to one whole
+/// generation.
+///
+/// Every path the scanner *saw* leaves exactly one of these. There is no
+/// eighth "silently skipped" state, and that is the whole design: F10's
+/// secrets posture is only honest if an excluded byte is reported as
+/// excluded rather than being absent from the record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Coverage {
+    /// Seen by the walk. Every other status implies this one happened first;
+    /// it is recorded on its own only for a container (a directory) whose
+    /// children carry their own rows.
+    Discovered,
+    /// Bytes were read, an extractor ran, and units were written.
+    Indexed,
+    /// Refused at the acquisition boundary by the default deny set or a
+    /// per-source `ignore` glob — **before** the bytes were read (F10).
+    Excluded,
+    /// Present but unreadable right now (permissions, vanished mid-scan, a
+    /// symlink this build does not follow).
+    Unavailable,
+    /// Readable, but no extractor in this build claims it.
+    Unsupported,
+    /// An extractor was chosen and failed.
+    Error,
+    /// A whole generation's rows were removed — either because the source
+    /// bytes changed (ruling §4's eviction) or because reconciliation found
+    /// rows with no `source.scanned` summary (F1's crash window). Reported,
+    /// never a silent gap.
+    GenerationEvicted,
+}
+
+impl Coverage {
+    /// The stable wire/DB spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Discovered => "discovered",
+            Self::Indexed => "indexed",
+            Self::Excluded => "excluded",
+            Self::Unavailable => "unavailable",
+            Self::Unsupported => "unsupported",
+            Self::Error => "error",
+            Self::GenerationEvicted => "generation_evicted",
+        }
+    }
+
+    /// The inverse of [`Self::as_str`] — see [`SourceKind::parse`].
+    pub fn parse(text: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|c| c.as_str() == text)
+    }
+
+    /// Every status, for callers that summarize counts over all of them.
+    pub const ALL: &'static [Coverage] = &[
+        Coverage::Discovered,
+        Coverage::Indexed,
+        Coverage::Excluded,
+        Coverage::Unavailable,
+        Coverage::Unsupported,
+        Coverage::Error,
+        Coverage::GenerationEvicted,
+    ];
+}
+
+impl std::fmt::Display for Coverage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One coverage observation: what happened to one path (or, with `path`
+/// unset, to the generation as a whole).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoverageRow {
+    /// Path relative to the source root, or `None` for a generation-wide row.
+    pub path: Option<String>,
+    /// What happened.
+    pub status: Coverage,
+    /// Why, in one line — the deny pattern that matched, the io error, the
+    /// extension nothing claims. Always populated for a status that is not
+    /// self-explanatory.
+    pub detail: Option<String>,
+    /// Size in bytes as the filesystem reported it, when known. Present for
+    /// [`Coverage::Excluded`] too: an excluded byte is counted, which is what
+    /// makes "never silently absent" checkable rather than aspirational.
+    pub bytes: Option<u64>,
+}
+
+/// The kind of structure unit an extractor produced (§3's `EvidenceUnit`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UnitKind {
+    /// The whole resource, as one unit.
+    Document,
+    /// A heading-delimited span within a document.
+    Section,
+}
+
+impl UnitKind {
+    /// The stable wire/DB spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Document => "document",
+            Self::Section => "section",
+        }
+    }
+
+    /// The inverse of [`Self::as_str`] — see [`SourceKind::parse`].
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "document" => Some(Self::Document),
+            "section" => Some(Self::Section),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for UnitKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// F7, stated as a test: the key moves when *either* input moves, and the
+    /// content hash alone is never the key.
+    #[test]
+    fn a_local_key_is_content_and_extractor_and_neither_alone() {
+        let a = content_hash(b"# title\n");
+        let b = content_hash(b"# other\n");
+        assert_ne!(a, b);
+
+        assert_eq!(local_key(&a, "markdown/v1"), local_key(&a, "markdown/v1"));
+        // Same bytes, different extractor -> different reusable extraction.
+        assert_ne!(local_key(&a, "markdown/v1"), local_key(&a, "text/v1"));
+        // Different bytes, same extractor -> different extraction.
+        assert_ne!(local_key(&a, "markdown/v1"), local_key(&b, "markdown/v1"));
+        // And the key is never just the content hash handed back.
+        assert_ne!(local_key(&a, "markdown/v1"), a);
+    }
+
+    /// The domain-separation prefix is not decoration: without it, a caller
+    /// that hashed the same two strings for another purpose would collide
+    /// with a cache key.
+    #[test]
+    fn a_local_key_is_domain_separated_from_a_bare_hash_of_the_same_strings() {
+        let hash = content_hash(b"x");
+        let naive = {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(hash.as_bytes());
+            hasher.update(b"\n");
+            hasher.update(b"markdown/v1");
+            hasher.finalize().to_hex().to_string()
+        };
+        assert_ne!(local_key(&hash, "markdown/v1"), naive);
+    }
+
+    /// Ruling §4's eviction rule is stated over content, so the key has to be
+    /// a pure function of content: same resources in, same key out —
+    /// whatever order the walk found them in.
+    #[test]
+    fn a_generation_key_is_content_only_and_order_independent() {
+        let mut one = BTreeMap::new();
+        one.insert("b.md".to_string(), content_hash(b"b"));
+        one.insert("a.md".to_string(), content_hash(b"a"));
+        let mut two = BTreeMap::new();
+        two.insert("a.md".to_string(), content_hash(b"a"));
+        two.insert("b.md".to_string(), content_hash(b"b"));
+        assert_eq!(generation_key(&one), generation_key(&two));
+
+        // A byte change anywhere moves it.
+        let mut three = two.clone();
+        three.insert("a.md".to_string(), content_hash(b"a!"));
+        assert_ne!(generation_key(&two), generation_key(&three));
+
+        // So does a rename, even with identical bytes: provenance is part of
+        // the observed world.
+        let mut four = BTreeMap::new();
+        four.insert("a.md".to_string(), content_hash(b"a"));
+        four.insert("c.md".to_string(), content_hash(b"b"));
+        assert_ne!(generation_key(&two), generation_key(&four));
+
+        // An empty source has a stable identity of its own, not the empty
+        // string — "nothing here" is an observation, not an absent one.
+        assert_eq!(generation_key(&BTreeMap::new()).len(), 64);
+    }
+
+    /// The three axes are spelled once, here, and every DB/wire consumer
+    /// reads them from these functions. A silent rename is a silent schema
+    /// migration.
+    #[test]
+    fn the_wire_spellings_are_pinned() {
+        assert_eq!(SourceKind::LocalKnowledge.as_str(), "local_knowledge");
+        assert_eq!(SourceKind::EstateGit.as_str(), "estate_git");
+        assert_eq!(SourceKind::ExternalGit.as_str(), "external_git");
+        assert_eq!(AuthorityClass::EstateReadonly.as_str(), "estate_readonly");
+        assert_eq!(UnitKind::Section.as_str(), "section");
+        assert_eq!(KIND_SOURCE_SCANNED, "source.scanned");
+        for kind in [
+            SourceKind::EstateGit,
+            SourceKind::LocalKnowledge,
+            SourceKind::ExternalGit,
+        ] {
+            assert_eq!(SourceKind::parse(kind.as_str()), Some(kind));
+        }
+        for status in Coverage::ALL {
+            assert_eq!(Coverage::parse(status.as_str()), Some(*status));
+        }
+        assert_eq!(SourceKind::parse("something_new"), None);
+        assert_eq!(
+            UnitKind::parse(UnitKind::Section.as_str()),
+            Some(UnitKind::Section)
+        );
+        assert_eq!(
+            AuthorityClass::parse(AuthorityClass::External.as_str()),
+            Some(AuthorityClass::External)
+        );
+        let spellings: Vec<&str> = Coverage::ALL.iter().map(|c| c.as_str()).collect();
+        assert_eq!(
+            spellings,
+            [
+                "discovered",
+                "indexed",
+                "excluded",
+                "unavailable",
+                "unsupported",
+                "error",
+                "generation_evicted",
+            ]
+        );
+    }
+
+    /// `serde` sees the same spellings the DB does — one vocabulary, not two
+    /// that drift.
+    #[test]
+    fn serde_and_as_str_agree() {
+        for kind in [
+            SourceKind::EstateGit,
+            SourceKind::LocalKnowledge,
+            SourceKind::ExternalGit,
+        ] {
+            let json = serde_json::to_string(&kind).expect("serialize");
+            assert_eq!(json, format!("\"{}\"", kind.as_str()));
+        }
+        for status in Coverage::ALL {
+            let json = serde_json::to_string(status).expect("serialize");
+            assert_eq!(json, format!("\"{}\"", status.as_str()));
+        }
+    }
+}

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -60,17 +60,29 @@
 //! file filters on it:
 //!
 //! ```text
-//! provisional  rows are written, the `source.scanned` summary is not yet journaled
+//! provisional  rows are written, the `source.scanned` summary is not yet confirmed
 //! confirmed    the summary exists; this generation is what coverage reports
 //! evicted      superseded (bytes changed) or reconciled away (rows, no summary)
 //! ```
 //!
 //! Nothing reads a `provisional` generation — [`AtlasDb::stage_scan`] writes
-//! one, [`AtlasDb::confirm_scan`] promotes it, and [`AtlasDb::reconcile`]
-//! evicts any that a crash left behind. That is what makes a half-finished
-//! scan *neither-reported* rather than half-reported: the rows may exist for
-//! a while, but no read path can see them, and reconciliation removes them
-//! leaving a `generation_evicted` coverage row rather than a silent gap.
+//! one and [`AtlasDb::confirm_scan`] promotes it. That is what makes a
+//! half-finished scan *neither-reported* rather than half-reported: the rows
+//! may exist for a while, but no read path can see them.
+//!
+//! **Recovery is not in this file, and that is deliberate.** Whether a
+//! provisional generation a crash left behind should be promoted or evicted
+//! is a question about the *journal* — the summary either got appended or it
+//! did not — and this module owns a database, not a journal. So the state
+//! column and the two primitives are here
+//! ([`AtlasDb::provisional_generations`], [`AtlasDb::evict_provisional`]),
+//! and the adjudication is
+//! [`record::reconcile_sources`](crate::runtime::atlas::record::reconcile_sources),
+//! which is the only place both halves of the evidence are in scope. Opening
+//! this store therefore does **not** evict on its own: an evict-on-open would
+//! destroy exactly the generations whose summary is sitting in the journal,
+//! and "journal-present, database-evicted" is the same both-present violation
+//! as its mirror image, only harder to notice.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -134,6 +146,21 @@ pub enum AtlasError {
         /// The value as stored.
         value: String,
     },
+    /// [`AtlasDb::confirm_scan`] was handed a generation that is not
+    /// `provisional` — already confirmed, already evicted, or never staged.
+    ///
+    /// Refused rather than absorbed **because the same call evicts a
+    /// predecessor**. A promotion that matched no row would otherwise still
+    /// delete the standing confirmed generation's units and files, leaving
+    /// the source with nothing confirmed at all: data destroyed with nothing
+    /// promoted in its place. The predecessor may only be evicted by the
+    /// transaction that actually promoted its successor, so a promotion that
+    /// changed no row takes nothing with it.
+    #[error("atlas: generation {generation_id} is not awaiting confirmation")]
+    NotProvisional {
+        /// The generation the caller named.
+        generation_id: String,
+    },
 }
 
 /// The schema-namespace DDL, applied on every open.
@@ -155,8 +182,11 @@ CREATE SCHEMA IF NOT EXISTS context;\n";
 /// * `content_key` on a generation is what ruling §4's eviction rule is
 ///   phrased over — a re-scan producing the same key evicts nothing.
 /// * `summary_event_id` is nullable **on purpose**: its absence is precisely
-///   "rows exist, no `source.scanned` summary", which is the crash window
-///   [`AtlasDb::reconcile`] closes.
+///   "rows exist, this database has not seen a `source.scanned` summary" —
+///   which is the crash window
+///   [`record::reconcile_sources`](crate::runtime::atlas::record::reconcile_sources)
+///   closes, by asking the journal whether the summary exists rather than
+///   inferring from this column that it does not.
 /// * `mtime_millis` is nullable and is a hint. Nothing joins on it, nothing
 ///   keys on it, and no reuse decision reads it (F7).
 /// * `byte_start`/`byte_end` index the **original** file bytes, so a unit can
@@ -273,15 +303,13 @@ impl AtlasDb {
         conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
         conn.execute_batch(SCHEMA_DDL)?;
         conn.execute_batch(TABLE_DDL)?;
-        let mut db = Self { conn, path };
-        // F1's startup reconciliation, run by the act of opening the store.
-        //
-        // Deliberately here rather than in one caller: "reconcile before
-        // anything reads" is a property of the store, and a caller that
-        // forgot would read a crash-window generation that no test of *that
-        // caller* would catch. Every opener — daemon, CLI, test — gets it.
-        db.reconcile()?;
-        Ok(db)
+        // No reconciliation here. A provisional generation is already
+        // unreadable — every read below filters on `state` — so nothing is
+        // exposed by leaving one standing until the journal can be consulted,
+        // and evicting one here would be a decision taken without the
+        // evidence that decides it (see this module's doc, and
+        // `record::reconcile_sources`, which the daemon runs at startup).
+        Ok(Self { conn, path })
     }
 
     /// Where this database lives (`:memory:` for [`AtlasDb::open_in_memory`]).
@@ -311,7 +339,7 @@ impl AtlasDb {
         Ok(out)
     }
 
-    /// Step 1 of [`scan_and_record`](crate::runtime::atlas::scan::scan_and_record):
+    /// Step 1 of [`scan_and_record`](crate::runtime::atlas::record::scan_and_record):
     /// write a whole scan's rows in **one transaction**, as a `provisional`
     /// generation.
     ///
@@ -321,11 +349,53 @@ impl AtlasDb {
     /// enforcement point: a generation is evicted only when source bytes
     /// changed, so an unchanged re-scan must not churn one.
     ///
+    /// Returns [`ScanCommit::RootUnavailable`], also without writing a
+    /// generation, when the walk could not read the source root at all and a
+    /// confirmed generation already stands — see
+    /// [`SourceScan::root_unavailable`]. An unplugged drive changed no source
+    /// bytes, so ruling §4 gives it no eviction: the standing generation is
+    /// what still has evidence behind it, and superseding it with an empty
+    /// scan would destroy exactly the derived facts F1 exists to keep across
+    /// restarts. The unavailability is recorded as a coverage row against the
+    /// generation that survived it, so "this source was unreachable at this
+    /// time, and we kept what we had" is queryable rather than inferred from
+    /// an absence.
+    ///
     /// One transaction is not an optimization. Partial rows for a generation
     /// nothing has confirmed would be indistinguishable from a completed one
     /// after the state column was promoted — the atomic batch is what makes
     /// "provisional" mean "all of it, or none of it, awaiting a summary".
     pub fn stage_scan(&mut self, scan: &SourceScan) -> Result<ScanCommit, AtlasError> {
+        // Asked before the `content_key` comparison below, because the two
+        // answers are indistinguishable by key: an unreachable root and an
+        // emptied one both hash an empty resource map, and only this row can
+        // tell them apart.
+        if let Some(unavailable) = scan.root_unavailable()
+            && let Some(current) = self.confirmed_generation(&scan.source_name)?
+        {
+            let detail = format!(
+                "the source root was unreadable on this scan ({}); \
+                 the confirmed generation was kept — no source bytes changed",
+                unavailable.detail.as_deref().unwrap_or("no detail")
+            );
+            insert_coverage(
+                &self.conn,
+                &current.id,
+                &scan.source_name,
+                &CoverageRow {
+                    path: None,
+                    status: Coverage::Unavailable,
+                    detail: Some(detail.clone()),
+                    bytes: None,
+                },
+                &scan.observed_at,
+            )?;
+            return Ok(ScanCommit::RootUnavailable {
+                generation_id: current.id,
+                content_key: current.content_key,
+                detail,
+            });
+        }
         if let Some(current) = self.confirmed_generation(&scan.source_name)?
             && current.content_key == scan.content_key
         {
@@ -382,6 +452,17 @@ impl AtlasDb {
     /// rather than at staging time is the deliberate half of F1's ordering:
     /// a crash before this point leaves the previous generation standing,
     /// which is the answer that still has evidence behind it.
+    ///
+    /// **The promotion is checked, not assumed.** The `UPDATE` is gated on
+    /// `state = 'provisional'`, and its affected-row count decides whether
+    /// the eviction runs at all: a caller naming a generation that is no
+    /// longer provisional — a stale id after a reconcile, a retry after a
+    /// partial failure — gets [`AtlasError::NotProvisional`] and an untouched
+    /// database, rather than a predecessor deleted on behalf of a successor
+    /// that was never promoted. Today's sole caller cannot reach that state;
+    /// this method is public on the store that owns the only copy of these
+    /// rows, and an invariant that only holds because of who happens to call
+    /// it is not an invariant.
     pub fn confirm_scan(
         &mut self,
         generation_id: &str,
@@ -397,7 +478,7 @@ impl AtlasDb {
         };
         let observed_at = crate::domain::event::rfc3339_utc_now();
         let tx = self.conn.transaction()?;
-        tx.execute(
+        let promoted = tx.execute(
             "UPDATE source.generations SET state = ?, summary_event_id = ? \
              WHERE generation_id = ? AND state = ?",
             duckdb::params![
@@ -407,6 +488,15 @@ impl AtlasDb {
                 STATE_PROVISIONAL
             ],
         )?;
+        if promoted == 0 {
+            // Nothing was promoted, so nothing may be evicted. Rolling back
+            // rather than committing an empty transaction keeps the two
+            // halves inseparable in both directions.
+            tx.rollback()?;
+            return Err(AtlasError::NotProvisional {
+                generation_id: generation_id.to_string(),
+            });
+        }
         if let (Some(previous), Some(name)) = (&superseded, &source_name) {
             evict(
                 &tx,
@@ -420,34 +510,54 @@ impl AtlasDb {
         Ok(superseded)
     }
 
-    /// F1's startup reconciliation: evict every generation whose rows exist
-    /// with no `source.scanned` summary.
+    /// Every generation still awaiting confirmation, newest first, as
+    /// `(generation_id, source_name)`.
     ///
-    /// Run by [`AtlasDb::open`] itself, so no caller can skip it. Each
-    /// eviction leaves an explicit `generation_evicted` coverage row —
-    /// ruling §4's "reported, never a silent gap" — naming the crash window
-    /// as the reason, so an operator reading coverage can tell a superseded
-    /// generation from one a crash cost them.
+    /// Half of F1's startup reconciliation — the half a database can answer.
+    /// The other half is whether the journal holds each one's
+    /// `source.scanned` summary, which decides promotion versus eviction and
+    /// is not this module's to know
+    /// ([`record::reconcile_sources`](crate::runtime::atlas::record::reconcile_sources)).
     ///
-    /// Returns the ids evicted, newest first.
-    pub fn reconcile(&mut self) -> Result<Vec<String>, AtlasError> {
-        let unconfirmed = self.generations_in_state(STATE_PROVISIONAL)?;
-        if unconfirmed.is_empty() {
+    /// The common answer is an empty vector, and that matters: it is what
+    /// lets the reconciler skip reading the journal entirely on every start
+    /// that did not follow a crash.
+    pub fn provisional_generations(&self) -> Result<Vec<(String, String)>, AtlasError> {
+        self.generations_in_state(STATE_PROVISIONAL)
+    }
+
+    /// Evict named generations that are still `provisional`, in one
+    /// transaction, each leaving an explicit `generation_evicted` coverage
+    /// row carrying `reason`.
+    ///
+    /// Ruling §4's "reported, never a silent gap": an operator reading
+    /// coverage can tell a superseded generation from one a crash cost them,
+    /// because the reason says which.
+    ///
+    /// Only `provisional` ids are touched. A confirmed generation is never
+    /// evictable this way — the sole path that supersedes one is
+    /// [`Self::confirm_scan`], in the same transaction that promotes its
+    /// replacement. Returns the ids actually evicted.
+    pub fn evict_provisional(
+        &mut self,
+        generation_ids: &[String],
+        reason: &str,
+    ) -> Result<Vec<String>, AtlasError> {
+        let awaiting = self.generations_in_state(STATE_PROVISIONAL)?;
+        let targets: Vec<(String, String)> = awaiting
+            .into_iter()
+            .filter(|(id, _)| generation_ids.iter().any(|wanted| wanted == id))
+            .collect();
+        if targets.is_empty() {
             return Ok(Vec::new());
         }
         let observed_at = crate::domain::event::rfc3339_utc_now();
         let tx = self.conn.transaction()?;
-        for (generation_id, source_name) in &unconfirmed {
-            evict(
-                &tx,
-                generation_id,
-                source_name,
-                "reconciled at startup: rows exist with no source.scanned summary",
-                &observed_at,
-            )?;
+        for (generation_id, source_name) in &targets {
+            evict(&tx, generation_id, source_name, reason, &observed_at)?;
         }
         tx.commit()?;
-        Ok(unconfirmed.into_iter().map(|(id, _)| id).collect())
+        Ok(targets.into_iter().map(|(id, _)| id).collect())
     }
 
     /// The newest **confirmed** generation for one source, if there is one.
@@ -767,6 +877,18 @@ pub enum ScanCommit {
         /// Its content identity.
         content_key: String,
     },
+    /// Nothing was written **and nothing was evicted**: the walk could not
+    /// read the source root, and a confirmed generation stands. Ruling §4
+    /// evicts only when the source bytes changed, and an unreachable path
+    /// changed none.
+    RootUnavailable {
+        /// The generation that still stands, untouched.
+        generation_id: String,
+        /// Its content identity.
+        content_key: String,
+        /// What was recorded as coverage against the surviving generation.
+        detail: String,
+    },
     /// Rows are written and awaiting their `source.scanned` summary.
     Staged {
         /// The new, provisional generation.
@@ -856,6 +978,220 @@ mod tests {
             path.display()
         );
         assert_eq!(path, data.join(ATLAS_DIR).join(ATLAS_DB_FILE));
+    }
+
+    /// A scan of `source` holding one file with `body`, built by hand: these
+    /// tests are about the store's own invariants, not about the walk.
+    fn scan_of(source: &str, body: &str) -> SourceScan {
+        use std::collections::BTreeSet;
+        let hash = crate::domain::source::content_hash(body.as_bytes());
+        let key = crate::domain::source::local_key(&hash, "markdown/v1");
+        SourceScan {
+            source_name: source.to_string(),
+            kind: SourceKind::LocalKnowledge,
+            authority: AuthorityClass::EstateReadonly,
+            content_key: hash.clone(),
+            observed_at: crate::domain::event::rfc3339_utc_now(),
+            files: vec![ScannedFile {
+                relative_path: "doc.md".to_string(),
+                content_hash: hash,
+                extractor: "markdown/v1".to_string(),
+                local_key: key,
+                byte_len: body.len() as u64,
+                mtime_millis: None,
+                units: vec![ScannedUnit {
+                    ordinal: 0,
+                    kind: UnitKind::Document,
+                    heading_level: None,
+                    title: None,
+                    byte_start: 0,
+                    byte_end: body.len() as u64,
+                    text: body.to_string(),
+                }],
+            }],
+            coverage: vec![CoverageRow {
+                path: Some("doc.md".to_string()),
+                status: Coverage::Indexed,
+                detail: Some("markdown/v1".to_string()),
+                bytes: Some(body.len() as u64),
+            }],
+            extractors: BTreeSet::from(["markdown/v1".to_string()]),
+        }
+    }
+
+    /// Stage and confirm one generation, returning its id.
+    fn record(db: &mut AtlasDb, scan: &SourceScan, event: &str) -> String {
+        let ScanCommit::Staged { generation_id } = db.stage_scan(scan).expect("stage") else {
+            panic!("expected a staged generation");
+        };
+        db.confirm_scan(&generation_id, event).expect("confirm");
+        generation_id
+    }
+
+    /// The predecessor may only be evicted by the transaction that actually
+    /// promoted its successor.
+    ///
+    /// `confirm_scan` computes the superseded generation *before* it promotes,
+    /// so a stale id — one already confirmed, already evicted, or never
+    /// staged — would otherwise evict a perfectly good confirmed generation on
+    /// behalf of a promotion that matched zero rows, leaving the source with
+    /// nothing confirmed at all. The affected-row count is what makes that
+    /// impossible; this is the test that would fail without it.
+    #[test]
+    fn confirming_a_generation_that_is_not_provisional_evicts_nothing() {
+        let mut atlas = AtlasDb::open_in_memory().expect("atlas");
+        let first = record(&mut atlas, &scan_of("notes", "# One\n"), "evt-1");
+        let second = record(&mut atlas, &scan_of("notes", "# Two\n"), "evt-2");
+        assert_eq!(
+            atlas.generation_states().expect("states").get(&first),
+            Some(&STATE_EVICTED.to_string()),
+            "the ordinary supersession still happens"
+        );
+
+        // Replaying the *first* confirmation: its generation is long evicted.
+        let err = atlas
+            .confirm_scan(&first, "evt-1")
+            .expect_err("a stale confirmation must be refused");
+        assert!(
+            matches!(&err, AtlasError::NotProvisional { generation_id } if *generation_id == first),
+            "{err:?}"
+        );
+        // And re-confirming the generation that currently stands, which is no
+        // longer provisional either.
+        assert!(matches!(
+            atlas.confirm_scan(&second, "evt-2"),
+            Err(AtlasError::NotProvisional { .. })
+        ));
+
+        // The standing generation survived both, rows and all.
+        let standing = atlas
+            .confirmed_generation("notes")
+            .expect("generation")
+            .expect("the confirmed generation must still stand");
+        assert_eq!(standing.id, second);
+        assert_eq!(atlas.units("notes", 100).expect("units").len(), 1);
+    }
+
+    /// Ruling §4 evicts a generation only when the source *bytes* changed. An
+    /// unreadable root changed none — so an empty scan of an unplugged drive
+    /// must not supersede a good generation, and the unavailability is
+    /// recorded rather than swallowed.
+    #[test]
+    fn an_unreadable_root_keeps_the_confirmed_generation_and_says_so() {
+        let mut atlas = AtlasDb::open_in_memory().expect("atlas");
+        let good = record(&mut atlas, &scan_of("notes", "# Kept\n"), "evt-1");
+
+        let mut unreachable = scan_of("notes", "");
+        unreachable.files.clear();
+        unreachable.extractors.clear();
+        unreachable.content_key = crate::domain::source::generation_key(&BTreeMap::new());
+        unreachable.coverage = vec![CoverageRow {
+            path: None,
+            status: Coverage::Unavailable,
+            detail: Some("the declared knowledge path cannot be read: no such file".to_string()),
+            bytes: None,
+        }];
+        assert!(unreachable.root_unavailable().is_some(), "fixture");
+
+        let commit = atlas.stage_scan(&unreachable).expect("stage");
+        assert!(
+            matches!(&commit, ScanCommit::RootUnavailable { generation_id, .. } if *generation_id == good),
+            "{commit:?}"
+        );
+        assert_eq!(
+            atlas
+                .confirmed_generation("notes")
+                .expect("generation")
+                .expect("still standing")
+                .id,
+            good
+        );
+        assert_eq!(
+            atlas.units("notes", 100).expect("units").len(),
+            1,
+            "a transient mount failure must not destroy derived facts"
+        );
+        let unavailable = atlas
+            .coverage("notes", 100)
+            .expect("coverage")
+            .into_iter()
+            .find(|c| c.row.status == Coverage::Unavailable)
+            .expect("the unavailability must be recorded, not swallowed");
+        assert_eq!(unavailable.generation_id, good);
+        assert!(
+            !atlas
+                .coverage("notes", 100)
+                .expect("coverage")
+                .iter()
+                .any(|c| c.row.status == Coverage::GenerationEvicted),
+            "no eviction: the source bytes did not change"
+        );
+
+        // A readable root that is genuinely empty is a different fact, and it
+        // does supersede — emptiness that was actually observed is evidence.
+        let mut emptied = scan_of("notes", "");
+        emptied.files.clear();
+        emptied.extractors.clear();
+        emptied.content_key = crate::domain::source::generation_key(&BTreeMap::new());
+        emptied.coverage.clear();
+        assert!(matches!(
+            atlas.stage_scan(&emptied).expect("stage"),
+            ScanCommit::Staged { .. }
+        ));
+    }
+
+    /// The store no longer evicts on open: a provisional generation is
+    /// unreadable, and whether it deserves promotion is a question only the
+    /// journal answers.
+    #[test]
+    fn opening_the_store_leaves_a_provisional_generation_for_the_journal_to_judge() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let staged = {
+            let mut atlas = AtlasDb::open(dir.path()).expect("atlas");
+            let ScanCommit::Staged { generation_id } = atlas
+                .stage_scan(&scan_of("notes", "# Pending\n"))
+                .expect("stage")
+            else {
+                panic!("expected a staged generation");
+            };
+            generation_id
+        };
+        let mut atlas = AtlasDb::open(dir.path()).expect("reopen");
+        assert_eq!(
+            atlas.generation_states().expect("states").get(&staged),
+            Some(&STATE_PROVISIONAL.to_string()),
+            "opening must not decide the crash window on its own"
+        );
+        assert!(
+            atlas
+                .confirmed_generation("notes")
+                .expect("generation")
+                .is_none(),
+            "and it is still unreadable while it waits"
+        );
+        assert_eq!(
+            atlas.provisional_generations().expect("awaiting"),
+            vec![(staged.clone(), "notes".to_string())]
+        );
+        // The eviction half, once something has consulted the journal.
+        assert_eq!(
+            atlas
+                .evict_provisional(std::slice::from_ref(&staged), "no summary")
+                .expect("evict"),
+            vec![staged.clone()]
+        );
+        assert_eq!(
+            atlas.generation_states().expect("states").get(&staged),
+            Some(&STATE_EVICTED.to_string())
+        );
+        // Idempotent: a second pass has nothing left to evict, and a
+        // confirmed generation is never reachable this way.
+        assert!(
+            atlas
+                .evict_provisional(&[staged], "no summary")
+                .expect("evict")
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -48,14 +48,39 @@
 //!
 //! # Scope today
 //!
-//! Schema namespaces only — no table. Every table lands in the wave that
-//! lands its writer (the empty-table refusal doctrine); a declared-but-never
-//! populated table is a false promise, not completeness.
+//! The four tables the local-knowledge scanner writes, and nothing else.
+//! Every table lands in the wave that lands its writer (the empty-table
+//! refusal doctrine); a declared-but-never populated table is a false
+//! promise, not completeness. `git.*` and `context.*` are still empty
+//! namespaces because nothing writes them yet.
+//!
+//! # The confirmation protocol (F1's crash window)
+//!
+//! `source.generations.state` is the whole mechanism, and every read in this
+//! file filters on it:
+//!
+//! ```text
+//! provisional  rows are written, the `source.scanned` summary is not yet journaled
+//! confirmed    the summary exists; this generation is what coverage reports
+//! evicted      superseded (bytes changed) or reconciled away (rows, no summary)
+//! ```
+//!
+//! Nothing reads a `provisional` generation — [`AtlasDb::stage_scan`] writes
+//! one, [`AtlasDb::confirm_scan`] promotes it, and [`AtlasDb::reconcile`]
+//! evicts any that a crash left behind. That is what makes a half-finished
+//! scan *neither-reported* rather than half-reported: the rows may exist for
+//! a while, but no read path can see them, and reconciliation removes them
+//! leaving a `generation_evicted` coverage row rather than a silent gap.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use duckdb::Connection;
 
+use crate::domain::source::{
+    AuthorityClass, Coverage, CoverageRow, SourceGeneration, SourceKind, UnitKind,
+};
+use crate::runtime::atlas::scan::{ScannedFile, ScannedUnit, SourceScan};
 use crate::runtime::fsutil::create_dir_all_durable;
 
 /// Directory under the data dir holding Atlas's durable store.
@@ -98,6 +123,17 @@ pub enum AtlasError {
     /// Filesystem failure around Atlas's directory.
     #[error("atlas io error: {0}")]
     Io(#[from] std::io::Error),
+    /// A stored row spells a value this build does not know — almost always
+    /// a database written by a newer version. Refused by name rather than
+    /// guessed at or silently skipped: a vocabulary this reader cannot
+    /// interpret is not a row it may interpret approximately.
+    #[error("atlas: column {column} holds unknown value {value:?}")]
+    UnknownValue {
+        /// Column the value came from.
+        column: String,
+        /// The value as stored.
+        value: String,
+    },
 }
 
 /// The schema-namespace DDL, applied on every open.
@@ -110,6 +146,89 @@ CREATE SCHEMA IF NOT EXISTS meta;\n\
 CREATE SCHEMA IF NOT EXISTS source;\n\
 CREATE SCHEMA IF NOT EXISTS git;\n\
 CREATE SCHEMA IF NOT EXISTS context;\n";
+
+/// The tables the local-knowledge scanner writes (X2). Applied after
+/// [`SCHEMA_DDL`], on every open, for the same idempotency reason.
+///
+/// Column choices worth stating, because each one is a contract:
+///
+/// * `content_key` on a generation is what ruling §4's eviction rule is
+///   phrased over — a re-scan producing the same key evicts nothing.
+/// * `summary_event_id` is nullable **on purpose**: its absence is precisely
+///   "rows exist, no `source.scanned` summary", which is the crash window
+///   [`AtlasDb::reconcile`] closes.
+/// * `mtime_millis` is nullable and is a hint. Nothing joins on it, nothing
+///   keys on it, and no reuse decision reads it (F7).
+/// * `byte_start`/`byte_end` index the **original** file bytes, so a unit can
+///   always be traced back to the resource it came from (A1 §3).
+/// * `meta.coverage.path` is nullable: a null path is a generation-wide row,
+///   which is how an eviction reports itself.
+const TABLE_DDL: &str = "\
+CREATE TABLE IF NOT EXISTS source.generations (\n\
+  generation_id    TEXT NOT NULL,\n\
+  source_name      TEXT NOT NULL,\n\
+  source_kind      TEXT NOT NULL,\n\
+  authority_class  TEXT NOT NULL,\n\
+  content_key      TEXT NOT NULL,\n\
+  observed_at      TEXT NOT NULL,\n\
+  state            TEXT NOT NULL,\n\
+  summary_event_id TEXT,\n\
+  extractors       TEXT NOT NULL\n\
+);\n\
+CREATE TABLE IF NOT EXISTS source.files (\n\
+  generation_id TEXT NOT NULL,\n\
+  source_name   TEXT NOT NULL,\n\
+  relative_path TEXT NOT NULL,\n\
+  content_hash  TEXT NOT NULL,\n\
+  extractor     TEXT NOT NULL,\n\
+  local_key     TEXT NOT NULL,\n\
+  byte_len      BIGINT NOT NULL,\n\
+  mtime_millis  BIGINT,\n\
+  unit_count    BIGINT NOT NULL\n\
+);\n\
+CREATE TABLE IF NOT EXISTS source.units (\n\
+  generation_id TEXT NOT NULL,\n\
+  source_name   TEXT NOT NULL,\n\
+  relative_path TEXT NOT NULL,\n\
+  local_key     TEXT NOT NULL,\n\
+  ordinal       BIGINT NOT NULL,\n\
+  unit_kind     TEXT NOT NULL,\n\
+  heading_level BIGINT,\n\
+  title         TEXT,\n\
+  byte_start    BIGINT NOT NULL,\n\
+  byte_end      BIGINT NOT NULL,\n\
+  body          TEXT NOT NULL\n\
+);\n\
+CREATE TABLE IF NOT EXISTS meta.coverage (\n\
+  generation_id TEXT NOT NULL,\n\
+  source_name   TEXT NOT NULL,\n\
+  path          TEXT,\n\
+  status        TEXT NOT NULL,\n\
+  detail        TEXT,\n\
+  bytes         BIGINT,\n\
+  observed_at   TEXT NOT NULL\n\
+);\n";
+
+/// A generation whose rows are written but whose summary is not yet journaled
+/// (F1). Nothing reads it.
+const STATE_PROVISIONAL: &str = "provisional";
+
+/// A generation whose `source.scanned` summary exists. The only state any
+/// read path here will look at.
+const STATE_CONFIRMED: &str = "confirmed";
+
+/// A generation whose rows have been removed — superseded, or reconciled away
+/// after a crash. Kept as a row (with its coverage row) rather than deleted,
+/// because "this world was observed and is no longer indexed" is evidence.
+const STATE_EVICTED: &str = "evicted";
+
+/// The default row ceiling on a read from this store (F12).
+///
+/// Every read here is bounded. Not a performance tuning figure — a refusal to
+/// build an unbounded result set in a process that also serves a daemon: the
+/// recon's own `unbounded-select()` risk. Callers that want fewer say so;
+/// none can ask for "all".
+pub const MAX_ROWS: usize = 10_000;
 
 /// Atlas's database over one data dir.
 ///
@@ -153,7 +272,16 @@ impl AtlasDb {
     fn over(conn: Connection, path: PathBuf) -> Result<Self, AtlasError> {
         conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
         conn.execute_batch(SCHEMA_DDL)?;
-        Ok(Self { conn, path })
+        conn.execute_batch(TABLE_DDL)?;
+        let mut db = Self { conn, path };
+        // F1's startup reconciliation, run by the act of opening the store.
+        //
+        // Deliberately here rather than in one caller: "reconcile before
+        // anything reads" is a property of the store, and a caller that
+        // forgot would read a crash-window generation that no test of *that
+        // caller* would catch. Every opener — daemon, CLI, test — gets it.
+        db.reconcile()?;
+        Ok(db)
     }
 
     /// Where this database lives (`:memory:` for [`AtlasDb::open_in_memory`]).
@@ -182,6 +310,503 @@ impl AtlasDb {
         }
         Ok(out)
     }
+
+    /// Step 1 of [`scan_and_record`](crate::runtime::atlas::scan::scan_and_record):
+    /// write a whole scan's rows in **one transaction**, as a `provisional`
+    /// generation.
+    ///
+    /// Returns [`ScanCommit::Unchanged`] without writing anything when the
+    /// scan's `content_key` matches the source's newest confirmed
+    /// generation — ruling §4's eviction rule, enforced at its only
+    /// enforcement point: a generation is evicted only when source bytes
+    /// changed, so an unchanged re-scan must not churn one.
+    ///
+    /// One transaction is not an optimization. Partial rows for a generation
+    /// nothing has confirmed would be indistinguishable from a completed one
+    /// after the state column was promoted — the atomic batch is what makes
+    /// "provisional" mean "all of it, or none of it, awaiting a summary".
+    pub fn stage_scan(&mut self, scan: &SourceScan) -> Result<ScanCommit, AtlasError> {
+        if let Some(current) = self.confirmed_generation(&scan.source_name)?
+            && current.content_key == scan.content_key
+        {
+            return Ok(ScanCommit::Unchanged {
+                generation_id: current.id,
+                content_key: current.content_key,
+            });
+        }
+        let generation_id = ulid::Ulid::generate().to_string();
+        let extractors = scan
+            .extractors
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(",");
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "INSERT INTO source.generations \
+             (generation_id, source_name, source_kind, authority_class, content_key, \
+              observed_at, state, summary_event_id, extractors) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)",
+            duckdb::params![
+                &generation_id,
+                &scan.source_name,
+                scan.kind.as_str(),
+                scan.authority.as_str(),
+                &scan.content_key,
+                &scan.observed_at,
+                STATE_PROVISIONAL,
+                &extractors,
+            ],
+        )?;
+        for file in &scan.files {
+            insert_file(&tx, &generation_id, &scan.source_name, file)?;
+        }
+        for row in &scan.coverage {
+            insert_coverage(
+                &tx,
+                &generation_id,
+                &scan.source_name,
+                row,
+                &scan.observed_at,
+            )?;
+        }
+        tx.commit()?;
+        Ok(ScanCommit::Staged { generation_id })
+    }
+
+    /// Step 3: promote a staged generation to `confirmed` and evict the one it
+    /// supersedes — **in one transaction**, so "confirmed" and "predecessor
+    /// evicted" are never separately observable.
+    ///
+    /// Returns the evicted predecessor's id, if there was one. Eviction here
+    /// rather than at staging time is the deliberate half of F1's ordering:
+    /// a crash before this point leaves the previous generation standing,
+    /// which is the answer that still has evidence behind it.
+    pub fn confirm_scan(
+        &mut self,
+        generation_id: &str,
+        summary_event_id: &str,
+    ) -> Result<Option<String>, AtlasError> {
+        let source_name = self.generation_source(generation_id)?;
+        let superseded = match &source_name {
+            Some(name) => self
+                .confirmed_generation(name)?
+                .map(|generation| generation.id)
+                .filter(|id| id != generation_id),
+            None => None,
+        };
+        let observed_at = crate::domain::event::rfc3339_utc_now();
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "UPDATE source.generations SET state = ?, summary_event_id = ? \
+             WHERE generation_id = ? AND state = ?",
+            duckdb::params![
+                STATE_CONFIRMED,
+                summary_event_id,
+                generation_id,
+                STATE_PROVISIONAL
+            ],
+        )?;
+        if let (Some(previous), Some(name)) = (&superseded, &source_name) {
+            evict(
+                &tx,
+                previous,
+                name,
+                "superseded: the source bytes changed",
+                &observed_at,
+            )?;
+        }
+        tx.commit()?;
+        Ok(superseded)
+    }
+
+    /// F1's startup reconciliation: evict every generation whose rows exist
+    /// with no `source.scanned` summary.
+    ///
+    /// Run by [`AtlasDb::open`] itself, so no caller can skip it. Each
+    /// eviction leaves an explicit `generation_evicted` coverage row —
+    /// ruling §4's "reported, never a silent gap" — naming the crash window
+    /// as the reason, so an operator reading coverage can tell a superseded
+    /// generation from one a crash cost them.
+    ///
+    /// Returns the ids evicted, newest first.
+    pub fn reconcile(&mut self) -> Result<Vec<String>, AtlasError> {
+        let unconfirmed = self.generations_in_state(STATE_PROVISIONAL)?;
+        if unconfirmed.is_empty() {
+            return Ok(Vec::new());
+        }
+        let observed_at = crate::domain::event::rfc3339_utc_now();
+        let tx = self.conn.transaction()?;
+        for (generation_id, source_name) in &unconfirmed {
+            evict(
+                &tx,
+                generation_id,
+                source_name,
+                "reconciled at startup: rows exist with no source.scanned summary",
+                &observed_at,
+            )?;
+        }
+        tx.commit()?;
+        Ok(unconfirmed.into_iter().map(|(id, _)| id).collect())
+    }
+
+    /// The newest **confirmed** generation for one source, if there is one.
+    ///
+    /// Every read below goes through the same filter. A provisional or
+    /// evicted generation is never what coverage or retrieval answers with,
+    /// which is the property that makes a crash mid-scan invisible rather
+    /// than half-visible.
+    pub fn confirmed_generation(
+        &self,
+        source_name: &str,
+    ) -> Result<Option<SourceGeneration>, AtlasError> {
+        let mut statement = self.conn.prepare(
+            "SELECT generation_id, source_name, source_kind, authority_class, content_key, \
+                    observed_at \
+             FROM source.generations WHERE source_name = ? AND state = ? \
+             ORDER BY observed_at DESC, generation_id DESC LIMIT 1",
+        )?;
+        let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        let kind: String = row.get(2)?;
+        let authority: String = row.get(3)?;
+        Ok(Some(SourceGeneration {
+            id: row.get(0)?,
+            source_name: row.get(1)?,
+            kind: SourceKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
+                column: "source_kind".to_string(),
+                value: kind.clone(),
+            })?,
+            authority: AuthorityClass::parse(&authority).ok_or_else(|| {
+                AtlasError::UnknownValue {
+                    column: "authority_class".to_string(),
+                    value: authority.clone(),
+                }
+            })?,
+            content_key: row.get(4)?,
+            observed_at: row.get(5)?,
+        }))
+    }
+
+    /// Units of one source's confirmed generation, in path then ordinal
+    /// order, bounded by `limit` (capped at [`MAX_ROWS`], F12).
+    pub fn units(&self, source_name: &str, limit: usize) -> Result<Vec<StoredUnit>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let mut statement = self.conn.prepare(
+            "SELECT u.relative_path, u.local_key, u.ordinal, u.unit_kind, u.heading_level, \
+                    u.title, u.byte_start, u.byte_end, u.body \
+             FROM source.units u JOIN source.generations g USING (generation_id) \
+             WHERE g.source_name = ? AND g.state = ? \
+             ORDER BY u.relative_path, u.ordinal LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            let kind: String = row.get(3)?;
+            out.push(StoredUnit {
+                relative_path: row.get(0)?,
+                local_key: row.get(1)?,
+                ordinal: row.get::<usize, i64>(2)? as u64,
+                kind: UnitKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
+                    column: "unit_kind".to_string(),
+                    value: kind.clone(),
+                })?,
+                heading_level: row.get::<usize, Option<i64>>(4)?.map(|v| v as u8),
+                title: row.get(5)?,
+                byte_start: row.get::<usize, i64>(6)? as u64,
+                byte_end: row.get::<usize, i64>(7)? as u64,
+                body: row.get(8)?,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Coverage rows for one source's confirmed generations, newest first,
+    /// bounded by `limit` (capped at [`MAX_ROWS`], F12).
+    ///
+    /// Confirmed **and evicted** generations both answer here, unlike
+    /// [`Self::units`]: an eviction row exists precisely so a source that
+    /// used to be indexed and no longer is says so out loud.
+    pub fn coverage(
+        &self,
+        source_name: &str,
+        limit: usize,
+    ) -> Result<Vec<StoredCoverage>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let mut statement = self.conn.prepare(
+            "SELECT c.generation_id, c.path, c.status, c.detail, c.bytes, c.observed_at \
+             FROM meta.coverage c JOIN source.generations g USING (generation_id) \
+             WHERE g.source_name = ? AND g.state IN (?, ?) \
+             ORDER BY c.observed_at DESC, c.path NULLS FIRST LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![
+            source_name,
+            STATE_CONFIRMED,
+            STATE_EVICTED,
+            limit
+        ])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            let status: String = row.get(2)?;
+            out.push(StoredCoverage {
+                generation_id: row.get(0)?,
+                row: CoverageRow {
+                    path: row.get(1)?,
+                    status: Coverage::parse(&status).ok_or_else(|| AtlasError::UnknownValue {
+                        column: "status".to_string(),
+                        value: status.clone(),
+                    })?,
+                    detail: row.get(3)?,
+                    bytes: row.get::<usize, Option<i64>>(4)?.map(|v| v as u64),
+                },
+                observed_at: row.get(5)?,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Coverage counts by status for one source's confirmed generation —
+    /// what `sgt intelligence status` and the doctor row will read (F8).
+    pub fn coverage_counts(&self, source_name: &str) -> Result<BTreeMap<String, u64>, AtlasError> {
+        let mut statement = self.conn.prepare(
+            "SELECT c.status, count(*) FROM meta.coverage c \
+             JOIN source.generations g USING (generation_id) \
+             WHERE g.source_name = ? AND g.state = ? GROUP BY c.status ORDER BY c.status",
+        )?;
+        let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED])?;
+        let mut out = BTreeMap::new();
+        while let Some(row) = rows.next()? {
+            out.insert(
+                row.get::<usize, String>(0)?,
+                row.get::<usize, i64>(1)? as u64,
+            );
+        }
+        Ok(out)
+    }
+
+    /// Every generation's state, keyed by id — a diagnostic read, and what a
+    /// crash-window test inspects.
+    pub fn generation_states(&self) -> Result<BTreeMap<String, String>, AtlasError> {
+        let mut statement = self.conn.prepare(
+            "SELECT generation_id, state FROM source.generations \
+             ORDER BY observed_at, generation_id LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![MAX_ROWS as i64])?;
+        let mut out = BTreeMap::new();
+        while let Some(row) = rows.next()? {
+            out.insert(row.get::<usize, String>(0)?, row.get::<usize, String>(1)?);
+        }
+        Ok(out)
+    }
+
+    /// Ids and source names of every generation in one state.
+    fn generations_in_state(&self, state: &str) -> Result<Vec<(String, String)>, AtlasError> {
+        let mut statement = self.conn.prepare(
+            "SELECT generation_id, source_name FROM source.generations WHERE state = ? \
+             ORDER BY observed_at DESC, generation_id DESC LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![state, MAX_ROWS as i64])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push((row.get(0)?, row.get(1)?));
+        }
+        Ok(out)
+    }
+
+    /// Which source a generation belongs to.
+    fn generation_source(&self, generation_id: &str) -> Result<Option<String>, AtlasError> {
+        let mut statement = self
+            .conn
+            .prepare("SELECT source_name FROM source.generations WHERE generation_id = ?")?;
+        let mut rows = statement.query(duckdb::params![generation_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row.get(0)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Insert one acquired file and its units.
+fn insert_file(
+    conn: &Connection,
+    generation_id: &str,
+    source_name: &str,
+    file: &ScannedFile,
+) -> Result<(), AtlasError> {
+    conn.execute(
+        "INSERT INTO source.files \
+         (generation_id, source_name, relative_path, content_hash, extractor, local_key, \
+          byte_len, mtime_millis, unit_count) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        duckdb::params![
+            generation_id,
+            source_name,
+            &file.relative_path,
+            &file.content_hash,
+            &file.extractor,
+            &file.local_key,
+            file.byte_len as i64,
+            file.mtime_millis,
+            file.units.len() as i64,
+        ],
+    )?;
+    for unit in &file.units {
+        insert_unit(conn, generation_id, source_name, file, unit)?;
+    }
+    Ok(())
+}
+
+/// Insert one structure unit.
+fn insert_unit(
+    conn: &Connection,
+    generation_id: &str,
+    source_name: &str,
+    file: &ScannedFile,
+    unit: &ScannedUnit,
+) -> Result<(), AtlasError> {
+    conn.execute(
+        "INSERT INTO source.units \
+         (generation_id, source_name, relative_path, local_key, ordinal, unit_kind, \
+          heading_level, title, byte_start, byte_end, body) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        duckdb::params![
+            generation_id,
+            source_name,
+            &file.relative_path,
+            &file.local_key,
+            unit.ordinal as i64,
+            unit.kind.as_str(),
+            unit.heading_level.map(i64::from),
+            unit.title.as_deref(),
+            unit.byte_start as i64,
+            unit.byte_end as i64,
+            &unit.text,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Insert one coverage observation.
+fn insert_coverage(
+    conn: &Connection,
+    generation_id: &str,
+    source_name: &str,
+    row: &CoverageRow,
+    observed_at: &str,
+) -> Result<(), AtlasError> {
+    conn.execute(
+        "INSERT INTO meta.coverage \
+         (generation_id, source_name, path, status, detail, bytes, observed_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+        duckdb::params![
+            generation_id,
+            source_name,
+            row.path.as_deref(),
+            row.status.as_str(),
+            row.detail.as_deref(),
+            row.bytes.map(|b| b as i64),
+            observed_at,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Evict one generation: drop its derived rows, mark it, and leave the
+/// `generation_evicted` coverage row that says so.
+///
+/// The generation row itself survives, because "this world was observed, and
+/// its derived evidence is gone" is a fact worth keeping — a deleted row
+/// would be exactly the silent gap ruling §4 forbids.
+fn evict(
+    conn: &Connection,
+    generation_id: &str,
+    source_name: &str,
+    reason: &str,
+    observed_at: &str,
+) -> Result<(), AtlasError> {
+    conn.execute(
+        "DELETE FROM source.units WHERE generation_id = ?",
+        duckdb::params![generation_id],
+    )?;
+    conn.execute(
+        "DELETE FROM source.files WHERE generation_id = ?",
+        duckdb::params![generation_id],
+    )?;
+    conn.execute(
+        "DELETE FROM meta.coverage WHERE generation_id = ? AND path IS NOT NULL",
+        duckdb::params![generation_id],
+    )?;
+    conn.execute(
+        "UPDATE source.generations SET state = ? WHERE generation_id = ?",
+        duckdb::params![STATE_EVICTED, generation_id],
+    )?;
+    insert_coverage(
+        conn,
+        generation_id,
+        source_name,
+        &CoverageRow {
+            path: None,
+            status: Coverage::GenerationEvicted,
+            detail: Some(reason.to_string()),
+            bytes: None,
+        },
+        observed_at,
+    )
+}
+
+/// What [`AtlasDb::stage_scan`] did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScanCommit {
+    /// Nothing was written: this source's newest confirmed generation was
+    /// derived from exactly these bytes.
+    Unchanged {
+        /// The generation that still stands.
+        generation_id: String,
+        /// Its content identity.
+        content_key: String,
+    },
+    /// Rows are written and awaiting their `source.scanned` summary.
+    Staged {
+        /// The new, provisional generation.
+        generation_id: String,
+    },
+}
+
+/// One unit read back out of the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredUnit {
+    /// Path relative to the source root.
+    pub relative_path: String,
+    /// F7's reusable extraction key.
+    pub local_key: String,
+    /// Position within its file.
+    pub ordinal: u64,
+    /// Document or section.
+    pub kind: UnitKind,
+    /// Heading depth, for a section under a heading.
+    pub heading_level: Option<u8>,
+    /// Heading text, when there is one.
+    pub title: Option<String>,
+    /// Offset into the original file bytes.
+    pub byte_start: u64,
+    /// End offset into the original file bytes, exclusive.
+    pub byte_end: u64,
+    /// The unit's text.
+    pub body: String,
+}
+
+/// One coverage row read back out of the store, with the generation it
+/// belongs to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredCoverage {
+    /// Generation this observation belongs to.
+    pub generation_id: String,
+    /// The observation itself.
+    pub row: CoverageRow,
+    /// When it was recorded.
+    pub observed_at: String,
 }
 
 #[cfg(test)]

--- a/src/runtime/atlas/deny.rs
+++ b/src/runtime/atlas/deny.rs
@@ -1,0 +1,300 @@
+//! F10's secrets posture, enforced at the acquisition boundary.
+//!
+//! One rule, and the whole module exists to make it structurally true: **a
+//! denied path's bytes are never read.** Not read-then-discarded, not
+//! read-then-redacted — the verdict is a pure function of the path, so the
+//! scanner can ask it *before* it opens anything, and a file it never opens
+//! cannot leak through a fold, a cache, a log line, or a crash dump.
+//!
+//! Everything here is a pure function over a relative path string. No IO, no
+//! DB handle, no daemon state (F6's adapter-shape mandate).
+//!
+//! # Two layers, one direction
+//!
+//! [`DEFAULT_DENY`] is the built-in minimum and a per-source
+//! `[[knowledge]] ignore` list **extends** it. There is deliberately no
+//! syntax for narrowing: a source cannot opt back into a pattern the default
+//! set protects it from, because the one thing a secrets floor may not have
+//! is a per-source override that turns it off.
+//!
+//! # A denied byte is a counted byte
+//!
+//! Nothing here silently drops a path. The scanner turns every verdict into a
+//! [`Coverage::Excluded`](crate::domain::source::Coverage::Excluded) row
+//! naming the pattern that matched — which is what makes "the deny set is
+//! working" a checkable claim rather than an absence of evidence.
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+
+/// The built-in deny set (F10's G4 minimum), in addition to the dotfile rule
+/// below.
+///
+/// Deliberately conservative and deliberately *small*. Every entry names a
+/// file family whose whole purpose is to hold a credential — private keys,
+/// keystores, credential and secret files, environment files. Broad
+/// catch-alls that would sweep up ordinary prose (`*token*`, `*password*`,
+/// `env.*`) are **not** here: a false positive is unfixable from a manifest,
+/// since `ignore` only ever extends this list, so the default set stays
+/// narrow and the operator widens it.
+pub const DEFAULT_DENY: &[&str] = &[
+    // Private keys and key material.
+    "**/*.pem",
+    "**/*.key",
+    "**/*.p8",
+    "**/*.p12",
+    "**/*.pfx",
+    "**/*.jks",
+    "**/*.keystore",
+    "**/*.kdbx",
+    "**/*.ppk",
+    "**/*.asc",
+    "**/*.gpg",
+    "**/id_rsa*",
+    "**/id_dsa*",
+    "**/id_ecdsa*",
+    "**/id_ed25519*",
+    // Environment files that are not already dotfiles (`.env`, `.env.local`
+    // and friends are caught by the dotfile rule).
+    "**/*.env",
+    // Credential and secret files by convention.
+    "**/credentials",
+    "**/credentials.*",
+    "**/secrets",
+    "**/secrets.*",
+    "**/*.secret",
+    "**/service-account*.json",
+];
+
+/// The dotfile rule's own reported reason — a pattern-shaped string so a
+/// coverage row's `detail` reads the same whichever layer refused the path.
+pub const DOTFILE_PATTERN: &str = "<dotfile>";
+
+/// A pattern the caller supplied that is not a valid glob.
+#[derive(Debug, thiserror::Error)]
+#[error("{pattern:?} is not a valid ignore glob: {source}")]
+pub struct BadPattern {
+    /// The offending pattern.
+    pub pattern: String,
+    /// globset's own diagnostic.
+    #[source]
+    pub source: globset::Error,
+}
+
+/// What the boundary decided about one path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    /// May be opened.
+    Allowed,
+    /// Must not be opened; the pattern that refused it, for the coverage row.
+    Denied {
+        /// The matching pattern, or [`DOTFILE_PATTERN`].
+        pattern: String,
+    },
+}
+
+impl Verdict {
+    /// Whether the path may be opened.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+}
+
+/// The compiled acquisition boundary for one source.
+#[derive(Debug)]
+pub struct AcquisitionFilter {
+    set: GlobSet,
+    /// Patterns in the same index order [`GlobSet::matches`] reports, so a
+    /// match can name itself. `GlobSet` gives back indices, not patterns.
+    patterns: Vec<String>,
+}
+
+impl AcquisitionFilter {
+    /// Compile [`DEFAULT_DENY`] plus this source's own `ignore` globs.
+    ///
+    /// The defaults are compiled first so an index reported by the set maps
+    /// back onto the same pattern list every time, and a source pattern can
+    /// never displace a default one.
+    pub fn new(ignore: &[String]) -> Result<Self, BadPattern> {
+        let mut builder = GlobSetBuilder::new();
+        let mut patterns = Vec::with_capacity(DEFAULT_DENY.len() + ignore.len());
+        for pattern in DEFAULT_DENY.iter().map(|p| (*p).to_string()).chain(
+            // A bare `foo.log` from an operator means "anywhere", the same
+            // thing it means in a `.gitignore`; `**/` makes globset agree.
+            // A pattern that already carries a separator is left exactly as
+            // written, because then the operator is being specific on
+            // purpose.
+            ignore.iter().map(|p| {
+                if p.contains('/') || p.starts_with("**") {
+                    p.clone()
+                } else {
+                    format!("**/{p}")
+                }
+            }),
+        ) {
+            let glob = Glob::new(&pattern).map_err(|source| BadPattern {
+                pattern: pattern.clone(),
+                source,
+            })?;
+            builder.add(glob);
+            patterns.push(pattern);
+        }
+        let set = builder.build().map_err(|source| BadPattern {
+            pattern: "<set>".to_string(),
+            source,
+        })?;
+        Ok(Self { set, patterns })
+    }
+
+    /// The verdict for one path, relative to the source root, `/`-separated.
+    ///
+    /// Answers for directories exactly as for files — a denied directory is
+    /// one the walk must not descend into, which is how `.git`, `.ssh` and a
+    /// `node_modules` in an `ignore` list cost one verdict rather than one
+    /// per contained file.
+    ///
+    /// The two spellings of "exclude a directory" therefore differ in
+    /// *reporting*, not in what is excluded: `build` matches the directory
+    /// itself, so the walk refuses it once and never descends; `build/**`
+    /// matches its contents, so each excluded file gets its own coverage row
+    /// and the directory is merely `discovered`. Both exclude the same bytes,
+    /// and both say so out loud.
+    pub fn verdict(&self, relative: &str) -> Verdict {
+        // The dotfile rule, first and separately: it is a component rule, not
+        // a glob, and it is the one that catches `.git`, `.ssh`, `.env` and
+        // every `.env.<anything>` in a single line of ordinary Rust (R6 —
+        // and R3, since `str::split` is all it needs).
+        if relative
+            .split('/')
+            .any(|component| component.starts_with('.') && component != "." && component != "..")
+        {
+            return Verdict::Denied {
+                pattern: DOTFILE_PATTERN.to_string(),
+            };
+        }
+        match self.set.matches(relative).first() {
+            Some(&index) => Verdict::Denied {
+                pattern: self.patterns[index].clone(),
+            },
+            None => Verdict::Allowed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filter() -> AcquisitionFilter {
+        AcquisitionFilter::new(&[]).expect("compile defaults")
+    }
+
+    /// The G4 minimum, checked as behavior rather than as a constant: each
+    /// family the default set names is actually refused, at the top level and
+    /// nested.
+    #[test]
+    fn the_default_set_refuses_every_family_it_names() {
+        let filter = filter();
+        for denied in [
+            ".env",
+            ".env.production",
+            ".git/config",
+            ".ssh/known_hosts",
+            "notes/.hidden.md",
+            "server.pem",
+            "deep/nest/server.key",
+            "keys/id_rsa",
+            "keys/id_ed25519.pub",
+            "local.env",
+            "credentials",
+            "aws/credentials.json",
+            "secrets.yaml",
+            "deploy/service-account-prod.json",
+            "vault.kdbx",
+        ] {
+            assert!(
+                !filter.verdict(denied).is_allowed(),
+                "{denied:?} must be refused at the acquisition boundary"
+            );
+        }
+    }
+
+    /// And ordinary prose is not swept up. A deny set that refuses the corpus
+    /// it was meant to protect is a deny set nobody keeps switched on.
+    #[test]
+    fn ordinary_documents_are_allowed() {
+        let filter = filter();
+        for allowed in [
+            "README.md",
+            "notes/2026-08-27.md",
+            "design/keystore-design.md",
+            "runbooks/rotate-credentials-quarterly.md",
+            "env-vars.md",
+            "monkey.txt",
+        ] {
+            assert_eq!(
+                filter.verdict(allowed),
+                Verdict::Allowed,
+                "{allowed:?} is ordinary evidence"
+            );
+        }
+    }
+
+    /// A verdict names the pattern that produced it — a coverage row that
+    /// said only "excluded" would leave the operator unable to tell a
+    /// deliberate `ignore` from the built-in floor.
+    #[test]
+    fn a_denial_names_the_pattern_that_refused_it() {
+        let filter = AcquisitionFilter::new(&["*.log".to_string(), "build/**".to_string()])
+            .expect("compile");
+        assert_eq!(
+            filter.verdict("server.pem"),
+            Verdict::Denied {
+                pattern: "**/*.pem".to_string()
+            }
+        );
+        assert_eq!(
+            filter.verdict(".env"),
+            Verdict::Denied {
+                pattern: DOTFILE_PATTERN.to_string()
+            }
+        );
+        // A bare operator pattern means "anywhere", `.gitignore`-style.
+        assert_eq!(
+            filter.verdict("deep/nest/run.log"),
+            Verdict::Denied {
+                pattern: "**/*.log".to_string()
+            }
+        );
+        // One that already carries a separator is honoured exactly as
+        // written, and stays anchored at the source root.
+        assert_eq!(
+            filter.verdict("build/out.md"),
+            Verdict::Denied {
+                pattern: "build/**".to_string()
+            }
+        );
+        assert_eq!(filter.verdict("src/build/out.md"), Verdict::Allowed);
+    }
+
+    /// F10's direction rule: `ignore` extends, never narrows. There is no
+    /// spelling of an entry that re-admits a defaulted-denied path — the
+    /// closest an operator can get is a negation, and globset treats `!` as
+    /// an ordinary character, so it simply fails to match anything rather
+    /// than quietly disabling the floor.
+    #[test]
+    fn a_source_pattern_cannot_reopen_a_defaulted_denial() {
+        let filter =
+            AcquisitionFilter::new(&["!*.pem".to_string(), "!.env".to_string()]).expect("compile");
+        assert!(!filter.verdict("server.pem").is_allowed());
+        assert!(!filter.verdict(".env").is_allowed());
+    }
+
+    /// A malformed operator pattern is refused by name at compile time, not
+    /// silently dropped — a silently dropped `ignore` is a silently indexed
+    /// directory.
+    #[test]
+    fn a_malformed_pattern_is_refused_by_name() {
+        let err = AcquisitionFilter::new(&["a[".to_string()]).expect_err("must refuse");
+        assert!(err.to_string().contains("a["), "{err}");
+    }
+}

--- a/src/runtime/atlas/deny.rs
+++ b/src/runtime/atlas/deny.rs
@@ -17,6 +17,23 @@
 //! set protects it from, because the one thing a secrets floor may not have
 //! is a per-source override that turns it off.
 //!
+//! # Case is not a way through the floor
+//!
+//! Every glob here is compiled **case-insensitively**. The reason is an
+//! asymmetry that would otherwise be exploitable by accident: extractor
+//! routing lowercases the extension before it decides
+//! ([`extractor_for`](crate::runtime::atlas::scan)), so `NOTES.MD` is read
+//! exactly as `notes.md` is — while a case-sensitive deny set would let
+//! `Secrets.md`, `CREDENTIALS.txt` or `ID_RSA` walk straight past the very
+//! families [`DEFAULT_DENY`] names, be read, hashed, extracted and persisted.
+//! A secrets floor may not be narrower than the reader it guards, so the two
+//! agree about case in the one direction that is safe: the floor tolerates
+//! everything the reader tolerates.
+//!
+//! Operator `ignore` globs are compiled the same way, for the same reason and
+//! in the same direction — case-insensitivity only ever *widens* an
+//! exclusion, and `ignore` is a list that may only widen.
+//!
 //! # A denied byte is a counted byte
 //!
 //! Nothing here silently drops a path. The scanner turns every verdict into a
@@ -24,7 +41,7 @@
 //! naming the pattern that matched — which is what makes "the deny set is
 //! working" a checkable claim rather than an absence of evidence.
 
-use globset::{Glob, GlobSet, GlobSetBuilder};
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 
 /// The built-in deny set (F10's G4 minimum), in addition to the dotfile rule
 /// below.
@@ -114,6 +131,11 @@ impl AcquisitionFilter {
     /// The defaults are compiled first so an index reported by the set maps
     /// back onto the same pattern list every time, and a source pattern can
     /// never displace a default one.
+    ///
+    /// Every glob is built with `case_insensitive(true)` — see this module's
+    /// "Case is not a way through the floor". That is a property of the
+    /// compilation, not of the pattern strings, so a default entry and an
+    /// operator entry cannot drift apart on it.
     pub fn new(ignore: &[String]) -> Result<Self, BadPattern> {
         let mut builder = GlobSetBuilder::new();
         let mut patterns = Vec::with_capacity(DEFAULT_DENY.len() + ignore.len());
@@ -131,10 +153,13 @@ impl AcquisitionFilter {
                 }
             }),
         ) {
-            let glob = Glob::new(&pattern).map_err(|source| BadPattern {
-                pattern: pattern.clone(),
-                source,
-            })?;
+            let glob = GlobBuilder::new(&pattern)
+                .case_insensitive(true)
+                .build()
+                .map_err(|source| BadPattern {
+                    pattern: pattern.clone(),
+                    source,
+                })?;
             builder.add(glob);
             patterns.push(pattern);
         }
@@ -218,6 +243,54 @@ mod tests {
         }
     }
 
+    /// The floor is as case-tolerant as the reader it guards.
+    ///
+    /// [`extractor_for`](crate::runtime::atlas::scan) lowercases the
+    /// extension before routing, so `Secrets.md` and `CREDENTIALS.txt` are
+    /// files this build will happily read, hash, extract and persist. A
+    /// case-sensitive deny set would therefore let exactly the families
+    /// [`DEFAULT_DENY`] names through the acquisition boundary — which is the
+    /// leak F10 exists to prevent, arriving by way of a shift key.
+    #[test]
+    fn the_default_set_refuses_case_variants_of_the_families_it_names() {
+        let filter = filter();
+        for denied in [
+            "Secrets.md",
+            "SECRETS.md",
+            "Secrets.MD",
+            "notes/CREDENTIALS.txt",
+            "Credentials.markdown",
+            "CREDENTIALS",
+            "keys/ID_RSA",
+            "keys/Id_Ed25519.txt",
+            "Server.PEM",
+            "deep/API.Key",
+            "Local.ENV",
+            "deploy/Service-Account-Prod.json",
+            "Vault.KDBX",
+        ] {
+            assert!(
+                !filter.verdict(denied).is_allowed(),
+                "{denied:?} must be refused at the acquisition boundary — the \
+                 extractor routing that follows is case-insensitive, so the \
+                 floor cannot be case-sensitive"
+            );
+        }
+    }
+
+    /// An operator `ignore` entry is compiled the same way, and case can only
+    /// ever widen what it excludes — never re-admit anything.
+    #[test]
+    fn an_operator_pattern_is_case_insensitive_too() {
+        let filter = AcquisitionFilter::new(&["*.log".to_string()]).expect("compile");
+        assert_eq!(
+            filter.verdict("deep/RUN.LOG"),
+            Verdict::Denied {
+                pattern: "**/*.log".to_string()
+            }
+        );
+    }
+
     /// And ordinary prose is not swept up. A deny set that refuses the corpus
     /// it was meant to protect is a deny set nobody keeps switched on.
     #[test]
@@ -230,6 +303,11 @@ mod tests {
             "runbooks/rotate-credentials-quarterly.md",
             "env-vars.md",
             "monkey.txt",
+            // Case-insensitivity widens the floor; it must not widen it onto
+            // ordinary prose that merely mentions a sensitive word.
+            "Design/Keystore-Design.md",
+            "Runbooks/Rotate-Credentials-Quarterly.md",
+            "NOTES.MD",
         ] {
             assert_eq!(
                 filter.verdict(allowed),

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -51,10 +51,34 @@
 //!
 //! # Scope of what exists here today
 //!
-//! Schema namespaces only. `meta`, `source`, `git` and `context` are created
-//! by [`db`]; no table is declared yet. That is the same empty-table refusal
-//! doctrine the operations projection states: a table that can only ever
-//! answer "zero rows" is a false promise, not completeness, so every table
-//! lands in the wave that lands its writer.
+//! The four namespaces, and the four tables the local-knowledge scanner
+//! writes: `source.generations`, `source.files`, `source.units` and
+//! `meta.coverage`. `git` and `context` are still empty namespaces, by the
+//! same empty-table refusal doctrine the operations projection states — a
+//! table that can only ever answer "zero rows" is a false promise, not
+//! completeness, so every table lands in the wave that lands its writer.
+//!
+//! ```text
+//! deny   ── pure predicate over a path (F10, the acquisition boundary)
+//! text   ── pure functions over bytes  (F6, extraction)
+//! scan   ── the walk: filesystem in, plain Rust out; no DB, no journal
+//! db     ── the one module that reaches the database driver, in or out
+//! record ── the thin three-step glue F1's crash window is stated over
+//! ```
+//!
+//! The dependency arrows run strictly downward through that list. `scan` does
+//! not import `db`, and `db` does not import the journal — which is what
+//! makes F6's "DB-touching glue kept thin and separately reviewable" a
+//! property of the module graph rather than a promise in a comment.
+//!
+//! (This file, like every sibling, is forbidden by
+//! `tests/x1_atlas_substrate.rs` from even *naming* the driver crate, so it
+//! says "the database driver" where a reader might expect the crate's own
+//! name. That is the one-owner rule biting its own documentation, which is
+//! the correct direction for it to bite.)
 
 pub mod db;
+pub mod deny;
+pub mod record;
+pub mod scan;
+pub mod text;

--- a/src/runtime/atlas/record.rs
+++ b/src/runtime/atlas/record.rs
@@ -1,0 +1,149 @@
+//! The thin DB/journal glue around the scanner (F6).
+//!
+//! This module is deliberately small and deliberately its own file. F6's
+//! adapter-shape mandate is that extraction is a pure function over bytes and
+//! that "DB-touching glue stays thin and separately reviewable" — so the glue
+//! is a file you can read in one sitting, sitting *above* both halves it
+//! joins:
+//!
+//! ```text
+//! deny, text  pure predicates and pure functions over bytes
+//!    -> scan  the walk: filesystem in, plain Rust out; no DB, no journal
+//!       -> db the one owner of Atlas's database file; plain Rust in and out
+//!          -> record  this file: three ordered steps, and nothing else
+//! ```
+//!
+//! The arrows run one way. Nothing below depends on anything above it, so
+//! there is no cycle for a shortcut to hide in — the scanner cannot quietly
+//! grow a database handle, and the database cannot quietly grow a filesystem
+//! walk.
+
+use crate::domain::event::{EventDraft, EventSource};
+use crate::domain::source::KIND_SOURCE_SCANNED;
+use crate::runtime::atlas::db::{AtlasDb, AtlasError, ScanCommit};
+use crate::runtime::atlas::deny::BadPattern;
+use crate::runtime::atlas::scan::{KnowledgeSource, SourceScan, scan_local_knowledge};
+use crate::runtime::journal::{Journal, JournalError};
+
+/// What one call to [`scan_and_record`] did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScanRecord {
+    /// The source's bytes are exactly what the newest confirmed generation
+    /// was derived from, so nothing was written and nothing was evicted
+    /// (ruling §4: a generation is evicted only when source bytes changed).
+    Unchanged {
+        /// The generation that still stands.
+        generation_id: String,
+        /// Its content identity.
+        content_key: String,
+    },
+    /// A new generation was written, journaled and confirmed.
+    Recorded {
+        /// The new generation.
+        generation_id: String,
+        /// Its content identity.
+        content_key: String,
+        /// Id of the `source.scanned` event that completes it.
+        summary_event_id: String,
+        /// The generation this one superseded, if any — evicted in the same
+        /// transaction that confirmed the new one, leaving a
+        /// `generation_evicted` coverage row.
+        evicted: Option<String>,
+    },
+}
+
+/// Failures of a scan-and-record.
+#[derive(Debug, thiserror::Error)]
+pub enum ScanRecordError {
+    /// A `[[knowledge]] ignore` glob does not compile.
+    #[error(transparent)]
+    Pattern(#[from] BadPattern),
+    /// Atlas refused a write.
+    #[error(transparent)]
+    Atlas(#[from] AtlasError),
+    /// The journal refused the summary.
+    #[error(transparent)]
+    Journal(#[from] JournalError),
+}
+
+/// Scan one source and record it — **F1's crash-window coupling, in three
+/// ordered steps.**
+///
+/// ```text
+/// 1. stage    one transaction: generation (provisional) + files + units + coverage
+/// 2. journal  one compact `source.scanned` summary
+/// 3. confirm  one transaction: mark confirmed, evict the superseded generation
+/// ```
+///
+/// The order is the only safe one, and each boundary is worth stating:
+///
+/// * **Crash between 1 and 2, or between 2 and 3** leaves a generation with
+///   rows and no confirmation. Nothing reads it — every read filters to
+///   confirmed generations — and startup reconciliation
+///   ([`AtlasDb::reconcile`]) evicts it, leaving a `generation_evicted`
+///   coverage row. Neither-reported, never half-reported.
+/// * **The eviction of the superseded generation is in step 3, not step 1.**
+///   Putting it in the staging transaction would mean a crash before the
+///   summary destroys a perfectly good previous generation and leaves
+///   nothing in its place. Deferred to the confirming transaction, a crash
+///   anywhere leaves the *old* generation standing, which is the answer that
+///   still has evidence behind it.
+/// * **Step 3 is one transaction**, so "confirmed" and "predecessor evicted"
+///   are never separately observable.
+pub fn scan_and_record(
+    db: &mut AtlasDb,
+    journal: &mut Journal,
+    source: &KnowledgeSource,
+    workspace_id: Option<&str>,
+) -> Result<ScanRecord, ScanRecordError> {
+    let scan = scan_local_knowledge(source)?;
+    let staged = match db.stage_scan(&scan)? {
+        ScanCommit::Unchanged {
+            generation_id,
+            content_key,
+        } => {
+            return Ok(ScanRecord::Unchanged {
+                generation_id,
+                content_key,
+            });
+        }
+        ScanCommit::Staged { generation_id } => generation_id,
+    };
+    let mut draft = EventDraft::new(
+        EventSource::new("daemon", "atlas"),
+        KIND_SOURCE_SCANNED,
+        summary_payload(&scan, &staged),
+    );
+    if let Some(workspace_id) = workspace_id {
+        draft = draft.with_workspace_id(workspace_id);
+    }
+    let event = journal.append(draft)?;
+    let evicted = db.confirm_scan(&staged, &event.id)?;
+    Ok(ScanRecord::Recorded {
+        generation_id: staged,
+        content_key: scan.content_key,
+        summary_event_id: event.id,
+        evicted,
+    })
+}
+
+/// The one compact summary a completed scan journals (F1).
+///
+/// Source, generation, counts, extractor identities — and deliberately not a
+/// path list. Coverage detail belongs in the table that can be queried; the
+/// journal carries the authoritative *trail* (that this scan happened, over
+/// this world, producing this shape), not a second copy of the data.
+fn summary_payload(scan: &SourceScan, generation_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "source": scan.source_name,
+        "source_kind": scan.kind.as_str(),
+        "authority_class": scan.authority.as_str(),
+        "generation": generation_id,
+        "content_key": scan.content_key,
+        "observed_at": scan.observed_at,
+        "files": scan.files.len(),
+        "units": scan.unit_count(),
+        "coverage": scan.counts(),
+        "extractors": scan.extractors.iter().collect::<Vec<_>>(),
+    })
+}

--- a/src/runtime/atlas/record.rs
+++ b/src/runtime/atlas/record.rs
@@ -18,6 +18,8 @@
 //! grow a database handle, and the database cannot quietly grow a filesystem
 //! walk.
 
+use std::collections::BTreeMap;
+
 use crate::domain::event::{EventDraft, EventSource};
 use crate::domain::source::KIND_SOURCE_SCANNED;
 use crate::runtime::atlas::db::{AtlasDb, AtlasError, ScanCommit};
@@ -36,6 +38,20 @@ pub enum ScanRecord {
         generation_id: String,
         /// Its content identity.
         content_key: String,
+    },
+    /// The source root could not be read at all, and a confirmed generation
+    /// already stands, so nothing was written and — the point of the
+    /// variant — **nothing was evicted**. An unplugged drive changed no
+    /// source bytes, and ruling §4 evicts only when they changed. The
+    /// unavailability is recorded as coverage against the generation that
+    /// survived it.
+    RootUnavailable {
+        /// The generation that still stands, untouched.
+        generation_id: String,
+        /// Its content identity.
+        content_key: String,
+        /// What was recorded as coverage.
+        detail: String,
     },
     /// A new generation was written, journaled and confirmed.
     Recorded {
@@ -75,13 +91,23 @@ pub enum ScanRecordError {
 /// 3. confirm  one transaction: mark confirmed, evict the superseded generation
 /// ```
 ///
-/// The order is the only safe one, and each boundary is worth stating:
+/// The order is the only safe one, and each boundary is worth stating —
+/// including the fact that the two crash windows are **not** the same window:
 ///
-/// * **Crash between 1 and 2, or between 2 and 3** leaves a generation with
-///   rows and no confirmation. Nothing reads it — every read filters to
-///   confirmed generations — and startup reconciliation
-///   ([`AtlasDb::reconcile`]) evicts it, leaving a `generation_evicted`
-///   coverage row. Neither-reported, never half-reported.
+/// * **Crash between 1 and 2** leaves rows with no summary anywhere. Nothing
+///   reads them (every read filters to confirmed generations) and
+///   [`reconcile_sources`] evicts them at startup, leaving a
+///   `generation_evicted` coverage row. Neither-reported.
+/// * **Crash between 2 and 3** leaves rows *and* a durable summary naming
+///   them — the event is in the journal, and was already broadcast. Evicting
+///   here would be the mirror-image violation of the same both-present rule:
+///   journal-present, database-evicted, with the eviction row claiming a
+///   missing summary that plainly exists. So [`reconcile_sources`] promotes
+///   instead, finishing step 3 on the next start. Both-present.
+///
+///   This is why reconciliation reads the journal rather than the `state`
+///   column alone: the column cannot tell the two windows apart, and they
+///   have opposite correct answers.
 /// * **The eviction of the superseded generation is in step 3, not step 1.**
 ///   Putting it in the staging transaction would mean a crash before the
 ///   summary destroys a perfectly good previous generation and leaves
@@ -107,12 +133,23 @@ pub fn scan_and_record(
                 content_key,
             });
         }
+        ScanCommit::RootUnavailable {
+            generation_id,
+            content_key,
+            detail,
+        } => {
+            return Ok(ScanRecord::RootUnavailable {
+                generation_id,
+                content_key,
+                detail,
+            });
+        }
         ScanCommit::Staged { generation_id } => generation_id,
     };
     let mut draft = EventDraft::new(
         EventSource::new("daemon", "atlas"),
         KIND_SOURCE_SCANNED,
-        summary_payload(&scan, &staged),
+        scan_summary(&scan, &staged),
     );
     if let Some(workspace_id) = workspace_id {
         draft = draft.with_workspace_id(workspace_id);
@@ -127,13 +164,105 @@ pub fn scan_and_record(
     })
 }
 
+/// What one startup reconciliation resolved.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Reconciliation {
+    /// Generations finished on this start: their summary was in the journal,
+    /// so step 3 ran now instead of before the crash.
+    pub promoted: Vec<String>,
+    /// Generations evicted: no summary anywhere, so the scan never completed.
+    pub evicted: Vec<String>,
+}
+
+impl Reconciliation {
+    /// Whether anything at all needed resolving.
+    pub fn is_empty(&self) -> bool {
+        self.promoted.is_empty() && self.evicted.is_empty()
+    }
+}
+
+/// The detail a crash-window eviction leaves on its coverage row.
+const NO_SUMMARY: &str =
+    "reconciled at startup: rows exist with no source.scanned summary in the journal";
+
+/// **F1's startup reconciliation** — the whole of it, in the one place that
+/// can see both halves of the evidence.
+///
+/// [`scan_and_record`]'s three steps have two crash windows with opposite
+/// correct answers, and the database cannot tell them apart on its own: a
+/// generation left `provisional` either never got its `source.scanned`
+/// summary (step 1→2 — evict; the scan did not complete) or got it and died
+/// before the confirming transaction (step 2→3 — promote; the summary is
+/// durable, and was already broadcast, so evicting would leave the journal
+/// claiming a scan the database had thrown away). The `state` column records
+/// the same value in both cases. The journal is what distinguishes them, so
+/// the journal is what this consults.
+///
+/// Cost: **nothing at all** on a start that did not follow a crash.
+/// [`AtlasDb::provisional_generations`] is a single indexed-free read of a
+/// small table and answers empty on every ordinary start; the journal is only
+/// read when it does not.
+///
+/// **The read is floor-aware** ([`Journal::replay_from_floor`], I-W3-10): on
+/// a pruned journal the strict primitive would report a healthy floor above 1
+/// as a sequence discontinuity. A summary old enough to have been pruned away
+/// is *itself* the answer, and it is eviction: once the trail is gone, no
+/// both-present state is reachable for that generation, and the safe
+/// direction — nothing half-reported as coverage, with an explicit eviction
+/// row saying so — is the one that stays true. In practice a provisional
+/// generation is from the run that just died, so its summary is at the tail.
+pub fn reconcile_sources(
+    db: &mut AtlasDb,
+    journal: &Journal,
+) -> Result<Reconciliation, ScanRecordError> {
+    let awaiting = db.provisional_generations()?;
+    if awaiting.is_empty() {
+        return Ok(Reconciliation::default());
+    }
+    // Which of them the journal can vouch for. One pass, and only ever
+    // reached because something was actually left unresolved.
+    let mut summaries: BTreeMap<String, String> = BTreeMap::new();
+    for event in journal.replay_from_floor()? {
+        let event = event?;
+        if event.kind != KIND_SOURCE_SCANNED {
+            continue;
+        }
+        if let Some(generation) = event.payload.get("generation").and_then(|g| g.as_str()) {
+            summaries.insert(generation.to_string(), event.id.clone());
+        }
+    }
+
+    let mut out = Reconciliation::default();
+    let mut orphaned = Vec::new();
+    for (generation_id, _) in awaiting {
+        match summaries.get(&generation_id) {
+            // Step 3, finished late. `confirm_scan` promotes and evicts the
+            // predecessor in one transaction, exactly as the live path would
+            // have — a recovered scan is a completed scan, not a special one.
+            Some(event_id) => {
+                db.confirm_scan(&generation_id, event_id)?;
+                out.promoted.push(generation_id);
+            }
+            None => orphaned.push(generation_id),
+        }
+    }
+    out.evicted = db.evict_provisional(&orphaned, NO_SUMMARY)?;
+    Ok(out)
+}
+
 /// The one compact summary a completed scan journals (F1).
 ///
 /// Source, generation, counts, extractor identities — and deliberately not a
 /// path list. Coverage detail belongs in the table that can be queried; the
 /// journal carries the authoritative *trail* (that this scan happened, over
 /// this world, producing this shape), not a second copy of the data.
-fn summary_payload(scan: &SourceScan, generation_id: &str) -> serde_json::Value {
+///
+/// Public because the payload is a **contract, not an implementation
+/// detail**: `generation` is the field [`reconcile_sources`] matches a
+/// crash-window generation on, so the writer and the reader of that field
+/// have to be pinnable together. A test that hand-rolled its own summary
+/// would keep passing on the day this function stopped emitting it.
+pub fn scan_summary(scan: &SourceScan, generation_id: &str) -> serde_json::Value {
     serde_json::json!({
         "source": scan.source_name,
         "source_kind": scan.kind.as_str(),

--- a/src/runtime/atlas/scan.rs
+++ b/src/runtime/atlas/scan.rs
@@ -169,6 +169,30 @@ impl SourceScan {
     pub fn unit_count(&self) -> u64 {
         self.files.iter().map(|f| f.units.len() as u64).sum()
     }
+
+    /// The coverage row saying the **source root itself** could not be read,
+    /// when there is one.
+    ///
+    /// Three walk outcomes produce it, and only those three: the root's
+    /// metadata could not be taken, the root is not a directory, or the root
+    /// directory could not be listed. Each writes an
+    /// [`Unavailable`](Coverage::Unavailable) row whose path is the root's own
+    /// — `None` before the walk starts, `Some("")` once it has.
+    ///
+    /// It exists because an unreadable root and an emptied one are
+    /// indistinguishable by [`content_key`](Self::content_key) alone: both
+    /// hash an empty resource map. Ruling §4 evicts a generation *only* when
+    /// the source bytes changed, and an unplugged drive changed no bytes — so
+    /// the decision to supersede needs this signal, which the walk already
+    /// recorded, rather than a key comparison that cannot tell the two apart.
+    /// A readable directory that is genuinely empty produces no such row and
+    /// may still legitimately supersede.
+    pub fn root_unavailable(&self) -> Option<&CoverageRow> {
+        self.coverage.iter().find(|row| {
+            row.status == Coverage::Unavailable
+                && row.path.as_deref().is_none_or(|path| path.is_empty())
+        })
+    }
 }
 
 /// Walk one declared knowledge root.
@@ -662,6 +686,39 @@ mod tests {
         assert_eq!(scan.coverage.len(), 1);
         assert_eq!(scan.coverage[0].status, Coverage::Unavailable);
         assert_eq!(scan.coverage[0].path, None);
+        assert!(
+            scan.root_unavailable().is_some(),
+            "an unreachable root must be distinguishable from an empty one"
+        );
+    }
+
+    /// The signal that lets ruling §4 tell "the bytes are gone" from "the
+    /// path is gone": an empty *readable* directory reports no root
+    /// unavailability, and neither does a file-level one.
+    #[test]
+    fn an_empty_readable_root_is_not_an_unavailable_root() {
+        let (dir, empty) = scan_tree(&[], &[]);
+        assert!(empty.files.is_empty());
+        assert!(
+            empty.root_unavailable().is_none(),
+            "a readable, genuinely empty root is a real observation of \
+             emptiness: {:?}",
+            empty.coverage
+        );
+
+        // A file the walk could not read is a *file's* unavailability. The
+        // root was listed perfectly well, so nothing about the source's own
+        // reachability is in doubt.
+        std::fs::write(dir.path().join("keep.md"), b"# Keep\n").expect("write");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/etc", dir.path().join("escape")).expect("symlink");
+        let source = KnowledgeSource {
+            name: "notes".to_string(),
+            root: dir.path().to_path_buf(),
+            ignore: Vec::new(),
+        };
+        let scan = scan_local_knowledge(&source).expect("scan");
+        assert!(scan.root_unavailable().is_none(), "{:?}", scan.coverage);
     }
 
     /// A symlink is not followed: a knowledge source's boundary is the

--- a/src/runtime/atlas/scan.rs
+++ b/src/runtime/atlas/scan.rs
@@ -1,0 +1,709 @@
+//! The local-knowledge scanner: Atlas's first real `source.*` writer.
+//!
+//! Walks one declared `[[knowledge]]` root and produces **plain Rust** — a
+//! [`SourceScan`] of files, units and coverage rows. It opens files; it names
+//! no database, no journal and no daemon state, and it imports neither
+//! [`super::db`] nor the journal. The glue that turns a [`SourceScan`] into
+//! rows and an event is its own small module, [`super::record`] — F6's
+//! "DB-touching glue kept thin and separately reviewable", made structural
+//! rather than aspirational: the dependency runs `deny`/`text` -> `scan` ->
+//! `db` -> `record`, in one direction, with no cycle to hide a shortcut in.
+//!
+//! # The three rules this module exists to hold
+//!
+//! * **F10 — nothing denied is ever opened.** The verdict
+//!   ([`super::deny`]) is a pure function of the path and is asked *before*
+//!   the file is opened, and before a directory is descended into. Excluded
+//!   bytes are counted, with the matching pattern named, so an exclusion is
+//!   visible rather than absent.
+//! * **F7 — keys are content plus extractor.** A resource's identity is
+//!   BLAKE3 of its bytes; its extraction's identity is that hash plus the
+//!   extractor's own versioned name
+//!   ([`local_key`](crate::domain::source::local_key)). `mtime` is recorded
+//!   as a *change hint* and is part of no key, so touching a file changes
+//!   nothing derived and editing one changes everything derived from it.
+//! * **F8 — every path seen leaves exactly one coverage row.** Indexed,
+//!   excluded, unavailable, unsupported or error: there is no sixth outcome
+//!   where a path is silently not mentioned.
+//!
+//! # F1's crash window
+//!
+//! [`super::record::scan_and_record`] is the whole of the coupling rule, in
+//! three steps that are worth reading in order — its own doc explains why the
+//! order is the only safe one.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use crate::domain::estate::KnowledgeSpec;
+use crate::domain::event::rfc3339_utc_now;
+use crate::domain::source::{
+    AuthorityClass, Coverage, CoverageRow, SourceKind, UnitKind, content_hash, generation_key,
+    local_key,
+};
+use crate::runtime::atlas::deny::{AcquisitionFilter, BadPattern, Verdict};
+use crate::runtime::atlas::text::{
+    MARKDOWN_EXTRACTOR, TEXT_EXTRACTOR, as_text, markdown_units, plain_units,
+};
+
+/// Extensions routed to the Markdown extractor.
+const MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown"];
+
+/// Extensions routed to the plain-text extractor.
+const TEXT_EXTENSIONS: &[&str] = &["txt", "text"];
+
+/// The largest resource this build reads into memory to extract.
+///
+/// **Declared, not measured** — and said plainly rather than dressed up as a
+/// tuned figure. It is a refusal ceiling on a whole-file read whose result is
+/// stored as a single DuckDB `TEXT` value and can be returned whole; 4 MiB of
+/// prose is on the order of a thousand printed pages, which is far past
+/// anything a heading-sectioned document plausibly is. A file above it is
+/// reported `unsupported` **naming this bound**, never silently skipped, so
+/// the day a real corpus argues for a different number the evidence for it is
+/// already in the coverage table.
+pub const MAX_RESOURCE_BYTES: u64 = 4 * 1024 * 1024;
+
+/// One source to scan: the manifest's declaration, resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KnowledgeSource {
+    /// Declared name — the source coordinate every derived row carries.
+    pub name: String,
+    /// Absolute path to the source root.
+    pub root: PathBuf,
+    /// Per-source ignore globs, extending the built-in deny set.
+    pub ignore: Vec<String>,
+}
+
+impl From<&KnowledgeSpec> for KnowledgeSource {
+    fn from(spec: &KnowledgeSpec) -> Self {
+        Self {
+            name: spec.name.clone(),
+            root: spec.path.clone(),
+            ignore: spec.ignore.clone(),
+        }
+    }
+}
+
+/// One extracted unit, ready to become a row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScannedUnit {
+    /// Position within its file's unit list — stable for identical bytes and
+    /// extractor, which is what makes a unit addressable across generations.
+    pub ordinal: u64,
+    /// Whole document, or a heading-delimited section.
+    pub kind: UnitKind,
+    /// Heading depth, for a section under a heading.
+    pub heading_level: Option<u8>,
+    /// Heading text, when there is one.
+    pub title: Option<String>,
+    /// Offset into the **original** file bytes.
+    pub byte_start: u64,
+    /// End offset into the original file bytes, exclusive.
+    pub byte_end: u64,
+    /// The unit's own text, exactly as it appears in the original.
+    pub text: String,
+}
+
+/// One acquired resource and everything derived from it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScannedFile {
+    /// Path relative to the source root, `/`-separated.
+    pub relative_path: String,
+    /// BLAKE3 hex of the file's bytes (F7's content half).
+    pub content_hash: String,
+    /// Identity of the extractor that read it (F7's other half).
+    pub extractor: String,
+    /// The reusable extraction key: [`local_key`] of the two above.
+    pub local_key: String,
+    /// Size in bytes, as read.
+    pub byte_len: u64,
+    /// Modification time in Unix milliseconds, when the filesystem offered
+    /// one. **A change hint only** (A1 §3): part of no key, consulted by no
+    /// reuse decision, recorded because "what looked different" is useful
+    /// evidence when a scan is being explained.
+    pub mtime_millis: Option<i64>,
+    /// Units extracted from it, in document order.
+    pub units: Vec<ScannedUnit>,
+}
+
+/// Everything one completed walk observed. Plain data — no handle, no
+/// connection, no borrow of anything live.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceScan {
+    /// The declared source.
+    pub source_name: String,
+    /// How it was acquired.
+    pub kind: SourceKind,
+    /// What the estate may do with it.
+    pub authority: AuthorityClass,
+    /// Content identity of the whole generation (see
+    /// [`generation_key`]) — the value ruling §4's eviction rule is stated
+    /// over.
+    pub content_key: String,
+    /// When the walk finished (RFC3339 UTC).
+    pub observed_at: String,
+    /// Acquired resources, in path order.
+    pub files: Vec<ScannedFile>,
+    /// One row per path seen, in path order.
+    pub coverage: Vec<CoverageRow>,
+    /// Distinct extractor identities that ran — carried into the journal
+    /// summary, because "which parser produced this?" is one of A1 §3's four
+    /// provenance questions.
+    pub extractors: BTreeSet<String>,
+}
+
+impl SourceScan {
+    /// Counts by coverage status, for the journal summary and for a caller
+    /// that wants to assert on them.
+    pub fn counts(&self) -> BTreeMap<&'static str, u64> {
+        let mut counts = BTreeMap::new();
+        for row in &self.coverage {
+            *counts.entry(row.status.as_str()).or_insert(0) += 1;
+        }
+        counts
+    }
+
+    /// Total units across every acquired file.
+    pub fn unit_count(&self) -> u64 {
+        self.files.iter().map(|f| f.units.len() as u64).sum()
+    }
+}
+
+/// Walk one declared knowledge root.
+///
+/// Fails only when the source's own `ignore` globs do not compile — an
+/// operator error that must be named, not absorbed. Everything else the
+/// filesystem can do (a missing root, an unreadable directory, a vanished
+/// file, a symlink, a binary blob) becomes a coverage row, because a scanner
+/// that refuses to finish when one file is unreadable reports nothing about
+/// the thousand that were.
+pub fn scan_local_knowledge(source: &KnowledgeSource) -> Result<SourceScan, BadPattern> {
+    let filter = AcquisitionFilter::new(&source.ignore)?;
+    let mut walk = Walk {
+        filter: &filter,
+        files: Vec::new(),
+        coverage: Vec::new(),
+        extractors: BTreeSet::new(),
+    };
+    match std::fs::metadata(&source.root) {
+        Ok(meta) if meta.is_dir() => walk.directory(&source.root, ""),
+        Ok(_) => walk.coverage.push(CoverageRow {
+            path: None,
+            status: Coverage::Unavailable,
+            detail: Some("the declared knowledge path is not a directory".to_string()),
+            bytes: None,
+        }),
+        Err(e) => walk.coverage.push(CoverageRow {
+            path: None,
+            status: Coverage::Unavailable,
+            detail: Some(format!("the declared knowledge path cannot be read: {e}")),
+            bytes: None,
+        }),
+    }
+    let Walk {
+        files,
+        coverage,
+        extractors,
+        ..
+    } = walk;
+    let resources: BTreeMap<String, String> = files
+        .iter()
+        .map(|f| (f.relative_path.clone(), f.content_hash.clone()))
+        .collect();
+    Ok(SourceScan {
+        source_name: source.name.clone(),
+        kind: SourceKind::LocalKnowledge,
+        authority: AuthorityClass::EstateReadonly,
+        content_key: generation_key(&resources),
+        observed_at: rfc3339_utc_now(),
+        files,
+        coverage,
+        extractors,
+    })
+}
+
+/// The walk's mutable state. Separate from [`SourceScan`] so the produced
+/// value is inert data with no borrow of the filter that made it.
+struct Walk<'a> {
+    filter: &'a AcquisitionFilter,
+    files: Vec<ScannedFile>,
+    coverage: Vec<CoverageRow>,
+    extractors: BTreeSet<String>,
+}
+
+impl Walk<'_> {
+    /// Recurse into one directory. `relative` is `""` for the root.
+    fn directory(&mut self, path: &Path, relative: &str) {
+        let entries = match std::fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(e) => {
+                self.coverage.push(CoverageRow {
+                    path: Some(relative.to_string()),
+                    status: Coverage::Unavailable,
+                    detail: Some(format!("directory cannot be read: {e}")),
+                    bytes: None,
+                });
+                return;
+            }
+        };
+        // Sorted, so two scans of an unchanged tree produce identical
+        // coverage in identical order — a diff of two scans should show what
+        // changed in the world, never what order the filesystem answered in.
+        let mut names: Vec<(std::ffi::OsString, PathBuf)> = Vec::new();
+        for entry in entries {
+            match entry {
+                Ok(entry) => names.push((entry.file_name(), entry.path())),
+                Err(e) => self.coverage.push(CoverageRow {
+                    path: Some(relative.to_string()),
+                    status: Coverage::Error,
+                    detail: Some(format!("directory entry cannot be read: {e}")),
+                    bytes: None,
+                }),
+            }
+        }
+        names.sort();
+
+        for (name, child) in names {
+            let Some(name) = name.to_str() else {
+                self.coverage.push(CoverageRow {
+                    path: Some(relative.to_string()),
+                    status: Coverage::Unsupported,
+                    detail: Some("entry name is not valid UTF-8".to_string()),
+                    bytes: None,
+                });
+                continue;
+            };
+            let child_relative = if relative.is_empty() {
+                name.to_string()
+            } else {
+                format!("{relative}/{name}")
+            };
+            // F10: the verdict is taken from the path alone, before anything
+            // is opened or descended into.
+            if let Verdict::Denied { pattern } = self.filter.verdict(&child_relative) {
+                self.coverage.push(CoverageRow {
+                    path: Some(child_relative),
+                    status: Coverage::Excluded,
+                    detail: Some(format!("refused at acquisition by {pattern}")),
+                    // Size comes from metadata, which reads no content — an
+                    // excluded byte is counted without ever being read.
+                    bytes: std::fs::symlink_metadata(&child)
+                        .ok()
+                        .filter(|m| m.is_file())
+                        .map(|m| m.len()),
+                });
+                continue;
+            }
+            let meta = match std::fs::symlink_metadata(&child) {
+                Ok(meta) => meta,
+                Err(e) => {
+                    self.coverage.push(CoverageRow {
+                        path: Some(child_relative),
+                        status: Coverage::Unavailable,
+                        detail: Some(format!("cannot be inspected: {e}")),
+                        bytes: None,
+                    });
+                    continue;
+                }
+            };
+            if meta.file_type().is_symlink() {
+                // Not followed: a symlink can leave the declared root
+                // entirely, and a knowledge source's boundary is the path the
+                // manifest declared, not wherever a link points.
+                self.coverage.push(CoverageRow {
+                    path: Some(child_relative),
+                    status: Coverage::Unavailable,
+                    detail: Some("symlink is not followed".to_string()),
+                    bytes: None,
+                });
+                continue;
+            }
+            if meta.is_dir() {
+                self.coverage.push(CoverageRow {
+                    path: Some(child_relative.clone()),
+                    status: Coverage::Discovered,
+                    detail: Some("directory".to_string()),
+                    bytes: None,
+                });
+                self.directory(&child, &child_relative);
+                continue;
+            }
+            if !meta.is_file() {
+                self.coverage.push(CoverageRow {
+                    path: Some(child_relative),
+                    status: Coverage::Unsupported,
+                    detail: Some("not a regular file".to_string()),
+                    bytes: None,
+                });
+                continue;
+            }
+            self.file(&child, child_relative, meta);
+        }
+    }
+
+    /// Acquire and extract one regular file that passed the boundary.
+    fn file(&mut self, path: &Path, relative: String, meta: std::fs::Metadata) {
+        let Some(extractor) = extractor_for(&relative) else {
+            self.coverage.push(CoverageRow {
+                path: Some(relative),
+                status: Coverage::Unsupported,
+                detail: Some("no extractor in this build claims this extension".to_string()),
+                bytes: Some(meta.len()),
+            });
+            return;
+        };
+        if meta.len() > MAX_RESOURCE_BYTES {
+            self.coverage.push(CoverageRow {
+                path: Some(relative),
+                status: Coverage::Unsupported,
+                detail: Some(format!(
+                    "larger than the {MAX_RESOURCE_BYTES}-byte resource ceiling"
+                )),
+                bytes: Some(meta.len()),
+            });
+            return;
+        }
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                self.coverage.push(CoverageRow {
+                    path: Some(relative),
+                    status: Coverage::Unavailable,
+                    detail: Some(format!("cannot be read: {e}")),
+                    bytes: Some(meta.len()),
+                });
+                return;
+            }
+        };
+        let Some(text) = as_text(&bytes) else {
+            self.coverage.push(CoverageRow {
+                path: Some(relative),
+                status: Coverage::Unsupported,
+                detail: Some("not valid UTF-8 text".to_string()),
+                bytes: Some(bytes.len() as u64),
+            });
+            return;
+        };
+        let structure = if extractor == MARKDOWN_EXTRACTOR {
+            markdown_units(text)
+        } else {
+            plain_units(text)
+        };
+        let hash = content_hash(&bytes);
+        let units = structure
+            .into_iter()
+            .enumerate()
+            .map(|(ordinal, unit)| ScannedUnit {
+                ordinal: ordinal as u64,
+                kind: unit.kind,
+                heading_level: unit.heading_level,
+                title: unit.title,
+                byte_start: unit.byte_start as u64,
+                byte_end: unit.byte_end as u64,
+                text: text[unit.byte_start..unit.byte_end].to_string(),
+            })
+            .collect();
+        self.extractors.insert(extractor.to_string());
+        self.coverage.push(CoverageRow {
+            path: Some(relative.clone()),
+            status: Coverage::Indexed,
+            detail: Some(extractor.to_string()),
+            bytes: Some(bytes.len() as u64),
+        });
+        self.files.push(ScannedFile {
+            relative_path: relative,
+            local_key: local_key(&hash, extractor),
+            content_hash: hash,
+            extractor: extractor.to_string(),
+            byte_len: bytes.len() as u64,
+            mtime_millis: mtime_millis(&meta),
+            units,
+        });
+    }
+}
+
+/// The extractor for a path, by extension, or `None` for a family this build
+/// does not claim.
+///
+/// Extension-driven and nothing else: sniffing content to guess a format
+/// would mean reading bytes to decide whether to read bytes, and the honest
+/// answer for an unclaimed extension is `unsupported`, which coverage
+/// reports.
+fn extractor_for(relative: &str) -> Option<&'static str> {
+    let extension = Path::new(relative)
+        .extension()
+        .and_then(|e| e.to_str())?
+        .to_ascii_lowercase();
+    if MARKDOWN_EXTENSIONS.contains(&extension.as_str()) {
+        Some(MARKDOWN_EXTRACTOR)
+    } else if TEXT_EXTENSIONS.contains(&extension.as_str()) {
+        Some(TEXT_EXTRACTOR)
+    } else {
+        None
+    }
+}
+
+/// Modification time in Unix milliseconds, when the platform offers one.
+fn mtime_millis(meta: &std::fs::Metadata) -> Option<i64> {
+    meta.modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_millis() as i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a source tree and scan it.
+    fn scan_tree(files: &[(&str, &[u8])], ignore: &[&str]) -> (tempfile::TempDir, SourceScan) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (path, bytes) in files {
+            let full = dir.path().join(path);
+            std::fs::create_dir_all(full.parent().expect("parent")).expect("mkdir");
+            std::fs::write(&full, bytes).expect("write");
+        }
+        let source = KnowledgeSource {
+            name: "notes".to_string(),
+            root: dir.path().to_path_buf(),
+            ignore: ignore.iter().map(|s| (*s).to_string()).collect(),
+        };
+        let scan = scan_local_knowledge(&source).expect("scan");
+        (dir, scan)
+    }
+
+    fn row<'a>(scan: &'a SourceScan, path: &str) -> &'a CoverageRow {
+        scan.coverage
+            .iter()
+            .find(|r| r.path.as_deref() == Some(path))
+            .unwrap_or_else(|| panic!("no coverage row for {path:?}"))
+    }
+
+    /// F8: every path the walk saw leaves exactly one row, and the statuses
+    /// are the ones the situation actually warrants.
+    #[test]
+    fn every_path_seen_leaves_exactly_one_coverage_row() {
+        let (_dir, scan) = scan_tree(
+            &[
+                ("README.md", b"# Top\n\nbody\n"),
+                ("notes/one.md", b"# One\n"),
+                ("notes/plain.txt", b"just text\n"),
+                ("notes/binary.bin", b"\x00\x01\x02"),
+                ("notes/image.png", &[0x89, 0x50, 0x4e, 0x47]),
+                (".env", b"SECRET=1\n"),
+                ("keys/server.pem", b"-----BEGIN\n"),
+            ],
+            &[],
+        );
+        let paths: Vec<&str> = scan
+            .coverage
+            .iter()
+            .filter_map(|r| r.path.as_deref())
+            .collect();
+        let mut sorted = paths.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(paths.len(), sorted.len(), "a path got two rows: {paths:?}");
+
+        assert_eq!(row(&scan, "README.md").status, Coverage::Indexed);
+        assert_eq!(row(&scan, "notes/one.md").status, Coverage::Indexed);
+        assert_eq!(row(&scan, "notes/plain.txt").status, Coverage::Indexed);
+        // `.bin` has no extractor at all; `.png` neither. Both unsupported,
+        // and neither pretends to be indexed.
+        assert_eq!(row(&scan, "notes/binary.bin").status, Coverage::Unsupported);
+        assert_eq!(row(&scan, "notes/image.png").status, Coverage::Unsupported);
+        assert_eq!(row(&scan, ".env").status, Coverage::Excluded);
+        assert_eq!(row(&scan, "keys/server.pem").status, Coverage::Excluded);
+        assert_eq!(row(&scan, "notes").status, Coverage::Discovered);
+
+        assert_eq!(
+            scan.extractors,
+            BTreeSet::from([MARKDOWN_EXTRACTOR.to_string(), TEXT_EXTRACTOR.to_string()])
+        );
+    }
+
+    /// F10, stated where it can actually fail: an excluded file's bytes are
+    /// counted and its refusing pattern named, and no unit anywhere carries
+    /// its contents.
+    #[test]
+    fn excluded_bytes_are_counted_and_never_reach_a_unit() {
+        let secret = b"SECRET=hunter2\n";
+        let (_dir, scan) = scan_tree(
+            &[
+                ("keep.md", b"# Keep\n"),
+                (".env", secret),
+                ("build/out.md", b"# Generated\n"),
+            ],
+            &["build/**"],
+        );
+        let env = row(&scan, ".env");
+        assert_eq!(env.status, Coverage::Excluded);
+        assert_eq!(env.bytes, Some(secret.len() as u64));
+        assert!(
+            env.detail.as_deref().is_some_and(|d| d.contains("dotfile")),
+            "{env:?}"
+        );
+        assert_eq!(row(&scan, "build/out.md").status, Coverage::Excluded);
+        assert!(
+            row(&scan, "build/out.md")
+                .detail
+                .as_deref()
+                .is_some_and(|d| d.contains("build/**"))
+        );
+
+        assert_eq!(scan.files.len(), 1, "only the allowed file was acquired");
+        let all_text: String = scan
+            .files
+            .iter()
+            .flat_map(|f| f.units.iter().map(|u| u.text.clone()))
+            .collect();
+        assert!(!all_text.contains("hunter2"), "secret reached a unit");
+        assert!(
+            !scan.files.iter().any(|f| f.relative_path == ".env"),
+            "an excluded path was acquired"
+        );
+    }
+
+    /// A denied *directory* is refused once and never descended into, so its
+    /// children cost nothing and appear nowhere.
+    #[test]
+    fn a_denied_directory_is_refused_once_and_not_descended() {
+        let (_dir, scan) = scan_tree(
+            &[
+                ("keep.md", b"# Keep\n"),
+                (".git/config", b"[core]\n"),
+                (".git/objects/deep/thing", b"binary"),
+            ],
+            &[],
+        );
+        assert_eq!(row(&scan, ".git").status, Coverage::Excluded);
+        assert!(
+            !scan
+                .coverage
+                .iter()
+                .any(|r| r.path.as_deref().is_some_and(|p| p.starts_with(".git/"))),
+            "the walk descended into a denied directory: {:?}",
+            scan.coverage
+        );
+    }
+
+    /// F7: the local key is content plus extractor. Two files with identical
+    /// bytes share one; touching a file changes nothing; editing it changes
+    /// the key and the generation identity together.
+    #[test]
+    fn keys_are_content_and_extractor_and_mtime_is_only_a_hint() {
+        let (dir, first) = scan_tree(&[("a.md", b"# Same\n"), ("copy/b.md", b"# Same\n")], &[]);
+        assert_eq!(first.files.len(), 2);
+        assert_eq!(first.files[0].content_hash, first.files[1].content_hash);
+        assert_eq!(first.files[0].local_key, first.files[1].local_key);
+        assert_eq!(first.files[0].extractor, MARKDOWN_EXTRACTOR);
+
+        let source = KnowledgeSource {
+            name: "notes".to_string(),
+            root: dir.path().to_path_buf(),
+            ignore: Vec::new(),
+        };
+        // Touch: mtime moves, content does not. Nothing derived may move.
+        let touched = dir.path().join("a.md");
+        let now = std::time::SystemTime::now() + std::time::Duration::from_secs(120);
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&touched)
+            .expect("open");
+        file.set_modified(now).expect("set mtime");
+        drop(file);
+        let second = scan_local_knowledge(&source).expect("rescan");
+        assert_eq!(second.content_key, first.content_key, "mtime moved a key");
+        assert_eq!(second.files[0].local_key, first.files[0].local_key);
+
+        // Edit: content moves, so the key and the generation identity move.
+        std::fs::write(&touched, b"# Same but different\n").expect("write");
+        let third = scan_local_knowledge(&source).expect("rescan");
+        assert_ne!(third.content_key, first.content_key);
+        assert_ne!(third.files[0].local_key, first.files[0].local_key);
+    }
+
+    /// Units carry provenance into the original bytes, and the text stored is
+    /// exactly the bytes at those offsets.
+    #[test]
+    fn units_slice_back_out_of_the_original_file() {
+        let body = "# Title\n\nfirst\n\n## Sub\n\nsecond\n";
+        let (dir, scan) = scan_tree(&[("doc.md", body.as_bytes())], &[]);
+        let file = &scan.files[0];
+        let original = std::fs::read(dir.path().join("doc.md")).expect("read");
+        assert!(file.units.len() >= 3);
+        for unit in &file.units {
+            let slice = &original[unit.byte_start as usize..unit.byte_end as usize];
+            assert_eq!(
+                unit.text.as_bytes(),
+                slice,
+                "unit {} does not match its own offsets",
+                unit.ordinal
+            );
+        }
+        assert_eq!(file.units[0].kind, UnitKind::Document);
+        assert_eq!(file.units[0].byte_end, body.len() as u64);
+    }
+
+    /// A missing root is a coverage fact, not a failure — otherwise one
+    /// unplugged external drive stops every other source being scanned.
+    #[test]
+    fn a_missing_root_reports_unavailable_rather_than_failing() {
+        let source = KnowledgeSource {
+            name: "gone".to_string(),
+            root: PathBuf::from("/nonexistent/knowledge/root"),
+            ignore: Vec::new(),
+        };
+        let scan = scan_local_knowledge(&source).expect("scan must not fail");
+        assert!(scan.files.is_empty());
+        assert_eq!(scan.coverage.len(), 1);
+        assert_eq!(scan.coverage[0].status, Coverage::Unavailable);
+        assert_eq!(scan.coverage[0].path, None);
+    }
+
+    /// A symlink is not followed: a knowledge source's boundary is the
+    /// declared path, and a link can leave it entirely.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_is_reported_and_not_followed() {
+        let (dir, _) = scan_tree(&[("real.md", b"# Real\n")], &[]);
+        std::os::unix::fs::symlink("/etc", dir.path().join("escape")).expect("symlink");
+        let source = KnowledgeSource {
+            name: "notes".to_string(),
+            root: dir.path().to_path_buf(),
+            ignore: Vec::new(),
+        };
+        let scan = scan_local_knowledge(&source).expect("scan");
+        let link = row(&scan, "escape");
+        assert_eq!(link.status, Coverage::Unavailable);
+        assert!(
+            link.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("symlink")),
+            "{link:?}"
+        );
+        assert_eq!(scan.files.len(), 1);
+    }
+
+    /// Coverage order is the walk's sorted path order, so two scans of an
+    /// unchanged tree are byte-identical evidence.
+    #[test]
+    fn an_unchanged_tree_scans_identically_twice() {
+        let (dir, first) = scan_tree(
+            &[("b.md", b"# B\n"), ("a.md", b"# A\n"), ("z/c.md", b"# C\n")],
+            &[],
+        );
+        let source = KnowledgeSource {
+            name: "notes".to_string(),
+            root: dir.path().to_path_buf(),
+            ignore: Vec::new(),
+        };
+        let second = scan_local_knowledge(&source).expect("rescan");
+        assert_eq!(first.coverage, second.coverage);
+        assert_eq!(first.files, second.files);
+        assert_eq!(first.content_key, second.content_key);
+    }
+}

--- a/src/runtime/atlas/text.rs
+++ b/src/runtime/atlas/text.rs
@@ -1,0 +1,420 @@
+//! Text and Markdown structure extraction — **pure functions over bytes**
+//! (F6's adapter-shape mandate).
+//!
+//! Nothing in this module opens a file, touches a database, reads a clock, or
+//! knows a source exists. Every entry point takes bytes (or the `&str` that
+//! decoding them produced) and returns owned structure. That is not stylistic
+//! tidiness: it is the one property that lets extraction be reviewed,
+//! fuzzed and unit-tested without a daemon, and the reason the DB glue in
+//! [`super::record`] can be read on its own and seen to add nothing.
+//!
+//! # Provenance is byte offsets into the original
+//!
+//! Every [`StructureUnit`] carries `byte_start`/`byte_end` into the bytes it
+//! was extracted from — not into a normalized, re-wrapped or re-encoded copy.
+//! A1 §3's provenance question ("can the original resource still be
+//! identified?") is answerable by slicing the original file, which is exactly
+//! what makes the original bytes canonical and this output derived (A1-12).
+//! Decoding is UTF-8 and lossless, so a `&str` offset *is* a byte offset.
+//!
+//! # What this build understands
+//!
+//! ATX headings (`# ` .. `###### `), outside fenced code blocks. Setext
+//! headings (`===`/`---` underlines) are **not** recognized: they interact
+//! with lazy continuation lines and list interruption in ways that cost far
+//! more than they buy for a first content family (R1). A document that uses
+//! them is still fully indexed — it simply has one Document unit and no
+//! sections, which coverage reports as `indexed` because it is.
+
+use crate::domain::source::UnitKind;
+
+/// Extractor identity for Markdown (F7's second cache-key input).
+///
+/// Versioned in the string on purpose: changing what [`markdown_units`]
+/// produces means bumping this, which changes every derived key, which is
+/// what makes a re-extraction happen instead of a stale reuse.
+pub const MARKDOWN_EXTRACTOR: &str = "markdown/v1";
+
+/// Extractor identity for plain text.
+pub const TEXT_EXTRACTOR: &str = "text/v1";
+
+/// One extracted structure unit, positioned in the original bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructureUnit {
+    /// Whole resource, or a heading-delimited span.
+    pub kind: UnitKind,
+    /// Heading depth for a section (1..=6); `None` for a document and for a
+    /// preamble section that precedes the first heading.
+    pub heading_level: Option<u8>,
+    /// Heading text, trimmed of its `#` markers; `None` when there is none.
+    pub title: Option<String>,
+    /// Inclusive start offset into the original bytes.
+    pub byte_start: usize,
+    /// Exclusive end offset into the original bytes.
+    pub byte_end: usize,
+}
+
+impl StructureUnit {
+    /// The unit's own bytes, sliced back out of the original.
+    ///
+    /// Total by construction for any `original` this unit was extracted from;
+    /// returns `None` for a mismatched buffer rather than panicking, because
+    /// the one caller that could get that wrong is DB glue reading a row back
+    /// against a re-read file.
+    pub fn slice<'a>(&self, original: &'a [u8]) -> Option<&'a [u8]> {
+        original.get(self.byte_start..self.byte_end)
+    }
+}
+
+/// Decode bytes as UTF-8, or refuse.
+///
+/// The whole of this build's "is it text?" test, and deliberately strict:
+/// a lossy decode would invent replacement characters that appear in a unit's
+/// text but not in the original bytes, silently breaking the provenance rule
+/// above. Bytes this refuses are reported `unsupported`, not indexed badly.
+pub fn as_text(bytes: &[u8]) -> Option<&str> {
+    std::str::from_utf8(bytes).ok()
+}
+
+/// Structure units for a Markdown document: one [`UnitKind::Document`] unit
+/// spanning the whole input, then one [`UnitKind::Section`] per span.
+///
+/// Sections are flat and exhaustive — every byte of the document belongs to
+/// exactly one section (a preamble section covers anything before the first
+/// heading) — and nesting is carried by `heading_level` rather than by
+/// containment. Flat-and-exhaustive is the shape retrieval wants: a section
+/// can be returned whole without reconstructing a tree, and no byte is
+/// unreachable through any unit.
+pub fn markdown_units(text: &str) -> Vec<StructureUnit> {
+    let mut units = vec![StructureUnit {
+        kind: UnitKind::Document,
+        heading_level: None,
+        title: None,
+        byte_start: 0,
+        byte_end: text.len(),
+    }];
+
+    let headings = atx_headings(text);
+    if headings.is_empty() {
+        return units;
+    }
+    // The Document unit borrows the first heading's text as a title: a
+    // document's own name is the most useful single label retrieval can show,
+    // and inventing one from the filename would be provenance this module
+    // does not have (it never sees a path).
+    units[0].title = headings[0].title.clone();
+
+    // Anything before the first heading is its own section, unless it is
+    // only whitespace — a blank preamble is not evidence.
+    let first = headings[0].byte_start;
+    if !text[..first].trim().is_empty() {
+        units.push(StructureUnit {
+            kind: UnitKind::Section,
+            heading_level: None,
+            title: None,
+            byte_start: 0,
+            byte_end: first,
+        });
+    }
+    for (index, heading) in headings.iter().enumerate() {
+        let end = headings
+            .get(index + 1)
+            .map_or(text.len(), |next| next.byte_start);
+        units.push(StructureUnit {
+            kind: UnitKind::Section,
+            heading_level: Some(heading.level),
+            title: heading.title.clone(),
+            byte_start: heading.byte_start,
+            byte_end: end,
+        });
+    }
+    units
+}
+
+/// Structure units for plain text: exactly one [`UnitKind::Document`] unit.
+///
+/// Plain text has no structure this build can claim to see. Inventing
+/// paragraph units would assert a document model the format does not carry
+/// (R1); one honest whole-document unit is what it is.
+pub fn plain_units(text: &str) -> Vec<StructureUnit> {
+    vec![StructureUnit {
+        kind: UnitKind::Document,
+        heading_level: None,
+        title: None,
+        byte_start: 0,
+        byte_end: text.len(),
+    }]
+}
+
+/// One ATX heading found in the source.
+struct Heading {
+    level: u8,
+    title: Option<String>,
+    byte_start: usize,
+}
+
+/// Every ATX heading outside a fenced code block, in document order.
+///
+/// Fence tracking is the part that has to be right: a `# ` inside a fenced
+/// block is code being shown, not a heading, and treating it as one would cut
+/// a section boundary through the middle of an example.
+fn atx_headings(text: &str) -> Vec<Heading> {
+    let mut headings = Vec::new();
+    let mut fence: Option<(char, usize)> = None;
+    let mut offset = 0usize;
+    for line in text.split_inclusive('\n') {
+        let start = offset;
+        offset += line.len();
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        let indent = trimmed.len() - trimmed.trim_start_matches(' ').len();
+        // More than three leading spaces is an indented code block, which no
+        // heading can start inside.
+        if indent > 3 {
+            continue;
+        }
+        let body = &trimmed[indent..];
+        if let Some((fence_char, fence_len)) = fence {
+            // A closing fence is the same character, at least as long, and
+            // followed by nothing but whitespace.
+            let run = body.chars().take_while(|c| *c == fence_char).count();
+            if run >= fence_len && body[run..].trim().is_empty() {
+                fence = None;
+            }
+            continue;
+        }
+        for fence_char in ['`', '~'] {
+            let run = body.chars().take_while(|c| *c == fence_char).count();
+            if run >= 3 {
+                fence = Some((fence_char, run));
+                break;
+            }
+        }
+        if fence.is_some() {
+            continue;
+        }
+        let hashes = body.chars().take_while(|c| *c == '#').count();
+        if hashes == 0 || hashes > 6 {
+            continue;
+        }
+        let rest = &body[hashes..];
+        // `#hashtag` is not a heading: CommonMark requires the run of `#` to
+        // be followed by a space or end of line.
+        if !rest.is_empty() && !rest.starts_with(' ') && !rest.starts_with('\t') {
+            continue;
+        }
+        let title = rest.trim().trim_end_matches('#').trim();
+        headings.push(Heading {
+            level: hashes as u8,
+            title: (!title.is_empty()).then(|| title.to_string()),
+            byte_start: start,
+        });
+    }
+    headings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The provenance rule, as an executable claim: every unit slices back
+    /// out of the exact bytes it was extracted from, and the sections tile
+    /// the document with no gap and no overlap.
+    fn assert_tiles(text: &str, units: &[StructureUnit]) {
+        let bytes = text.as_bytes();
+        for unit in units {
+            assert!(
+                unit.slice(bytes).is_some(),
+                "unit {unit:?} does not slice its own source"
+            );
+        }
+        let mut cursor = 0usize;
+        for section in units.iter().filter(|u| u.kind == UnitKind::Section) {
+            assert_eq!(section.byte_start, cursor, "gap or overlap at {cursor}");
+            cursor = section.byte_end;
+        }
+        if units.iter().any(|u| u.kind == UnitKind::Section) {
+            assert_eq!(cursor, text.len(), "sections do not reach the end");
+        }
+    }
+
+    #[test]
+    fn a_document_with_headings_becomes_a_document_and_flat_sections() {
+        let text = "intro line\n\n# Title\n\nbody\n\n## Sub\n\nmore\n";
+        let units = markdown_units(text);
+        assert_tiles(text, &units);
+
+        assert_eq!(units[0].kind, UnitKind::Document);
+        assert_eq!(units[0].byte_start, 0);
+        assert_eq!(units[0].byte_end, text.len());
+        assert_eq!(units[0].title.as_deref(), Some("Title"));
+
+        let sections: Vec<_> = units
+            .iter()
+            .filter(|u| u.kind == UnitKind::Section)
+            .collect();
+        assert_eq!(sections.len(), 3, "preamble + two headings");
+        assert_eq!(sections[0].heading_level, None);
+        assert_eq!(
+            sections[0].slice(text.as_bytes()),
+            Some(b"intro line\n\n".as_slice())
+        );
+        assert_eq!(sections[1].heading_level, Some(1));
+        assert_eq!(sections[1].title.as_deref(), Some("Title"));
+        assert_eq!(
+            sections[1].slice(text.as_bytes()),
+            Some(b"# Title\n\nbody\n\n".as_slice())
+        );
+        assert_eq!(sections[2].heading_level, Some(2));
+        assert_eq!(sections[2].title.as_deref(), Some("Sub"));
+    }
+
+    /// No headings is not a failure — it is one honest document unit.
+    #[test]
+    fn a_document_without_headings_is_one_unit_and_an_empty_one_still_exists() {
+        let units = markdown_units("just prose\n");
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].kind, UnitKind::Document);
+
+        let empty = markdown_units("");
+        assert_eq!(empty.len(), 1);
+        assert_eq!((empty[0].byte_start, empty[0].byte_end), (0, 0));
+    }
+
+    /// The fence rule. A `#` inside a fenced block is code being shown; a
+    /// section boundary there would cut an example in half.
+    #[test]
+    fn headings_inside_fenced_code_are_not_headings() {
+        let text = "\
+# Real
+
+```sh
+# not a heading
+```
+
+~~~
+## also not one
+~~~
+
+## Second real
+";
+        let units = markdown_units(text);
+        assert_tiles(text, &units);
+        let titles: Vec<_> = units
+            .iter()
+            .filter(|u| u.kind == UnitKind::Section)
+            .map(|u| u.title.clone())
+            .collect();
+        assert_eq!(
+            titles,
+            vec![Some("Real".to_string()), Some("Second real".to_string())]
+        );
+    }
+
+    /// A fence closes only on its own character at its own length or longer —
+    /// so a shorter run, or the other fence character, stays inside the block.
+    #[test]
+    fn a_fence_closes_only_on_a_matching_longer_or_equal_run() {
+        let text = "````\n``\n~~~\n# still code\n````\n# out\n";
+        let units = markdown_units(text);
+        assert_tiles(text, &units);
+        let titles: Vec<_> = units
+            .into_iter()
+            .filter(|u| u.kind == UnitKind::Section)
+            .map(|u| u.title)
+            .collect();
+        // The fenced block itself is the (untitled) preamble section: it is
+        // content, so it belongs to a unit. Only `# out` is a heading.
+        assert_eq!(titles, vec![None, Some("out".to_string())]);
+    }
+
+    /// CommonMark's own edge cases, kept because each one is a silent
+    /// mis-section if it regresses.
+    #[test]
+    fn atx_edge_cases_match_commonmark_where_this_build_claims_to() {
+        // `#hashtag` needs a space to be a heading.
+        assert!(atx_headings("#hashtag\n").is_empty());
+        // Seven hashes is not a heading.
+        assert!(atx_headings("####### deep\n").is_empty());
+        // Up to three spaces of indent is fine; four is an indented code
+        // block.
+        assert_eq!(atx_headings("   # ok\n").len(), 1);
+        assert!(atx_headings("    # code\n").is_empty());
+        // Closing hashes are decoration, not title text.
+        assert_eq!(
+            atx_headings("## Title ##\n")[0].title.as_deref(),
+            Some("Title")
+        );
+        // A bare `#` is a heading with no title, not a heading named "#".
+        let bare = atx_headings("#\n");
+        assert_eq!(bare.len(), 1);
+        assert_eq!(bare[0].title, None);
+        // CRLF input keeps its offsets and loses no bytes.
+        let crlf = "# A\r\nbody\r\n";
+        assert_tiles(crlf, &markdown_units(crlf));
+    }
+
+    /// Multi-byte input: offsets stay byte offsets, so a slice is still
+    /// valid UTF-8 at a unit boundary and no character is split.
+    #[test]
+    fn offsets_are_byte_offsets_over_multibyte_text() {
+        let text = "# Café ☕\n\nnaïve — em—dash\n\n## Ünter\n\nbody\n";
+        let units = markdown_units(text);
+        assert_tiles(text, &units);
+        for unit in &units {
+            let slice = unit.slice(text.as_bytes()).expect("slice");
+            assert!(
+                std::str::from_utf8(slice).is_ok(),
+                "unit boundary split a character: {unit:?}"
+            );
+        }
+        assert_eq!(units[0].title.as_deref(), Some("Café ☕"));
+    }
+
+    #[test]
+    fn plain_text_is_exactly_one_document_unit_and_non_utf8_is_refused() {
+        let units = plain_units("a\nb\n");
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].kind, UnitKind::Document);
+        assert_eq!(units[0].byte_end, 4);
+
+        assert!(as_text(b"plain").is_some());
+        // A lone continuation byte is not UTF-8, and a lossy decode would
+        // invent a character the original bytes do not contain.
+        assert!(as_text(&[0x66, 0x80, 0x66]).is_none());
+        assert!(as_text(&[0x00, 0x01, 0x02]).is_some_and(|t| t.len() == 3));
+    }
+
+    /// F6, stated where it can be checked: these are functions of their
+    /// input and nothing else. Two calls on equal bytes are equal, and the
+    /// module names no path, clock, connection or environment.
+    #[test]
+    fn extraction_is_a_pure_function_of_its_input() {
+        let text = "# One\n\ntext\n";
+        assert_eq!(markdown_units(text), markdown_units(text));
+        // Equal *bytes*, not the same buffer: the result depends on content,
+        // never on where the content lives.
+        let copied = String::from_utf8(text.as_bytes().to_vec()).expect("utf8");
+        assert_eq!(markdown_units(text), markdown_units(copied.as_str()));
+
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/runtime/atlas/text.rs"
+        ))
+        .expect("read own source");
+        let body = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("non-test half of this module");
+        // The database driver is deliberately absent from this list:
+        // `tests/x1_atlas_substrate.rs` already asserts, for every file in
+        // this tree, that only `db.rs` names it — and asserting it a second
+        // time here would mean this file names the crate, which that test
+        // then (correctly) refuses.
+        for forbidden in ["std::fs", "SystemTime", "std::env", "Connection"] {
+            assert!(
+                !body.contains(forbidden),
+                "the extractor names {forbidden}, so it is not a pure function over bytes (F6)"
+            );
+        }
+    }
+}

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -5288,6 +5288,7 @@ mod tests {
                     path: PathBuf::from(format!("/nowhere/{name}")),
                 })
                 .collect(),
+            knowledge: Vec::new(),
             default_backend: None,
             default_workflow: None,
             profiles: Vec::new(),
@@ -5705,6 +5706,7 @@ mod tests {
                 name: "solo".to_string(),
                 root: dir.path().to_path_buf(),
                 repositories: Vec::new(),
+                knowledge: Vec::new(),
                 default_backend: None,
                 default_workflow: None,
                 profiles: Vec::new(),

--- a/src/runtime/sweep.rs
+++ b/src/runtime/sweep.rs
@@ -547,6 +547,7 @@ mod tests {
             name: "sweep-fixture".to_string(),
             root: root.to_path_buf(),
             repositories,
+            knowledge: Vec::new(),
             default_backend: None,
             default_workflow: None,
             profiles: Vec::new(),

--- a/tests/x2_knowledge_sources.rs
+++ b/tests/x2_knowledge_sources.rs
@@ -1,0 +1,663 @@
+//! S3 X2 acceptance: `[[knowledge]]` sources, the local-knowledge scanner,
+//! and **F1's persistence contract** — the one this wave exists to make
+//! checkable.
+//!
+//! The sharpest risk the recon named for S3 is a contributor pattern-matching
+//! the operations projection's disposable discipline onto `source.*`. The
+//! module docs say not to; the tests here are what would actually fail if
+//! someone did:
+//!
+//! * `source_facts_survive_a_real_daemon_restart` starts and stops a real
+//!   daemon twice over a data dir that already holds scanned rows, and
+//!   asserts the rows are still there while the operations projection was
+//!   refolded from scratch. A "delete Atlas on start like we delete
+//!   analytics" change fails here immediately.
+//! * `a_crash_between_the_rows_and_the_summary_reports_neither` is F1's
+//!   crash-window variant: rows are committed and the process dies before the
+//!   `source.scanned` summary. Startup reconciliation must leave
+//!   neither-reported (with an explicit eviction row), never a half-scan
+//!   reported as coverage.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use sergeant_rs::daemon::{self, DaemonConfig};
+use sergeant_rs::domain::event::Event;
+use sergeant_rs::domain::source::{Coverage, KIND_SOURCE_SCANNED, UnitKind};
+use sergeant_rs::runtime::analytics::Analytics;
+use sergeant_rs::runtime::atlas::db::AtlasDb;
+use sergeant_rs::runtime::atlas::record::{ScanRecord, scan_and_record};
+use sergeant_rs::runtime::atlas::scan::{KnowledgeSource, scan_local_knowledge};
+use sergeant_rs::runtime::journal::Journal;
+
+mod support;
+
+const SGT: &str = env!("CARGO_BIN_EXE_sgt");
+
+// ---------------------------------------------------------------- helpers
+
+fn run(cwd: &Path, data_dir: &Path, args: &[&str]) -> Output {
+    let output = Command::new(SGT)
+        .current_dir(cwd)
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args(args)
+        .output()
+        .expect("run sgt");
+    Output {
+        code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    }
+}
+
+struct Output {
+    code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+impl Output {
+    fn json(&self) -> Value {
+        serde_json::from_str(&self.stdout)
+            .unwrap_or_else(|e| panic!("stdout is not JSON ({e}): {}", self.stdout))
+    }
+
+    fn assert_ok(&self, what: &str) -> &Self {
+        assert_eq!(
+            self.code,
+            Some(0),
+            "{what} must succeed\nstdout: {}\nstderr: {}",
+            self.stdout,
+            self.stderr
+        );
+        self
+    }
+
+    fn assert_fails(&self, what: &str) -> &Self {
+        assert_ne!(
+            self.code,
+            Some(0),
+            "{what} must fail\nstdout: {}",
+            self.stdout
+        );
+        self
+    }
+}
+
+/// A knowledge tree with the given files, outside any estate.
+fn knowledge_tree(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    for (path, body) in files {
+        let full = dir.path().join(path);
+        std::fs::create_dir_all(full.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&full, body).expect("write");
+    }
+    dir
+}
+
+fn source(name: &str, root: &Path) -> KnowledgeSource {
+    KnowledgeSource {
+        name: name.to_string(),
+        root: root.to_path_buf(),
+        ignore: Vec::new(),
+    }
+}
+
+/// Every `source.scanned` event in a data dir's journal.
+fn scan_summaries(data_dir: &Path) -> Vec<Event> {
+    // A data dir with no journal yet has no summaries — which is exactly the
+    // state the crash-window test inspects, so this must answer rather than
+    // fail.
+    if !data_dir.join("journal").exists() {
+        return Vec::new();
+    }
+    Journal::replay_data_dir(data_dir)
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.kind == KIND_SOURCE_SCANNED)
+        .collect()
+}
+
+/// Start a real daemon on `data_dir` and stop it cleanly — the restart this
+/// suite's persistence claims are stated over.
+async fn start_and_stop(data_dir: &Path) {
+    let handle = daemon::start_with(data_dir, DaemonConfig::default())
+        .await
+        .expect("daemon start");
+    handle.shutdown().await;
+}
+
+// ------------------------------------------------------- the CLI surface
+
+/// guard-map: `sgt knowledge add` writes a `[[knowledge]]` entry the parser
+/// accepts, `sgt knowledge list` reads it back, and a second add under the
+/// same name is refused rather than silently merged.
+///
+/// Mutation this kills: dropping `knowledge_names`' duplicate check in
+/// `domain::manifest::add_knowledge` (two entries would then share a name,
+/// and every derived row would key onto one of two sources at random).
+#[test]
+fn knowledge_add_declares_a_source_and_list_reads_it_back() {
+    let estate = TempDir::new().expect("tempdir");
+    let data_dir = estate.path().join("data-dir");
+    let notes = knowledge_tree(&[("README.md", "# Notes\n")]);
+
+    run(estate.path(), &data_dir, &["init"]).assert_ok("init");
+    run(
+        estate.path(),
+        &data_dir,
+        &[
+            "knowledge",
+            "add",
+            "notes",
+            notes.path().to_str().expect("utf8"),
+            "--ignore",
+            "*.log",
+            "--ignore",
+            "drafts/**",
+        ],
+    )
+    .assert_ok("knowledge add");
+
+    let listed = run(estate.path(), &data_dir, &["--json", "knowledge", "list"]);
+    listed.assert_ok("knowledge list");
+    let sources = listed.json();
+    let entry = &sources["knowledge"][0];
+    assert_eq!(entry["name"], "notes");
+    assert_eq!(entry["path"], notes.path().to_str().expect("utf8"));
+    assert_eq!(entry["ignore"][0], "*.log");
+    assert_eq!(entry["ignore"][1], "drafts/**");
+
+    // Declaring a knowledge source is a manifest edit and nothing else: no
+    // mount, no clone, no directory created (A1-03).
+    assert!(!estate.path().join("repos/notes").exists());
+
+    let again = run(
+        estate.path(),
+        &data_dir,
+        &[
+            "knowledge",
+            "add",
+            "notes",
+            notes.path().to_str().expect("utf8"),
+        ],
+    );
+    again.assert_fails("a duplicate name");
+    assert!(
+        again.stderr.contains("already declared"),
+        "the refusal must name the conflict: {}",
+        again.stderr
+    );
+}
+
+/// guard-map: F9's containment refusal reaches the operator through the CLI
+/// with its own diagnostic, and the manifest is left untouched by the
+/// refused edit.
+///
+/// Mutation this kills: dropping the containment loop in
+/// `domain::estate::resolve_knowledge` — the add would then succeed and the
+/// estate would index its own repository mount as outside evidence.
+#[test]
+fn knowledge_add_refuses_a_path_inside_the_estates_own_territory() {
+    let estate = TempDir::new().expect("tempdir");
+    let data_dir = estate.path().join("data-dir");
+    run(estate.path(), &data_dir, &["init"]).assert_ok("init");
+
+    let upstream = TempDir::new().expect("tempdir");
+    support::init_repo(upstream.path());
+    run(
+        estate.path(),
+        &data_dir,
+        &[
+            "repo",
+            "add",
+            "api",
+            "--origin",
+            upstream.path().to_str().expect("utf8"),
+        ],
+    )
+    .assert_ok("repo add");
+
+    let before = std::fs::read_to_string(estate.path().join("sergeant.toml")).expect("read");
+    let refused = run(
+        estate.path(),
+        &data_dir,
+        &["knowledge", "add", "docs", "repos/api"],
+    );
+    refused.assert_fails("a knowledge path inside a repository mount");
+    assert!(
+        refused.stderr.contains("read-only evidence") && refused.stderr.contains("api"),
+        "the refusal must name the rule and the mount: {}",
+        refused.stderr
+    );
+    assert_eq!(
+        std::fs::read_to_string(estate.path().join("sergeant.toml")).expect("read"),
+        before,
+        "a refused edit must not touch the real manifest"
+    );
+}
+
+// -------------------------------------------------- the scanner, end to end
+
+/// guard-map: one completed scan writes exactly one `source.scanned` summary
+/// and a full set of rows; a re-scan of unchanged bytes writes neither;
+/// editing a byte produces a new generation and evicts the old one with an
+/// explicit coverage row.
+///
+/// Mutation this kills: dropping the `content_key` comparison in
+/// `AtlasDb::stage_scan` (every scan would then churn a new generation and
+/// evict a perfectly good one, violating ruling §4's "evicted only when
+/// source bytes changed").
+#[test]
+fn a_scan_records_once_reuses_an_unchanged_generation_and_evicts_a_changed_one() {
+    let data = TempDir::new().expect("tempdir");
+    let notes = knowledge_tree(&[
+        ("index.md", "# Index\n\nbody\n\n## Section\n\nmore\n"),
+        ("plain.txt", "no structure here\n"),
+        (".env", "SECRET=hunter2\n"),
+    ]);
+    let source = source("notes", notes.path());
+
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let mut journal = Journal::open(data.path()).expect("journal");
+
+    let first = scan_and_record(&mut db, &mut journal, &source, None).expect("scan");
+    let ScanRecord::Recorded {
+        generation_id: first_generation,
+        evicted,
+        ..
+    } = first
+    else {
+        panic!("the first scan of a source must record a generation, got {first:?}");
+    };
+    assert_eq!(evicted, None, "nothing to supersede on a first scan");
+    assert_eq!(scan_summaries(data.path()).len(), 1, "one summary per scan");
+
+    // Units are there, and they carry provenance back to the original bytes.
+    let units = db.units("notes", 100).expect("units");
+    assert!(
+        units
+            .iter()
+            .any(|u| u.relative_path == "index.md" && u.kind == UnitKind::Document)
+    );
+    assert!(
+        units
+            .iter()
+            .any(|u| u.title.as_deref() == Some("Section") && u.kind == UnitKind::Section)
+    );
+    assert!(
+        !units.iter().any(|u| u.body.contains("hunter2")),
+        "an excluded file's bytes reached a unit"
+    );
+    let counts = db.coverage_counts("notes").expect("coverage");
+    assert_eq!(counts.get(Coverage::Indexed.as_str()), Some(&2));
+    assert_eq!(counts.get(Coverage::Excluded.as_str()), Some(&1));
+
+    // A re-scan of unchanged bytes: no new generation, no new summary, no
+    // eviction. Ruling §4 stated as behavior.
+    let again = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    assert!(
+        matches!(&again, ScanRecord::Unchanged { generation_id, .. } if *generation_id == first_generation),
+        "an unchanged source must reuse its generation, got {again:?}"
+    );
+    assert_eq!(
+        scan_summaries(data.path()).len(),
+        1,
+        "an unchanged re-scan must not journal a second summary"
+    );
+
+    // Edit one byte: a new generation, and the old one evicted with a row
+    // that says so rather than simply vanishing.
+    std::fs::write(notes.path().join("index.md"), "# Index\n\nedited\n").expect("write");
+    let third = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let ScanRecord::Recorded {
+        generation_id: second_generation,
+        evicted,
+        summary_event_id,
+        ..
+    } = third
+    else {
+        panic!("a changed source must record a new generation");
+    };
+    assert_ne!(second_generation, first_generation);
+    assert_eq!(evicted.as_deref(), Some(first_generation.as_str()));
+    assert_eq!(scan_summaries(data.path()).len(), 2);
+    assert_eq!(
+        scan_summaries(data.path())[1].id,
+        summary_event_id,
+        "the record must name the summary that completed it"
+    );
+
+    let eviction = db
+        .coverage("notes", 100)
+        .expect("coverage")
+        .into_iter()
+        .find(|c| c.row.status == Coverage::GenerationEvicted)
+        .expect("an eviction leaves an explicit coverage row");
+    assert_eq!(eviction.generation_id, first_generation);
+    assert!(
+        eviction
+            .row
+            .detail
+            .as_deref()
+            .is_some_and(|d| d.contains("source bytes changed")),
+        "the eviction must say why: {eviction:?}"
+    );
+    // And the superseded generation's units are gone, not merged in beside
+    // the new ones.
+    let units = db.units("notes", 100).expect("units");
+    assert!(units.iter().all(|u| !u.body.contains("Section")));
+}
+
+/// guard-map: the one journal summary is compact and carries A1 §3's
+/// provenance answers — source, generation, content key, counts, extractor
+/// identities — and does **not** carry a per-path list.
+///
+/// Mutation this kills: journaling per-file events (the journal would become
+/// a slower second copy of the coverage table, and F1's "one compact summary"
+/// would be false).
+#[test]
+fn the_scan_summary_is_one_compact_event_with_provenance_and_no_path_list() {
+    let data = TempDir::new().expect("tempdir");
+    let notes = knowledge_tree(&[
+        ("a.md", "# A\n"),
+        ("b.md", "# B\n"),
+        ("c.txt", "c\n"),
+        ("secret.pem", "-----BEGIN\n"),
+    ]);
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    scan_and_record(&mut db, &mut journal, &source("notes", notes.path()), None).expect("scan");
+
+    let summaries = scan_summaries(data.path());
+    assert_eq!(summaries.len(), 1);
+    let payload = &summaries[0].payload;
+    assert_eq!(payload["source"], "notes");
+    assert_eq!(payload["source_kind"], "local_knowledge");
+    assert_eq!(payload["authority_class"], "estate_readonly");
+    assert!(
+        payload["generation"]
+            .as_str()
+            .is_some_and(|g| !g.is_empty())
+    );
+    assert!(
+        payload["content_key"]
+            .as_str()
+            .is_some_and(|k| k.len() == 64)
+    );
+    assert_eq!(payload["files"], 3);
+    assert_eq!(payload["coverage"]["indexed"], 3);
+    assert_eq!(payload["coverage"]["excluded"], 1);
+    let extractors: Vec<&str> = payload["extractors"]
+        .as_array()
+        .expect("extractors")
+        .iter()
+        .map(|v| v.as_str().expect("str"))
+        .collect();
+    assert_eq!(extractors, vec!["markdown/v1", "text/v1"]);
+
+    // Compact: the summary names counts, not paths. The unit-level detail
+    // lives in the table that can be queried.
+    let rendered = serde_json::to_string(payload).expect("render");
+    for path in ["a.md", "b.md", "c.txt", "secret.pem"] {
+        assert!(
+            !rendered.contains(path),
+            "the summary carries a path list ({path}): {rendered}"
+        );
+    }
+}
+
+/// guard-map: a declared `[[knowledge]]` source converts straight into what
+/// the scanner walks, `ignore` globs included — so the manifest and the
+/// acquisition boundary can never disagree about which paths are in scope.
+#[test]
+fn a_declared_source_scans_exactly_what_the_manifest_says() {
+    let estate = TempDir::new().expect("tempdir");
+    let data_dir = estate.path().join("data-dir");
+    let notes = knowledge_tree(&[
+        ("keep.md", "# Keep\n"),
+        ("drafts/wip.md", "# WIP\n"),
+        ("run.log", "noise\n"),
+    ]);
+    run(estate.path(), &data_dir, &["init"]).assert_ok("init");
+    run(
+        estate.path(),
+        &data_dir,
+        &[
+            "knowledge",
+            "add",
+            "notes",
+            notes.path().to_str().expect("utf8"),
+            "--ignore",
+            "*.log",
+            "--ignore",
+            "drafts/**",
+        ],
+    )
+    .assert_ok("knowledge add");
+
+    let estate_config = sergeant_rs::domain::estate::Estate::from_config_structural(
+        &estate.path().join("sergeant.toml"),
+    )
+    .expect("parse");
+    let declared = KnowledgeSource::from(&estate_config.knowledge[0]);
+    let scan = scan_local_knowledge(&declared).expect("scan");
+
+    let indexed: Vec<&str> = scan
+        .coverage
+        .iter()
+        .filter(|r| r.status == Coverage::Indexed)
+        .filter_map(|r| r.path.as_deref())
+        .collect();
+    assert_eq!(indexed, vec!["keep.md"]);
+    let excluded: Vec<&str> = scan
+        .coverage
+        .iter()
+        .filter(|r| r.status == Coverage::Excluded)
+        .filter_map(|r| r.path.as_deref())
+        .collect();
+    // `drafts/**` names the directory's *contents*, so each excluded file
+    // gets its own row (the directory itself is merely `discovered`). A bare
+    // `drafts` would have refused the directory once and not descended —
+    // both spellings exclude the same bytes, and both say so out loud.
+    assert_eq!(excluded, vec!["drafts/wip.md", "run.log"]);
+    assert_eq!(
+        scan.coverage
+            .iter()
+            .find(|r| r.path.as_deref() == Some("drafts"))
+            .expect("the directory itself is still reported")
+            .status,
+        Coverage::Discovered
+    );
+}
+
+// ------------------------------------------------------------ F1: persistence
+
+/// guard-map (**F1's regression test, moved here from X1 with its writer**):
+/// scanned source facts survive real daemon restarts, while the operations
+/// projection is refolded from the journal on every one of them. The two
+/// rebuild disciplines, checked side by side in one test.
+///
+/// Mutation this kills: treating Atlas the way `Analytics::begin_rebuild`
+/// treats its own file — deleting it on start, or putting it under the
+/// disposable `projections/` directory. Either change loses the rows this
+/// asserts are still there, and no journal replay brings them back.
+#[tokio::test]
+async fn source_facts_survive_a_real_daemon_restart() {
+    let data = support::DataDir::new();
+    let notes = knowledge_tree(&[("index.md", "# Index\n\nbody\n\n## Deep\n\nmore\n")]);
+
+    let generation = {
+        let mut db = AtlasDb::open(data.path()).expect("atlas");
+        let mut journal = Journal::open(data.path()).expect("journal");
+        let record = scan_and_record(&mut db, &mut journal, &source("notes", notes.path()), None)
+            .expect("scan");
+        let ScanRecord::Recorded { generation_id, .. } = record else {
+            panic!("expected a recorded generation");
+        };
+        generation_id
+    };
+    let before = {
+        let db = AtlasDb::open(data.path()).expect("atlas");
+        db.units("notes", 100).expect("units")
+    };
+    assert!(!before.is_empty(), "the fixture must produce units to lose");
+
+    // Two full daemon lifecycles over the same data dir.
+    start_and_stop(data.path()).await;
+    start_and_stop(data.path()).await;
+
+    let db = AtlasDb::open(data.path()).expect("atlas after restart");
+    assert_eq!(
+        db.units("notes", 100).expect("units"),
+        before,
+        "source units must survive a daemon restart — they are derived from \
+         source bytes, and no journal replay reproduces them"
+    );
+    let still = db
+        .confirmed_generation("notes")
+        .expect("generation")
+        .expect("a confirmed generation must survive");
+    assert_eq!(still.id, generation);
+    assert!(
+        db.coverage_counts("notes")
+            .expect("coverage")
+            .contains_key(Coverage::Indexed.as_str())
+    );
+
+    // The contrast, in the same test so the two disciplines cannot silently
+    // converge: the operations projection was rebuilt from the journal, and
+    // deleting its whole directory loses nothing.
+    let projections = sergeant_rs::runtime::analytics::projections_dir(data.path());
+    assert!(projections.exists(), "the projection rebuilt on start");
+    std::fs::remove_dir_all(&projections).expect("the projection is disposable");
+    start_and_stop(data.path()).await;
+    assert!(projections.exists(), "and rebuilt again from the journal");
+    assert_eq!(
+        AtlasDb::open(data.path())
+            .expect("atlas")
+            .units("notes", 100)
+            .expect("units"),
+        before,
+        "deleting the disposable projection must not touch Atlas"
+    );
+    let _ = Analytics::begin_rebuild(data.path()).expect("the projection still opens");
+    data.reap();
+}
+
+/// guard-map (**F1's crash-mid-scan variant**): a process that dies between
+/// committing a scan's rows and journaling its `source.scanned` summary
+/// leaves *neither* reported — the rows exist for a moment, no read path can
+/// see them, and startup reconciliation evicts them with an explicit
+/// coverage row.
+///
+/// The kill is simulated exactly where the window is: `stage_scan` runs (its
+/// transaction commits), and then nothing else does. Reopening the store is
+/// the restart.
+///
+/// Mutation this kills: promoting a generation to `confirmed` inside
+/// `stage_scan`, or letting a read path see a provisional one. Either change
+/// makes a half-finished scan answer as coverage, which is precisely what
+/// F1's crash-window rule forbids.
+#[tokio::test]
+async fn a_crash_between_the_rows_and_the_summary_reports_neither() {
+    let data = support::DataDir::new();
+    let notes = knowledge_tree(&[("a.md", "# A\n"), ("b.md", "# B\n")]);
+    let source = source("notes", notes.path());
+
+    let staged = {
+        let mut db = AtlasDb::open(data.path()).expect("atlas");
+        let scan = scan_local_knowledge(&source).expect("scan");
+        // Step 1 only. The process "dies" here: no journal append, no
+        // confirmation.
+        match db.stage_scan(&scan).expect("stage") {
+            sergeant_rs::runtime::atlas::db::ScanCommit::Staged { generation_id } => generation_id,
+            other => panic!("expected a staged generation, got {other:?}"),
+        }
+    };
+
+    // Even before any restart, nothing reads a provisional generation.
+    {
+        let db = AtlasDb::open(data.path()).expect("atlas");
+        // (Opening already reconciled it — assert on the state below.)
+        assert!(
+            db.confirmed_generation("notes")
+                .expect("generation")
+                .is_none(),
+            "a generation with no summary must never answer as confirmed"
+        );
+    }
+    assert!(
+        scan_summaries(data.path()).is_empty(),
+        "the fixture must not have journaled a summary"
+    );
+
+    // The restart: a real daemon start over the same data dir runs Atlas's
+    // reconciliation.
+    start_and_stop(data.path()).await;
+
+    let db = AtlasDb::open(data.path()).expect("atlas after restart");
+    assert_eq!(
+        db.generation_states().expect("states").get(&staged),
+        Some(&"evicted".to_string()),
+        "a generation with rows and no summary must be evicted at startup"
+    );
+    assert!(
+        db.units("notes", 100).expect("units").is_empty(),
+        "a half-scan's units must not survive reconciliation"
+    );
+    // Neither-reported, and *reported as* neither: an explicit eviction row,
+    // never a silent gap (ruling §4).
+    let rows = db.coverage("notes", 100).expect("coverage");
+    let eviction = rows
+        .iter()
+        .find(|c| c.row.status == Coverage::GenerationEvicted)
+        .expect("reconciliation must leave an explicit eviction row");
+    assert_eq!(eviction.generation_id, staged);
+    assert!(
+        eviction
+            .row
+            .detail
+            .as_deref()
+            .is_some_and(|d| d.contains("no source.scanned summary")),
+        "the eviction must name the crash window: {eviction:?}"
+    );
+    assert!(
+        !rows.iter().any(|c| c.row.status == Coverage::Indexed),
+        "a half-scan must not report indexed coverage"
+    );
+
+    // And the source is scannable again afterwards: reconciliation clears the
+    // window, it does not poison the source.
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let record = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    assert!(matches!(record, ScanRecord::Recorded { .. }), "{record:?}");
+    assert!(!db.units("notes", 100).expect("units").is_empty());
+    data.reap();
+}
+
+/// guard-map: Atlas's file lives beside the journal, **not** inside the
+/// directory whose documented contract is that deleting it loses nothing.
+///
+/// Mutation this kills: moving Atlas under `projections/` — an acceptance
+/// test elsewhere deletes that directory wholesale and asserts nothing was
+/// lost, which would then be false.
+#[test]
+fn the_atlas_store_is_not_inside_the_disposable_projection_directory() {
+    let data = TempDir::new().expect("tempdir");
+    let db = AtlasDb::open(data.path()).expect("atlas");
+    let path: PathBuf = db.path().to_path_buf();
+    assert!(path.starts_with(data.path()));
+    assert!(
+        !path.starts_with(sergeant_rs::runtime::analytics::projections_dir(
+            data.path()
+        )),
+        "{} must not live under the disposable projections directory",
+        path.display()
+    );
+}

--- a/tests/x2_knowledge_sources.rs
+++ b/tests/x2_knowledge_sources.rs
@@ -17,6 +17,11 @@
 //!   `source.scanned` summary. Startup reconciliation must leave
 //!   neither-reported (with an explicit eviction row), never a half-scan
 //!   reported as coverage.
+//! * `a_crash_after_the_summary_but_before_confirmation_completes_the_scan`
+//!   is the *other* window, one boundary later, and its correct answer is the
+//!   opposite one: the summary is durable and already broadcast, so
+//!   reconciliation promotes rather than evicts. Both-present is a rule in
+//!   both directions — journal-present/database-evicted breaks it too.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -29,7 +34,7 @@ use sergeant_rs::domain::event::Event;
 use sergeant_rs::domain::source::{Coverage, KIND_SOURCE_SCANNED, UnitKind};
 use sergeant_rs::runtime::analytics::Analytics;
 use sergeant_rs::runtime::atlas::db::AtlasDb;
-use sergeant_rs::runtime::atlas::record::{ScanRecord, scan_and_record};
+use sergeant_rs::runtime::atlas::record::{ScanRecord, scan_and_record, scan_summary};
 use sergeant_rs::runtime::atlas::scan::{KnowledgeSource, scan_local_knowledge};
 use sergeant_rs::runtime::journal::Journal;
 
@@ -559,6 +564,12 @@ async fn source_facts_survive_a_real_daemon_restart() {
 /// transaction commits), and then nothing else does. Reopening the store is
 /// the restart.
 ///
+/// Its counterpart is
+/// `a_crash_after_the_summary_but_before_confirmation_completes_the_scan`,
+/// which kills the process one boundary later and must reach the *opposite*
+/// answer. Read the two together: they are what pin reconciliation to the
+/// journal rather than to the `state` column.
+///
 /// Mutation this kills: promoting a generation to `confirmed` inside
 /// `stage_scan`, or letting a read path see a provisional one. Either change
 /// makes a half-finished scan answer as coverage, which is precisely what
@@ -580,10 +591,12 @@ async fn a_crash_between_the_rows_and_the_summary_reports_neither() {
         }
     };
 
-    // Even before any restart, nothing reads a provisional generation.
+    // Even before any restart, nothing reads a provisional generation. The
+    // state filter is what holds that, not the eviction — opening the store
+    // deliberately decides nothing, because the evidence that decides it is
+    // in the journal.
     {
         let db = AtlasDb::open(data.path()).expect("atlas");
-        // (Opening already reconciled it — assert on the state below.)
         assert!(
             db.confirmed_generation("notes")
                 .expect("generation")
@@ -639,6 +652,275 @@ async fn a_crash_between_the_rows_and_the_summary_reports_neither() {
     assert!(matches!(record, ScanRecord::Recorded { .. }), "{record:?}");
     assert!(!db.units("notes", 100).expect("units").is_empty());
     data.reap();
+}
+
+/// guard-map (**F1's other crash window — 2→3, not 1→2**): a process that
+/// dies *after* journaling the `source.scanned` summary but before the
+/// confirming transaction leaves the summary durable and already broadcast.
+/// Startup reconciliation must therefore **promote**, not evict: both-present
+/// is the rule in both directions, and journal-present/database-evicted
+/// breaks it exactly as badly as its mirror image — with the added insult
+/// that the eviction row would claim a missing summary that plainly exists.
+///
+/// The kill is at the other boundary from
+/// `a_crash_between_the_rows_and_the_summary_reports_neither`: `stage_scan`
+/// runs, the summary is appended with the real
+/// [`scan_summary`](sergeant_rs::runtime::atlas::record::scan_summary)
+/// payload the live path would have written, and then nothing else does.
+///
+/// Mutation this kills: reconciling against the database's `state` column
+/// alone (evict every provisional generation). That answer is right for the
+/// 1→2 window and wrong for this one — the column records the same value in
+/// both, so any reconciler that does not read the journal fails here.
+#[tokio::test]
+async fn a_crash_after_the_summary_but_before_confirmation_completes_the_scan() {
+    let data = support::DataDir::new();
+    let notes = knowledge_tree(&[("a.md", "# A\n\nbody\n"), ("b.md", "# B\n")]);
+    let source = source("notes", notes.path());
+
+    let (staged, summary_id) = {
+        let mut db = AtlasDb::open(data.path()).expect("atlas");
+        let mut journal = Journal::open(data.path()).expect("journal");
+        let scan = scan_local_knowledge(&source).expect("scan");
+        // Step 1.
+        let staged = match db.stage_scan(&scan).expect("stage") {
+            sergeant_rs::runtime::atlas::db::ScanCommit::Staged { generation_id } => generation_id,
+            other => panic!("expected a staged generation, got {other:?}"),
+        };
+        // Step 2 — the real payload, so the field the reconciler matches on
+        // is the field the writer emits.
+        let event = journal
+            .append(sergeant_rs::domain::event::EventDraft::new(
+                sergeant_rs::domain::event::EventSource::new("daemon", "atlas"),
+                KIND_SOURCE_SCANNED,
+                scan_summary(&scan, &staged),
+            ))
+            .expect("append");
+        // The process "dies" here: step 3 never runs.
+        (staged, event.id)
+    };
+    assert_eq!(
+        scan_summaries(data.path()).len(),
+        1,
+        "the fixture must have journaled exactly one summary"
+    );
+
+    // The restart.
+    start_and_stop(data.path()).await;
+
+    let db = AtlasDb::open(data.path()).expect("atlas after restart");
+    assert_eq!(
+        db.generation_states().expect("states").get(&staged),
+        Some(&"confirmed".to_string()),
+        "a generation whose summary is in the journal must be promoted, not \
+         evicted — the scan completed; only the confirming transaction was lost"
+    );
+    let standing = db
+        .confirmed_generation("notes")
+        .expect("generation")
+        .expect("the recovered generation must answer as confirmed");
+    assert_eq!(standing.id, staged);
+    assert!(
+        !db.units("notes", 100).expect("units").is_empty(),
+        "the rows the summary names must survive reconciliation"
+    );
+    // Both-present, and nothing pretending otherwise: no eviction row that
+    // claims this generation had no summary.
+    assert!(
+        !db.coverage("notes", 100)
+            .expect("coverage")
+            .iter()
+            .any(|c| c.row.status == Coverage::GenerationEvicted),
+        "a promoted generation must leave no eviction row"
+    );
+    assert_eq!(scan_summaries(data.path()).len(), 1, "no second summary");
+    assert_eq!(scan_summaries(data.path())[0].id, summary_id);
+
+    // And the recovered generation behaves exactly like a live-confirmed one:
+    // a re-scan of unchanged bytes reuses it rather than churning a new one.
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let again = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    assert!(
+        matches!(&again, ScanRecord::Unchanged { generation_id, .. } if *generation_id == staged),
+        "{again:?}"
+    );
+    data.reap();
+}
+
+/// guard-map (**ruling §4, the eviction rule's actual precondition**): a
+/// source whose root is temporarily unreachable — an unplugged drive, an
+/// unmounted share — must not supersede the generation derived from its
+/// bytes. The bytes did not change; the path did.
+///
+/// An empty scan of an unreadable root and a real scan of an emptied one are
+/// indistinguishable by content key (both hash an empty resource map), so the
+/// decision has to read the coverage row the walk already recorded.
+///
+/// Mutation this kills: dropping the `root_unavailable` guard in
+/// `AtlasDb::stage_scan`. Every transient mount failure would then stage an
+/// empty generation, and confirming it would evict the good one — deleting
+/// its units and files, and reporting the deletion as "the source bytes
+/// changed", which is false.
+#[test]
+fn an_unreachable_root_keeps_the_generation_it_cannot_rescan() {
+    let data = TempDir::new().expect("tempdir");
+    let outer = knowledge_tree(&[("docs/index.md", "# Index\n\nbody\n\n## Deep\n\nmore\n")]);
+    let root = outer.path().join("docs");
+    let source = source("notes", &root);
+
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let first = scan_and_record(&mut db, &mut journal, &source, None).expect("scan");
+    let ScanRecord::Recorded { generation_id, .. } = first else {
+        panic!("expected a recorded generation, got {first:?}");
+    };
+    let before = db.units("notes", 100).expect("units");
+    assert!(!before.is_empty(), "the fixture must produce units to lose");
+
+    // The drive goes away.
+    std::fs::remove_dir_all(&root).expect("remove the root");
+
+    let second = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let ScanRecord::RootUnavailable {
+        generation_id: still,
+        detail,
+        ..
+    } = second
+    else {
+        panic!("an unreachable root must not supersede anything, got {second:?}");
+    };
+    assert_eq!(still, generation_id);
+    assert!(
+        detail.contains("no source bytes changed"),
+        "the record must say why nothing was evicted: {detail}"
+    );
+
+    // The derived facts F1 exists to preserve are still here.
+    assert_eq!(
+        db.units("notes", 100).expect("units"),
+        before,
+        "a transient mount failure must not destroy derived facts"
+    );
+    assert_eq!(
+        db.confirmed_generation("notes")
+            .expect("generation")
+            .expect("still standing")
+            .id,
+        generation_id
+    );
+    assert!(
+        !db.coverage("notes", 100)
+            .expect("coverage")
+            .iter()
+            .any(|c| c.row.status == Coverage::GenerationEvicted),
+        "nothing may be evicted: the bytes never changed, the path was unreachable"
+    );
+    // And the unavailability is evidence, not an absence.
+    let unavailable = db
+        .coverage("notes", 100)
+        .expect("coverage")
+        .into_iter()
+        .find(|c| c.row.status == Coverage::Unavailable)
+        .expect("the unreachable root must leave a coverage row");
+    assert_eq!(unavailable.generation_id, generation_id);
+    assert_eq!(
+        scan_summaries(data.path()).len(),
+        1,
+        "a scan that acquired nothing did not complete, so it journals no summary"
+    );
+
+    // The drive comes back, with the same bytes: still one generation, still
+    // no churn.
+    std::fs::create_dir_all(&root).expect("mkdir");
+    std::fs::write(
+        root.join("index.md"),
+        "# Index\n\nbody\n\n## Deep\n\nmore\n",
+    )
+    .expect("write");
+    let third = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    assert!(
+        matches!(&third, ScanRecord::Unchanged { generation_id: id, .. } if *id == generation_id),
+        "{third:?}"
+    );
+
+    // But a root that is genuinely readable and genuinely empty is a real
+    // observation, and it does supersede.
+    std::fs::remove_file(root.join("index.md")).expect("remove");
+    let fourth = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    assert!(
+        matches!(&fourth, ScanRecord::Recorded { evicted, .. } if evicted.as_deref() == Some(generation_id.as_str())),
+        "an emptied-but-readable root is evidence of emptiness: {fourth:?}"
+    );
+}
+
+/// guard-map (**F10, through the whole pipeline**): the secrets floor is at
+/// least as case-tolerant as the extractor routing behind it. `Secrets.md`,
+/// `CREDENTIALS.txt` and `ID_RSA` are refused at acquisition, and their bytes
+/// reach no unit, no file row and no journal payload.
+///
+/// Mutation this kills: compiling the deny globs case-sensitively (globset's
+/// default). Extractor selection lowercases the extension, so every one of
+/// these files would be opened, read, BLAKE3-hashed, extracted and persisted
+/// in full — the exact leak F10 exists to prevent, arriving by way of a shift
+/// key.
+#[test]
+fn case_variants_of_the_denied_families_never_reach_a_unit() {
+    let data = TempDir::new().expect("tempdir");
+    let notes = knowledge_tree(&[
+        ("keep.md", "# Keep\n\nordinary evidence\n"),
+        ("Secrets.md", "# Secrets\n\napi_token: hunter2\n"),
+        ("SECRETS.md", "shouting-hunter2\n"),
+        ("notes/CREDENTIALS.txt", "aws_secret_access_key = hunter2\n"),
+        (
+            "keys/ID_RSA",
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nhunter2\n",
+        ),
+        ("Server.PEM", "-----BEGIN CERTIFICATE-----\nhunter2\n"),
+    ]);
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    scan_and_record(&mut db, &mut journal, &source("notes", notes.path()), None).expect("scan");
+
+    let units = db.units("notes", 100).expect("units");
+    assert!(
+        units.iter().any(|u| u.relative_path == "keep.md"),
+        "the ordinary document is still indexed"
+    );
+    assert!(
+        !units.iter().any(|u| u.body.contains("hunter2")),
+        "a denied file's bytes reached a unit: {units:?}"
+    );
+    assert!(
+        units.iter().all(|u| u.relative_path == "keep.md"),
+        "only the allowed file was acquired: {units:?}"
+    );
+
+    let coverage = db.coverage("notes", 100).expect("coverage");
+    for denied in [
+        "Secrets.md",
+        "SECRETS.md",
+        "notes/CREDENTIALS.txt",
+        "keys/ID_RSA",
+        "Server.PEM",
+    ] {
+        let row = coverage
+            .iter()
+            .find(|c| c.row.path.as_deref() == Some(denied))
+            .unwrap_or_else(|| panic!("no coverage row for {denied:?}"));
+        assert_eq!(
+            row.row.status,
+            Coverage::Excluded,
+            "{denied:?} must be refused at the acquisition boundary, not indexed"
+        );
+    }
+    let counts = db.coverage_counts("notes").expect("counts");
+    assert_eq!(counts.get(Coverage::Indexed.as_str()), Some(&1));
+    assert_eq!(counts.get(Coverage::Excluded.as_str()), Some(&5));
+
+    // And nothing leaked into the journal either.
+    let rendered = serde_json::to_string(&scan_summaries(data.path())[0].payload).expect("render");
+    assert!(!rendered.contains("hunter2"), "{rendered}");
 }
 
 /// guard-map: Atlas's file lives beside the journal, **not** inside the


### PR DESCRIPTION
Wave X2 of S3 (Atlas core, A1a). Plan: workspace `host-atlas-s3-series/sprint-plan-2026-08-27.md` (amended register: F1/F6-F10 as adjudicated).

- **F9**: `[[knowledge]]` manifest section mirroring `RepositoryEntry` (plain-name rules, `ignore` globs, deny_unknown_fields) + path-containment refusal — a knowledge path under any repo mount or `surfaces_dir`/`data_dir` refuses with a named `EstateError` variant, red-then-green.
- **domain/source.rs spine**: SourceKind/Authority/SourceGeneration; ExternalGit named as the S4 seam.
- **The scanner** (first source.* writer; its tables' DDL lands with it): F7 BLAKE3+extractor-identity keys (mtime = hint only, rename-safe generation keys), F10 default secrets deny set enforced at acquisition before bytes reach any fold (per-source `ignore` extends, never shrinks; excluded bytes coverage-counted), F8 coverage rows, one compact `source.scanned` journal summary per completed scan.
- **F1 crash-window**: rows staged provisional, confirmed coupled to the summary event; startup reconciliation evicts row-only generations — both crash variants pinned by test (kill before summary → neither reported; kill after summary → scan completes).
- **Text/Markdown structure units** as pure functions over bytes (F6 mandate), fence-aware heading segmentation pinned against CommonMark edges.
- **CLI**: `sgt knowledge add/list` (manifest-direct), docs same-wave.
- Restart-persistence regression (real daemon restart) moved here from X1 per panel adjudication; both one-owner structural tests stay green.

Gates: wave workflow wf_b5e06c82 — 11 panel findings (incl. dedicated security axis), 4 confirmed, all fixed in one round (journal-aware reconciliation, root-unavailability, self-defending confirm, case-blind deny floor); verify gate green (nextest 1988/1988, clippy/fmt clean, cargo-deny ok); aria seat SOUND (executed pinned suites; no material findings). New deps: blake3, globset (R5; cargo-deny green). Rung citations in commit bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4