### PR TITLE
S3 X3a — Estate-git plumbing: pinned-SHA walk, OID keys, Work overlays, intelligence-lane permits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,36 @@ release.
 - New dependency: `globset`, for the exclusion set and `[[knowledge]]
   ignore` glob matching.
 
+### Estate-repository indexing (S3)
+
+- Atlas now indexes declared repositories as well as knowledge paths. A
+  repository is read **at the commit its Work admission pinned**, out of the
+  Git object store — never from the mount's working tree, and never by
+  fetching, pulling, switching or writing anything. A scan running while the
+  mount's HEAD moves stays on the commit it pinned; the move is reported as a
+  drift observation beside the scan, never blended into it.
+- Blob reads are batched: one `git cat-file --batch` process answers many
+  objects, instead of one Git process per file.
+- Cached extractions of repository content are keyed by **Git's own blob
+  object id** plus the extractor's identity. Bytes Git has already hashed are
+  never hashed a second time, and two identical files share one extraction by
+  construction. A repository generation is identified by its tree, so a commit
+  that changed no file — an empty commit, a reworded message — is recognized
+  as the same world and evicts nothing.
+- A Work surface is indexed as an **overlay** over its base commit: files the
+  Work changed are content-hashed from the surface, every unchanged file keeps
+  the base tree's object-id key, and the generation is identified by the base
+  commit composed with a digest of the changes. Overlay evidence is scoped to
+  its Work and removed when that Work is retired, leaving an explicit eviction
+  row.
+- The intelligence capacity lane declared in the host-runtime work now has a
+  real consumer: extraction acquires it, runs on the blocking pool, and is
+  bounded by `SGT_INTELLIGENCE_LANE_CAP`. It never draws on the execution
+  lane, so indexing a large repository cannot reduce the number of Works that
+  can run.
+- No new dependency: the existing Git-CLI module gained a batched object-read
+  primitive rather than the codebase gaining a Git library.
+
 ## [0.2.4] - 2026-08-25
 
 sergeant-rs narrows to a product-documents-only repo, codex actors gain

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -147,3 +147,21 @@ cov_stage_end 1 "the v4_w1_acceptance test binary must write its own profile"
 cov_stage_begin c2-x1_atlas_substrate
 cov_run cargo llvm-cov --no-report --test x1_atlas_substrate --locked || cov_fail "x1_atlas_substrate failed under instrumentation"
 cov_stage_end 1 "the x1_atlas_substrate test binary must write its own profile"
+
+# S3 X3a: the mechanical estate-git plumbing — a tree walk at an
+# admission-pinned SHA, batched blob reads, the concurrent-HEAD-advance rule,
+# Work-overlay hashing, and F6's intelligence-lane permits. Real `git`
+# subprocesses over tempdir repositories plus an in-process Atlas store and a
+# tokio runtime; no daemon, no estate root, no backend, so C2 rather than C3.
+# Floor 1.
+cov_stage_begin c2-x3a_git_plumbing
+cov_run cargo llvm-cov --no-report --test x3a_git_plumbing --locked || cov_fail "x3a_git_plumbing failed under instrumentation"
+cov_stage_end 1 "the x3a_git_plumbing test binary must write its own profile"
+
+# S3 X3a, the read-only claim: one test in its own process (it sets the
+# process-global `SGT_GIT_BIN` override to a recording shim), asserting that a
+# scan runs only read-only Git verbs and leaves the mount byte-identical.
+# Floor 1.
+cov_stage_begin c2-x3a_scan_uses_only_local_reads
+cov_run cargo llvm-cov --no-report --test x3a_scan_uses_only_local_reads --locked || cov_fail "x3a_scan_uses_only_local_reads failed under instrumentation"
+cov_stage_end 1 "the x3a_scan_uses_only_local_reads test binary must write its own profile"

--- a/src/domain/source.rs
+++ b/src/domain/source.rs
@@ -189,6 +189,91 @@ pub fn content_hash(bytes: &[u8]) -> String {
     blake3::hash(bytes).to_hex().to_string()
 }
 
+/// **F7's estate-git cache key**: the Git blob OID **plus** extractor
+/// identity, and nothing else.
+///
+/// The rule this function exists to make unavoidable is the negative one:
+/// *never a second hash of bytes Git already hashed*. A blob's OID is a
+/// cryptographic digest of exactly those bytes, computed once, when the object
+/// was written, by the tool that owns them. Re-hashing them with BLAKE3 to
+/// produce a "content hash" would cost a full pass over every byte in the
+/// repository on every scan, to arrive at a second name for a thing that
+/// already has one. The OID is the content half; this composes it with the
+/// extractor half.
+///
+/// The composition hashes two short strings — an OID and an extractor
+/// identity, tens of bytes between them — which is not the thing the rule
+/// forbids. What it buys is one fixed-width key whichever source kind produced
+/// it, so `source.files.local_key` stays one column with one meaning.
+///
+/// **Domain-separated from [`local_key`] on purpose.** A blob OID and a BLAKE3
+/// content hash are different lengths from different hash families, but they
+/// are both "hex of some bytes", and two key spaces that could ever collide
+/// would let a local-knowledge extraction be reused for a Git blob whose OID
+/// happened to be spelled the same. The separator makes that impossible rather
+/// than unlikely.
+pub fn estate_git_key(blob_oid: &str, extractor: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"sergeant.atlas.estate-git-key/v1\n");
+    hasher.update(blob_oid.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(extractor.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+/// The content identity of a Work overlay's *changed* paths: BLAKE3 over each
+/// changed path and what the overlay recorded for it, in path order.
+///
+/// "What the overlay recorded" is the BLAKE3 hash of the working-tree bytes for
+/// a path that has bytes, and a marker for one that does not — deleted,
+/// unreadable, not a regular file. A path with no bytes still changed the
+/// world, so it still has to move this digest;
+/// [`crate::runtime::atlas::overlay`] owns those markers and the
+/// argument for each.
+///
+/// The changed half only. Unchanged paths are the base tree's, by definition,
+/// and are already identified by [`overlay_generation_key`]'s other input —
+/// folding them in again would mean hashing a whole repository to describe a
+/// two-file edit. Paths *excluded* at the acquisition boundary are folded in
+/// nowhere at all, exactly as [`generation_key`] excludes them: what these keys
+/// identify is the world evidence was derived from, and a denied path
+/// contributed no bytes to it.
+///
+/// An empty map is a real answer, not a degenerate one: a Work surface that
+/// has changed nothing has exactly this digest, and [`overlay_generation_key`]
+/// then names the base plus "nothing", which is what a freshly cut surface
+/// actually is.
+pub fn overlay_digest(changed: &BTreeMap<String, String>) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"sergeant.atlas.overlay-digest/v1\n");
+    for (path, hash) in changed {
+        hasher.update(path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash.as_bytes());
+        hasher.update(b"\n");
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+/// A Work overlay generation's identity: **the base commit SHA composed with
+/// the overlay digest of what the surface changed.**
+///
+/// Both halves are load-bearing and neither is sufficient. The base alone
+/// cannot distinguish two Works cut from the same commit that have edited
+/// different files; the overlay digest alone cannot distinguish one edit
+/// applied over two different bases, which is a different world with different
+/// unchanged neighbours. Composing them means an overlay generation is the
+/// same generation exactly when both the ground it stands on and the change it
+/// makes are the same — the only condition under which reusing it is correct.
+pub fn overlay_generation_key(base_sha: &str, overlay_digest: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"sergeant.atlas.overlay-generation-key/v1\n");
+    hasher.update(base_sha.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(overlay_digest.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
 /// Content identity of a whole generation: a hash over every acquired
 /// resource's `(relative path, content hash)` pair, in path order.
 ///

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -575,19 +575,34 @@ impl AtlasDb {
     /// That difference is the whole point: an overlay's confirmed rows are
     /// exactly the ones that must not outlive their Work.
     ///
-    /// The scope filter is applied **in Rust, over a bounded read**, rather
-    /// than as a `LIKE` pattern built into SQL. `source.generations` is a
-    /// small table this build already reads whole elsewhere, and F12's rule
-    /// against string-built SQL is worth more here than one avoided scan —
-    /// a Work id interpolated into a `LIKE` is a pattern, and `%` and `_` in a
-    /// pattern do not mean what a caller passing an id means.
+    /// The read is **range-bounded on the overlay prefix itself** — plain
+    /// parameterized comparisons, so F12's rule against string-built SQL
+    /// holds without a `LIKE` (a Work id interpolated into a pattern would
+    /// let `%` and `_` mean things a caller passing an id never meant), and
+    /// the row cap bounds *this Work's* generations rather than the whole
+    /// estate. A cap shared with every other source's live generations could
+    /// push a retiring Work's overlays out of the window, and a confirmed
+    /// generation that survives here outlives its Work — exactly what this
+    /// eviction exists to forbid. The `starts_with` check stays as a belt
+    /// over the range's braces.
     pub fn evict_work_overlays(&mut self, work_id: &str) -> Result<Vec<String>, AtlasError> {
         let prefix = crate::runtime::atlas::overlay::overlay_source_prefix(work_id);
+        // The prefix ends in '/', so its exclusive upper bound is the same
+        // string with the final byte bumped to '0' ('/' + 1).
+        let mut upper = prefix.clone();
+        let last = upper.pop().expect("overlay prefix is never empty");
+        upper.push((last as u8 + 1) as char);
         let mut statement = self.conn.prepare(
             "SELECT generation_id, source_name FROM source.generations \
-             WHERE state != ? ORDER BY observed_at DESC, generation_id DESC LIMIT ?",
+             WHERE state != ? AND source_name >= ? AND source_name < ? \
+             ORDER BY observed_at DESC, generation_id DESC LIMIT ?",
         )?;
-        let mut rows = statement.query(duckdb::params![STATE_EVICTED, MAX_ROWS as i64])?;
+        let mut rows = statement.query(duckdb::params![
+            STATE_EVICTED,
+            prefix,
+            upper,
+            MAX_ROWS as i64
+        ])?;
         let mut targets: Vec<(String, String)> = Vec::new();
         while let Some(row) = rows.next()? {
             let source_name: String = row.get(1)?;

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -560,6 +560,56 @@ impl AtlasDb {
         Ok(targets.into_iter().map(|(id, _)| id).collect())
     }
 
+    /// Evict **every** generation belonging to one Work's overlay sources, in
+    /// one transaction, each leaving its own `generation_evicted` coverage row.
+    ///
+    /// A Work overlay describes a world only that Work can see: its base tree
+    /// plus that surface's uncommitted changes. When the Work is gone, the
+    /// world is gone, and rows describing it are no longer derived evidence
+    /// about anything — they are claims about a surface that does not exist.
+    /// So this is the one eviction that is *not* keyed on source bytes
+    /// changing (ruling §4's rule, which governs a durable source); an overlay
+    /// generation's lifetime is its Work's, and that is the rule for it.
+    ///
+    /// **Confirmed generations included**, unlike [`Self::evict_provisional`].
+    /// That difference is the whole point: an overlay's confirmed rows are
+    /// exactly the ones that must not outlive their Work.
+    ///
+    /// The scope filter is applied **in Rust, over a bounded read**, rather
+    /// than as a `LIKE` pattern built into SQL. `source.generations` is a
+    /// small table this build already reads whole elsewhere, and F12's rule
+    /// against string-built SQL is worth more here than one avoided scan —
+    /// a Work id interpolated into a `LIKE` is a pattern, and `%` and `_` in a
+    /// pattern do not mean what a caller passing an id means.
+    pub fn evict_work_overlays(&mut self, work_id: &str) -> Result<Vec<String>, AtlasError> {
+        let prefix = crate::runtime::atlas::overlay::overlay_source_prefix(work_id);
+        let mut statement = self.conn.prepare(
+            "SELECT generation_id, source_name FROM source.generations \
+             WHERE state != ? ORDER BY observed_at DESC, generation_id DESC LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![STATE_EVICTED, MAX_ROWS as i64])?;
+        let mut targets: Vec<(String, String)> = Vec::new();
+        while let Some(row) = rows.next()? {
+            let source_name: String = row.get(1)?;
+            if source_name.starts_with(&prefix) {
+                targets.push((row.get(0)?, source_name));
+            }
+        }
+        drop(rows);
+        drop(statement);
+        if targets.is_empty() {
+            return Ok(Vec::new());
+        }
+        let reason = format!("the Work this overlay was scoped to ({work_id}) was retired");
+        let observed_at = crate::domain::event::rfc3339_utc_now();
+        let tx = self.conn.transaction()?;
+        for (generation_id, source_name) in &targets {
+            evict(&tx, generation_id, source_name, &reason, &observed_at)?;
+        }
+        tx.commit()?;
+        Ok(targets.into_iter().map(|(id, _)| id).collect())
+    }
+
     /// The newest **confirmed** generation for one source, if there is one.
     ///
     /// Every read below goes through the same filter. A provisional or
@@ -991,6 +1041,7 @@ mod tests {
             kind: SourceKind::LocalKnowledge,
             authority: AuthorityClass::EstateReadonly,
             content_key: hash.clone(),
+            revision: None,
             observed_at: crate::domain::event::rfc3339_utc_now(),
             files: vec![ScannedFile {
                 relative_path: "doc.md".to_string(),

--- a/src/runtime/atlas/git.rs
+++ b/src/runtime/atlas/git.rs
@@ -1,0 +1,879 @@
+//! The estate-git walk: Atlas's `estate_git` source reader (X3a).
+//!
+//! One declared `[[repo]]` mount, read **at the SHA admission pinned**, out of
+//! the object store and never out of the working tree. Filesystem in is
+//! [`super::scan`]'s job; this module's input is a commit, and its output is
+//! the same plain-Rust [`SourceScan`] that module produces — which is what
+//! lets one set of `source.*` rows, one coverage vocabulary and one
+//! crash-window discipline serve both source kinds (R2).
+//!
+//! # The pin is the whole point
+//!
+//! §8.2 pins a Work's base commit at admission so materialization uses the
+//! commit preflight judged rather than whatever HEAD has since become. Atlas
+//! inherits that pin for *reads*: every byte this module returns is addressed
+//! by a commit SHA the caller supplied, and Git resolves that SHA in the
+//! object store. A mount whose HEAD advances mid-scan — Captain committing,
+//! another Work, an unrelated process — changes no object this scan is
+//! reading, because a commit's tree is immutable and reachable regardless of
+//! what any ref points at.
+//!
+//! The advance is nonetheless *observed*, never blended:
+//! [`observe_drift`] asks the mount for its committed HEAD and reports an
+//! [`EstateDriftObservation`] when it is no longer the pinned SHA (§11.4's
+//! existing vocabulary, reused — R2). A scan therefore answers with one
+//! world plus an honest note that the mount has moved on, and never with a
+//! mixture of two.
+//!
+//! # What this module will not do
+//!
+//! Never fetch, pull, switch, reset, or write. Never read the mount's working
+//! tree or index. `ls-tree` and `cat-file` are the entire Git surface used
+//! here, and both are pure object reads. The estate's own rule — workers do
+//! not edit a `repos/` mount — applies with more force to a derived index
+//! that has no business writing anything at all.
+//!
+//! # Rungs
+//!
+//! **R2, over the brief's R5.** The X3a brief names `git2` and calls it "a
+//! dependency already"; it is not one, in this tree, at this commit — nothing
+//! in `Cargo.toml` or `Cargo.lock` names `git2` or `libgit2-sys`. Adopting it
+//! would be a new native dependency (the brief's own "no new heavy
+//! dependency" exclusion) *and* a reversal of proposal §11, which is explicit
+//! that this codebase shells out to the installed Git rather than embedding
+//! libgit2 — a governing constraint, so J5. The requirement the brief actually
+//! states — read-only object access at a pinned SHA, with batched blob reads —
+//! is satisfied whole at R2 by [`crate::runtime::git`], which already owns
+//! every Git invocation this codebase makes. The one thing it lacked was a
+//! batch primitive, and that is now
+//! [`crate::runtime::git::git_cat_file_batch`]: one Git
+//! process for many objects, rather than one process per file.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use crate::domain::event::rfc3339_utc_now;
+use crate::domain::source::{AuthorityClass, Coverage, CoverageRow, SourceKind, estate_git_key};
+use crate::runtime::atlas::deny::{AcquisitionFilter, BadPattern, Verdict};
+use crate::runtime::atlas::scan::{MAX_RESOURCE_BYTES, ScannedFile, SourceScan, extract_units};
+use crate::runtime::atlas::text::{as_text, extractor_for};
+use crate::runtime::git::{GitError, git, git_bytes, git_cat_file_batch};
+use crate::runtime::integrity::{DriftAttribution, EstateDriftObservation};
+
+/// How many bytes of blob content one `cat-file --batch` invocation is
+/// allowed to answer with before the next batch is started.
+///
+/// **Declared, not measured**, and said plainly rather than dressed up: it
+/// bounds the peak heap one batch can cost, which is the only property the
+/// number has to have. 64 MiB is comfortably above any single blob this
+/// module will accept (the per-resource ceiling is
+/// [`MAX_RESOURCE_BYTES`], 4 MiB) — so a batch is never fewer than one file —
+/// and far below anything that would matter on a host already running a
+/// bundled analytical database. A repository whose blobs total less than this
+/// is read in exactly one Git process, which is the case the batching exists
+/// for.
+pub const BATCH_BYTE_BUDGET: u64 = 64 * 1024 * 1024;
+
+/// How many objects one `cat-file --batch` invocation is allowed to request.
+///
+/// The companion bound to [`BATCH_BYTE_BUDGET`], for the opposite shape: ten
+/// thousand tiny files cost nothing in bytes and would still build a
+/// ten-thousand-line request and a ten-thousand-element answer before any of
+/// it was consumed. Also declared, not measured.
+pub const BATCH_OBJECT_LIMIT: usize = 1024;
+
+/// One declared repository mount, to be read at one pinned commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EstateGitSource {
+    /// Declared repository name — the source coordinate derived rows carry.
+    pub name: String,
+    /// The estate's mount, `<estate-root>/repos/<name>`. Read-only here.
+    pub mount: PathBuf,
+    /// §8.2's admission-pinned commit: the exact world this scan is of.
+    pub pinned_sha: String,
+    /// Per-source ignore globs, extending the built-in deny set (F10).
+    pub ignore: Vec<String>,
+}
+
+/// What one tree entry is, by its Git file mode.
+///
+/// Three cases rather than "blob or not", because the two non-blob cases have
+/// different honest coverage answers and neither is an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    /// An ordinary file (mode `100644`/`100755`).
+    File,
+    /// A symlink (mode `120000`): the blob holds a *path*, not content.
+    Symlink,
+    /// A gitlink (mode `160000`): another repository's commit, whose objects
+    /// are not in this object store at all.
+    Submodule,
+}
+
+/// One blob-level entry of a commit's tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeEntry {
+    /// Path relative to the repository root, `/`-separated, as Git spells it.
+    pub path: String,
+    /// The object id. For a [`EntryKind::File`] this is **F7's content half**:
+    /// Git already hashed exactly these bytes, and Atlas never hashes them a
+    /// second time.
+    pub oid: String,
+    /// Git's own file mode word.
+    pub mode: String,
+    /// What the mode means.
+    pub kind: EntryKind,
+    /// The object's size in bytes, as `ls-tree --long` reports it — known
+    /// **before** any content is read, which is what lets the resource
+    /// ceiling refuse an oversized blob without ever fetching it.
+    pub size: u64,
+}
+
+/// One commit's tree, listed. Phase one of a scan, and a value in its own
+/// right: everything below is addressed by [`Self::commit_sha`], so a caller
+/// holding this holds a world that cannot move.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitTree {
+    /// The pinned commit, resolved to a full SHA.
+    pub commit_sha: String,
+    /// That commit's root tree object id — the **content** identity of the
+    /// world, as distinct from the commit's. Two commits with different
+    /// messages, authors or parents but identical trees changed no source
+    /// bytes, and ruling §4 evicts a generation only when the source bytes
+    /// changed; keying the generation on the tree is what makes that literally
+    /// true rather than approximately true.
+    pub tree_oid: String,
+    /// Blob-level entries, in path order.
+    pub entries: Vec<TreeEntry>,
+}
+
+/// One completed estate-git scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EstateGitScan {
+    /// The rows, in the shape every `source.*` writer already takes.
+    pub scan: SourceScan,
+    /// The tree the generation is keyed on (also [`SourceScan::content_key`]).
+    pub tree_oid: String,
+    /// §11.4's observation, when the mount's committed HEAD is no longer the
+    /// SHA this scan pinned. Reported beside the scan, never folded into it.
+    pub drift: Option<EstateDriftObservation>,
+}
+
+/// Failures of an estate-git scan.
+///
+/// Deliberately few. Everything the *repository content* can do — an
+/// unreadable blob, a submodule, an extension nothing claims, a file past the
+/// ceiling — is a coverage row, exactly as in [`super::scan`]. Only a failure
+/// that makes the whole scan meaningless is an error.
+#[derive(Debug, thiserror::Error)]
+pub enum GitScanError {
+    /// An `ignore` glob does not compile — an operator error, named not
+    /// absorbed.
+    #[error(transparent)]
+    Pattern(#[from] BadPattern),
+    /// Git itself refused: the mount is not a repository, or the pinned SHA
+    /// is not in its object store.
+    #[error(transparent)]
+    Git(#[from] GitError),
+    /// `ls-tree` produced a record this build cannot read.
+    #[error("git ls-tree of {sha} in {mount} produced an unreadable record: {record:?}")]
+    MalformedTree {
+        /// The commit being listed.
+        sha: String,
+        /// The mount it was listed in.
+        mount: String,
+        /// The record verbatim.
+        record: String,
+    },
+}
+
+/// **Phase one**: list the pinned commit's tree.
+///
+/// Resolves the caller's SHA to a full commit id and a tree id first, so a
+/// short SHA, a tag, or `HEAD` all become an immutable pair before a single
+/// entry is read — and so a caller that stores [`GitTree::commit_sha`] stores
+/// something unambiguous.
+///
+/// `ls-tree -r -z --long` is the whole listing: recursive (so trees are
+/// flattened to blob paths), `-z` (so a path containing a newline or a quote
+/// is delivered verbatim rather than C-quoted), `--long` (so each entry's
+/// size arrives with it, before any content is read).
+pub fn list_tree(source: &EstateGitSource) -> Result<GitTree, GitScanError> {
+    let commit_sha = git(
+        &source.mount,
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("{}^{{commit}}", source.pinned_sha),
+        ],
+    )?;
+    let tree_oid = git(
+        &source.mount,
+        &["rev-parse", "--verify", &format!("{commit_sha}^{{tree}}")],
+    )?;
+    let raw = git_bytes(
+        &source.mount,
+        &["ls-tree", "-r", "-z", "--long", &commit_sha, "--"],
+    )?;
+    let mut entries = Vec::new();
+    for record in raw.split(|b| *b == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        entries.push(parse_tree_record(record, &commit_sha, source)?);
+    }
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(GitTree {
+        commit_sha,
+        tree_oid,
+        entries,
+    })
+}
+
+/// `<mode> SP <type> SP <oid> SP <size> TAB <path>` — `ls-tree --long`'s own
+/// record shape, with `size` right-aligned in spaces and `-` for a gitlink.
+fn parse_tree_record(
+    record: &[u8],
+    sha: &str,
+    source: &EstateGitSource,
+) -> Result<TreeEntry, GitScanError> {
+    let malformed = |record: &[u8]| GitScanError::MalformedTree {
+        sha: sha.to_string(),
+        mount: source.mount.display().to_string(),
+        record: String::from_utf8_lossy(record).into_owned(),
+    };
+    let tab = record
+        .iter()
+        .position(|b| *b == b'\t')
+        .ok_or_else(|| malformed(record))?;
+    // A path is bytes, not necessarily UTF-8. One that is not is reported as
+    // unsupported later, the same way the filesystem walk reports a non-UTF-8
+    // entry name — so it is carried lossily here rather than refused.
+    let path = String::from_utf8_lossy(&record[tab + 1..]).into_owned();
+    let head = String::from_utf8_lossy(&record[..tab]).into_owned();
+    let mut words = head.split_whitespace();
+    let mode = words.next().ok_or_else(|| malformed(record))?.to_string();
+    let _kind_word = words.next().ok_or_else(|| malformed(record))?;
+    let oid = words.next().ok_or_else(|| malformed(record))?.to_string();
+    let size_word = words.next().ok_or_else(|| malformed(record))?;
+    let kind = match mode.as_str() {
+        "120000" => EntryKind::Symlink,
+        "160000" => EntryKind::Submodule,
+        _ => EntryKind::File,
+    };
+    // `-` is what `--long` prints for a gitlink, whose size is not a fact
+    // this object store holds.
+    let size = if size_word == "-" {
+        0
+    } else {
+        size_word.parse().map_err(|_| malformed(record))?
+    };
+    Ok(TreeEntry {
+        path,
+        oid,
+        mode,
+        kind,
+        size,
+    })
+}
+
+/// **Phase two**: acquire and extract a listed tree.
+///
+/// Takes the [`GitTree`] rather than re-listing, which is what makes the
+/// concurrent-HEAD-advance property *checkable*: a caller can list, let the
+/// world move, and extract, and the result is still one world. It is also the
+/// honest shape — the two phases really are two Git conversations, and
+/// pretending otherwise would hide the only window that exists.
+pub fn extract_tree(source: &EstateGitSource, tree: &GitTree) -> Result<SourceScan, GitScanError> {
+    let filter = AcquisitionFilter::new(&source.ignore)?;
+    let mut out = Extracted::default();
+    let paths: BTreeSet<String> = tree.entries.iter().map(|e| e.path.clone()).collect();
+    let denied_dirs = directory_coverage(&paths, &filter, &mut out.coverage);
+    extract_blobs(
+        &source.mount,
+        &filter,
+        &tree.entries,
+        &denied_dirs,
+        &mut out,
+    )?;
+    out.files
+        .sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    out.coverage.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(SourceScan {
+        source_name: source.name.clone(),
+        kind: SourceKind::EstateGit,
+        authority: AuthorityClass::EstateMutable,
+        content_key: tree.tree_oid.clone(),
+        revision: Some(tree.commit_sha.clone()),
+        observed_at: rfc3339_utc_now(),
+        files: out.files,
+        coverage: out.coverage,
+        extractors: out.extractors,
+    })
+}
+
+/// The three parallel outputs every walk accumulates — rows, coverage, and
+/// which extractors actually ran.
+#[derive(Debug, Default)]
+pub(crate) struct Extracted {
+    /// Acquired resources.
+    pub(crate) files: Vec<ScannedFile>,
+    /// One row per path considered.
+    pub(crate) coverage: Vec<CoverageRow>,
+    /// Distinct extractor identities that ran.
+    pub(crate) extractors: BTreeSet<String>,
+}
+
+/// Acquire and extract tree entries out of `mount`'s object store, appending
+/// to `out`.
+///
+/// The whole of the estate-git acquisition boundary, shared by
+/// [`extract_tree`] and by [`super::overlay`]'s unchanged half so the two can
+/// never diverge on what a symlink, a gitlink, an oversized blob or a denied
+/// path becomes.
+pub(crate) fn extract_blobs(
+    mount: &std::path::Path,
+    filter: &AcquisitionFilter,
+    entries: &[TreeEntry],
+    denied_dirs: &[String],
+    out: &mut Extracted,
+) -> Result<(), GitScanError> {
+    // Decide every path from metadata alone, before one byte is requested.
+    // F10's boundary is a predicate over a path, and the resource ceiling is a
+    // predicate over a size `ls-tree --long` already told us.
+    let mut wanted: Vec<&TreeEntry> = Vec::new();
+    for entry in entries {
+        if denied_dirs.iter().any(|dir| entry.path.starts_with(dir)) {
+            // Its directory was refused once, and carries the one row.
+            continue;
+        }
+        if let Verdict::Denied { pattern } = filter.verdict(&entry.path) {
+            out.coverage.push(CoverageRow {
+                path: Some(entry.path.clone()),
+                status: Coverage::Excluded,
+                detail: Some(format!("refused at acquisition by {pattern}")),
+                bytes: Some(entry.size),
+            });
+            continue;
+        }
+        match entry.kind {
+            EntryKind::Submodule => {
+                out.coverage.push(CoverageRow {
+                    path: Some(entry.path.clone()),
+                    status: Coverage::Unsupported,
+                    detail: Some(format!(
+                        "gitlink to commit {}: another repository's objects are not in this \
+                         object store",
+                        entry.oid
+                    )),
+                    bytes: None,
+                });
+                continue;
+            }
+            EntryKind::Symlink => {
+                // The blob holds a target path, not content. Following it
+                // would read whatever the link points at in a *working tree*
+                // this module deliberately never touches — see the module doc.
+                out.coverage.push(CoverageRow {
+                    path: Some(entry.path.clone()),
+                    status: Coverage::Unavailable,
+                    detail: Some("symlink is not followed".to_string()),
+                    bytes: Some(entry.size),
+                });
+                continue;
+            }
+            EntryKind::File => {}
+        }
+        if extractor_for(&entry.path).is_none() {
+            out.coverage.push(CoverageRow {
+                path: Some(entry.path.clone()),
+                status: Coverage::Unsupported,
+                detail: Some("no extractor in this build claims this extension".to_string()),
+                bytes: Some(entry.size),
+            });
+            continue;
+        }
+        if entry.size > MAX_RESOURCE_BYTES {
+            out.coverage.push(CoverageRow {
+                path: Some(entry.path.clone()),
+                status: Coverage::Unsupported,
+                detail: Some(format!(
+                    "larger than the {MAX_RESOURCE_BYTES}-byte resource ceiling"
+                )),
+                bytes: Some(entry.size),
+            });
+            continue;
+        }
+        wanted.push(entry);
+    }
+
+    for batch in batches(&wanted) {
+        let oids: Vec<String> = batch.iter().map(|e| e.oid.clone()).collect();
+        let objects = git_cat_file_batch(mount, &oids)?;
+        for (entry, object) in batch.iter().zip(objects) {
+            let extractor = extractor_for(&entry.path).expect("filtered above");
+            let Some(object) = object else {
+                out.coverage.push(CoverageRow {
+                    path: Some(entry.path.clone()),
+                    status: Coverage::Unavailable,
+                    detail: Some(format!(
+                        "blob {} is not in this object store (a partial clone, or a \
+                         corrupt one)",
+                        entry.oid
+                    )),
+                    bytes: Some(entry.size),
+                });
+                continue;
+            };
+            let Some(text) = as_text(&object.bytes) else {
+                out.coverage.push(CoverageRow {
+                    path: Some(entry.path.clone()),
+                    status: Coverage::Unsupported,
+                    detail: Some("not valid UTF-8 text".to_string()),
+                    bytes: Some(object.bytes.len() as u64),
+                });
+                continue;
+            };
+            let units = extract_units(text, extractor);
+            out.extractors.insert(extractor.to_string());
+            out.coverage.push(CoverageRow {
+                path: Some(entry.path.clone()),
+                status: Coverage::Indexed,
+                detail: Some(extractor.to_string()),
+                bytes: Some(object.bytes.len() as u64),
+            });
+            out.files.push(ScannedFile {
+                relative_path: entry.path.clone(),
+                // **F7, estate-git half.** The key is the blob OID plus the
+                // extractor's identity. The OID *is* Git's hash of exactly
+                // these bytes; hashing them again would produce a second name
+                // for one thing and cost a full pass over every byte in the
+                // repository to do it.
+                local_key: estate_git_key(&entry.oid, extractor),
+                content_hash: entry.oid.clone(),
+                extractor: extractor.to_string(),
+                byte_len: object.bytes.len() as u64,
+                // Not a fact a Git object has, and not one this path needs:
+                // F7 makes mtime a change hint for the *filesystem* scanner,
+                // and an object store has content identity instead.
+                mtime_millis: None,
+                units,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// One coverage row per directory the tree contains, and the prefixes a
+/// denied directory takes out of the walk entirely.
+///
+/// Mirrors [`super::scan`]'s two spellings exactly (see
+/// [`AcquisitionFilter::verdict`]'s own doc): `build` refuses the directory
+/// once and nothing under it is mentioned again; `build/**` leaves the
+/// directory `discovered` and refuses each file with its own row. Same bytes
+/// excluded either way, same rows, whichever source kind is being read.
+pub(crate) fn directory_coverage(
+    paths: &BTreeSet<String>,
+    filter: &AcquisitionFilter,
+    coverage: &mut Vec<CoverageRow>,
+) -> Vec<String> {
+    let mut directories = BTreeSet::new();
+    for path in paths {
+        let mut at = 0;
+        while let Some(offset) = path[at..].find('/') {
+            at += offset;
+            directories.insert(path[..at].to_string());
+            at += 1;
+        }
+    }
+    let mut denied: Vec<String> = Vec::new();
+    for directory in directories {
+        // Shortest first (BTreeSet order puts `a` before `a/b`), so an
+        // ancestor's refusal is already recorded when its children are
+        // considered.
+        if denied.iter().any(|dir| directory.starts_with(dir)) {
+            continue;
+        }
+        match filter.verdict(&directory) {
+            Verdict::Denied { pattern } => {
+                coverage.push(CoverageRow {
+                    path: Some(directory.clone()),
+                    status: Coverage::Excluded,
+                    detail: Some(format!("refused at acquisition by {pattern}")),
+                    bytes: None,
+                });
+                denied.push(format!("{directory}/"));
+            }
+            Verdict::Allowed => coverage.push(CoverageRow {
+                path: Some(directory),
+                status: Coverage::Discovered,
+                detail: Some("directory".to_string()),
+                bytes: None,
+            }),
+        }
+    }
+    denied
+}
+
+/// Split the wanted entries into batches bounded by both
+/// [`BATCH_OBJECT_LIMIT`] and [`BATCH_BYTE_BUDGET`].
+///
+/// A single entry always gets a batch of its own rather than being dropped
+/// for exceeding the byte budget alone — the per-resource ceiling is the only
+/// thing allowed to refuse a file, and it already ran.
+pub(crate) fn batches<'a>(wanted: &[&'a TreeEntry]) -> Vec<Vec<&'a TreeEntry>> {
+    let mut out: Vec<Vec<&TreeEntry>> = Vec::new();
+    let mut current: Vec<&TreeEntry> = Vec::new();
+    let mut bytes = 0u64;
+    for entry in wanted {
+        let over_budget = !current.is_empty()
+            && (current.len() >= BATCH_OBJECT_LIMIT
+                || bytes.saturating_add(entry.size) > BATCH_BYTE_BUDGET);
+        if over_budget {
+            out.push(std::mem::take(&mut current));
+            bytes = 0;
+        }
+        bytes = bytes.saturating_add(entry.size);
+        current.push(entry);
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// List and extract in one call — the ordinary path.
+pub fn scan_estate_git(source: &EstateGitSource) -> Result<EstateGitScan, GitScanError> {
+    let tree = list_tree(source)?;
+    let scan = extract_tree(source, &tree)?;
+    let drift = observe_drift(source, &tree);
+    Ok(EstateGitScan {
+        scan,
+        tree_oid: tree.tree_oid,
+        drift,
+    })
+}
+
+/// §11.4's observation for a scan: has the mount's committed HEAD moved off
+/// the SHA this scan was pinned to?
+///
+/// **One `git rev-parse HEAD`**, exactly as [`crate::runtime::integrity`]'s
+/// retirement-time observer is bounded to — no status, no worktree walk, no
+/// polling. `None` means the mount is still where the scan pinned it. `Some`
+/// means it moved, and the scan is still the world it said it was: the
+/// observation rides *beside* the rows
+/// ([`EstateGitScan::drift`]), never inside them, because a scan that blended
+/// the two would be evidence about no world at all.
+///
+/// A mount whose HEAD cannot be read at all is not drift and is not an error
+/// here — it is the absence of an observation, and `Ok(None)` says so.
+pub fn observe_drift(source: &EstateGitSource, tree: &GitTree) -> Option<EstateDriftObservation> {
+    let head = git(&source.mount, &["rev-parse", "HEAD"]).ok()?;
+    if head == tree.commit_sha {
+        return None;
+    }
+    Some(EstateDriftObservation {
+        repository: source.name.clone(),
+        before: tree.commit_sha.clone(),
+        observed: head,
+        attribution: DriftAttribution::Unknown,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+    use crate::runtime::git::git as run_git;
+
+    /// A repository built from `(path, contents)` pairs, committed once.
+    fn repo(files: &[(&str, &str)]) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        run_git(root, &["init", "--initial-branch=main"]).expect("init");
+        run_git(root, &["config", "user.email", "t@example.com"]).expect("email");
+        run_git(root, &["config", "user.name", "T"]).expect("name");
+        let sha = commit(root, files, "one");
+        (dir, sha)
+    }
+
+    fn commit(root: &std::path::Path, files: &[(&str, &str)], message: &str) -> String {
+        for (path, body) in files {
+            let full = root.join(path);
+            std::fs::create_dir_all(full.parent().expect("parent")).expect("mkdir");
+            std::fs::write(&full, body).expect("write");
+        }
+        run_git(root, &["add", "-A"]).expect("add");
+        run_git(root, &["commit", "-m", message]).expect("commit");
+        run_git(root, &["rev-parse", "HEAD"]).expect("rev-parse")
+    }
+
+    fn source(root: &std::path::Path, sha: &str, ignore: &[&str]) -> EstateGitSource {
+        EstateGitSource {
+            name: "product".to_string(),
+            mount: root.to_path_buf(),
+            pinned_sha: sha.to_string(),
+            ignore: ignore.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn row<'a>(scan: &'a SourceScan, path: &str) -> &'a CoverageRow {
+        scan.coverage
+            .iter()
+            .find(|r| r.path.as_deref() == Some(path))
+            .unwrap_or_else(|| panic!("no coverage row for {path:?}"))
+    }
+
+    /// F8, on the git path: every path the tree holds leaves exactly one row,
+    /// with the status the situation warrants, and the deny set applies at
+    /// the acquisition boundary exactly as it does on the filesystem path.
+    #[test]
+    fn every_tree_path_leaves_exactly_one_coverage_row() {
+        let (dir, sha) = repo(&[
+            ("README.md", "# Top\n\nbody\n"),
+            ("docs/one.md", "# One\n"),
+            ("docs/plain.txt", "just text\n"),
+            ("src/main.rs", "fn main() {}\n"),
+            ("keys/server.pem", "-----BEGIN\n"),
+            (".env", "SECRET=1\n"),
+        ]);
+        let scanned = scan_estate_git(&source(dir.path(), &sha, &[])).expect("scan");
+        let scan = &scanned.scan;
+        let paths: Vec<&str> = scan
+            .coverage
+            .iter()
+            .filter_map(|r| r.path.as_deref())
+            .collect();
+        let mut sorted = paths.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(paths.len(), sorted.len(), "a path got two rows: {paths:?}");
+
+        assert_eq!(row(scan, "README.md").status, Coverage::Indexed);
+        assert_eq!(row(scan, "docs/one.md").status, Coverage::Indexed);
+        assert_eq!(row(scan, "docs/plain.txt").status, Coverage::Indexed);
+        assert_eq!(row(scan, "src/main.rs").status, Coverage::Unsupported);
+        assert_eq!(row(scan, "keys/server.pem").status, Coverage::Excluded);
+        assert_eq!(row(scan, ".env").status, Coverage::Excluded);
+        assert_eq!(row(scan, "docs").status, Coverage::Discovered);
+        assert_eq!(scan.kind, SourceKind::EstateGit);
+        assert_eq!(scan.authority, AuthorityClass::EstateMutable);
+        assert_eq!(scan.revision.as_deref(), Some(sha.as_str()));
+        assert!(scanned.drift.is_none(), "the mount never moved");
+
+        let secret = scan
+            .files
+            .iter()
+            .flat_map(|f| f.units.iter().map(|u| u.text.as_str()))
+            .any(|t| t.contains("SECRET=1"));
+        assert!(!secret, "an excluded blob reached a unit");
+    }
+
+    /// F7's estate-git half, where it can actually fail: the stored content
+    /// identity **is** the blob OID Git reports, and the key is that OID plus
+    /// the extractor. Two identical files share one blob and therefore one
+    /// key, by construction and not by a second hash.
+    #[test]
+    fn keys_are_the_blob_oid_plus_the_extractor_never_a_second_hash() {
+        let (dir, sha) = repo(&[("a.md", "# Same\n"), ("copy/b.md", "# Same\n")]);
+        let src = source(dir.path(), &sha, &[]);
+        let tree = list_tree(&src).expect("list");
+        let scan = extract_tree(&src, &tree).expect("extract");
+        assert_eq!(scan.files.len(), 2);
+        let a = &scan.files[0];
+        let b = &scan.files[1];
+        assert_eq!(a.content_hash, b.content_hash, "one blob, one oid");
+        assert_eq!(a.local_key, b.local_key);
+
+        let oid = run_git(dir.path(), &["rev-parse", &format!("{sha}:a.md")]).expect("rev-parse");
+        assert_eq!(a.content_hash, oid, "the content key is Git's own oid");
+        assert_eq!(a.local_key, estate_git_key(&oid, MARKDOWN_EXTRACTOR));
+        assert_ne!(
+            a.local_key,
+            crate::domain::source::local_key(&oid, MARKDOWN_EXTRACTOR),
+            "the two key spaces are domain-separated"
+        );
+        assert!(a.mtime_millis.is_none(), "an object store has no mtime");
+        assert_eq!(scan.content_key, tree.tree_oid);
+    }
+
+    /// A gitlink and a symlink are coverage facts, not errors and not
+    /// followed.
+    #[test]
+    fn a_symlink_and_a_gitlink_are_reported_and_never_followed() {
+        let (dir, _) = repo(&[("real.md", "# Real\n")]);
+        let root = dir.path();
+        std::os::unix::fs::symlink("/etc/passwd", root.join("escape.md")).expect("symlink");
+        // A gitlink without a submodule checkout: the index entry is all a
+        // tree needs, and it is what a partial clone leaves behind anyway.
+        // The commit it names is this repository's own, which is simply a
+        // valid id that is not in any *submodule* — exactly the situation
+        // that makes a gitlink unreadable here.
+        let elsewhere = run_git(root, &["rev-parse", "HEAD"]).expect("head");
+        run_git(
+            root,
+            &[
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                &format!("160000,{elsewhere},vendor/dep"),
+            ],
+        )
+        .expect("update-index");
+        run_git(root, &["add", "escape.md"]).expect("add");
+        run_git(root, &["commit", "-m", "two"]).expect("commit");
+        let sha = run_git(root, &["rev-parse", "HEAD"]).expect("head");
+
+        let scan = scan_estate_git(&source(root, &sha, &[]))
+            .expect("scan")
+            .scan;
+        assert_eq!(row(&scan, "escape.md").status, Coverage::Unavailable);
+        assert!(
+            row(&scan, "escape.md")
+                .detail
+                .as_deref()
+                .is_some_and(|d| d.contains("symlink"))
+        );
+        assert_eq!(row(&scan, "vendor/dep").status, Coverage::Unsupported);
+        assert!(
+            row(&scan, "vendor/dep")
+                .detail
+                .as_deref()
+                .is_some_and(|d| d.contains("gitlink"))
+        );
+        assert_eq!(scan.files.len(), 1, "only the real file was acquired");
+    }
+
+    /// A denied *directory* is refused once and nothing under it is mentioned
+    /// again — the same two spellings the filesystem walk has.
+    #[test]
+    fn a_denied_directory_is_refused_once_and_its_children_are_not_listed() {
+        let (dir, sha) = repo(&[
+            ("keep.md", "# Keep\n"),
+            ("build/out.md", "# Generated\n"),
+            ("build/deep/more.md", "# More\n"),
+            ("vendor/lib.md", "# Vendored\n"),
+        ]);
+        let scan = scan_estate_git(&source(dir.path(), &sha, &["build", "vendor/**"]))
+            .expect("scan")
+            .scan;
+        assert_eq!(row(&scan, "build").status, Coverage::Excluded);
+        assert!(
+            !scan
+                .coverage
+                .iter()
+                .any(|r| r.path.as_deref().is_some_and(|p| p.starts_with("build/"))),
+            "a refused directory's children were listed: {:?}",
+            scan.coverage
+        );
+        // The `/**` spelling reports per file and leaves the directory
+        // discovered.
+        assert_eq!(row(&scan, "vendor").status, Coverage::Discovered);
+        assert_eq!(row(&scan, "vendor/lib.md").status, Coverage::Excluded);
+        assert_eq!(scan.files.len(), 1);
+    }
+
+    /// Batching is a real property, not a comment: many blobs are grouped,
+    /// and the grouping never drops or reorders one.
+    #[test]
+    fn many_blobs_are_read_in_grouped_batches() {
+        let bodies: Vec<(String, String)> = (0..40)
+            .map(|i| (format!("d{}/f{i}.md", i % 4), format!("# Doc {i}\n")))
+            .collect();
+        let files: Vec<(&str, &str)> = bodies
+            .iter()
+            .map(|(p, b)| (p.as_str(), b.as_str()))
+            .collect();
+        let (dir, sha) = repo(&files);
+        let src = source(dir.path(), &sha, &[]);
+        let tree = list_tree(&src).expect("list");
+        let scan = extract_tree(&src, &tree).expect("extract");
+        assert_eq!(scan.files.len(), 40);
+        for (path, body) in &bodies {
+            let file = scan
+                .files
+                .iter()
+                .find(|f| &f.relative_path == path)
+                .unwrap_or_else(|| panic!("missing {path}"));
+            assert_eq!(file.units[0].text, *body);
+        }
+
+        // The bounds are what group them, and both directions are exercised
+        // rather than assumed.
+        let wanted: Vec<&TreeEntry> = tree.entries.iter().collect();
+        assert_eq!(batches(&wanted).len(), 1, "40 tiny blobs are one batch");
+        let huge: Vec<TreeEntry> = (0..3)
+            .map(|i| TreeEntry {
+                path: format!("big{i}.md"),
+                oid: "0".repeat(40),
+                mode: "100644".to_string(),
+                kind: EntryKind::File,
+                size: BATCH_BYTE_BUDGET,
+            })
+            .collect();
+        let refs: Vec<&TreeEntry> = huge.iter().collect();
+        assert_eq!(batches(&refs).len(), 3, "the byte budget splits them");
+        assert!(
+            batches(&refs).iter().all(|b| b.len() == 1),
+            "one oversized entry still gets its own batch rather than none"
+        );
+    }
+
+    /// The scan is a pure function of the pinned commit: the same SHA scanned
+    /// twice, with the working tree scribbled on in between, is identical
+    /// evidence — the working tree is not an input.
+    #[test]
+    fn the_working_tree_is_not_an_input() {
+        let (dir, sha) = repo(&[("a.md", "# A\n"), ("b.md", "# B\n")]);
+        let src = source(dir.path(), &sha, &[]);
+        let first = extract_tree(&src, &list_tree(&src).expect("list")).expect("extract");
+        std::fs::write(dir.path().join("a.md"), "# TOTALLY DIFFERENT\n").expect("write");
+        std::fs::write(dir.path().join("untracked.md"), "# Not committed\n").expect("write");
+        std::fs::remove_file(dir.path().join("b.md")).expect("remove");
+        let second = extract_tree(&src, &list_tree(&src).expect("list")).expect("extract");
+        assert_eq!(first.files, second.files);
+        assert_eq!(first.coverage, second.coverage);
+        assert_eq!(first.content_key, second.content_key);
+        assert!(
+            !second
+                .coverage
+                .iter()
+                .any(|r| r.path.as_deref() == Some("untracked.md")),
+            "an uncommitted file entered a pinned scan"
+        );
+    }
+
+    /// A SHA that is not in the object store is a named Git failure, never an
+    /// empty scan silently reported as coverage.
+    #[test]
+    fn an_unknown_revision_fails_rather_than_reporting_an_empty_world() {
+        let (dir, _) = repo(&[("a.md", "# A\n")]);
+        let err = list_tree(&source(dir.path(), &"f".repeat(40), &[])).expect_err("unknown sha");
+        assert!(matches!(err, GitScanError::Git(_)), "{err}");
+    }
+
+    /// The record parser reads `--long`'s own shape, including the gitlink's
+    /// `-` size and a path containing a space.
+    #[test]
+    fn tree_records_are_parsed_by_their_declared_shape() {
+        let src = EstateGitSource {
+            name: "r".to_string(),
+            mount: PathBuf::from("/tmp"),
+            pinned_sha: "abc".to_string(),
+            ignore: Vec::new(),
+        };
+        let entry =
+            parse_tree_record(b"100644 blob aaa      12\tdocs/a file.md", "abc", &src).expect("ok");
+        assert_eq!(entry.path, "docs/a file.md");
+        assert_eq!(entry.size, 12);
+        assert_eq!(entry.kind, EntryKind::File);
+        let link = parse_tree_record(b"120000 blob bbb       4\tlink", "abc", &src).expect("ok");
+        assert_eq!(link.kind, EntryKind::Symlink);
+        let sub =
+            parse_tree_record(b"160000 commit ccc       -\tvendor/dep", "abc", &src).expect("ok");
+        assert_eq!(sub.kind, EntryKind::Submodule);
+        assert_eq!(sub.size, 0);
+        let err = parse_tree_record(b"nonsense", "abc", &src).expect_err("malformed");
+        assert!(matches!(err, GitScanError::MalformedTree { .. }), "{err}");
+    }
+}

--- a/src/runtime/atlas/lane.rs
+++ b/src/runtime/atlas/lane.rs
@@ -1,0 +1,71 @@
+//! The thin F6 glue: extraction on the intelligence lane (X3a).
+//!
+//! H1-15 shipped two capacity lanes and one consumer. The execution lane
+//! bounds per-Work native processes; the intelligence lane was declared,
+//! bounded, and — in that sprint's own words — acquired by nothing, because
+//! the work it exists for had not been built. This file is where that stops
+//! being true: Atlas's source extraction is the intelligence lane's first
+//! real consumer, and F6 is the decision it implements.
+//!
+//! ```text
+//! Engine::run_intelligence   permit, then the blocking pool
+//!    -> scan_estate_git      one pinned commit's objects, extracted
+//!    -> scan_work_overlay    one Work surface, over its base
+//! ```
+//!
+//! # Why these two functions exist rather than a call site inlining them
+//!
+//! F6's adapter-shape mandate is that extraction is a pure function over
+//! bytes with "DB-touching glue kept thin and separately reviewable". The
+//! same argument applies to *daemon-state*-touching glue, which is what
+//! acquiring a lane permit is. [`super::git`] and [`super::overlay`] know
+//! nothing about an [`Engine`]; this file knows nothing about a database. Two
+//! small files at the bottom of the module graph, each joining exactly one
+//! thing to the pure middle, is the shape that keeps either half reviewable
+//! on its own.
+//!
+//! # What is bounded, and what is not
+//!
+//! The lane bounds *concurrency*, not duration or size. A scan that would read
+//! an enormous repository is not made small by waiting for a permit — the
+//! per-resource ceiling and the batch budgets in [`super::git`] are what bound
+//! that, and they are separate deliberately. The lane's one promise is the one
+//! F6 asks for: however much extraction the daemon is asked to do, it never
+//! spends the execution lane's budget doing it.
+
+use crate::runtime::atlas::git::{EstateGitScan, EstateGitSource, GitScanError, scan_estate_git};
+use crate::runtime::atlas::overlay::{OverlayScan, WorkOverlay, scan_work_overlay};
+use crate::runtime::engine::{Engine, IntelligenceError};
+
+/// Why an extraction on the lane did not produce an answer.
+#[derive(Debug, thiserror::Error)]
+pub enum LaneError {
+    /// The lane itself refused, or the job did not complete.
+    #[error(transparent)]
+    Lane(#[from] IntelligenceError),
+    /// The extraction ran and failed.
+    #[error(transparent)]
+    Scan(#[from] GitScanError),
+}
+
+/// Scan one estate-git source under an intelligence-lane permit, on the
+/// blocking pool (F6).
+pub async fn scan_estate_git_on_lane(
+    engine: &Engine,
+    source: EstateGitSource,
+) -> Result<EstateGitScan, LaneError> {
+    Ok(engine
+        .run_intelligence(move || scan_estate_git(&source))
+        .await??)
+}
+
+/// Scan one Work surface as an overlay under an intelligence-lane permit, on
+/// the blocking pool (F6).
+pub async fn scan_work_overlay_on_lane(
+    engine: &Engine,
+    overlay: WorkOverlay,
+) -> Result<OverlayScan, LaneError> {
+    Ok(engine
+        .run_intelligence(move || scan_work_overlay(&overlay))
+        .await??)
+}

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -51,25 +51,39 @@
 //!
 //! # Scope of what exists here today
 //!
-//! The four namespaces, and the four tables the local-knowledge scanner
-//! writes: `source.generations`, `source.files`, `source.units` and
-//! `meta.coverage`. `git` and `context` are still empty namespaces, by the
-//! same empty-table refusal doctrine the operations projection states — a
-//! table that can only ever answer "zero rows" is a false promise, not
-//! completeness, so every table lands in the wave that lands its writer.
+//! The four namespaces, and the four tables three walks now write:
+//! `source.generations`, `source.files`, `source.units` and `meta.coverage`.
+//! Local knowledge, an estate repository at an admission-pinned commit, and a
+//! Work surface overlaid on its base all land in the same four tables, because
+//! they produce the same kind of fact — a resource, its content identity, its
+//! extractor, and its units — and the source kind is a column, not a schema.
+//!
+//! `git` and `context` are still empty namespaces, and deliberately so even
+//! now that estate-git bytes are indexed: the `git.*` namespace is for
+//! *history* facts (commits, authorship, churn), which nothing in this build
+//! derives. The empty-table refusal doctrine the operations projection states
+//! applies — a table that can only ever answer "zero rows" is a false promise,
+//! not completeness — so every table still lands in the wave that lands its
+//! writer.
 //!
 //! ```text
-//! deny   ── pure predicate over a path (F10, the acquisition boundary)
-//! text   ── pure functions over bytes  (F6, extraction)
-//! scan   ── the walk: filesystem in, plain Rust out; no DB, no journal
-//! db     ── the one module that reaches the database driver, in or out
-//! record ── the thin three-step glue F1's crash window is stated over
+//! deny    ── pure predicate over a path (F10, the acquisition boundary)
+//! text    ── pure functions over bytes, and the one extractor routing table
+//! scan    ── the walk: filesystem in, plain Rust out; no DB, no journal
+//! git     ── the same, from a pinned commit's Git objects (X3a)
+//! overlay ── a Work surface's changes, over a base tree (X3a)
+//! db      ── the one module that reaches the database driver, in or out
+//! record  ── the thin three-step glue F1's crash window is stated over
+//! lane    ── the thin F6 glue: an intelligence permit and the blocking pool
 //! ```
 //!
-//! The dependency arrows run strictly downward through that list. `scan` does
-//! not import `db`, and `db` does not import the journal — which is what
-//! makes F6's "DB-touching glue kept thin and separately reviewable" a
-//! property of the module graph rather than a promise in a comment.
+//! The dependency arrows run strictly downward through that list. `scan`,
+//! `git` and `overlay` do not import `db`; `db` does not import the journal;
+//! and neither the walks nor `db` import the engine — which is what makes
+//! F6's "DB-touching glue kept thin and separately reviewable" a property of
+//! the module graph rather than a promise in a comment. `record` and `lane`
+//! are the two thin files at the bottom, and they are thin because everything
+//! above them is a pure function they merely call.
 //!
 //! (This file, like every sibling, is forbidden by
 //! `tests/x1_atlas_substrate.rs` from even *naming* the driver crate, so it
@@ -79,6 +93,9 @@
 
 pub mod db;
 pub mod deny;
+pub mod git;
+pub mod lane;
+pub mod overlay;
 pub mod record;
 pub mod scan;
 pub mod text;

--- a/src/runtime/atlas/overlay.rs
+++ b/src/runtime/atlas/overlay.rs
@@ -359,10 +359,25 @@ fn changed_file(overlay: &WorkOverlay, path: &str, out: &mut Extracted) -> Strin
 /// deletions; `ls-files --others --exclude-standard` covers files Git has
 /// never been told about, which the diff cannot see. `-z` on both, so a path
 /// containing a newline or a quote arrives verbatim.
+///
+/// **`--no-renames`, and not as a stylistic preference.** Git's default
+/// rename detection (`diff.renames`, true since 2.9, and configurable to
+/// `copies`) collapses `git mv a.md z.md` into one record naming only `z.md`.
+/// That is the right answer for a human reading a patch and the wrong one
+/// here twice over: the old path never enters the change set, so
+/// [`extract_overlay`] reads it out of the *base tree* and reports a file the
+/// Work deleted as `Indexed` — a pinned base blended with a false view of the
+/// working tree; and the digest omits the deletion, so "renamed `a.md` to
+/// `z.md`" and "kept `a.md`, added `z.md`" — two different worlds, one with a
+/// file the other has — produce the same generation key. A change set is a
+/// set of paths, not a story about them, so the similarity heuristic is
+/// turned off rather than interpreted. Passing the flag explicitly also makes
+/// the answer independent of whatever `diff.renames` the surface's config
+/// inherited.
 pub fn changed_paths(surface: &Path, base_sha: &str) -> Result<BTreeSet<String>, GitError> {
     let mut out = BTreeSet::new();
     for args in [
-        vec!["diff", "--name-only", "-z", base_sha, "--"],
+        vec!["diff", "--name-only", "--no-renames", "-z", base_sha, "--"],
         vec!["ls-files", "--others", "--exclude-standard", "-z"],
     ] {
         let raw = git_bytes(surface, &args)?;
@@ -630,5 +645,77 @@ mod tests {
         // Staging must not change the answer: a staged edit is still an edit.
         run_git(&surface, &["add", "untracked.md"]).expect("add");
         assert_eq!(changed_paths(&surface, &base).expect("staged"), changed);
+    }
+
+    /// A staged rename is a deletion *and* an addition, and the overlay must
+    /// see both halves.
+    ///
+    /// Git's own default answer here is one record naming only the new path.
+    /// Believing it would leave the old path outside the change set, where
+    /// [`extract_overlay`] extracts it from the base tree and reports a file
+    /// that is not on the surface as `Indexed` — the pinned base blended with
+    /// a false view of the working tree.
+    #[test]
+    fn a_staged_rename_reports_the_old_path_as_deleted() {
+        let (_dir, _mount, surface, base) =
+            mount_and_surface(&[("a.md", "# A\n"), ("b.md", "# B\n")]);
+        run_git(&surface, &["mv", "a.md", "z.md"]).expect("mv");
+
+        let changed = changed_paths(&surface, &base).expect("changed");
+        assert!(
+            changed.contains("a.md"),
+            "the vacated path is a change: {changed:?}"
+        );
+        assert!(changed.contains("z.md"), "so is the new one: {changed:?}");
+
+        let scanned = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+        assert_eq!(row(&scanned.scan, "a.md").status, Coverage::Unavailable);
+        assert!(
+            row(&scanned.scan, "a.md")
+                .detail
+                .as_deref()
+                .is_some_and(|d| d.contains("deleted on this Work's surface"))
+        );
+        assert!(
+            !scanned.scan.files.iter().any(|f| f.relative_path == "a.md"),
+            "a path the Work vacated must not be extracted from the base tree"
+        );
+        assert_eq!(
+            file(&scanned.scan, "z.md").content_hash,
+            content_hash(b"# A\n")
+        );
+        assert_eq!(
+            scanned.overlay_digest,
+            overlay_digest(&BTreeMap::from([
+                ("a.md".to_string(), DELETED_MARKER.to_string()),
+                ("z.md".to_string(), content_hash(b"# A\n")),
+            ]))
+        );
+    }
+
+    /// The collision the same bug produces in the key: a rename and a copy
+    /// are different worlds — one still has the original file, the other does
+    /// not — and a change set that drops the vacated path cannot tell them
+    /// apart.
+    #[test]
+    fn a_rename_and_a_copy_do_not_share_a_generation_key() {
+        // One surface, walked from the copy world into the rename world, so
+        // the base commit is the same SHA by construction and the only thing
+        // that moves between the two keys is the vacated path.
+        let (_dir, _mount, surface, base) = mount_and_surface(&[("a.md", "# A\n")]);
+        std::fs::write(surface.join("z.md"), "# A\n").expect("write");
+        run_git(&surface, &["add", "-A"]).expect("add");
+        let copied = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+
+        std::fs::remove_file(surface.join("a.md")).expect("remove");
+        run_git(&surface, &["add", "-A"]).expect("add");
+        let renamed = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+
+        assert_ne!(
+            renamed.scan.content_key, copied.scan.content_key,
+            "a world missing a.md and a world keeping it are not one generation"
+        );
+        assert_eq!(copied.scan.files.len(), 2);
+        assert_eq!(renamed.scan.files.len(), 1);
     }
 }

--- a/src/runtime/atlas/overlay.rs
+++ b/src/runtime/atlas/overlay.rs
@@ -1,0 +1,634 @@
+//! Work-overlay hashing: a Work surface's changes, over its base tree (X3a).
+//!
+//! A Work's mutation surface is a linked worktree cut from a mount at an
+//! admission-pinned commit. Almost all of it is that commit — a Work that
+//! edits four files leaves every other file byte-identical to the base tree,
+//! and re-deriving evidence for all of them would be the whole cost of a
+//! repository scan to describe four files.
+//!
+//! So an overlay generation is exactly that: **the base tree, plus a
+//! difference.**
+//!
+//! ```text
+//! unchanged paths  keyed by blob OID + extractor   (F7's estate-git rule)
+//! changed paths    keyed by BLAKE3 + extractor     (F7's local rule)
+//! the generation   base commit SHA + overlay digest of the changed paths
+//! ```
+//!
+//! Each half uses the key rule that is *true* for it, which is the whole
+//! reason F7 has two. An unchanged path's bytes are in the object store and
+//! Git has already hashed them; hashing them again would be the second hash
+//! F7 forbids. A changed path's bytes are in a working tree and Git has *not*
+//! hashed them — there is no OID to reuse, and BLAKE3 over the file is the
+//! only content identity available. Nothing here re-hashes anything Git
+//! already named, and nothing here pretends an uncommitted file has an OID.
+//!
+//! # Scoped to one Work, and evicted with it
+//!
+//! An overlay generation describes a world only one Work can see, and only
+//! while that Work exists. Its source name carries the Work id
+//! ([`overlay_source_name`]) so the rows are addressable as a set, and
+//! [`AtlasDb::evict_work_overlays`](crate::runtime::atlas::db::AtlasDb::evict_work_overlays)
+//! removes that set — leaving a `generation_evicted` coverage row per
+//! generation, the same reported-never-silent discipline every other eviction
+//! follows. A retired Work's overlay evidence does not linger as facts about
+//! a surface that no longer exists.
+//!
+//! # What an overlay is not
+//!
+//! Not a second opinion about the mount. The base half is read from the
+//! object store at the pinned SHA, exactly as [`super::git`] reads it, so an
+//! overlay and a plain estate-git scan of the same base agree on every
+//! unchanged path by construction rather than by coincidence.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use crate::domain::event::rfc3339_utc_now;
+use crate::domain::source::{
+    AuthorityClass, Coverage, CoverageRow, SourceKind, content_hash, local_key, overlay_digest,
+    overlay_generation_key,
+};
+use crate::runtime::atlas::deny::{AcquisitionFilter, Verdict};
+use crate::runtime::atlas::git::{
+    EstateGitSource, Extracted, GitScanError, GitTree, TreeEntry, directory_coverage,
+    extract_blobs, list_tree,
+};
+use crate::runtime::atlas::scan::{MAX_RESOURCE_BYTES, ScannedFile, SourceScan, extract_units};
+use crate::runtime::atlas::text::{as_text, extractor_for};
+use crate::runtime::git::{GitError, git_bytes};
+
+/// What an overlay digest records for a path the Work **deleted**.
+///
+/// A deletion has no bytes to hash, and leaving it out of the digest
+/// altogether would make "deleted `a.md`" and "changed nothing" the same
+/// overlay — which they are not: the first has one fewer indexed file. Hex is
+/// what every other value in the map is, so a marker in angle brackets cannot
+/// collide with one.
+pub const DELETED_MARKER: &str = "<deleted>";
+
+/// What the digest records for a changed path that could not be read at all.
+///
+/// Deliberately **does not carry the io error's own text**, however useful
+/// that text is: the coverage row carries it, and a generation key that
+/// embedded it would move whenever the wording of a `strerror` did. A key has
+/// to be a function of the world, not of a message about it.
+pub const UNREADABLE_MARKER: &str = "<unreadable>";
+
+/// What the digest records for a changed path that is not a regular file (a
+/// symlink, a fifo, a directory that replaced a file).
+pub const NOT_A_FILE_MARKER: &str = "<not-a-regular-file>";
+
+/// What the digest records for a changed path past the resource ceiling.
+///
+/// Carries the size, which *is* a fact about the world: a Work that grows an
+/// over-ceiling file further has changed something, and the key should move.
+pub fn over_ceiling_marker(bytes: u64) -> String {
+    format!("<over-ceiling:{bytes}>")
+}
+
+/// The prefix an overlay source name starts with. Public because eviction
+/// matches on it.
+pub const OVERLAY_PREFIX: &str = "work:";
+
+/// One Work surface, to be read as an overlay over its base.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkOverlay {
+    /// The Work whose surface this is — the scope the generation is evicted
+    /// with.
+    pub work_id: String,
+    /// The repository within that Work's scope.
+    pub repository: String,
+    /// The linked worktree itself: `<surfaces-dir>/<work-id>/<repo>`.
+    pub surface: PathBuf,
+    /// §8.2's admission-pinned base commit the surface was cut from.
+    pub base_sha: String,
+    /// Per-source ignore globs, extending the built-in deny set (F10).
+    pub ignore: Vec<String>,
+}
+
+/// The source coordinate an overlay generation's rows carry.
+///
+/// Work id first so the whole of one Work's overlay evidence is a single
+/// prefix — which is what makes "evicted with the Work" one filter rather
+/// than a join.
+pub fn overlay_source_name(work_id: &str, repository: &str) -> String {
+    format!("{OVERLAY_PREFIX}{work_id}/{repository}")
+}
+
+/// The prefix every one of `work_id`'s overlay sources begins with.
+pub fn overlay_source_prefix(work_id: &str) -> String {
+    format!("{OVERLAY_PREFIX}{work_id}/")
+}
+
+/// One completed overlay scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverlayScan {
+    /// The rows, in the shape every `source.*` writer already takes.
+    pub scan: SourceScan,
+    /// The base commit the overlay stands on.
+    pub base_sha: String,
+    /// The digest of what the surface changed — the other half of
+    /// [`SourceScan::content_key`].
+    pub overlay_digest: String,
+    /// Paths the surface changed, added or deleted relative to the base.
+    pub changed: BTreeSet<String>,
+}
+
+/// Scan one Work surface as an overlay over its admission-pinned base.
+///
+/// Three Git conversations and no more: list the base tree, ask what the
+/// surface changed, and batch-read the unchanged blobs. Changed paths are read
+/// from the surface's working tree — which is the one place in Atlas that
+/// legitimately reads a working tree, because uncommitted work has nowhere
+/// else to live.
+pub fn scan_work_overlay(overlay: &WorkOverlay) -> Result<OverlayScan, GitScanError> {
+    let base_source = EstateGitSource {
+        name: overlay.repository.clone(),
+        // A linked worktree shares its mount's object store, so the base
+        // commit resolves here without going near the mount — and without any
+        // chance of reading a mount whose HEAD has since moved.
+        mount: overlay.surface.clone(),
+        pinned_sha: overlay.base_sha.clone(),
+        ignore: overlay.ignore.clone(),
+    };
+    let base = list_tree(&base_source)?;
+    let changed = changed_paths(&overlay.surface, &base.commit_sha)?;
+    extract_overlay(overlay, &base, &changed)
+}
+
+/// The extraction half, over an already-listed base and an already-computed
+/// change set.
+///
+/// Separate from [`scan_work_overlay`] for the same reason
+/// [`super::git::extract_tree`] is separate from `list_tree`: it makes the
+/// world the scan is of an *input*, so a test can hold one fixed while
+/// something else moves.
+pub fn extract_overlay(
+    overlay: &WorkOverlay,
+    base: &GitTree,
+    changed: &BTreeSet<String>,
+) -> Result<OverlayScan, GitScanError> {
+    let filter = AcquisitionFilter::new(&overlay.ignore)?;
+    let mut out = Extracted::default();
+
+    // The path universe is the base tree plus whatever the surface added, so
+    // a directory that exists only because of this Work still gets its row.
+    let mut universe: BTreeSet<String> = base.entries.iter().map(|e| e.path.clone()).collect();
+    universe.extend(changed.iter().cloned());
+    let denied_dirs = directory_coverage(&universe, &filter, &mut out.coverage);
+
+    let unchanged: Vec<TreeEntry> = base
+        .entries
+        .iter()
+        .filter(|entry| !changed.contains(&entry.path))
+        .cloned()
+        .collect();
+    extract_blobs(
+        &overlay.surface,
+        &filter,
+        &unchanged,
+        &denied_dirs,
+        &mut out,
+    )?;
+
+    let mut digest_input: BTreeMap<String, String> = BTreeMap::new();
+    for path in changed {
+        if denied_dirs.iter().any(|dir| path.starts_with(dir)) {
+            continue;
+        }
+        if let Verdict::Denied { pattern } = filter.verdict(path) {
+            out.coverage.push(CoverageRow {
+                path: Some(path.clone()),
+                status: Coverage::Excluded,
+                detail: Some(format!("refused at acquisition by {pattern}")),
+                bytes: std::fs::symlink_metadata(overlay.surface.join(path))
+                    .ok()
+                    .filter(|m| m.is_file())
+                    .map(|m| m.len()),
+            });
+            continue;
+        }
+        digest_input.insert(path.clone(), changed_file(overlay, path, &mut out));
+    }
+
+    out.files
+        .sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    out.coverage.sort_by(|a, b| a.path.cmp(&b.path));
+    let digest = overlay_digest(&digest_input);
+    Ok(OverlayScan {
+        scan: SourceScan {
+            source_name: overlay_source_name(&overlay.work_id, &overlay.repository),
+            kind: SourceKind::EstateGit,
+            authority: AuthorityClass::EstateMutable,
+            content_key: overlay_generation_key(&base.commit_sha, &digest),
+            // The commit the overlay stands *on*. Not the world's whole
+            // identity — that is `content_key`, which composes this with the
+            // digest — but the provenance question "cut from what?" has this
+            // one answer and a reader needs it.
+            revision: Some(base.commit_sha.clone()),
+            observed_at: rfc3339_utc_now(),
+            files: out.files,
+            coverage: out.coverage,
+            extractors: out.extractors,
+        },
+        base_sha: base.commit_sha.clone(),
+        overlay_digest: digest,
+        changed: changed.clone(),
+    })
+}
+
+/// Acquire one changed path from the surface's working tree, appending its
+/// rows to `out`, and answer with what the overlay digest records for it.
+///
+/// Every refusal still returns a digest value, because the digest has to
+/// distinguish "this Work deleted it", "this Work made it unreadable" and
+/// "this Work did nothing to it" — three different worlds that would otherwise
+/// share one key.
+fn changed_file(overlay: &WorkOverlay, path: &str, out: &mut Extracted) -> String {
+    let full = overlay.surface.join(path);
+    let meta = match std::fs::symlink_metadata(&full) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            out.coverage.push(CoverageRow {
+                path: Some(path.to_string()),
+                status: Coverage::Unavailable,
+                detail: Some("deleted on this Work's surface".to_string()),
+                bytes: None,
+            });
+            return DELETED_MARKER.to_string();
+        }
+        Err(e) => {
+            out.coverage.push(CoverageRow {
+                path: Some(path.to_string()),
+                status: Coverage::Unavailable,
+                detail: Some(format!("cannot be inspected: {e}")),
+                bytes: None,
+            });
+            return UNREADABLE_MARKER.to_string();
+        }
+    };
+    if meta.file_type().is_symlink() || !meta.is_file() {
+        out.coverage.push(CoverageRow {
+            path: Some(path.to_string()),
+            status: if meta.file_type().is_symlink() {
+                Coverage::Unavailable
+            } else {
+                Coverage::Unsupported
+            },
+            detail: Some(if meta.file_type().is_symlink() {
+                "symlink is not followed".to_string()
+            } else {
+                "not a regular file".to_string()
+            }),
+            bytes: None,
+        });
+        return NOT_A_FILE_MARKER.to_string();
+    }
+    let Some(extractor) = extractor_for(path) else {
+        out.coverage.push(CoverageRow {
+            path: Some(path.to_string()),
+            status: Coverage::Unsupported,
+            detail: Some("no extractor in this build claims this extension".to_string()),
+            bytes: Some(meta.len()),
+        });
+        // Still hashed: an unextractable file whose bytes changed changed the
+        // world, and the generation key has to move even though no unit does.
+        return std::fs::read(&full)
+            .map_or_else(|_| UNREADABLE_MARKER.to_string(), |b| content_hash(&b));
+    };
+    if meta.len() > MAX_RESOURCE_BYTES {
+        out.coverage.push(CoverageRow {
+            path: Some(path.to_string()),
+            status: Coverage::Unsupported,
+            detail: Some(format!(
+                "larger than the {MAX_RESOURCE_BYTES}-byte resource ceiling"
+            )),
+            bytes: Some(meta.len()),
+        });
+        return over_ceiling_marker(meta.len());
+    }
+    let bytes = match std::fs::read(&full) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            out.coverage.push(CoverageRow {
+                path: Some(path.to_string()),
+                status: Coverage::Unavailable,
+                detail: Some(format!("cannot be read: {e}")),
+                bytes: Some(meta.len()),
+            });
+            return UNREADABLE_MARKER.to_string();
+        }
+    };
+    // **F7's local rule**, and the only place in the overlay it applies:
+    // these bytes are not in any object store, so no OID names them.
+    let hash = content_hash(&bytes);
+    let Some(text) = as_text(&bytes) else {
+        out.coverage.push(CoverageRow {
+            path: Some(path.to_string()),
+            status: Coverage::Unsupported,
+            detail: Some("not valid UTF-8 text".to_string()),
+            bytes: Some(bytes.len() as u64),
+        });
+        return hash;
+    };
+    out.extractors.insert(extractor.to_string());
+    out.coverage.push(CoverageRow {
+        path: Some(path.to_string()),
+        status: Coverage::Indexed,
+        detail: Some(extractor.to_string()),
+        bytes: Some(bytes.len() as u64),
+    });
+    out.files.push(ScannedFile {
+        relative_path: path.to_string(),
+        local_key: local_key(&hash, extractor),
+        content_hash: hash.clone(),
+        extractor: extractor.to_string(),
+        byte_len: bytes.len() as u64,
+        mtime_millis: None,
+        units: extract_units(text, extractor),
+    });
+    hash
+}
+
+/// Every path the surface changed relative to `base_sha`: tracked differences
+/// and untracked additions, together.
+///
+/// Two reads, because Git answers them separately and neither subsumes the
+/// other. `diff --name-only <sha>` covers modifications, staged or not, and
+/// deletions; `ls-files --others --exclude-standard` covers files Git has
+/// never been told about, which the diff cannot see. `-z` on both, so a path
+/// containing a newline or a quote arrives verbatim.
+pub fn changed_paths(surface: &Path, base_sha: &str) -> Result<BTreeSet<String>, GitError> {
+    let mut out = BTreeSet::new();
+    for args in [
+        vec!["diff", "--name-only", "-z", base_sha, "--"],
+        vec!["ls-files", "--others", "--exclude-standard", "-z"],
+    ] {
+        let raw = git_bytes(surface, &args)?;
+        for record in raw.split(|b| *b == 0) {
+            if record.is_empty() {
+                continue;
+            }
+            out.insert(String::from_utf8_lossy(record).into_owned());
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::source::estate_git_key;
+    use crate::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+    use crate::runtime::git::git as run_git;
+
+    /// A mount with one commit, plus a linked worktree cut from it — the real
+    /// shape a Work surface has.
+    fn mount_and_surface(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf, PathBuf, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mount = dir.path().join("mount");
+        std::fs::create_dir_all(&mount).expect("mkdir");
+        run_git(&mount, &["init", "--initial-branch=main"]).expect("init");
+        run_git(&mount, &["config", "user.email", "t@example.com"]).expect("email");
+        run_git(&mount, &["config", "user.name", "T"]).expect("name");
+        for (path, body) in files {
+            let full = mount.join(path);
+            std::fs::create_dir_all(full.parent().expect("parent")).expect("mkdir");
+            std::fs::write(&full, body).expect("write");
+        }
+        run_git(&mount, &["add", "-A"]).expect("add");
+        run_git(&mount, &["commit", "-m", "base"]).expect("commit");
+        let base = run_git(&mount, &["rev-parse", "HEAD"]).expect("head");
+        let surface = dir.path().join("surface");
+        run_git(
+            &mount,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "sergeant/01WORK",
+                surface.to_str().expect("utf8"),
+                &base,
+            ],
+        )
+        .expect("worktree add");
+        (dir, mount, surface, base)
+    }
+
+    fn overlay(surface: &Path, base: &str) -> WorkOverlay {
+        WorkOverlay {
+            work_id: "01WORK".to_string(),
+            repository: "product".to_string(),
+            surface: surface.to_path_buf(),
+            base_sha: base.to_string(),
+            ignore: Vec::new(),
+        }
+    }
+
+    fn file<'a>(scan: &'a SourceScan, path: &str) -> &'a ScannedFile {
+        scan.files
+            .iter()
+            .find(|f| f.relative_path == path)
+            .unwrap_or_else(|| panic!("no file row for {path:?}"))
+    }
+
+    fn row<'a>(scan: &'a SourceScan, path: &str) -> &'a CoverageRow {
+        scan.coverage
+            .iter()
+            .find(|r| r.path.as_deref() == Some(path))
+            .unwrap_or_else(|| panic!("no coverage row for {path:?}"))
+    }
+
+    /// The whole rule, in one test: changed paths are BLAKE3-keyed, unchanged
+    /// paths keep their blob-OID keys, and the generation key composes the
+    /// base SHA with the overlay digest.
+    #[test]
+    fn changed_paths_are_blake3_keyed_and_unchanged_paths_keep_their_oids() {
+        let (_dir, mount, surface, base) =
+            mount_and_surface(&[("a.md", "# A\n"), ("b.md", "# B\n"), ("docs/c.md", "# C\n")]);
+        std::fs::write(surface.join("a.md"), "# A, edited\n").expect("write");
+        std::fs::write(surface.join("new.md"), "# New\n").expect("write");
+
+        let scanned = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+        let scan = &scanned.scan;
+        assert_eq!(
+            scanned.changed,
+            BTreeSet::from(["a.md".to_string(), "new.md".to_string()])
+        );
+
+        // Unchanged: the key is Git's own OID plus the extractor, and it is
+        // exactly what a plain estate-git scan of the base produces.
+        let b_oid = run_git(&mount, &["rev-parse", &format!("{base}:b.md")]).expect("oid");
+        assert_eq!(file(scan, "b.md").content_hash, b_oid);
+        assert_eq!(
+            file(scan, "b.md").local_key,
+            estate_git_key(&b_oid, MARKDOWN_EXTRACTOR)
+        );
+        assert_eq!(file(scan, "docs/c.md").content_hash.len(), b_oid.len());
+
+        // Changed and added: BLAKE3 of the working-tree bytes, and never an
+        // OID — there is no object for bytes Git has not been given.
+        let edited = content_hash(b"# A, edited\n");
+        assert_eq!(file(scan, "a.md").content_hash, edited);
+        assert_eq!(
+            file(scan, "a.md").local_key,
+            local_key(&edited, MARKDOWN_EXTRACTOR)
+        );
+        let added = content_hash(b"# New\n");
+        assert_eq!(file(scan, "new.md").content_hash, added);
+        assert_eq!(file(scan, "a.md").units[0].text, "# A, edited\n");
+
+        // The generation key is the composition, and it is reproducible from
+        // its two declared halves rather than from anything opaque.
+        let expected = overlay_generation_key(
+            &base,
+            &overlay_digest(&BTreeMap::from([
+                ("a.md".to_string(), edited),
+                ("new.md".to_string(), added),
+            ])),
+        );
+        assert_eq!(scan.content_key, expected);
+        assert_eq!(scanned.base_sha, base);
+        assert_eq!(scan.revision.as_deref(), Some(base.as_str()));
+    }
+
+    /// The base half and a plain estate-git scan agree on every unchanged
+    /// path — by construction, since both go through the same extractor.
+    #[test]
+    fn the_unchanged_half_agrees_with_a_plain_scan_of_the_base() {
+        let (_dir, mount, surface, base) =
+            mount_and_surface(&[("a.md", "# A\n"), ("b.md", "# B\n")]);
+        std::fs::write(surface.join("a.md"), "# A, edited\n").expect("write");
+        let overlaid = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+        let plain = crate::runtime::atlas::git::scan_estate_git(&EstateGitSource {
+            name: "product".to_string(),
+            mount,
+            pinned_sha: base.clone(),
+            ignore: Vec::new(),
+        })
+        .expect("scan");
+        assert_eq!(
+            file(&overlaid.scan, "b.md").local_key,
+            file(&plain.scan, "b.md").local_key
+        );
+        assert_ne!(
+            file(&overlaid.scan, "a.md").local_key,
+            file(&plain.scan, "a.md").local_key,
+            "the edited file must not reuse the base extraction"
+        );
+    }
+
+    /// A deletion changes the world and must move the key, even though it
+    /// produces no unit — the case a "hash what is there" digest gets wrong.
+    #[test]
+    fn a_deletion_is_reported_and_moves_the_generation_key() {
+        let (_dir, _mount, surface, base) =
+            mount_and_surface(&[("a.md", "# A\n"), ("b.md", "# B\n")]);
+        let untouched = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+        assert_eq!(untouched.scan.files.len(), 2);
+        assert!(untouched.changed.is_empty());
+
+        std::fs::remove_file(surface.join("b.md")).expect("remove");
+        let deleted = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+        assert_eq!(
+            deleted.scan.files.len(),
+            1,
+            "the deleted file is not indexed"
+        );
+        assert_eq!(row(&deleted.scan, "b.md").status, Coverage::Unavailable);
+        assert!(
+            row(&deleted.scan, "b.md")
+                .detail
+                .as_deref()
+                .is_some_and(|d| d.contains("deleted on this Work's surface"))
+        );
+        assert_ne!(
+            deleted.scan.content_key, untouched.scan.content_key,
+            "a deletion changed the world and must change the key"
+        );
+        assert_eq!(
+            deleted.overlay_digest,
+            overlay_digest(&BTreeMap::from([(
+                "b.md".to_string(),
+                DELETED_MARKER.to_string()
+            )]))
+        );
+    }
+
+    /// Two Works cut from the same base with the same edit still get separate,
+    /// separately-evictable generations — and one that edits something else
+    /// gets a different key.
+    #[test]
+    fn overlays_are_scoped_to_their_work_and_keyed_by_what_they_changed() {
+        let (_dir, _mount, surface, base) =
+            mount_and_surface(&[("a.md", "# A\n"), ("b.md", "# B\n")]);
+        std::fs::write(surface.join("a.md"), "# Edited\n").expect("write");
+        let one = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+
+        let mut other = overlay(&surface, &base);
+        other.work_id = "01OTHER".to_string();
+        let two = scan_work_overlay(&other).expect("overlay");
+
+        assert_eq!(one.scan.source_name, "work:01WORK/product");
+        assert_eq!(two.scan.source_name, "work:01OTHER/product");
+        assert!(
+            one.scan
+                .source_name
+                .starts_with(&overlay_source_prefix("01WORK"))
+        );
+        assert!(
+            !one.scan
+                .source_name
+                .starts_with(&overlay_source_prefix("01OTHER"))
+        );
+        // Same base, same change: the same world, and therefore the same
+        // content key even though the rows are scoped separately.
+        assert_eq!(one.scan.content_key, two.scan.content_key);
+
+        std::fs::write(surface.join("b.md"), "# Also edited\n").expect("write");
+        let three = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+        assert_ne!(three.scan.content_key, one.scan.content_key);
+    }
+
+    /// F10 holds on the overlay path too: a secret a Work *creates* is
+    /// refused at the boundary and never reaches a unit.
+    #[test]
+    fn a_secret_created_on_the_surface_is_refused_at_the_boundary() {
+        let (_dir, _mount, surface, base) = mount_and_surface(&[("a.md", "# A\n")]);
+        std::fs::write(surface.join(".env"), "SECRET=hunter2\n").expect("write");
+        std::fs::create_dir_all(surface.join("keys")).expect("mkdir");
+        std::fs::write(surface.join("keys/server.pem"), "-----BEGIN\n").expect("write");
+        let scanned = scan_work_overlay(&overlay(&surface, &base)).expect("overlay");
+        assert_eq!(row(&scanned.scan, ".env").status, Coverage::Excluded);
+        assert_eq!(
+            row(&scanned.scan, "keys/server.pem").status,
+            Coverage::Excluded
+        );
+        let text: String = scanned
+            .scan
+            .files
+            .iter()
+            .flat_map(|f| f.units.iter().map(|u| u.text.clone()))
+            .collect();
+        assert!(!text.contains("hunter2"), "a secret reached a unit");
+    }
+
+    /// The change set is Git's own answer, and it sees both halves: a tracked
+    /// modification and a file Git has never been told about.
+    #[test]
+    fn the_change_set_covers_tracked_edits_and_untracked_additions() {
+        let (_dir, _mount, surface, base) = mount_and_surface(&[("a.md", "# A\n")]);
+        assert!(changed_paths(&surface, &base).expect("clean").is_empty());
+        std::fs::write(surface.join("a.md"), "# Edited\n").expect("write");
+        std::fs::write(surface.join("untracked.md"), "# New\n").expect("write");
+        let changed = changed_paths(&surface, &base).expect("changed");
+        assert_eq!(
+            changed,
+            BTreeSet::from(["a.md".to_string(), "untracked.md".to_string()])
+        );
+        // Staging must not change the answer: a staged edit is still an edit.
+        run_git(&surface, &["add", "untracked.md"]).expect("add");
+        assert_eq!(changed_paths(&surface, &base).expect("staged"), changed);
+    }
+}

--- a/src/runtime/atlas/record.rs
+++ b/src/runtime/atlas/record.rs
@@ -24,7 +24,10 @@ use crate::domain::event::{EventDraft, EventSource};
 use crate::domain::source::KIND_SOURCE_SCANNED;
 use crate::runtime::atlas::db::{AtlasDb, AtlasError, ScanCommit};
 use crate::runtime::atlas::deny::BadPattern;
+use crate::runtime::atlas::git::{EstateGitSource, GitScanError, scan_estate_git};
+use crate::runtime::atlas::overlay::{WorkOverlay, scan_work_overlay};
 use crate::runtime::atlas::scan::{KnowledgeSource, SourceScan, scan_local_knowledge};
+use crate::runtime::integrity::EstateDriftObservation;
 use crate::runtime::journal::{Journal, JournalError};
 
 /// What one call to [`scan_and_record`] did.
@@ -74,6 +77,9 @@ pub enum ScanRecordError {
     /// A `[[knowledge]] ignore` glob does not compile.
     #[error(transparent)]
     Pattern(#[from] BadPattern),
+    /// An estate-git or overlay scan failed before any row was written.
+    #[error(transparent)]
+    GitScan(#[from] GitScanError),
     /// Atlas refused a write.
     #[error(transparent)]
     Atlas(#[from] AtlasError),
@@ -122,8 +128,59 @@ pub fn scan_and_record(
     source: &KnowledgeSource,
     workspace_id: Option<&str>,
 ) -> Result<ScanRecord, ScanRecordError> {
-    let scan = scan_local_knowledge(source)?;
-    let staged = match db.stage_scan(&scan)? {
+    record_scan(db, journal, &scan_local_knowledge(source)?, workspace_id)
+}
+
+/// [`scan_and_record`] for one estate-git source: the same three steps, over a
+/// commit instead of a directory.
+///
+/// The steps are shared rather than mirrored, which is the point. F1's crash
+/// window is a property of the *order* — stage, journal, confirm — and a
+/// second copy of that order for a second source kind would be a second place
+/// for it to be got subtly wrong. What differs between the two source kinds is
+/// how bytes are acquired, and that difference is entirely upstream of here.
+///
+/// Returns the [`ScanRecord`] alongside the scan's drift observation, when the
+/// mount's HEAD has moved off the pinned SHA. The observation rides beside the
+/// record for the same reason it rides beside the scan: it is a fact about the
+/// mount, not about the generation, and folding it in would make a clean scan
+/// look unclean.
+pub fn scan_and_record_estate_git(
+    db: &mut AtlasDb,
+    journal: &mut Journal,
+    source: &EstateGitSource,
+    workspace_id: Option<&str>,
+) -> Result<(ScanRecord, Option<EstateDriftObservation>), ScanRecordError> {
+    let scanned = scan_estate_git(source)?;
+    let record = record_scan(db, journal, &scanned.scan, workspace_id)?;
+    Ok((record, scanned.drift))
+}
+
+/// [`scan_and_record`] for one Work overlay — same three steps again.
+///
+/// The generation this writes is scoped to its Work and removed by
+/// [`AtlasDb::evict_work_overlays`], never by ruling §4's byte-change rule;
+/// see [`super::overlay`] for why those are two different lifetimes.
+pub fn scan_and_record_overlay(
+    db: &mut AtlasDb,
+    journal: &mut Journal,
+    overlay: &WorkOverlay,
+    workspace_id: Option<&str>,
+) -> Result<ScanRecord, ScanRecordError> {
+    let scanned = scan_work_overlay(overlay)?;
+    record_scan(db, journal, &scanned.scan, workspace_id)
+}
+
+/// **F1's crash-window coupling itself**, over an already-completed scan of
+/// any source kind. See [`scan_and_record`] for the ordering argument — this
+/// is the code that argument is about.
+pub fn record_scan(
+    db: &mut AtlasDb,
+    journal: &mut Journal,
+    scan: &SourceScan,
+    workspace_id: Option<&str>,
+) -> Result<ScanRecord, ScanRecordError> {
+    let staged = match db.stage_scan(scan)? {
         ScanCommit::Unchanged {
             generation_id,
             content_key,
@@ -149,7 +206,7 @@ pub fn scan_and_record(
     let mut draft = EventDraft::new(
         EventSource::new("daemon", "atlas"),
         KIND_SOURCE_SCANNED,
-        scan_summary(&scan, &staged),
+        scan_summary(scan, &staged),
     );
     if let Some(workspace_id) = workspace_id {
         draft = draft.with_workspace_id(workspace_id);
@@ -158,7 +215,7 @@ pub fn scan_and_record(
     let evicted = db.confirm_scan(&staged, &event.id)?;
     Ok(ScanRecord::Recorded {
         generation_id: staged,
-        content_key: scan.content_key,
+        content_key: scan.content_key.clone(),
         summary_event_id: event.id,
         evicted,
     })
@@ -263,7 +320,7 @@ pub fn reconcile_sources(
 /// have to be pinnable together. A test that hand-rolled its own summary
 /// would keep passing on the day this function stopped emitting it.
 pub fn scan_summary(scan: &SourceScan, generation_id: &str) -> serde_json::Value {
-    serde_json::json!({
+    let mut summary = serde_json::json!({
         "source": scan.source_name,
         "source_kind": scan.kind.as_str(),
         "authority_class": scan.authority.as_str(),
@@ -274,5 +331,15 @@ pub fn scan_summary(scan: &SourceScan, generation_id: &str) -> serde_json::Value
         "units": scan.unit_count(),
         "coverage": scan.counts(),
         "extractors": scan.extractors.iter().collect::<Vec<_>>(),
-    })
+    });
+    // Added only when the source actually has a revision (a pinned commit
+    // SHA). An explicit `null` would read as "this source has a revision and
+    // we do not know it", which is a different claim and a false one for a
+    // filesystem walk.
+    if let Some(revision) = &scan.revision
+        && let Some(object) = summary.as_object_mut()
+    {
+        object.insert("revision".to_string(), revision.as_str().into());
+    }
+    summary
 }

--- a/src/runtime/atlas/scan.rs
+++ b/src/runtime/atlas/scan.rs
@@ -44,14 +44,8 @@ use crate::domain::source::{
 };
 use crate::runtime::atlas::deny::{AcquisitionFilter, BadPattern, Verdict};
 use crate::runtime::atlas::text::{
-    MARKDOWN_EXTRACTOR, TEXT_EXTRACTOR, as_text, markdown_units, plain_units,
+    MARKDOWN_EXTRACTOR, as_text, extractor_for, markdown_units, plain_units,
 };
-
-/// Extensions routed to the Markdown extractor.
-const MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown"];
-
-/// Extensions routed to the plain-text extractor.
-const TEXT_EXTENSIONS: &[&str] = &["txt", "text"];
 
 /// The largest resource this build reads into memory to extract.
 ///
@@ -142,6 +136,17 @@ pub struct SourceScan {
     /// [`generation_key`]) — the value ruling §4's eviction rule is stated
     /// over.
     pub content_key: String,
+    /// The source's own revision identity, when it has one: the pinned commit
+    /// SHA for an [`SourceKind::EstateGit`] scan, `None` for a filesystem walk
+    /// that has no such thing.
+    ///
+    /// Deliberately *not* the same field as [`Self::content_key`], and not a
+    /// substitute for it. The content key answers "is this the same world?"
+    /// and drives ruling §4's eviction; the revision answers "which commit was
+    /// this?" and is provenance a reader needs but no comparison uses — two
+    /// commits with identical trees are the same world, and folding the commit
+    /// into the key would evict a generation that changed no source byte.
+    pub revision: Option<String>,
     /// When the walk finished (RFC3339 UTC).
     pub observed_at: String,
     /// Acquired resources, in path order.
@@ -241,6 +246,7 @@ pub fn scan_local_knowledge(source: &KnowledgeSource) -> Result<SourceScan, BadP
         kind: SourceKind::LocalKnowledge,
         authority: AuthorityClass::EstateReadonly,
         content_key: generation_key(&resources),
+        revision: None,
         observed_at: rfc3339_utc_now(),
         files,
         coverage,
@@ -410,25 +416,8 @@ impl Walk<'_> {
             });
             return;
         };
-        let structure = if extractor == MARKDOWN_EXTRACTOR {
-            markdown_units(text)
-        } else {
-            plain_units(text)
-        };
         let hash = content_hash(&bytes);
-        let units = structure
-            .into_iter()
-            .enumerate()
-            .map(|(ordinal, unit)| ScannedUnit {
-                ordinal: ordinal as u64,
-                kind: unit.kind,
-                heading_level: unit.heading_level,
-                title: unit.title,
-                byte_start: unit.byte_start as u64,
-                byte_end: unit.byte_end as u64,
-                text: text[unit.byte_start..unit.byte_end].to_string(),
-            })
-            .collect();
+        let units = extract_units(text, extractor);
         self.extractors.insert(extractor.to_string());
         self.coverage.push(CoverageRow {
             path: Some(relative.clone()),
@@ -448,25 +437,33 @@ impl Walk<'_> {
     }
 }
 
-/// The extractor for a path, by extension, or `None` for a family this build
-/// does not claim.
+/// Run one extractor over decoded text and number its units.
 ///
-/// Extension-driven and nothing else: sniffing content to guess a format
-/// would mean reading bytes to decide whether to read bytes, and the honest
-/// answer for an unclaimed extension is `unsupported`, which coverage
-/// reports.
-fn extractor_for(relative: &str) -> Option<&'static str> {
-    let extension = Path::new(relative)
-        .extension()
-        .and_then(|e| e.to_str())?
-        .to_ascii_lowercase();
-    if MARKDOWN_EXTENSIONS.contains(&extension.as_str()) {
-        Some(MARKDOWN_EXTRACTOR)
-    } else if TEXT_EXTENSIONS.contains(&extension.as_str()) {
-        Some(TEXT_EXTRACTOR)
+/// The one place `StructureUnit` becomes `ScannedUnit`, for every source kind
+/// there is. Three walks — the filesystem one below, the estate-git one
+/// ([`super::git`]) and a Work overlay ([`super::overlay`]) — reach identical
+/// bytes by different routes, and F7's premise is that identical bytes plus an
+/// identical extractor identity are *one* extraction. Two copies of this loop
+/// would be two ways for that to stop being true.
+pub fn extract_units(text: &str, extractor: &str) -> Vec<ScannedUnit> {
+    let structure = if extractor == MARKDOWN_EXTRACTOR {
+        markdown_units(text)
     } else {
-        None
-    }
+        plain_units(text)
+    };
+    structure
+        .into_iter()
+        .enumerate()
+        .map(|(ordinal, unit)| ScannedUnit {
+            ordinal: ordinal as u64,
+            kind: unit.kind,
+            heading_level: unit.heading_level,
+            title: unit.title,
+            byte_start: unit.byte_start as u64,
+            byte_end: unit.byte_end as u64,
+            text: text[unit.byte_start..unit.byte_end].to_string(),
+        })
+        .collect()
 }
 
 /// Modification time in Unix milliseconds, when the platform offers one.
@@ -481,6 +478,7 @@ fn mtime_millis(meta: &std::fs::Metadata) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::atlas::text::TEXT_EXTRACTOR;
 
     /// Build a source tree and scan it.
     fn scan_tree(files: &[(&str, &[u8])], ignore: &[&str]) -> (tempfile::TempDir, SourceScan) {

--- a/src/runtime/atlas/text.rs
+++ b/src/runtime/atlas/text.rs
@@ -38,6 +38,37 @@ pub const MARKDOWN_EXTRACTOR: &str = "markdown/v1";
 /// Extractor identity for plain text.
 pub const TEXT_EXTRACTOR: &str = "text/v1";
 
+/// Extensions routed to the Markdown extractor.
+pub const MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown"];
+
+/// Extensions routed to the plain-text extractor.
+pub const TEXT_EXTENSIONS: &[&str] = &["txt", "text"];
+
+/// The extractor for a path, by extension, or `None` for a family this build
+/// does not claim.
+///
+/// Extension-driven and nothing else: sniffing content to guess a format
+/// would mean reading bytes to decide whether to read bytes, and the honest
+/// answer for an unclaimed extension is `unsupported`, which coverage
+/// reports. That reasoning is why this lives *here* rather than beside a
+/// particular walk — routing has to be one function, or a Markdown file
+/// acquired from a Git object could be extracted differently from the same
+/// bytes acquired from a knowledge directory, and F7's whole premise is that
+/// identical bytes plus an identical extractor identity are one extraction.
+pub fn extractor_for(relative: &str) -> Option<&'static str> {
+    let extension = std::path::Path::new(relative)
+        .extension()
+        .and_then(|e| e.to_str())?
+        .to_ascii_lowercase();
+    if MARKDOWN_EXTENSIONS.contains(&extension.as_str()) {
+        Some(MARKDOWN_EXTRACTOR)
+    } else if TEXT_EXTENSIONS.contains(&extension.as_str()) {
+        Some(TEXT_EXTRACTOR)
+    } else {
+        None
+    }
+}
+
 /// One extracted structure unit, positioned in the original bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructureUnit {

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -1151,22 +1151,36 @@ pub fn default_execution_lane_cap() -> usize {
         .unwrap_or(4)
 }
 
-/// H1-15's second lane: config surface only in S1 (deliverable 3 — no
-/// workers, no scheduling behavior). The eventual consumer is A1/S3's
-/// intelligence workers (host-runtime batch/analysis work distinct from
-/// execution's per-Work native processes); until that lands, nothing ever
-/// acquires from [`Engine::intelligence_lane`], so this cap only proves the
-/// two lanes are structurally independent (separate `Arc<Semaphore>`s —
-/// see the config-only test pinning that the execution lane's occupancy
-/// never touches this one's `available_permits`).
+/// H1-15's second lane, and **as of S3/X3a a lane with a real consumer**:
+/// Atlas's source extraction acquires it ([`Engine::run_intelligence`], via
+/// [`crate::runtime::atlas::lane`]). Host-runtime batch/analysis work,
+/// deliberately distinct from execution's per-Work native processes, and
+/// bounded separately from them so a repository scan can never spend a Work's
+/// launch capacity.
 ///
 /// Same host-parallelism grounding as [`default_execution_lane_cap`] (R2:
-/// reusing the one number this build can trace to something real, rather
-/// than inventing a second unrelated rationale for a lane nothing consumes
-/// yet). Override with [`Engine::with_intelligence_lane_cap`]
+/// reusing the one number this build can trace to something real, rather than
+/// inventing a second unrelated rationale). Override with
+/// [`Engine::with_intelligence_lane_cap`]
 /// (`DaemonConfig::intelligence_lane_cap` / `SGT_INTELLIGENCE_LANE_CAP`).
 pub fn default_intelligence_lane_cap() -> usize {
     default_execution_lane_cap()
+}
+
+/// Why an intelligence-lane job did not produce an answer.
+///
+/// Neither variant is reachable in ordinary operation, and both are returned
+/// rather than panicked for the same reason: Atlas is derived evidence, and no
+/// failure of a derived index may cost the estate its daemon (A1-01).
+#[derive(Debug, thiserror::Error)]
+pub enum IntelligenceError {
+    /// The lane's semaphore was closed — only reachable during shutdown.
+    #[error("the intelligence lane is closed")]
+    LaneClosed,
+    /// The blocking job panicked or was cancelled; the join error's own text
+    /// is carried rather than summarized.
+    #[error("an intelligence job did not complete: {0}")]
+    Job(String),
 }
 
 /// The workflow engine: backends, defaults, and the data dir surfaces live in.
@@ -1325,12 +1339,78 @@ impl Engine {
         self
     }
 
-    /// Override the daemon-wide intelligence-lane cap (H1-15, deliverable
-    /// 3 — config surface only; nothing yet acquires from this lane).
+    /// Override the daemon-wide intelligence-lane cap (H1-15, deliverable 3).
+    /// Wired from `DaemonConfig::intelligence_lane_cap` /
+    /// `SGT_INTELLIGENCE_LANE_CAP`.
     pub fn with_intelligence_lane_cap(mut self, cap: usize) -> Self {
         self.intelligence_lane = Arc::new(Semaphore::new(cap));
         self.intelligence_lane_cap = cap;
         self
+    }
+
+    /// Take an intelligence-lane permit without waiting, or `None` when the
+    /// lane is at [`Self::intelligence_lane_cap`].
+    ///
+    /// The permit is **handed to the caller**, not stored in a map the way an
+    /// execution permit is, and the difference is deliberate. An execution
+    /// permit belongs to a Work — it outlives the call that took it, it has to
+    /// be findable by work id, and releasing it is a decision about whether a
+    /// native process is still alive. An intelligence permit belongs to a
+    /// *job*: taken, held for the job's duration, dropped when it returns.
+    /// Handing the caller the guard makes "released when the work finishes" a
+    /// property of ownership rather than of remembering to call a release
+    /// function on every path out.
+    pub fn try_admit_intelligence(&self) -> Option<OwnedSemaphorePermit> {
+        Arc::clone(&self.intelligence_lane).try_acquire_owned().ok()
+    }
+
+    /// Wait for an intelligence-lane permit.
+    ///
+    /// **Never the execution lane** (F6, and H1-15's whole point): the two are
+    /// separate `Arc<Semaphore>`s, so however much extraction queues here, a
+    /// Work's launch capacity is exactly what it was. The reverse holds too,
+    /// and both directions are pinned by tests.
+    pub async fn admit_intelligence(&self) -> Result<OwnedSemaphorePermit, IntelligenceError> {
+        Arc::clone(&self.intelligence_lane)
+            .acquire_owned()
+            .await
+            .map_err(|_| IntelligenceError::LaneClosed)
+    }
+
+    /// **F6's execution shape**: run one blocking intelligence job under an
+    /// intelligence-lane permit, on the blocking pool.
+    ///
+    /// Two properties, and both are the point:
+    ///
+    /// * **Bounded.** The permit is acquired before the job is spawned and
+    ///   dropped when it returns, so at most [`Self::intelligence_lane_cap`]
+    ///   extractions are ever in flight — not "usually", and not "unless a
+    ///   burst arrives".
+    /// * **Off the async runtime.** Extraction is CPU and IO work measured in
+    ///   whole files: parsing, hashing, waiting on a Git subprocess. Run
+    ///   directly in an async task it would hold a runtime worker thread for
+    ///   its whole duration and stall every unrelated future sharing it.
+    ///   `spawn_blocking` is the runtime's own answer, already in this build's
+    ///   `tokio` (R5).
+    ///
+    /// A job that panics surfaces as [`IntelligenceError::Job`] rather than
+    /// unwinding into the caller: one bad file must not take a daemon down,
+    /// and Atlas is derived evidence, never authority (A1-01).
+    pub async fn run_intelligence<F, T>(&self, job: F) -> Result<T, IntelligenceError>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        let permit = self.admit_intelligence().await?;
+        tokio::task::spawn_blocking(move || {
+            let result = job();
+            // Held across the whole job and released here by the guard's own
+            // `Drop` — on the panicking path exactly as on the ordinary one.
+            drop(permit);
+            result
+        })
+        .await
+        .map_err(|e| IntelligenceError::Job(e.to_string()))
     }
 
     /// Try to admit `work_id` to the execution lane without waiting. `true`

--- a/src/runtime/git.rs
+++ b/src/runtime/git.rs
@@ -282,6 +282,154 @@ pub fn git_remote_set_url(dir: &Path, name: &str, url: &str) -> Result<String, G
     git(dir, &["remote", "set-url", "--", name, url])
 }
 
+/// One object `git cat-file --batch` answered with.
+///
+/// `oid`/`kind` are Git's own header words, kept rather than re-derived: the
+/// header is what proves the bytes below it are the object that was asked
+/// for, and a caller keying on the OID (A1's F7 estate-git rule) wants the
+/// value Git echoed, not the one it sent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatFileObject {
+    /// The object's full OID, as Git echoed it.
+    pub oid: String,
+    /// `blob`, `tree`, `commit` or `tag`.
+    pub kind: String,
+    /// The object's contents, byte for byte.
+    pub bytes: Vec<u8>,
+}
+
+/// Read many objects from `dir`'s object store in **one** Git process
+/// (`cat-file --batch`), answering positionally: element `i` is `oids[i]`'s
+/// object, or `None` when Git reported it missing.
+///
+/// **Why a batch primitive exists at all (R6/R7).** The obvious spelling —
+/// `git cat-file blob <oid>` per file — is one process, one fork, one object
+/// database open and one pack index load *per file*. On a repository of a few
+/// thousand blobs that is the whole cost of the scan, and it is spent on
+/// process startup rather than on reading anything. `--batch` is Git's own
+/// answer to exactly this shape: one process, one object database, `n`
+/// answers. R2–R5 supply no in-tree batching helper, and R6's one-liner
+/// ([`git_bytes`] in a loop) is precisely the thing being replaced.
+///
+/// **Read-only, and only ever the object store.** `cat-file` reads objects; it
+/// does not consult, touch or need a working tree, and nothing here fetches,
+/// pulls, switches or writes. That is what lets a caller pin a SHA and keep
+/// reading it while the mount's HEAD moves underneath (§8.2's pin, made
+/// durable for reads).
+///
+/// **Deadlock, avoided rather than hoped against.** Git streams answers as it
+/// reads requests, so a caller that writes every OID before reading a byte
+/// can fill the stdout pipe buffer and block Git forever while Git blocks on
+/// the caller. The request is therefore written from its own thread while this
+/// one drains stdout. Callers bound each batch's cumulative object size; this
+/// function does not, because it cannot know a sensible ceiling for a caller
+/// it has never met.
+pub fn git_cat_file_batch(
+    dir: &Path,
+    oids: &[String],
+) -> Result<Vec<Option<CatFileObject>>, GitError> {
+    if oids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let args = ["cat-file", "--batch"];
+    let mut child = command(dir, &args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|source| GitError::Spawn {
+            args: owned(&args),
+            dir: dir.display().to_string(),
+            source,
+        })?;
+    let mut request = String::with_capacity(oids.len() * 41);
+    for oid in oids {
+        request.push_str(oid);
+        request.push('\n');
+    }
+    let mut stdin = child.stdin.take().expect("stdin was piped");
+    let writer = std::thread::spawn(move || {
+        use std::io::Write;
+        // The write's own error is deliberately dropped: a Git that died
+        // early makes this a broken pipe, and the *useful* diagnostic is the
+        // exit status and stderr collected below, not `EPIPE`.
+        let _ = stdin
+            .write_all(request.as_bytes())
+            .and_then(|()| stdin.flush());
+    });
+    let output = child.wait_with_output().map_err(|source| GitError::Spawn {
+        args: owned(&args),
+        dir: dir.display().to_string(),
+        source,
+    })?;
+    let _ = writer.join();
+    if !output.status.success() {
+        return Err(GitError::Failed {
+            args: owned(&args),
+            dir: dir.display().to_string(),
+            status: output.status.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    parse_cat_file_batch(&output.stdout, oids.len(), dir, &args)
+}
+
+/// Split `cat-file --batch`'s stream into one answer per request.
+///
+/// The wire shape, from `git cat-file`'s own documentation: an existing object
+/// is `<oid> SP <type> SP <size> LF <contents> LF`, and a missing one is
+/// `<name> SP missing LF`. Sizes are taken from the header rather than by
+/// scanning for a terminator, because blob contents may contain any byte
+/// including `LF` — a line-oriented parse of this stream is wrong on the first
+/// file that ends without a newline.
+fn parse_cat_file_batch(
+    stdout: &[u8],
+    expected: usize,
+    dir: &Path,
+    args: &[&str],
+) -> Result<Vec<Option<CatFileObject>>, GitError> {
+    let malformed = |detail: String| GitError::Failed {
+        args: owned(args),
+        dir: dir.display().to_string(),
+        status: "exit status: 0".to_string(),
+        stderr: detail,
+    };
+    let mut out = Vec::with_capacity(expected);
+    let mut at = 0usize;
+    while out.len() < expected {
+        let Some(offset) = stdout[at..].iter().position(|b| *b == b'\n') else {
+            return Err(malformed(format!(
+                "cat-file --batch answered {} of {expected} objects before its \
+                 stream ended",
+                out.len()
+            )));
+        };
+        let header = String::from_utf8_lossy(&stdout[at..at + offset]).into_owned();
+        at += offset + 1;
+        let mut words = header.split(' ');
+        let oid = words.next().unwrap_or_default().to_string();
+        let kind = words.next().unwrap_or_default().to_string();
+        if kind == "missing" || kind.is_empty() {
+            out.push(None);
+            continue;
+        }
+        let size: usize = words.next().and_then(|s| s.parse().ok()).ok_or_else(|| {
+            malformed(format!("cat-file --batch header is unreadable: {header:?}"))
+        })?;
+        if at + size > stdout.len() {
+            return Err(malformed(format!(
+                "cat-file --batch promised {size} bytes for {oid} and delivered {}",
+                stdout.len().saturating_sub(at)
+            )));
+        }
+        let bytes = stdout[at..at + size].to_vec();
+        // The record's own trailing LF, which is framing and not content.
+        at += size + 1;
+        out.push(Some(CatFileObject { oid, kind, bytes }));
+    }
+    Ok(out)
+}
+
 /// One hermetic Git invocation: no pager, no prompts, no editor, stdin closed.
 fn command(dir: &Path, args: &[&str]) -> Command {
     let git_bin = std::env::var(GIT_BIN_ENV).unwrap_or_else(|_| "git".to_string());
@@ -305,6 +453,72 @@ fn owned(args: &[&str]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The framing is size-prefixed, not line-oriented: a blob with no
+    /// trailing newline, a blob that is entirely newlines, an empty blob and a
+    /// missing object all have to survive one stream together.
+    #[test]
+    fn a_batch_stream_is_split_by_its_declared_sizes() {
+        let mut stream = Vec::new();
+        stream.extend_from_slice(b"aaa blob 5\nno-nl\n");
+        stream.extend_from_slice(b"bbb blob 3\n\n\n\n\n");
+        stream.extend_from_slice(b"ccc blob 0\n\n");
+        stream.extend_from_slice(b"deadbeef missing\n");
+        let parsed =
+            parse_cat_file_batch(&stream, 4, Path::new("/tmp"), &["cat-file"]).expect("parse");
+        assert_eq!(parsed.len(), 4);
+        assert_eq!(parsed[0].as_ref().expect("present").bytes, b"no-nl");
+        assert_eq!(parsed[0].as_ref().expect("present").oid, "aaa");
+        assert_eq!(parsed[1].as_ref().expect("present").bytes, b"\n\n\n");
+        assert!(parsed[2].as_ref().expect("present").bytes.is_empty());
+        assert!(
+            parsed[3].is_none(),
+            "a missing object is None, not an error"
+        );
+    }
+
+    /// A truncated stream is a named failure, never a short answer silently
+    /// treated as "these objects do not exist".
+    #[test]
+    fn a_truncated_batch_stream_is_an_error_not_a_short_answer() {
+        let err = parse_cat_file_batch(b"aaa blob 99\nshort", 1, Path::new("/tmp"), &["cat-file"])
+            .expect_err("truncated");
+        assert!(err.to_string().contains("promised 99 bytes"), "{err}");
+        let err = parse_cat_file_batch(b"", 2, Path::new("/tmp"), &["cat-file"])
+            .expect_err("empty stream");
+        assert!(err.to_string().contains("0 of 2 objects"), "{err}");
+    }
+
+    /// End to end against real Git: one process answers many objects, in
+    /// request order, and never needs a working tree to do it.
+    #[test]
+    fn one_process_reads_many_blobs_in_request_order() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+        git(root, &["init", "--initial-branch=main"]).expect("init");
+        git(root, &["config", "user.email", "t@example.com"]).expect("email");
+        git(root, &["config", "user.name", "T"]).expect("name");
+        let mut oids = Vec::new();
+        for (name, body) in [("a.txt", "alpha"), ("b.txt", "beta\n\nmore"), ("c.txt", "")] {
+            std::fs::write(root.join(name), body).expect("write");
+            let _ = name;
+            oids.push(
+                git(
+                    root,
+                    &["hash-object", "-w", root.join(name).to_str().expect("utf8")],
+                )
+                .expect("hash-object"),
+            );
+        }
+        oids.push("0".repeat(40));
+        let objects = git_cat_file_batch(root, &oids).expect("batch");
+        assert_eq!(objects.len(), 4);
+        assert_eq!(objects[0].as_ref().expect("a").bytes, b"alpha");
+        assert_eq!(objects[1].as_ref().expect("b").bytes, b"beta\n\nmore");
+        assert!(objects[2].as_ref().expect("c").bytes.is_empty());
+        assert!(objects[3].is_none());
+        assert!(git_cat_file_batch(root, &[]).expect("empty").is_empty());
+    }
 
     #[test]
     fn failure_carries_gits_own_diagnostic() {

--- a/tests/x3a_git_plumbing.rs
+++ b/tests/x3a_git_plumbing.rs
@@ -1,0 +1,492 @@
+//! S3 X3a acceptance: the mechanical estate-git extraction plumbing.
+//!
+//! Four claims this wave makes, and the tests that would actually fail if any
+//! of them stopped being true:
+//!
+//! * **A scan stays on the SHA it pinned while the mount moves underneath.**
+//!   `a_scan_stays_on_its_pinned_sha_while_head_advances` advances the mount's
+//!   HEAD *between* a scan's two phases and asserts the extraction is still
+//!   the world phase one listed;
+//!   `a_scan_racing_a_committing_thread_is_still_one_world` does the same with
+//!   a real concurrent committer rather than a staged window. Drift is
+//!   observed in both, and blended into the rows in neither.
+//! * **F7's estate-git key is the blob OID plus the extractor** — never a
+//!   second hash of bytes Git already hashed. Pinned here against the stored
+//!   rows, not only against the in-memory scan.
+//! * **A Work overlay is base + difference, and dies with its Work.**
+//! * **F6's intelligence lane has a real consumer, and it is not the execution
+//!   lane.**
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::domain::source::{Coverage, KIND_SOURCE_SCANNED, estate_git_key};
+use sergeant_rs::runtime::atlas::db::AtlasDb;
+use sergeant_rs::runtime::atlas::git::{
+    EstateGitSource, extract_tree, list_tree, observe_drift, scan_estate_git,
+};
+use sergeant_rs::runtime::atlas::lane::scan_estate_git_on_lane;
+use sergeant_rs::runtime::atlas::overlay::{WorkOverlay, scan_work_overlay};
+use sergeant_rs::runtime::atlas::record::{
+    ScanRecord, scan_and_record_estate_git, scan_and_record_overlay,
+};
+use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+use sergeant_rs::runtime::engine::Engine;
+use sergeant_rs::runtime::git::git;
+use sergeant_rs::runtime::journal::Journal;
+
+// ---------------------------------------------------------------- fixtures
+
+/// A repository with one commit per `commits` entry, and the SHA of each.
+fn repo(commits: &[&[(&str, &str)]]) -> (TempDir, PathBuf, Vec<String>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mount = dir.path().join("mount");
+    std::fs::create_dir_all(&mount).expect("mkdir");
+    git(&mount, &["init", "--initial-branch=main"]).expect("init");
+    git(&mount, &["config", "user.email", "t@example.com"]).expect("email");
+    git(&mount, &["config", "user.name", "T"]).expect("name");
+    let mut shas = Vec::new();
+    for (n, files) in commits.iter().enumerate() {
+        shas.push(commit(&mount, files, &format!("commit {n}")));
+    }
+    (dir, mount, shas)
+}
+
+fn commit(mount: &Path, files: &[(&str, &str)], message: &str) -> String {
+    for (path, body) in files {
+        let full = mount.join(path);
+        std::fs::create_dir_all(full.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&full, body).expect("write");
+    }
+    git(mount, &["add", "-A"]).expect("add");
+    git(mount, &["commit", "-m", message]).expect("commit");
+    git(mount, &["rev-parse", "HEAD"]).expect("rev-parse")
+}
+
+fn source(mount: &Path, sha: &str) -> EstateGitSource {
+    EstateGitSource {
+        name: "product".to_string(),
+        mount: mount.to_path_buf(),
+        pinned_sha: sha.to_string(),
+        ignore: Vec::new(),
+    }
+}
+
+fn journal_at(dir: &Path) -> Journal {
+    Journal::open(dir).expect("open journal")
+}
+
+fn summaries(journal: &Journal) -> Vec<Value> {
+    journal
+        .replay_from_floor()
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.kind == KIND_SOURCE_SCANNED)
+        .map(|e| e.payload)
+        .collect()
+}
+
+// ------------------------------------------- the concurrent-HEAD-advance rule
+
+/// **The wave's headline property.** A scan pins a SHA; the mount's HEAD then
+/// moves — a Captain commit, another Work, an unrelated process — and the scan
+/// is still evidence about the world it pinned, not a blend of two.
+///
+/// The advance happens in the one window where it could possibly matter:
+/// between listing the tree and reading its blobs. If the extraction consulted
+/// a ref, an index, or the working tree at any point, this is where it would
+/// show, and it would show as `after.md` appearing or `b.md` changing.
+#[test]
+fn a_scan_stays_on_its_pinned_sha_while_head_advances() {
+    let (_dir, mount, shas) =
+        repo(&[&[("a.md", "# A\n"), ("b.md", "# B\n"), ("docs/c.md", "# C\n")]]);
+    let pinned = shas[0].clone();
+    let src = source(&mount, &pinned);
+
+    // Phase one: the world is fixed here.
+    let tree = list_tree(&src).expect("list");
+    let reference = extract_tree(&src, &tree).expect("reference extraction");
+
+    // The mount moves: one file rewritten, one deleted, one added, and HEAD
+    // now points somewhere else entirely.
+    std::fs::remove_file(mount.join("b.md")).expect("remove");
+    let advanced = commit(
+        &mount,
+        &[("a.md", "# A, rewritten\n"), ("after.md", "# After\n")],
+        "advance",
+    );
+    assert_ne!(advanced, pinned);
+    assert_eq!(
+        git(&mount, &["rev-parse", "HEAD"]).expect("head"),
+        advanced,
+        "the mount really did move"
+    );
+
+    // Phase two, run *after* the advance, against the tree listed before it.
+    let scan = extract_tree(&src, &tree).expect("extraction after the advance");
+    assert_eq!(
+        scan.files, reference.files,
+        "the world moved under the scan"
+    );
+    assert_eq!(scan.coverage, reference.coverage);
+    assert_eq!(scan.content_key, reference.content_key);
+    assert_eq!(scan.revision.as_deref(), Some(pinned.as_str()));
+    assert_eq!(scan.files.len(), 3);
+    assert_eq!(
+        scan.files
+            .iter()
+            .find(|f| f.relative_path == "a.md")
+            .expect("a.md")
+            .units[0]
+            .text,
+        "# A\n",
+        "the pinned scan read the advanced commit's bytes"
+    );
+    assert!(
+        !scan
+            .coverage
+            .iter()
+            .any(|r| r.path.as_deref() == Some("after.md")),
+        "a file committed after the pin entered the scan"
+    );
+    assert!(
+        scan.files.iter().any(|f| f.relative_path == "b.md"),
+        "a file deleted after the pin left the scan"
+    );
+
+    // And the drift is *observed*, with both ends named, rather than absorbed.
+    let drift = observe_drift(&src, &tree).expect("the mount moved, so there is drift to report");
+    assert_eq!(drift.repository, "product");
+    assert_eq!(drift.before, pinned);
+    assert_eq!(drift.observed, advanced);
+}
+
+/// The same property against a genuinely concurrent mutator rather than a
+/// staged window: a thread commits to the mount in a loop while a full scan
+/// runs, and the scan's answer is byte-identical to a scan taken before any of
+/// it started.
+#[test]
+fn a_scan_racing_a_committing_thread_is_still_one_world() {
+    let (_dir, mount, _) = repo(&[&[("a.md", "# A\n"), ("b.md", "# B\n")]]);
+    // Enough files that a scan is not over before the committer's first commit
+    // lands.
+    for i in 0..60 {
+        std::fs::write(
+            mount.join(format!("f{i:02}.md")),
+            format!("# File {i}\n\nbody\n"),
+        )
+        .expect("write");
+    }
+    let pinned = commit(&mount, &[], "many files");
+    let src = source(&mount, &pinned);
+    let reference = scan_estate_git(&src).expect("reference").scan;
+
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let committer = {
+        let mount = mount.clone();
+        let stop = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            let mut n = 0;
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                std::fs::write(mount.join("a.md"), format!("# Churn {n}\n")).expect("write");
+                commit(&mount, &[], &format!("churn {n}"));
+                n += 1;
+            }
+            n
+        })
+    };
+    // Scan repeatedly while the mount churns underneath.
+    for _ in 0..5 {
+        let scanned = scan_estate_git(&src).expect("scan during churn");
+        assert_eq!(
+            scanned.scan.files, reference.files,
+            "a concurrent commit leaked into a pinned scan"
+        );
+        assert_eq!(scanned.scan.content_key, reference.content_key);
+    }
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    let commits = committer.join().expect("committer thread");
+    assert!(commits > 0, "the committer never actually moved HEAD");
+    let final_scan = scan_estate_git(&src).expect("final scan");
+    assert_eq!(final_scan.scan.files, reference.files);
+    assert!(
+        final_scan.drift.is_some(),
+        "HEAD moved {commits} times and no drift was reported"
+    );
+}
+
+// --------------------------------------------------- F7, through the store
+
+/// F7's estate-git half, checked where it durably lands: the stored
+/// `local_key` is `estate_git_key(blob oid, extractor)`, the stored content
+/// identity is Git's own OID, and a re-scan of the same tree evicts nothing
+/// because no source byte changed.
+#[test]
+fn stored_estate_git_keys_are_blob_oids_and_a_rescan_evicts_nothing() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let (_dir, mount, shas) = repo(&[&[("a.md", "# A\n"), ("docs/b.md", "# B\n")]]);
+    let src = source(&mount, &shas[0]);
+    let mut db = AtlasDb::open(data.path()).expect("open atlas");
+    let mut journal = journal_at(data.path());
+
+    let (recorded, drift) =
+        scan_and_record_estate_git(&mut db, &mut journal, &src, None).expect("record");
+    assert!(drift.is_none());
+    let generation = match &recorded {
+        ScanRecord::Recorded {
+            generation_id,
+            evicted,
+            ..
+        } => {
+            assert!(evicted.is_none(), "nothing to supersede on a first scan");
+            generation_id.clone()
+        }
+        other => panic!("expected a recorded generation, got {other:?}"),
+    };
+
+    let units = db.units("product", 100).expect("units");
+    assert!(!units.is_empty());
+    let oid = git(&mount, &["rev-parse", &format!("{}:a.md", shas[0])]).expect("oid");
+    let expected = estate_git_key(&oid, MARKDOWN_EXTRACTOR);
+    assert!(
+        units.iter().any(|u| u.local_key == expected),
+        "no stored unit carries the blob-oid key {expected}"
+    );
+
+    // The journal's one summary names the revision, which is what makes a
+    // stored generation traceable back to a commit.
+    let events = summaries(&journal);
+    assert_eq!(events.len(), 1, "exactly one summary per completed scan");
+    assert_eq!(
+        events[0].get("revision").and_then(Value::as_str),
+        Some(shas[0].as_str())
+    );
+    assert_eq!(
+        events[0].get("source_kind").and_then(Value::as_str),
+        Some("estate_git")
+    );
+    assert_eq!(
+        events[0].get("generation").and_then(Value::as_str),
+        Some(generation.as_str())
+    );
+
+    // Re-scanning the same commit is the same world: ruling §4 evicts nothing.
+    let (again, _) = scan_and_record_estate_git(&mut db, &mut journal, &src, None).expect("rescan");
+    assert!(
+        matches!(&again, ScanRecord::Unchanged { generation_id, .. } if *generation_id == generation),
+        "an unchanged tree churned a generation: {again:?}"
+    );
+    assert_eq!(summaries(&journal).len(), 1, "an unchanged scan journaled");
+}
+
+/// A commit whose *tree* is identical is the same world, however different the
+/// commit is — the reason the generation is keyed on the tree and not the SHA.
+#[test]
+fn a_new_commit_with_an_identical_tree_is_the_same_generation() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let (_dir, mount, shas) = repo(&[&[("a.md", "# A\n")]]);
+    let mut db = AtlasDb::open(data.path()).expect("open atlas");
+    let mut journal = journal_at(data.path());
+    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &shas[0]), None)
+        .expect("record");
+
+    // An empty commit: new SHA, new message, byte-identical tree.
+    git(
+        &mount,
+        &["commit", "--allow-empty", "-m", "no content change"],
+    )
+    .expect("empty commit");
+    let second = git(&mount, &["rev-parse", "HEAD"]).expect("head");
+    assert_ne!(second, shas[0]);
+    let (record, _) =
+        scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &second), None)
+            .expect("record");
+    assert!(
+        matches!(record, ScanRecord::Unchanged { .. }),
+        "a commit that changed no source byte evicted a generation: {record:?}"
+    );
+}
+
+// ------------------------------------------------------- the Work overlay
+
+/// A Work overlay is base + difference, is scoped to its Work, and is evicted
+/// with it — leaving a reported `generation_evicted` row rather than a gap.
+#[test]
+fn a_work_overlay_is_scoped_to_its_work_and_evicted_with_it() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let (dir, mount, shas) = repo(&[&[("a.md", "# A\n"), ("b.md", "# B\n")]]);
+    let base = shas[0].clone();
+    let surface = dir.path().join("surface");
+    git(
+        &mount,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "sergeant/01WORK",
+            surface.to_str().expect("utf8"),
+            &base,
+        ],
+    )
+    .expect("worktree add");
+    std::fs::write(surface.join("a.md"), "# A, in flight\n").expect("write");
+
+    let mut db = AtlasDb::open(data.path()).expect("open atlas");
+    let mut journal = journal_at(data.path());
+    // A plain estate-git generation for the same repository, which must
+    // survive the Work's eviction untouched.
+    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &base), None)
+        .expect("record mount");
+
+    let overlay = WorkOverlay {
+        work_id: "01WORK".to_string(),
+        repository: "product".to_string(),
+        surface: surface.clone(),
+        base_sha: base.clone(),
+        ignore: Vec::new(),
+    };
+    let recorded =
+        scan_and_record_overlay(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    let overlay_generation = match &recorded {
+        ScanRecord::Recorded { generation_id, .. } => generation_id.clone(),
+        other => panic!("expected a recorded overlay, got {other:?}"),
+    };
+    let overlay_source = "work:01WORK/product";
+    assert!(
+        db.confirmed_generation(overlay_source)
+            .expect("read")
+            .is_some()
+    );
+
+    // The uncommitted edit is what the overlay indexed, and the untouched file
+    // is still the base's.
+    let units = db.units(overlay_source, 100).expect("units");
+    assert!(
+        units
+            .iter()
+            .any(|u| u.relative_path == "a.md" && u.body.contains("in flight")),
+        "the overlay did not index the surface's uncommitted edit"
+    );
+    let scanned = scan_work_overlay(&overlay).expect("overlay");
+    assert_eq!(scanned.changed, BTreeSet::from(["a.md".to_string()]));
+    assert_eq!(scanned.base_sha, base);
+
+    // Retire the Work: its overlay generations go, and say so.
+    let evicted = db.evict_work_overlays("01WORK").expect("evict");
+    assert_eq!(evicted, vec![overlay_generation]);
+    assert!(
+        db.confirmed_generation(overlay_source)
+            .expect("read")
+            .is_none(),
+        "an overlay outlived the Work it was scoped to"
+    );
+    let coverage = db.coverage(overlay_source, 100).expect("coverage");
+    let eviction = coverage
+        .iter()
+        .find(|row| row.row.status == Coverage::GenerationEvicted)
+        .expect("an eviction must be reported, never a silent gap");
+    assert!(
+        eviction
+            .row
+            .detail
+            .as_deref()
+            .is_some_and(|d| d.contains("01WORK")),
+        "{eviction:?}"
+    );
+
+    // The mount's own generation is untouched — a Work retiring is not a
+    // statement about the repository.
+    assert!(
+        db.confirmed_generation("product").expect("read").is_some(),
+        "evicting a Work's overlay took the repository's generation with it"
+    );
+    assert!(
+        db.evict_work_overlays("01OTHER").expect("evict").is_empty(),
+        "an unrelated Work id evicted something"
+    );
+}
+
+// ------------------------------------------------- F6, the intelligence lane
+
+/// F6: extraction acquires the **intelligence** lane, it is bounded, and it
+/// never draws down the execution lane — H1-15's stub, now with a consumer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn extraction_runs_bounded_on_the_intelligence_lane_and_never_the_execution_lane() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let engine = Engine::new(Arc::new(BackendRegistry::new()), None, data.path())
+        .with_intelligence_lane_cap(2)
+        .with_execution_lane_cap(3);
+
+    let (_dir, mount, shas) = repo(&[&[("a.md", "# A\n"), ("docs/b.md", "# B\n")]]);
+    let src = source(&mount, &shas[0]);
+
+    // The lane's real consumer answers exactly what the direct call does.
+    let direct = scan_estate_git(&src).expect("direct");
+    let on_lane = scan_estate_git_on_lane(&engine, src.clone())
+        .await
+        .expect("on the lane");
+    assert_eq!(on_lane.scan.files, direct.scan.files);
+    assert_eq!(on_lane.tree_oid, direct.tree_oid);
+
+    // Bounded: with a cap of two, a third job cannot start until one of the
+    // first two finishes. Held permits are what prove it.
+    let first = engine.try_admit_intelligence().expect("permit 1");
+    let second = engine.try_admit_intelligence().expect("permit 2");
+    assert_eq!(engine.intelligence_lane.available_permits(), 0);
+    assert!(
+        engine.try_admit_intelligence().is_none(),
+        "the intelligence lane admitted past its cap"
+    );
+
+    // And a saturated intelligence lane leaves the execution lane whole —
+    // the mirror image of H1-15's own assertion, in the direction only a real
+    // consumer could break.
+    assert_eq!(engine.execution_lane.available_permits(), 3);
+    let scan_while_saturated = scan_estate_git_on_lane(&engine, src.clone());
+    tokio::pin!(scan_while_saturated);
+    tokio::select! {
+        _ = &mut scan_while_saturated => panic!("a job ran while the lane was full"),
+        _ = tokio::time::sleep(std::time::Duration::from_millis(150)) => {}
+    }
+    assert_eq!(
+        engine.execution_lane.available_permits(),
+        3,
+        "intelligence-lane pressure spent the execution lane's budget"
+    );
+
+    // Release one permit and the parked job completes — the wait was the lane,
+    // not a deadlock.
+    drop(first);
+    let finished = tokio::time::timeout(std::time::Duration::from_secs(30), scan_while_saturated)
+        .await
+        .expect("the parked job must run once a permit frees")
+        .expect("scan");
+    assert_eq!(finished.scan.files, direct.scan.files);
+    drop(second);
+    assert_eq!(engine.intelligence_lane.available_permits(), 2);
+}
+
+/// A job that panics is reported, not propagated: Atlas is derived evidence,
+/// and one bad file may not take the daemon down (A1-01).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_panicking_intelligence_job_is_reported_and_frees_its_permit() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let engine = Engine::new(Arc::new(BackendRegistry::new()), None, data.path())
+        .with_intelligence_lane_cap(1);
+    let failed = engine
+        .run_intelligence(|| panic!("an extractor exploded"))
+        .await;
+    assert!(failed.is_err(), "a panicking job must surface as an error");
+    assert_eq!(
+        engine.intelligence_lane.available_permits(),
+        1,
+        "a panicking job leaked its permit"
+    );
+    let ok: usize = engine.run_intelligence(|| 7).await.expect("still usable");
+    assert_eq!(ok, 7);
+}

--- a/tests/x3a_scan_uses_only_local_reads.rs
+++ b/tests/x3a_scan_uses_only_local_reads.rs
@@ -1,0 +1,244 @@
+//! X3a's read-only claim, via the recording Git binary: **an Atlas scan of a
+//! declared mount never fetches, pulls, switches, resets or writes, and never
+//! reads the working tree.**
+//!
+//! The module doc of `runtime::atlas::git` states this; a comment cannot be
+//! violated, so this is the test that can be. A shim records every Git
+//! invocation — working directory and full argument vector — and then `exec`s
+//! the real Git, so a complete, successful scan runs end to end and the
+//! recording is of the real thing rather than of a stub's idea of it.
+//!
+//! **This must stay the only test in this file.** `std::env::set_var` is
+//! process-global rather than thread-scoped, and `runtime::git::command` reads
+//! the override fresh on every invocation — a sibling test in this process
+//! would see the shim too, and would race the `TempDir` holding it. Cargo
+//! gives every integration-test file its own process, so a file with one test
+//! has no sibling to leak into. `tests/e_admission_uses_no_network_git.rs`
+//! carries the same rule for the same reason.
+//!
+//! # What is asserted, and why in two parts
+//!
+//! * **Verbs.** Everything that fetches, mutates history, moves a ref, or
+//!   changes a checkout is forbidden outright: a derived index has no business
+//!   running any of them, in any directory, ever. The allowed set is named
+//!   positively as well, so a scan that grew a *new* Git verb has to be
+//!   re-decided here rather than sliding in under "not on the forbidden list".
+//! * **State.** Verbs alone would not catch a read that happened to have side
+//!   effects, so the mount's HEAD, its full ref listing, its `git status`
+//!   porcelain and every file byte are compared before and after. A scan must
+//!   leave a repository indistinguishable from one that was never scanned.
+
+use std::collections::BTreeSet;
+
+use tempfile::TempDir;
+
+use sergeant_rs::runtime::atlas::git::{EstateGitSource, scan_estate_git};
+use sergeant_rs::runtime::git::{GIT_BIN_ENV, git};
+
+mod support;
+use support::{parse_log, real_git, write_recording_shim};
+
+/// Verbs that must never appear on a scan path, in any directory.
+const FORBIDDEN: &[&str] = &[
+    "fetch",
+    "pull",
+    "push",
+    "remote",
+    "ls-remote",
+    "clone",
+    "rebase",
+    "merge",
+    "cherry-pick",
+    "switch",
+    "checkout",
+    "reset",
+    "commit",
+    "add",
+    "worktree",
+    "gc",
+    "prune",
+    "repack",
+    "update-ref",
+    "symbolic-ref",
+    "branch",
+    "tag",
+    "stash",
+    "clean",
+    "restore",
+    "apply",
+    "update-index",
+    "write-tree",
+    "hash-object",
+];
+
+/// The complete set of verbs a scan is allowed to run. Named positively so a
+/// new one is a decision, not an omission.
+const ALLOWED: &[&str] = &["rev-parse", "ls-tree", "cat-file"];
+
+#[test]
+fn an_atlas_scan_runs_only_read_only_git_and_changes_nothing() {
+    let dir = TempDir::new().expect("tempdir");
+    let mount = dir.path().join("mount");
+    std::fs::create_dir_all(&mount).expect("mkdir");
+
+    // Built with the real Git, before the shim is installed, so the fixture's
+    // own setup is not part of the recording.
+    let real = real_git();
+    git(&mount, &["init", "--initial-branch=main"]).expect("init");
+    git(&mount, &["config", "user.email", "t@example.com"]).expect("email");
+    git(&mount, &["config", "user.name", "T"]).expect("name");
+    git(
+        &mount,
+        &["remote", "add", "origin", "https://example.invalid/x.git"],
+    )
+    .expect("remote add");
+    for (path, body) in [
+        ("README.md", "# Readme\n\nbody\n"),
+        ("docs/guide.md", "# Guide\n\n## Section\n\ntext\n"),
+        ("notes.txt", "plain\n"),
+        ("src/main.rs", "fn main() {}\n"),
+    ] {
+        let full = mount.join(path);
+        std::fs::create_dir_all(full.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&full, body).expect("write");
+    }
+    git(&mount, &["add", "-A"]).expect("add");
+    git(&mount, &["commit", "-m", "base"]).expect("commit");
+    let pinned = git(&mount, &["rev-parse", "HEAD"]).expect("head");
+
+    // An uncommitted edit and an untracked file: if the scan read the working
+    // tree at any point, this is what would show up in its rows.
+    std::fs::write(mount.join("README.md"), "# WORKING TREE ONLY\n").expect("write");
+    std::fs::write(mount.join("untracked.md"), "# Untracked\n").expect("write");
+
+    let before = State::of(&mount);
+
+    let shim_dir = TempDir::new().expect("tempdir");
+    let log = shim_dir.path().join("git-invocations.log");
+    let shim = shim_dir.path().join("recording-git");
+    write_recording_shim(&shim, &log, &real);
+
+    // SAFETY (test-only): this binary runs exactly one test, so there is no
+    // other thread in this process to observe the mutation — the whole reason
+    // this file holds one test. Removed only once every git invocation under
+    // test has finished, with the shim's `TempDir` still alive throughout.
+    unsafe { std::env::set_var(GIT_BIN_ENV, &shim) };
+    let scanned = scan_estate_git(&EstateGitSource {
+        name: "product".to_string(),
+        mount: mount.clone(),
+        pinned_sha: pinned.clone(),
+        ignore: Vec::new(),
+    });
+    unsafe { std::env::remove_var(GIT_BIN_ENV) };
+
+    let scanned = scanned.expect("the scan must succeed for the recording to mean anything");
+    assert_eq!(scanned.scan.files.len(), 3, "three extractable resources");
+    assert!(scanned.drift.is_none(), "HEAD never moved");
+
+    // The committed bytes, not the working tree's.
+    let readme = scanned
+        .scan
+        .files
+        .iter()
+        .find(|f| f.relative_path == "README.md")
+        .expect("README.md");
+    assert!(
+        readme.units[0].text.contains("# Readme"),
+        "the scan read the working tree instead of the object store: {:?}",
+        readme.units[0].text
+    );
+    assert!(
+        !scanned
+            .scan
+            .coverage
+            .iter()
+            .any(|r| r.path.as_deref() == Some("untracked.md")),
+        "an untracked working-tree file entered a pinned scan"
+    );
+
+    let recorded = parse_log(&std::fs::read_to_string(&log).expect("read recording"));
+    assert!(
+        !recorded.is_empty(),
+        "nothing was recorded — the shim was not actually used"
+    );
+    let verbs: BTreeSet<String> = recorded
+        .iter()
+        .filter_map(|invocation| invocation.verb().map(str::to_string))
+        .collect();
+    for forbidden in FORBIDDEN {
+        assert!(
+            !verbs.contains(*forbidden),
+            "a scan ran `git {forbidden}`; recorded verbs: {verbs:?}"
+        );
+    }
+    for verb in &verbs {
+        assert!(
+            ALLOWED.contains(&verb.as_str()),
+            "a scan ran `git {verb}`, which is not in the allowed read-only set \
+             {ALLOWED:?} — if it belongs there, add it here deliberately"
+        );
+    }
+    // Batched, not one process per file: three blobs were read, and
+    // `cat-file` ran once.
+    assert_eq!(
+        recorded
+            .iter()
+            .filter(|i| i.verb() == Some("cat-file"))
+            .count(),
+        1,
+        "blob reads were not batched: {recorded:?}"
+    );
+
+    assert_eq!(
+        before,
+        State::of(&mount),
+        "the scan changed the mount it was only supposed to read"
+    );
+}
+
+/// Everything about a repository that a scan must not move.
+#[derive(Debug, PartialEq, Eq)]
+struct State {
+    head: String,
+    refs: String,
+    porcelain: String,
+    files: Vec<(String, Vec<u8>)>,
+}
+
+impl State {
+    fn of(mount: &std::path::Path) -> Self {
+        let mut files = Vec::new();
+        collect(mount, mount, &mut files);
+        files.sort();
+        Self {
+            head: git(mount, &["rev-parse", "HEAD"]).expect("head"),
+            refs: git(mount, &["show-ref"]).unwrap_or_default(),
+            porcelain: git(mount, &["status", "--porcelain"]).expect("status"),
+            files,
+        }
+    }
+}
+
+/// Every working-tree file's bytes, excluding `.git` — whose internals Git
+/// itself rewrites for ordinary reasons (an index refresh, a pack), and which
+/// `head`/`refs` above already cover at the level that matters.
+fn collect(root: &std::path::Path, dir: &std::path::Path, out: &mut Vec<(String, Vec<u8>)>) {
+    for entry in std::fs::read_dir(dir).expect("read_dir").flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        if name == ".git" {
+            continue;
+        }
+        if path.is_dir() {
+            collect(root, &path, out);
+        } else {
+            out.push((
+                path.strip_prefix(root)
+                    .expect("under root")
+                    .display()
+                    .to_string(),
+                std::fs::read(&path).expect("read"),
+            ));
+        }
+    }
+}


### PR DESCRIPTION
Wave X3a of S3 (Atlas core) — the mechanical half of the panel-split X3. Plan: workspace `host-atlas-s3-series/sprint-plan-2026-08-27.md` (amended).

- **Pinned-SHA tree walk** (`runtime/atlas/git.rs`): rev-parse/ls-tree/cat-file against the mount's object store only — never the working tree, index, moved HEAD, or network; drift observed beside the rows, never blended. A recording-shim test pins the exact verb set and asserts the mount is byte-identical after a scan.
- **Batched blob acquisition**: one `cat-file --batch` process, size-framed parsing (truncated-stream refused by name), writer thread owns stdin so a full pipe cannot deadlock.
- **F7 estate-git keys**: blob OID + extractor identity — Git-hashed bytes are never hashed twice; empty commit ⇒ Unchanged.
- **Work-overlay hashing** (`overlay.rs`): overlay generations compose base SHA + BLAKE3 digest for changed paths (OID keys for unchanged), are scoped `work:<id>/<repo>`, and are evicted with their Work — eviction reads range-bounded on the Work prefix (aria-seat fix) so a large estate cannot push a retiring Work's overlays out of the row cap.
- **F6 intelligence-lane permits** (`lane.rs`, `engine.rs`): extraction runs bounded on the intelligence lane (H1-15's stub becomes its first real consumer), on the blocking pool, permit freed even on panic; the execution lane is untouched.
- **Concurrent-HEAD-advance tests**: a scan racing a committing thread stays on its pinned SHA — one world, drift reported.

Gates: wave workflow wf_e94b4e7e — 7 panel findings (concurrency axis included), 1 confirmed (staged rename must vacate the old path), fixed in one round; verify gate green (nextest 2016/2016, clippy/fmt clean); aria seat SOUND with one low-severity finding, fixed at the gate (range-bounded eviction, targeted tests green). No new dependencies. Rung citations in commit bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4