### PR TITLE
S3 X3b — tree-sitter adoption (F5 spike) + symbols/occurrences/edges extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,31 +150,40 @@ jobs:
         run: cargo check --locked --all-targets
 
   msrv:
-    # W1 §E: measured floor, not recon's static 1.88.0 prediction — the
-    # extra minor version comes from this crate's own use of
+    # W1 §E: a measured floor, not recon's static 1.88.0 prediction — the
+    # extra minor version came from this crate's own use of
     # std::fs::File::try_lock/TryLockError (stabilized 1.89.0), which a
     # cargo-metadata pass over dependency rust-version fields cannot see.
-    # Verified empirically: cargo +1.89.0 check --locked --all-targets and
-    # cargo +1.89.0 test --locked both passed cleanly before this job and
-    # Cargo.toml's rust-version were added. Check only, no clippy — lint
-    # policy belongs to the pinned dev compiler (rust-toolchain.toml), not
-    # to this deliberately-older floor.
+    # Check only, no clippy — lint policy belongs to the pinned dev compiler
+    # (rust-toolchain.toml), not to this floor.
+    #
+    # S3 X3b (F5d / A1-27): the floor moved 1.89.0 -> 1.98.0 together with
+    # Cargo.toml's rust-version, and it had to move in the SAME commit —
+    # cargo refuses to build a package whose rust-version exceeds the invoked
+    # compiler, so a 1.89.0 floor against a 1.98.0 rust-version is not a stale
+    # comment, it is a red job.
+    #
+    # NOTE FOR REVIEW: the floor now equals rust-toolchain.toml's pin, so this
+    # job no longer exercises an *older* compiler than the rest of CI — as of
+    # this commit it is a duplicate `--locked --all-targets` check. Whether to
+    # retire it or to re-establish a genuinely older measured floor is a
+    # decision this wave had no authority to take, and did not take.
     runs-on: ubuntu-24.04
     env:
-      # Single source of truth for this job's two 1.89.0 uses below. Keep in
-      # sync with Cargo.toml's rust-version (see the comment there) — YAML
-      # and TOML can't share a literal without added machinery, so this only
-      # collapses the duplication within this job, from two sites to one.
-      MSRV: 1.89.0
+      # Single source of truth for this job's two uses below. Keep in sync
+      # with Cargo.toml's rust-version (see the comment there) — YAML and TOML
+      # can't share a literal without added machinery, so this only collapses
+      # the duplication within this job, from two sites to one.
+      MSRV: 1.98.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: rustup toolchain install (MSRV floor — deliberately older than rust-toolchain.toml's pin)
+      - name: rustup toolchain install (the declared MSRV floor)
         run: rustup toolchain install ${{ env.MSRV }} --profile minimal
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
-      - name: cargo check --locked --all-targets (MSRV floor — check only, no clippy on an old compiler)
+      - name: cargo check --locked --all-targets (MSRV floor — check only, no clippy from this job)
         run: cargo +${{ env.MSRV }} check --locked --all-targets
 
   dependency-policy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,40 @@ release.
 - No new dependency: the existing Git-CLI module gained a batched object-read
   primitive rather than the codebase gaining a Git library.
 
+### Language-aware extraction (S3)
+
+- Source files are now parsed, not just read. Rust, TOML, Markdown, Python,
+  JavaScript, TypeScript and shell are indexed with tree-sitter grammars, and
+  what they yield lands in three new tables: a **symbol index**
+  (`source.symbols`), the **sites** that wrote each symbol
+  (`source.occurrences`), and **import edges** (`source.edges`).
+- Everything stored is **syntax, not semantics**. A symbol's label is what the
+  grammar called the node — `function`, `struct`, `class`, `heading` — and an
+  import's target is the text the file wrote, unresolved. Nothing follows a
+  re-export or decides which definition a name meant, and nothing claims to.
+- Files whose extension only a grammar claims — `.rs`, `.toml`, `.py`, `.ts` —
+  are now `indexed` where they used to be reported `unsupported`. A language
+  no grammar in this build claims (`.tsx`, for instance) is still
+  `unsupported` and says so, rather than being parsed by an almost-right
+  grammar.
+- A file a grammar cannot parse is reported `error` and contributes **no**
+  symbols at all. tree-sitter's error tolerance would otherwise produce a
+  shorter symbol list that nothing downstream could distinguish from a
+  complete one.
+- The syntax extraction of a file is cached separately from its structure
+  extraction: one blob read by two extractors is two extractions with two
+  keys, so revising a grammar re-derives symbols without invalidating a single
+  document unit. Repository content keys on Git's blob object id, exactly as
+  before; local knowledge keys on its content hash.
+- Extraction runs where the repository plumbing already ran — on the
+  intelligence lane, over batched blob reads — and the scan summary each
+  completed scan journals now carries symbol and edge counts.
+- Eight new dependencies, all from crates.io, all MIT, none vendored or
+  forked: `tree-sitter` and one grammar per indexed language. `cargo deny`
+  is green with them, with no new duplicate-version warning.
+- The declared minimum supported Rust version moves from 1.89 to 1.98,
+  matching the toolchain this repository already pins.
+
 ## [0.2.4] - 2026-08-25
 
 sergeant-rs narrows to a product-documents-only repo, codex actors gain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2963,6 +2964,14 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-javascript",
+ "tree-sitter-md",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-toml-ng",
+ "tree-sitter-typescript",
  "ulid",
 ]
 
@@ -3084,6 +3093,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -3598,6 +3613,96 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,14 @@ edition = "2024"
 # Keep in sync with the `msrv` job's `env.MSRV` in .github/workflows/ci.yml
 # (W1 spec §E) — cargo has no way to read this field back into that job's
 # `run:` steps without added machinery, so the two are hand-synced.
-rust-version = "1.89.0"
+#
+# S3 X3b (F5d / A1-27): 1.89.0 -> 1.98.0. This is paperwork the A1 plan routed
+# onto the first A1-dependency PR, not a new constraint discovered here: the
+# pinned dev compiler in rust-toolchain.toml has been 1.98.0, and 1.89.0 was a
+# floor nothing had re-verified. The two fields cannot move independently —
+# `cargo +1.89 check` refuses outright once this says 1.98.0 — so ci.yml's
+# `env.MSRV` moves in the same commit.
+rust-version = "1.98.0"
 license = "MIT"
 repository = "https://github.com/miztertea/sergeant-rs"
 description = "Local execution surface for coding agents: durable work, isolated git worktrees, and a complete evidence trail behind one daemon"
@@ -143,7 +150,17 @@ debug = false
 # axum 0.8's own `http-body-util` dependency.
 http-body-util = "0.1"
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace", "metrics", "testing"] }
+# S3 X3b: `tests/x3b_tslp_corpus.rs` reads its hand-verified expectations from
+# `tests/fixtures/tslp_corpus/manifest.toml`. Both crates are already direct
+# `[dependencies]` of this crate at these exact versions — an integration test
+# links the library plus dev-dependencies, not the library's own dependencies,
+# so naming them here adds two lines and ZERO packages to the resolved graph
+# (R5, verified: `Cargo.lock` package count is unchanged by these two entries).
+# The alternative, a hand-rolled parser for the manifest, is the R6/R7 bug farm
+# the rung order exists to prevent.
+serde = { version = "1.0.229", features = ["derive"] }
 tempfile = "3"
+toml = "1.1.4"
 
 # Packaging mechanics for release.yml (proposal §10: "`dist` may own packaging
 # mechanics. Sergeant owns release authority."). `ci = "github"` still selects

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,34 @@ toml = "1.1.4"
 toml_edit = { version = "0.25", features = ["parse", "display"] }
 tracing = "0.1.44"
 tracing-subscriber = "0.3"
+# S3 X3b (F5): language-aware symbol/import extraction. Rungs, in order: R2
+# fails (nothing in this crate parses source code; X2's `text.rs` splits
+# Markdown on heading bytes and answers a different question), R3 fails (std
+# has no parser for any of these languages), R4 fails (the OS offers none
+# either), R5 fails (nothing already in the graph parses source — `toml`/
+# `toml_edit` cover exactly one of the six languages and only as values, not
+# as a syntax tree with byte ranges, which is what `source.occurrences` is
+# keyed on), R6 fails (six hand-written parsers is the largest bug farm this
+# repo could adopt, and a regex "symbol finder" is precisely the silent
+# partial parse F5's exact-match criterion exists to forbid). R5-as-new-edge →
+# tree-sitter plus one grammar per language actually indexed.
+#
+# The grammar set is the LEAN one, not `tree-sitter-language-pack` (TSLP): the
+# pack resolves 143 crates for 371 languages and, at its default features
+# (`download` + `dynamic-loading`), FAILS this repo's `cargo deny` on MPL-2.0
+# (`option-ext` via `dirs`/`dirs-sys`) — recorded verbatim in
+# tests/fixtures/tslp_corpus/SPIKE-F5.md. Its `download` feature also fetches
+# parsers over the network at runtime, which is the same posture F4 forbids
+# for DuckDB extension autoload. Eight direct crates / ten new lock entries
+# buy the six languages F5 names and nothing else (R1 on the other 365).
+tree-sitter = "0.26.13"
+tree-sitter-bash = "0.25.1"
+tree-sitter-javascript = "0.25.0"
+tree-sitter-md = "0.5.3"
+tree-sitter-python = "0.25.0"
+tree-sitter-rust = "0.24.2"
+tree-sitter-toml-ng = "0.7.0"
+tree-sitter-typescript = "0.23.2"
 ulid = "3.0.0"
 
 # #310: `prctl(PR_SET_PDEATHSIG, SIGKILL)` on a probe child, and nothing else.

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -173,3 +173,12 @@ cov_stage_end 1 "the x3a_scan_uses_only_local_reads test binary must write its o
 cov_stage_begin c2-x3b_tslp_corpus
 cov_run cargo llvm-cov --no-report --test x3b_tslp_corpus --locked || cov_fail "x3b_tslp_corpus failed under instrumentation"
 cov_stage_end 1 "the x3b_tslp_corpus test binary must write its own profile"
+
+# S3 X3b, the wiring: symbols/occurrences/edges written by the ordinary
+# recording path over real Git objects, plus the intelligence-lane consumer.
+# Builds throwaway repositories and Atlas stores in tempdirs and drives an
+# in-process Engine; it spawns no `sgt` and starts no daemon, which is why it
+# is here rather than with the spawning suites. Floor 1.
+cov_stage_begin c2-x3b_syntax_wiring
+cov_run cargo llvm-cov --no-report --test x3b_syntax_wiring --locked || cov_fail "x3b_syntax_wiring failed under instrumentation"
+cov_stage_end 1 "the x3b_syntax_wiring test binary must write its own profile"

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -165,3 +165,11 @@ cov_stage_end 1 "the x3a_git_plumbing test binary must write its own profile"
 cov_stage_begin c2-x3a_scan_uses_only_local_reads
 cov_run cargo llvm-cov --no-report --test x3a_scan_uses_only_local_reads --locked || cov_fail "x3a_scan_uses_only_local_reads failed under instrumentation"
 cov_stage_end 1 "the x3a_scan_uses_only_local_reads test binary must write its own profile"
+
+# S3 X3b: the F5 corpus gate — the hand-verified multi-language fixture corpus
+# read through `runtime::atlas::syntax`'s pure extractor. Reads checked-in
+# fixture bytes and nothing else: no tempdir, no subprocess, no daemon, no
+# estate, no backend. Floor 1.
+cov_stage_begin c2-x3b_tslp_corpus
+cov_run cargo llvm-cov --no-report --test x3b_tslp_corpus --locked || cov_fail "x3b_tslp_corpus failed under instrumentation"
+cov_stage_end 1 "the x3b_tslp_corpus test binary must write its own profile"

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -48,11 +48,20 @@
 //!
 //! # Scope today
 //!
-//! The four tables the local-knowledge scanner writes, and nothing else.
-//! Every table lands in the wave that lands its writer (the empty-table
-//! refusal doctrine); a declared-but-never populated table is a false
-//! promise, not completeness. `git.*` and `context.*` are still empty
-//! namespaces because nothing writes them yet.
+//! The seven tables the three walks write, and nothing else. Every table
+//! lands in the wave that lands its writer (the empty-table refusal
+//! doctrine); a declared-but-never populated table is a false promise, not
+//! completeness — which is why `source.symbols`, `source.occurrences` and
+//! `source.edges` arrive here in X3b, with the extraction that fills them,
+//! rather than having been declared empty in X1. `git.*` and `context.*` are
+//! still empty namespaces because nothing writes them yet.
+//!
+//! **These tables are only ever added to, never altered.** The store persists
+//! across restarts (F1) and the DDL is `IF NOT EXISTS`, so a column added to
+//! an existing table would simply not appear in a database that already has
+//! it — a silent schema drift with no migration behind it. X3b's rows
+//! therefore live in new tables that carry their own copy of the coordinates
+//! they need, and `source.files` keeps exactly the columns X2 gave it.
 //!
 //! # The confirmation protocol (F1's crash window)
 //!
@@ -92,7 +101,7 @@ use duckdb::Connection;
 use crate::domain::source::{
     AuthorityClass, Coverage, CoverageRow, SourceGeneration, SourceKind, UnitKind,
 };
-use crate::runtime::atlas::scan::{ScannedFile, ScannedUnit, SourceScan};
+use crate::runtime::atlas::scan::{ScannedFile, ScannedSyntax, ScannedUnit, SourceScan};
 use crate::runtime::fsutil::create_dir_all_durable;
 
 /// Directory under the data dir holding Atlas's durable store.
@@ -174,10 +183,32 @@ CREATE SCHEMA IF NOT EXISTS source;\n\
 CREATE SCHEMA IF NOT EXISTS git;\n\
 CREATE SCHEMA IF NOT EXISTS context;\n";
 
-/// The tables the local-knowledge scanner writes (X2). Applied after
+/// The tables the scanners write — X2's four, plus X3b's three. Applied after
 /// [`SCHEMA_DDL`], on every open, for the same idempotency reason.
 ///
 /// Column choices worth stating, because each one is a contract:
+///
+/// * **`source.symbols` is the index; `source.occurrences` are the sites.**
+///   A symbol is `(language, label, name)` — two files defining `count` are
+///   one symbol row and two occurrence rows. The rollup is *syntactic*: it
+///   says two sites wrote the same name in the same language with the same
+///   grammar label, and it does **not** say they define the same thing, which
+///   would be the resolution A1-09 forbids claiming. `language` is part of the
+///   identity so two languages that spell a name alike are never merged.
+/// * **An occurrence is a definition site**, because that is what a grammar
+///   can tell you without resolving anything. Reference sites are absent
+///   rather than approximated: an unresolved token stream labelled
+///   "references" is exactly the false promise the empty-table doctrine
+///   exists to refuse, and the wave that can resolve them adds them.
+/// * **`syntax_key` is the F7 key of the *syntax* extraction**, which is not
+///   `source.files.local_key`: one blob read by a structure extractor and by
+///   a grammar is two extractions with two keys (see
+///   [`ScannedSyntax`](crate::runtime::atlas::scan::ScannedSyntax)). Both are
+///   derived from the same content identity — a blob OID for an estate-git
+///   source, a BLAKE3 hash for a local one — composed with different extractor
+///   identities.
+/// * **`source.edges.target` is unresolved text**, exactly as the file wrote
+///   it. `edge_kind` is `import`, the only kind this build derives.
 ///
 /// * `content_key` on a generation is what ruling §4's eviction rule is
 ///   phrased over — a re-scan producing the same key evicts nothing.
@@ -228,6 +259,40 @@ CREATE TABLE IF NOT EXISTS source.units (\n\
   byte_start    BIGINT NOT NULL,\n\
   byte_end      BIGINT NOT NULL,\n\
   body          TEXT NOT NULL\n\
+);\n\
+CREATE TABLE IF NOT EXISTS source.symbols (\n\
+  generation_id TEXT NOT NULL,\n\
+  source_name   TEXT NOT NULL,\n\
+  language      TEXT NOT NULL,\n\
+  label         TEXT NOT NULL,\n\
+  name          TEXT NOT NULL,\n\
+  occurrences   BIGINT NOT NULL\n\
+);\n\
+CREATE TABLE IF NOT EXISTS source.occurrences (\n\
+  generation_id TEXT NOT NULL,\n\
+  source_name   TEXT NOT NULL,\n\
+  relative_path TEXT NOT NULL,\n\
+  syntax_key    TEXT NOT NULL,\n\
+  extractor     TEXT NOT NULL,\n\
+  language      TEXT NOT NULL,\n\
+  ordinal       BIGINT NOT NULL,\n\
+  label         TEXT NOT NULL,\n\
+  name          TEXT NOT NULL,\n\
+  byte_start    BIGINT NOT NULL,\n\
+  byte_end      BIGINT NOT NULL\n\
+);\n\
+CREATE TABLE IF NOT EXISTS source.edges (\n\
+  generation_id TEXT NOT NULL,\n\
+  source_name   TEXT NOT NULL,\n\
+  relative_path TEXT NOT NULL,\n\
+  syntax_key    TEXT NOT NULL,\n\
+  extractor     TEXT NOT NULL,\n\
+  language      TEXT NOT NULL,\n\
+  ordinal       BIGINT NOT NULL,\n\
+  edge_kind     TEXT NOT NULL,\n\
+  target        TEXT NOT NULL,\n\
+  byte_start    BIGINT NOT NULL,\n\
+  byte_end      BIGINT NOT NULL\n\
 );\n\
 CREATE TABLE IF NOT EXISTS meta.coverage (\n\
   generation_id TEXT NOT NULL,\n\
@@ -428,8 +493,35 @@ impl AtlasDb {
                 &extractors,
             ],
         )?;
+        // The symbol *index* is a rollup across the whole generation, so it is
+        // accumulated as the files are written and inserted once — not once
+        // per file, which would make `occurrences` a per-file count wearing a
+        // generation-wide column's name.
+        let mut index: BTreeMap<(&str, &str, &str), u64> = BTreeMap::new();
         for file in &scan.files {
             insert_file(&tx, &generation_id, &scan.source_name, file)?;
+            if let Some(syntax) = &file.syntax {
+                for symbol in &syntax.symbols {
+                    *index
+                        .entry((syntax.language, symbol.label, symbol.name.as_str()))
+                        .or_insert(0) += 1;
+                }
+            }
+        }
+        for ((language, label, name), occurrences) in index {
+            tx.prepare_cached(
+                "INSERT INTO source.symbols \
+                 (generation_id, source_name, language, label, name, occurrences) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )?
+            .execute(duckdb::params![
+                &generation_id,
+                &scan.source_name,
+                language,
+                label,
+                name,
+                occurrences as i64,
+            ])?;
         }
         for row in &scan.coverage {
             insert_coverage(
@@ -698,6 +790,96 @@ impl AtlasDb {
         Ok(out)
     }
 
+    /// The symbol index of one source's confirmed generation, in
+    /// `(language, label, name)` order, bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    pub fn symbols(
+        &self,
+        source_name: &str,
+        limit: usize,
+    ) -> Result<Vec<StoredSymbol>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let mut statement = self.conn.prepare(
+            "SELECT s.language, s.label, s.name, s.occurrences \
+             FROM source.symbols s JOIN source.generations g USING (generation_id) \
+             WHERE g.source_name = ? AND g.state = ? \
+             ORDER BY s.language, s.label, s.name LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push(StoredSymbol {
+                language: row.get(0)?,
+                label: row.get(1)?,
+                name: row.get(2)?,
+                occurrences: row.get::<usize, i64>(3)? as u64,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Symbol sites of one source's confirmed generation, in path then
+    /// document order, bounded by `limit` (capped at [`MAX_ROWS`], F12).
+    pub fn occurrences(
+        &self,
+        source_name: &str,
+        limit: usize,
+    ) -> Result<Vec<StoredOccurrence>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let mut statement = self.conn.prepare(
+            "SELECT o.relative_path, o.syntax_key, o.extractor, o.language, o.ordinal, \
+                    o.label, o.name, o.byte_start, o.byte_end \
+             FROM source.occurrences o JOIN source.generations g USING (generation_id) \
+             WHERE g.source_name = ? AND g.state = ? \
+             ORDER BY o.relative_path, o.ordinal LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push(StoredOccurrence {
+                relative_path: row.get(0)?,
+                syntax_key: row.get(1)?,
+                extractor: row.get(2)?,
+                language: row.get(3)?,
+                ordinal: row.get::<usize, i64>(4)? as u64,
+                label: row.get(5)?,
+                name: row.get(6)?,
+                byte_start: row.get::<usize, i64>(7)? as u64,
+                byte_end: row.get::<usize, i64>(8)? as u64,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Edges out of one source's confirmed generation, in path then document
+    /// order, bounded by `limit` (capped at [`MAX_ROWS`], F12).
+    pub fn edges(&self, source_name: &str, limit: usize) -> Result<Vec<StoredEdge>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let mut statement = self.conn.prepare(
+            "SELECT e.relative_path, e.syntax_key, e.extractor, e.language, e.ordinal, \
+                    e.edge_kind, e.target, e.byte_start, e.byte_end \
+             FROM source.edges e JOIN source.generations g USING (generation_id) \
+             WHERE g.source_name = ? AND g.state = ? \
+             ORDER BY e.relative_path, e.ordinal LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push(StoredEdge {
+                relative_path: row.get(0)?,
+                syntax_key: row.get(1)?,
+                extractor: row.get(2)?,
+                language: row.get(3)?,
+                ordinal: row.get::<usize, i64>(4)? as u64,
+                kind: row.get(5)?,
+                target: row.get(6)?,
+                byte_start: row.get::<usize, i64>(7)? as u64,
+                byte_end: row.get::<usize, i64>(8)? as u64,
+            });
+        }
+        Ok(out)
+    }
+
     /// Coverage rows for one source's confirmed generations, newest first,
     /// bounded by `limit` (capped at [`MAX_ROWS`], F12).
     ///
@@ -810,25 +992,85 @@ fn insert_file(
     source_name: &str,
     file: &ScannedFile,
 ) -> Result<(), AtlasError> {
-    conn.execute(
+    conn.prepare_cached(
         "INSERT INTO source.files \
          (generation_id, source_name, relative_path, content_hash, extractor, local_key, \
           byte_len, mtime_millis, unit_count) \
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        duckdb::params![
+    )?
+    .execute(duckdb::params![
+        generation_id,
+        source_name,
+        &file.relative_path,
+        &file.content_hash,
+        &file.extractor,
+        &file.local_key,
+        file.byte_len as i64,
+        file.mtime_millis,
+        file.units.len() as i64,
+    ])?;
+    for unit in &file.units {
+        insert_unit(conn, generation_id, source_name, file, unit)?;
+    }
+    if let Some(syntax) = &file.syntax {
+        insert_syntax(conn, generation_id, source_name, file, syntax)?;
+    }
+    Ok(())
+}
+
+/// Insert one file's syntax extraction: its symbol sites and its edges.
+///
+/// The symbol *index* is not written here — it is a rollup over the whole
+/// generation and belongs to the transaction that knows all of it
+/// ([`AtlasDb::stage_scan`]).
+fn insert_syntax(
+    conn: &Connection,
+    generation_id: &str,
+    source_name: &str,
+    file: &ScannedFile,
+    syntax: &ScannedSyntax,
+) -> Result<(), AtlasError> {
+    for symbol in &syntax.symbols {
+        conn.prepare_cached(
+            "INSERT INTO source.occurrences \
+             (generation_id, source_name, relative_path, syntax_key, extractor, language, \
+              ordinal, label, name, byte_start, byte_end) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )?
+        .execute(duckdb::params![
             generation_id,
             source_name,
             &file.relative_path,
-            &file.content_hash,
-            &file.extractor,
-            &file.local_key,
-            file.byte_len as i64,
-            file.mtime_millis,
-            file.units.len() as i64,
-        ],
-    )?;
-    for unit in &file.units {
-        insert_unit(conn, generation_id, source_name, file, unit)?;
+            &syntax.syntax_key,
+            &syntax.extractor,
+            syntax.language,
+            symbol.ordinal as i64,
+            symbol.label,
+            &symbol.name,
+            symbol.byte_start as i64,
+            symbol.byte_end as i64,
+        ])?;
+    }
+    for edge in &syntax.edges {
+        conn.prepare_cached(
+            "INSERT INTO source.edges \
+             (generation_id, source_name, relative_path, syntax_key, extractor, language, \
+              ordinal, edge_kind, target, byte_start, byte_end) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )?
+        .execute(duckdb::params![
+            generation_id,
+            source_name,
+            &file.relative_path,
+            &syntax.syntax_key,
+            &syntax.extractor,
+            syntax.language,
+            edge.ordinal as i64,
+            edge.kind,
+            &edge.target,
+            edge.byte_start as i64,
+            edge.byte_end as i64,
+        ])?;
     }
     Ok(())
 }
@@ -841,25 +1083,25 @@ fn insert_unit(
     file: &ScannedFile,
     unit: &ScannedUnit,
 ) -> Result<(), AtlasError> {
-    conn.execute(
+    conn.prepare_cached(
         "INSERT INTO source.units \
          (generation_id, source_name, relative_path, local_key, ordinal, unit_kind, \
           heading_level, title, byte_start, byte_end, body) \
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        duckdb::params![
-            generation_id,
-            source_name,
-            &file.relative_path,
-            &file.local_key,
-            unit.ordinal as i64,
-            unit.kind.as_str(),
-            unit.heading_level.map(i64::from),
-            unit.title.as_deref(),
-            unit.byte_start as i64,
-            unit.byte_end as i64,
-            &unit.text,
-        ],
-    )?;
+    )?
+    .execute(duckdb::params![
+        generation_id,
+        source_name,
+        &file.relative_path,
+        &file.local_key,
+        unit.ordinal as i64,
+        unit.kind.as_str(),
+        unit.heading_level.map(i64::from),
+        unit.title.as_deref(),
+        unit.byte_start as i64,
+        unit.byte_end as i64,
+        &unit.text,
+    ])?;
     Ok(())
 }
 
@@ -871,20 +1113,20 @@ fn insert_coverage(
     row: &CoverageRow,
     observed_at: &str,
 ) -> Result<(), AtlasError> {
-    conn.execute(
+    conn.prepare_cached(
         "INSERT INTO meta.coverage \
          (generation_id, source_name, path, status, detail, bytes, observed_at) \
          VALUES (?, ?, ?, ?, ?, ?, ?)",
-        duckdb::params![
-            generation_id,
-            source_name,
-            row.path.as_deref(),
-            row.status.as_str(),
-            row.detail.as_deref(),
-            row.bytes.map(|b| b as i64),
-            observed_at,
-        ],
-    )?;
+    )?
+    .execute(duckdb::params![
+        generation_id,
+        source_name,
+        row.path.as_deref(),
+        row.status.as_str(),
+        row.detail.as_deref(),
+        row.bytes.map(|b| b as i64),
+        observed_at,
+    ])?;
     Ok(())
 }
 
@@ -903,6 +1145,18 @@ fn evict(
 ) -> Result<(), AtlasError> {
     conn.execute(
         "DELETE FROM source.units WHERE generation_id = ?",
+        duckdb::params![generation_id],
+    )?;
+    conn.execute(
+        "DELETE FROM source.occurrences WHERE generation_id = ?",
+        duckdb::params![generation_id],
+    )?;
+    conn.execute(
+        "DELETE FROM source.edges WHERE generation_id = ?",
+        duckdb::params![generation_id],
+    )?;
+    conn.execute(
+        "DELETE FROM source.symbols WHERE generation_id = ?",
         duckdb::params![generation_id],
     )?;
     conn.execute(
@@ -982,6 +1236,69 @@ pub struct StoredUnit {
     pub byte_end: u64,
     /// The unit's text.
     pub body: String,
+}
+
+/// One entry of the symbol index, read back out of the store.
+///
+/// A symbol is `(language, label, name)`. `occurrences` counts the sites in
+/// the same generation that wrote it — a syntactic rollup, never a claim that
+/// those sites define one thing (A1-09).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredSymbol {
+    /// The grammar's language name.
+    pub language: String,
+    /// What the grammar called it.
+    pub label: String,
+    /// The name as written.
+    pub name: String,
+    /// How many sites in this generation wrote it.
+    pub occurrences: u64,
+}
+
+/// One symbol site, read back out of the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredOccurrence {
+    /// Path relative to the source root.
+    pub relative_path: String,
+    /// F7 key of the *syntax* extraction this site came from.
+    pub syntax_key: String,
+    /// The grammar's versioned extractor identity.
+    pub extractor: String,
+    /// The grammar's language name.
+    pub language: String,
+    /// Position within its file's symbol list.
+    pub ordinal: u64,
+    /// What the grammar called it.
+    pub label: String,
+    /// The name as written.
+    pub name: String,
+    /// Offset into the original file bytes.
+    pub byte_start: u64,
+    /// End offset into the original file bytes, exclusive.
+    pub byte_end: u64,
+}
+
+/// One edge out of a file, read back out of the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredEdge {
+    /// Path the edge leaves from, relative to the source root.
+    pub relative_path: String,
+    /// F7 key of the *syntax* extraction this edge came from.
+    pub syntax_key: String,
+    /// The grammar's versioned extractor identity.
+    pub extractor: String,
+    /// The grammar's language name.
+    pub language: String,
+    /// Position within its file's edge list.
+    pub ordinal: u64,
+    /// The edge's syntax-derived kind — `import` today.
+    pub kind: String,
+    /// What the file named, exactly as written. **Unresolved.**
+    pub target: String,
+    /// Offset into the original file bytes.
+    pub byte_start: u64,
+    /// End offset into the original file bytes, exclusive.
+    pub byte_end: u64,
 }
 
 /// One coverage row read back out of the store, with the generation it
@@ -1074,6 +1391,7 @@ mod tests {
                     byte_end: body.len() as u64,
                     text: body.to_string(),
                 }],
+                syntax: None,
             }],
             coverage: vec![CoverageRow {
                 path: Some("doc.md".to_string()),

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -93,7 +93,7 @@
 //! and "journal-present, database-evicted" is the same both-present violation
 //! as its mirror image, only harder to notice.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use duckdb::Connection;
@@ -410,9 +410,30 @@ impl AtlasDb {
     ///
     /// Returns [`ScanCommit::Unchanged`] without writing anything when the
     /// scan's `content_key` matches the source's newest confirmed
-    /// generation — ruling §4's eviction rule, enforced at its only
-    /// enforcement point: a generation is evicted only when source bytes
-    /// changed, so an unchanged re-scan must not churn one.
+    /// generation **and the same extractor identities produced it** — ruling
+    /// §4's eviction rule, enforced at its only enforcement point: a
+    /// generation is evicted only when the derived facts could have changed,
+    /// so an unchanged re-scan must not churn one.
+    ///
+    /// **Both halves of F7's key participate, not just the content half.**
+    /// F7 keys a derived row on content identity *plus extractor identity*,
+    /// and a staleness test that consults only `content_key` would make the
+    /// second half decorative: after a grammar or version bump, a re-scan of
+    /// byte-identical sources would answer `Unchanged`, the fresh extraction
+    /// would be discarded, and `symbols`/`occurrences`/`edges` would keep
+    /// serving the *old* parser's rows forever with no path back. The
+    /// identities the standing generation stored are therefore compared
+    /// against the ones this scan ran, and a mismatch is a change: a new
+    /// generation is staged and the old one evicted on confirmation, exactly
+    /// as a byte change would be.
+    ///
+    /// The two inputs stay separate values rather than being folded into one
+    /// hash. `content_key` answers "is this the same world?" and is
+    /// deliberately content-only (see
+    /// [`generation_key`](crate::domain::source::generation_key)); mixing an
+    /// extractor version into it would make a bumped parser look like changed
+    /// source bytes to every reader of that column, including the eviction
+    /// row that has to say *why* a generation was superseded.
     ///
     /// Returns [`ScanCommit::RootUnavailable`], also without writing a
     /// generation, when the walk could not read the source root at all and a
@@ -463,6 +484,7 @@ impl AtlasDb {
         }
         if let Some(current) = self.confirmed_generation(&scan.source_name)?
             && current.content_key == scan.content_key
+            && self.generation_extractors(&current.id)? == scan.extractors
         {
             return Ok(ScanCommit::Unchanged {
                 generation_id: current.id,
@@ -470,12 +492,7 @@ impl AtlasDb {
             });
         }
         let generation_id = ulid::Ulid::generate().to_string();
-        let extractors = scan
-            .extractors
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .join(",");
+        let extractors = join_extractors(&scan.extractors);
         let tx = self.conn.transaction()?;
         tx.execute(
             "INSERT INTO source.generations \
@@ -568,6 +585,21 @@ impl AtlasDb {
                 .filter(|id| id != generation_id),
             None => None,
         };
+        // Why the predecessor is going, decided from the evidence rather than
+        // assumed. `stage_scan` stages a successor for either of two reasons —
+        // the source bytes changed, or the extractor identities did — and the
+        // coverage row an eviction leaves is the durable record of which. A
+        // fixed "the source bytes changed" string would be a false statement on
+        // every grammar bump, in the one row a reader consults to find out.
+        let reason = match &superseded {
+            Some(previous)
+                if self.generation_content_key(previous)?
+                    == self.generation_content_key(generation_id)? =>
+            {
+                "superseded: the extractor identities changed (the source bytes did not)"
+            }
+            _ => "superseded: the source bytes changed",
+        };
         let observed_at = crate::domain::event::rfc3339_utc_now();
         let tx = self.conn.transaction()?;
         let promoted = tx.execute(
@@ -590,13 +622,7 @@ impl AtlasDb {
             });
         }
         if let (Some(previous), Some(name)) = (&superseded, &source_name) {
-            evict(
-                &tx,
-                previous,
-                name,
-                "superseded: the source bytes changed",
-                &observed_at,
-            )?;
+            evict(&tx, previous, name, reason, &observed_at)?;
         }
         tx.commit()?;
         Ok(superseded)
@@ -983,6 +1009,63 @@ impl AtlasDb {
             None => Ok(None),
         }
     }
+
+    /// The extractor identities a stored generation's rows were derived from —
+    /// the second half of F7's key, read back for [`Self::stage_scan`]'s
+    /// staleness test.
+    ///
+    /// Round-trips exactly what [`join_extractors`] wrote, so the comparison is
+    /// against a set and not against a formatting accident. An unknown
+    /// generation and one that recorded no extractors both answer with the
+    /// empty set, which is the same answer a scan that ran none produces —
+    /// correct in both cases, because neither could have derived a row.
+    fn generation_extractors(&self, generation_id: &str) -> Result<BTreeSet<String>, AtlasError> {
+        let mut statement = self
+            .conn
+            .prepare("SELECT extractors FROM source.generations WHERE generation_id = ?")?;
+        let mut rows = statement.query(duckdb::params![generation_id])?;
+        let Some(row) = rows.next()? else {
+            return Ok(BTreeSet::new());
+        };
+        Ok(split_extractors(&row.get::<usize, String>(0)?))
+    }
+
+    /// The stored `content_key` of any generation, in any state.
+    ///
+    /// [`Self::confirmed_generation`] cannot answer this for a generation that
+    /// is being superseded *by* the call asking, which is exactly when
+    /// [`Self::confirm_scan`] needs it to say honestly why the predecessor is
+    /// going.
+    fn generation_content_key(&self, generation_id: &str) -> Result<Option<String>, AtlasError> {
+        let mut statement = self
+            .conn
+            .prepare("SELECT content_key FROM source.generations WHERE generation_id = ?")?;
+        let mut rows = statement.query(duckdb::params![generation_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row.get(0)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+/// The `extractors` column's stored form: identities, comma-joined, in the
+/// set's own sorted order.
+fn join_extractors(extractors: &BTreeSet<String>) -> String {
+    extractors
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// [`join_extractors`] backwards. Empty segments are dropped, so an empty
+/// column is the empty set rather than a set holding one empty name.
+fn split_extractors(stored: &str) -> BTreeSet<String> {
+    stored
+        .split(',')
+        .filter(|identity| !identity.is_empty())
+        .map(str::to_owned)
+        .collect()
 }
 
 /// Insert one acquired file and its units.

--- a/src/runtime/atlas/git.rs
+++ b/src/runtime/atlas/git.rs
@@ -53,10 +53,12 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use crate::domain::event::rfc3339_utc_now;
-use crate::domain::source::{AuthorityClass, Coverage, CoverageRow, SourceKind, estate_git_key};
+use crate::domain::source::{AuthorityClass, Coverage, CoverageRow, SourceKind};
 use crate::runtime::atlas::deny::{AcquisitionFilter, BadPattern, Verdict};
-use crate::runtime::atlas::scan::{MAX_RESOURCE_BYTES, ScannedFile, SourceScan, extract_units};
-use crate::runtime::atlas::text::{as_text, extractor_for};
+use crate::runtime::atlas::scan::{
+    KeySpace, MAX_RESOURCE_BYTES, ScannedFile, SourceScan, UNCLAIMED, claims_for, extract_resource,
+};
+use crate::runtime::atlas::text::as_text;
 use crate::runtime::git::{GitError, git, git_bytes, git_cat_file_batch};
 use crate::runtime::integrity::{DriftAttribution, EstateDriftObservation};
 
@@ -384,11 +386,11 @@ pub(crate) fn extract_blobs(
             }
             EntryKind::File => {}
         }
-        if extractor_for(&entry.path).is_none() {
+        if claims_for(&entry.path).is_none() {
             out.coverage.push(CoverageRow {
                 path: Some(entry.path.clone()),
                 status: Coverage::Unsupported,
-                detail: Some("no extractor in this build claims this extension".to_string()),
+                detail: Some(UNCLAIMED.to_string()),
                 bytes: Some(entry.size),
             });
             continue;
@@ -411,7 +413,7 @@ pub(crate) fn extract_blobs(
         let oids: Vec<String> = batch.iter().map(|e| e.oid.clone()).collect();
         let objects = git_cat_file_batch(mount, &oids)?;
         for (entry, object) in batch.iter().zip(objects) {
-            let extractor = extractor_for(&entry.path).expect("filtered above");
+            let claims = claims_for(&entry.path).expect("filtered above");
             let Some(object) = object else {
                 out.coverage.push(CoverageRow {
                     path: Some(entry.path.clone()),
@@ -434,30 +436,32 @@ pub(crate) fn extract_blobs(
                 });
                 continue;
             };
-            let units = extract_units(text, extractor);
-            out.extractors.insert(extractor.to_string());
+            // **F7, estate-git half.** Every key below is the blob OID plus an
+            // extractor identity. The OID *is* Git's hash of exactly these
+            // bytes; hashing them again would produce a second name for one
+            // thing and cost a full pass over every byte in the repository to
+            // do it. [`KeySpace::EstateGit`] is that rule, passed to the one
+            // shared extractor rather than restated here.
+            let extracted = extract_resource(claims, text, &entry.oid, KeySpace::EstateGit);
+            out.extractors.extend(extracted.identities.iter().cloned());
             out.coverage.push(CoverageRow {
                 path: Some(entry.path.clone()),
-                status: Coverage::Indexed,
-                detail: Some(extractor.to_string()),
+                status: extracted.status(),
+                detail: Some(extracted.detail()),
                 bytes: Some(object.bytes.len() as u64),
             });
             out.files.push(ScannedFile {
                 relative_path: entry.path.clone(),
-                // **F7, estate-git half.** The key is the blob OID plus the
-                // extractor's identity. The OID *is* Git's hash of exactly
-                // these bytes; hashing them again would produce a second name
-                // for one thing and cost a full pass over every byte in the
-                // repository to do it.
-                local_key: estate_git_key(&entry.oid, extractor),
+                local_key: extracted.key,
                 content_hash: entry.oid.clone(),
-                extractor: extractor.to_string(),
+                extractor: extracted.extractor.to_string(),
                 byte_len: object.bytes.len() as u64,
                 // Not a fact a Git object has, and not one this path needs:
                 // F7 makes mtime a change hint for the *filesystem* scanner,
                 // and an object store has content identity instead.
                 mtime_millis: None,
-                units,
+                units: extracted.units,
+                syntax: extracted.syntax,
             });
         }
     }
@@ -583,6 +587,7 @@ pub fn observe_drift(source: &EstateGitSource, tree: &GitTree) -> Option<EstateD
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::source::estate_git_key;
     use crate::runtime::atlas::text::MARKDOWN_EXTRACTOR;
     use crate::runtime::git::git as run_git;
 
@@ -652,7 +657,9 @@ mod tests {
         assert_eq!(row(scan, "README.md").status, Coverage::Indexed);
         assert_eq!(row(scan, "docs/one.md").status, Coverage::Indexed);
         assert_eq!(row(scan, "docs/plain.txt").status, Coverage::Indexed);
-        assert_eq!(row(scan, "src/main.rs").status, Coverage::Unsupported);
+        // Claimed by a grammar since X3b, so `unsupported` would now be the
+        // dishonest answer — the file *is* indexed, and its symbols are rows.
+        assert_eq!(row(scan, "src/main.rs").status, Coverage::Indexed);
         assert_eq!(row(scan, "keys/server.pem").status, Coverage::Excluded);
         assert_eq!(row(scan, ".env").status, Coverage::Excluded);
         assert_eq!(row(scan, "docs").status, Coverage::Discovered);

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -51,12 +51,29 @@
 //!
 //! # Scope of what exists here today
 //!
-//! The four namespaces, and the four tables three walks now write:
-//! `source.generations`, `source.files`, `source.units` and `meta.coverage`.
-//! Local knowledge, an estate repository at an admission-pinned commit, and a
-//! Work surface overlaid on its base all land in the same four tables, because
-//! they produce the same kind of fact — a resource, its content identity, its
-//! extractor, and its units — and the source kind is a column, not a schema.
+//! The four namespaces, and the seven tables three walks now write:
+//! `source.generations`, `source.files`, `source.units`, `source.symbols`,
+//! `source.occurrences`, `source.edges` and `meta.coverage`. Local knowledge,
+//! an estate repository at an admission-pinned commit, and a Work surface
+//! overlaid on its base all land in the same tables, because they produce the
+//! same kind of fact — a resource, its content identity, its extractors, and
+//! what those extractors derived — and the source kind is a column, not a
+//! schema.
+//!
+//! # Two extractions of one resource, never one ambiguous extraction (X3b)
+//!
+//! A path may be claimed by two routing tables at once: [`text`]'s
+//! structure-unit extractor and [`syntax`]'s grammar. A Markdown file is
+//! claimed by both. That is not a conflict, because F7 keys a derived row on
+//! content identity **plus extractor identity** — so one blob read two ways is
+//! two extractions with two keys, and `source.units` and
+//! `source.occurrences`/`source.edges` are keyed independently. Bumping a
+//! grammar therefore re-derives symbols without invalidating a single
+//! structure unit, which is the whole point of the second key input.
+//!
+//! [`scan::claims_for`] is the one place the two tables are unioned, and
+//! [`scan::extract_resource`] the one place a resource is extracted, for all
+//! three walks.
 //!
 //! `git` and `context` are still empty namespaces, and deliberately so even
 //! now that estate-git bytes are indexed: the `git.*` namespace is for

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -68,7 +68,9 @@
 //!
 //! ```text
 //! deny    ── pure predicate over a path (F10, the acquisition boundary)
-//! text    ── pure functions over bytes, and the one extractor routing table
+//! text    ── pure functions over bytes, and the structure-unit routing table
+//! syntax  ── the same, for symbols/imports: one grammar per claimed
+//!            language, and the symbol routing table (X3b)
 //! scan    ── the walk: filesystem in, plain Rust out; no DB, no journal
 //! git     ── the same, from a pinned commit's Git objects (X3a)
 //! overlay ── a Work surface's changes, over a base tree (X3a)
@@ -98,4 +100,5 @@ pub mod lane;
 pub mod overlay;
 pub mod record;
 pub mod scan;
+pub mod syntax;
 pub mod text;

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -67,9 +67,20 @@
 //! claimed by both. That is not a conflict, because F7 keys a derived row on
 //! content identity **plus extractor identity** — so one blob read two ways is
 //! two extractions with two keys, and `source.units` and
-//! `source.occurrences`/`source.edges` are keyed independently. Bumping a
-//! grammar therefore re-derives symbols without invalidating a single
-//! structure unit, which is the whole point of the second key input.
+//! `source.occurrences`/`source.edges` are keyed independently. A structure
+//! unit's key is unchanged by a grammar bump, so its extraction stays reusable
+//! across the re-derivation, which is the whole point of the second key input.
+//!
+//! **The second key input decides staleness too, not only addressing.** A
+//! generation's own `content_key` is content-only by construction, so it cannot
+//! notice a parser that changed under unchanged bytes; on its own it would let
+//! a re-scan answer "unchanged" after a grammar upgrade and serve the previous
+//! parser's rows indefinitely. So [`db::AtlasDb::stage_scan`] compares the
+//! standing generation's stored extractor identities against the ones the scan
+//! actually ran, and treats a mismatch as a change: a new generation is staged,
+//! and ruling §4's eviction takes the old one with its rows — leaving an
+//! eviction row that says the extractors changed rather than claiming the
+//! source bytes did.
 //!
 //! [`scan::claims_for`] is the one place the two tables are unioned, and
 //! [`scan::extract_resource`] the one place a resource is extracted, for all

--- a/src/runtime/atlas/overlay.rs
+++ b/src/runtime/atlas/overlay.rs
@@ -46,7 +46,7 @@ use std::path::{Path, PathBuf};
 
 use crate::domain::event::rfc3339_utc_now;
 use crate::domain::source::{
-    AuthorityClass, Coverage, CoverageRow, SourceKind, content_hash, local_key, overlay_digest,
+    AuthorityClass, Coverage, CoverageRow, SourceKind, content_hash, overlay_digest,
     overlay_generation_key,
 };
 use crate::runtime::atlas::deny::{AcquisitionFilter, Verdict};
@@ -54,8 +54,10 @@ use crate::runtime::atlas::git::{
     EstateGitSource, Extracted, GitScanError, GitTree, TreeEntry, directory_coverage,
     extract_blobs, list_tree,
 };
-use crate::runtime::atlas::scan::{MAX_RESOURCE_BYTES, ScannedFile, SourceScan, extract_units};
-use crate::runtime::atlas::text::{as_text, extractor_for};
+use crate::runtime::atlas::scan::{
+    KeySpace, MAX_RESOURCE_BYTES, ScannedFile, SourceScan, UNCLAIMED, claims_for, extract_resource,
+};
+use crate::runtime::atlas::text::as_text;
 use crate::runtime::git::{GitError, git_bytes};
 
 /// What an overlay digest records for a path the Work **deleted**.
@@ -285,11 +287,11 @@ fn changed_file(overlay: &WorkOverlay, path: &str, out: &mut Extracted) -> Strin
         });
         return NOT_A_FILE_MARKER.to_string();
     }
-    let Some(extractor) = extractor_for(path) else {
+    let Some(claims) = claims_for(path) else {
         out.coverage.push(CoverageRow {
             path: Some(path.to_string()),
             status: Coverage::Unsupported,
-            detail: Some("no extractor in this build claims this extension".to_string()),
+            detail: Some(UNCLAIMED.to_string()),
             bytes: Some(meta.len()),
         });
         // Still hashed: an unextractable file whose bytes changed changed the
@@ -332,21 +334,23 @@ fn changed_file(overlay: &WorkOverlay, path: &str, out: &mut Extracted) -> Strin
         });
         return hash;
     };
-    out.extractors.insert(extractor.to_string());
+    let extracted = extract_resource(claims, text, &hash, KeySpace::Local);
+    out.extractors.extend(extracted.identities.iter().cloned());
     out.coverage.push(CoverageRow {
         path: Some(path.to_string()),
-        status: Coverage::Indexed,
-        detail: Some(extractor.to_string()),
+        status: extracted.status(),
+        detail: Some(extracted.detail()),
         bytes: Some(bytes.len() as u64),
     });
     out.files.push(ScannedFile {
         relative_path: path.to_string(),
-        local_key: local_key(&hash, extractor),
+        local_key: extracted.key,
         content_hash: hash.clone(),
-        extractor: extractor.to_string(),
+        extractor: extracted.extractor.to_string(),
         byte_len: bytes.len() as u64,
         mtime_millis: None,
-        units: extract_units(text, extractor),
+        units: extracted.units,
+        syntax: extracted.syntax,
     });
     hash
 }
@@ -394,7 +398,7 @@ pub fn changed_paths(surface: &Path, base_sha: &str) -> Result<BTreeSet<String>,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::source::estate_git_key;
+    use crate::domain::source::{estate_git_key, local_key};
     use crate::runtime::atlas::text::MARKDOWN_EXTRACTOR;
     use crate::runtime::git::git as run_git;
 

--- a/src/runtime/atlas/record.rs
+++ b/src/runtime/atlas/record.rs
@@ -329,6 +329,11 @@ pub fn scan_summary(scan: &SourceScan, generation_id: &str) -> serde_json::Value
         "observed_at": scan.observed_at,
         "files": scan.files.len(),
         "units": scan.unit_count(),
+        // Symbol *sites* and edges, matching what was written row for row —
+        // not the deduplicated symbol index, which is a rollup of these and
+        // would make the trail disagree with the table it describes (X3b).
+        "symbols": scan.symbol_count(),
+        "edges": scan.edge_count(),
         "coverage": scan.counts(),
         "extractors": scan.extractors.iter().collect::<Vec<_>>(),
     });

--- a/src/runtime/atlas/scan.rs
+++ b/src/runtime/atlas/scan.rs
@@ -24,7 +24,20 @@
 //!   nothing derived and editing one changes everything derived from it.
 //! * **F8 — every path seen leaves exactly one coverage row.** Indexed,
 //!   excluded, unavailable, unsupported or error: there is no sixth outcome
-//!   where a path is silently not mentioned.
+//!   where a path is silently not mentioned. One row per *path*, not one per
+//!   extractor: a resource two extractors claimed still has one row, whose
+//!   `detail` names both, and whose status is `error` if either failed.
+//!
+//! # The shared extraction (X3b)
+//!
+//! Three walks acquire bytes by three different routes — this module's
+//! filesystem walk, [`super::git`]'s object-store read, and
+//! [`super::overlay`]'s Work surface. They all extract through exactly two
+//! functions here: [`claims_for`], which decides from a path alone what claims
+//! it, and [`extract_resource`], which runs every claiming extractor over the
+//! bytes. Three copies of that would be three ways for F7's premise —
+//! identical bytes plus an identical extractor identity are one extraction —
+//! to stop being true.
 //!
 //! # F1's crash window
 //!
@@ -39,12 +52,13 @@ use std::time::UNIX_EPOCH;
 use crate::domain::estate::KnowledgeSpec;
 use crate::domain::event::rfc3339_utc_now;
 use crate::domain::source::{
-    AuthorityClass, Coverage, CoverageRow, SourceKind, UnitKind, content_hash, generation_key,
-    local_key,
+    AuthorityClass, Coverage, CoverageRow, SourceKind, UnitKind, content_hash, estate_git_key,
+    generation_key, local_key,
 };
 use crate::runtime::atlas::deny::{AcquisitionFilter, BadPattern, Verdict};
+use crate::runtime::atlas::syntax::{SyntaxLanguage, language_for};
 use crate::runtime::atlas::text::{
-    MARKDOWN_EXTRACTOR, as_text, extractor_for, markdown_units, plain_units,
+    MARKDOWN_EXTRACTOR, TEXT_EXTRACTOR, as_text, extractor_for, markdown_units, plain_units,
 };
 
 /// The largest resource this build reads into memory to extract.
@@ -100,6 +114,79 @@ pub struct ScannedUnit {
     pub text: String,
 }
 
+/// The only edge kind this build derives (X3b).
+///
+/// One constant rather than an enum because there is exactly one, and an enum
+/// with one reachable variant is the promise R1 says not to make. A second
+/// edge kind — a call, a containment, a reference — needs resolution this
+/// build does not do (A1-09), so it arrives with the wave that can actually
+/// derive it.
+pub const EDGE_IMPORT: &str = "import";
+
+/// One syntax-derived symbol *site*, positioned in the original bytes (X3b).
+///
+/// A site, not a symbol: two `count` methods in one file are two of these,
+/// and they roll up to one entry in the symbol index. What makes them one
+/// symbol is `(language, label, name)`, and nothing here claims they are the
+/// same *definition* — that would be resolution (A1-09).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScannedSymbol {
+    /// Position within its file's symbol list, in document order.
+    pub ordinal: u64,
+    /// What the grammar called it — `function`, `struct`, `heading`.
+    pub label: &'static str,
+    /// The name as written. Unresolved, unqualified, not deduplicated.
+    pub name: String,
+    /// Offset into the **original** file bytes.
+    pub byte_start: u64,
+    /// End offset into the original file bytes, exclusive.
+    pub byte_end: u64,
+}
+
+/// One syntax-derived edge out of a file (X3b).
+///
+/// Today that is exactly one shape: an import, whose `target` is the text the
+/// file wrote. Unresolved by construction — `./lib/common.sh` is a string, not
+/// a path this build claims to have found.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScannedEdge {
+    /// Position within its file's edge list, in document order.
+    pub ordinal: u64,
+    /// The edge's syntax-derived kind — [`EDGE_IMPORT`] today.
+    pub kind: &'static str,
+    /// What the file named, exactly as written.
+    pub target: String,
+    /// Offset into the **original** file bytes.
+    pub byte_start: u64,
+    /// End offset into the original file bytes, exclusive.
+    pub byte_end: u64,
+}
+
+/// The syntax extraction of one resource: a **second** extraction of the same
+/// bytes, with its own extractor identity and its own F7 key (X3b).
+///
+/// Deliberately not folded into [`ScannedFile`]'s own `extractor`/`local_key`.
+/// F7 keys a derived row on content identity *plus extractor identity*, so a
+/// Markdown file read by both the structure extractor and the Markdown grammar
+/// is two extractions with two keys — never one extraction that could have
+/// been done two ways. Collapsing them would mean bumping the Markdown grammar
+/// invalidated every structure unit too.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScannedSyntax {
+    /// The grammar's language name, as coverage and rows spell it.
+    pub language: &'static str,
+    /// The grammar's versioned extractor identity (F7's second key input).
+    pub extractor: String,
+    /// The reusable key for *this* extraction: content identity composed with
+    /// [`Self::extractor`], in whichever key space the source uses
+    /// ([`KeySpace`]).
+    pub syntax_key: String,
+    /// Symbol sites, in document order.
+    pub symbols: Vec<ScannedSymbol>,
+    /// Edges out of this file, in document order.
+    pub edges: Vec<ScannedEdge>,
+}
+
 /// One acquired resource and everything derived from it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScannedFile {
@@ -120,6 +207,13 @@ pub struct ScannedFile {
     pub mtime_millis: Option<i64>,
     /// Units extracted from it, in document order.
     pub units: Vec<ScannedUnit>,
+    /// The syntax extraction, when a grammar in this build claims the path
+    /// **and parsed it** (X3b). `None` for a path no grammar claims, and
+    /// `None` for one whose parse failed — a failed parse carries no partial
+    /// symbol list, and the failure is a coverage fact
+    /// ([`Coverage::Error`]) rather than a shorter list nothing can
+    /// distinguish from a complete one.
+    pub syntax: Option<ScannedSyntax>,
 }
 
 /// Everything one completed walk observed. Plain data — no handle, no
@@ -173,6 +267,24 @@ impl SourceScan {
     /// Total units across every acquired file.
     pub fn unit_count(&self) -> u64 {
         self.files.iter().map(|f| f.units.len() as u64).sum()
+    }
+
+    /// Total syntax-derived symbol *sites* across every acquired file (X3b).
+    ///
+    /// Sites, not distinct symbols: the journal summary reports what was
+    /// written, and what was written is one row per site.
+    pub fn symbol_count(&self) -> u64 {
+        self.syntax().map(|s| s.symbols.len() as u64).sum()
+    }
+
+    /// Total syntax-derived edges across every acquired file (X3b).
+    pub fn edge_count(&self) -> u64 {
+        self.syntax().map(|s| s.edges.len() as u64).sum()
+    }
+
+    /// Every file's syntax extraction, skipping the files that have none.
+    fn syntax(&self) -> impl Iterator<Item = &ScannedSyntax> {
+        self.files.iter().filter_map(|f| f.syntax.as_ref())
     }
 
     /// The coverage row saying the **source root itself** could not be read,
@@ -375,11 +487,11 @@ impl Walk<'_> {
 
     /// Acquire and extract one regular file that passed the boundary.
     fn file(&mut self, path: &Path, relative: String, meta: std::fs::Metadata) {
-        let Some(extractor) = extractor_for(&relative) else {
+        let Some(claims) = claims_for(&relative) else {
             self.coverage.push(CoverageRow {
                 path: Some(relative),
                 status: Coverage::Unsupported,
-                detail: Some("no extractor in this build claims this extension".to_string()),
+                detail: Some(UNCLAIMED.to_string()),
                 bytes: Some(meta.len()),
             });
             return;
@@ -417,24 +529,214 @@ impl Walk<'_> {
             return;
         };
         let hash = content_hash(&bytes);
-        let units = extract_units(text, extractor);
-        self.extractors.insert(extractor.to_string());
+        let extracted = extract_resource(claims, text, &hash, KeySpace::Local);
+        self.extractors.extend(extracted.identities.iter().cloned());
         self.coverage.push(CoverageRow {
             path: Some(relative.clone()),
-            status: Coverage::Indexed,
-            detail: Some(extractor.to_string()),
+            status: extracted.status(),
+            detail: Some(extracted.detail()),
             bytes: Some(bytes.len() as u64),
         });
         self.files.push(ScannedFile {
             relative_path: relative,
-            local_key: local_key(&hash, extractor),
+            local_key: extracted.key,
             content_hash: hash,
-            extractor: extractor.to_string(),
+            extractor: extracted.extractor.to_string(),
             byte_len: bytes.len() as u64,
             mtime_millis: mtime_millis(&meta),
-            units,
+            units: extracted.units,
+            syntax: extracted.syntax,
         });
     }
+}
+
+/// The coverage detail for a path no extractor and no grammar claims (F8).
+///
+/// One constant, shared by all three walks, because "unsupported" has to mean
+/// the same thing whichever route the bytes arrived by — and because the
+/// sentence has to name *both* routing tables now that there are two.
+pub const UNCLAIMED: &str = "no extractor or grammar in this build claims this extension";
+
+/// Which key space a source's derived rows live in (F7).
+///
+/// The two halves of F7's cache-key rule, as a value the three walks can pass
+/// to one shared extractor instead of each spelling their own composition. The
+/// spaces are domain-separated by
+/// [`estate_git_key`]/[`local_key`] themselves — this enum only chooses
+/// between them, and cannot blur them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeySpace {
+    /// BLAKE3 of the bytes plus extractor identity — a filesystem resource,
+    /// which no object store has already named.
+    Local,
+    /// Git blob OID plus extractor identity — **never a second hash of bytes
+    /// Git already hashed**.
+    EstateGit,
+}
+
+impl KeySpace {
+    /// Compose a content identity with an extractor identity in this space.
+    pub fn key(self, content_id: &str, extractor: &str) -> String {
+        match self {
+            Self::Local => local_key(content_id, extractor),
+            Self::EstateGit => estate_git_key(content_id, extractor),
+        }
+    }
+}
+
+/// What claims one path, decided from the path alone (X3b).
+///
+/// Two routing tables, unioned at exactly one place. [`extractor_for`] routes
+/// bytes to a structure-unit extractor; [`language_for`] routes them to a
+/// grammar. A path either table claims is acquired; a path neither claims is
+/// honestly `unsupported` (F8).
+///
+/// The union has one deliberate consequence worth naming: a path a *grammar*
+/// claims but the structure table does not — `main.rs`, `Cargo.toml` — is
+/// acquired with the plain-text structure extractor
+/// ([`TEXT_EXTRACTOR`]), so every acquired resource still has units and
+/// `source.files`' existing columns keep the meaning X2 gave them. The
+/// alternative — a `source.files` row whose `extractor` names a grammar and
+/// whose `unit_count` is zero — would have made one column mean two things
+/// depending on the row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Claims {
+    /// The structure-unit extractor that will run.
+    pub structure: &'static str,
+    /// The grammar that will run too, when one claims this path.
+    pub language: Option<SyntaxLanguage>,
+}
+
+/// What claims `relative`, or `None` for a path nothing in this build claims.
+pub fn claims_for(relative: &str) -> Option<Claims> {
+    let language = language_for(relative);
+    let structure = extractor_for(relative).or(language.map(|_| TEXT_EXTRACTOR))?;
+    Some(Claims {
+        structure,
+        language,
+    })
+}
+
+/// Everything one resource's bytes yielded, for every extractor that claimed
+/// them (X3b).
+///
+/// **The one place a resource is extracted**, for all three walks — the
+/// filesystem one, the estate-git one and the Work-overlay one. Three copies
+/// of this would be three ways for F7's premise (identical bytes plus
+/// identical extractor identity are one extraction) to stop being true, which
+/// is the same argument [`extract_units`] already carries for its own loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceExtraction {
+    /// The structure extractor that ran, and the identity its units are keyed
+    /// by.
+    pub extractor: &'static str,
+    /// F7 key for the structure extraction.
+    pub key: String,
+    /// Structure units, in document order.
+    pub units: Vec<ScannedUnit>,
+    /// The syntax extraction, when a grammar claimed the path and parsed it.
+    pub syntax: Option<ScannedSyntax>,
+    /// Every extractor identity that actually produced rows, in the order they
+    /// ran. An extractor that failed is **not** here: the journal summary's
+    /// `extractors` list names what produced evidence, not what was attempted.
+    pub identities: Vec<String>,
+    /// Why a claimed extractor produced nothing, when one did. Its presence is
+    /// what turns this resource's coverage row from `indexed` into `error`
+    /// (F8).
+    pub failure: Option<String>,
+}
+
+impl ResourceExtraction {
+    /// The coverage status this extraction earns (F8).
+    pub fn status(&self) -> Coverage {
+        if self.failure.is_some() {
+            Coverage::Error
+        } else {
+            Coverage::Indexed
+        }
+    }
+
+    /// The coverage row's `detail`: which extractors produced rows, and what
+    /// failed if anything did.
+    pub fn detail(&self) -> String {
+        let ran = self.identities.join(",");
+        match &self.failure {
+            Some(failure) if ran.is_empty() => failure.clone(),
+            Some(failure) => format!("{ran}; {failure}"),
+            None => ran,
+        }
+    }
+}
+
+/// Run every extractor that claims `relative` over one resource's decoded
+/// text.
+///
+/// Pure (F6's adapter-shape mandate): no file is opened, no database is
+/// touched, no clock is read. `content_id` is the resource's already-computed
+/// content identity — a BLAKE3 hash for a filesystem resource, a blob OID for
+/// a Git one — and `keys` says which space to compose it in.
+///
+/// A grammar failure is not a scan failure. It leaves [`ResourceExtraction`]'s
+/// `syntax` empty and its `failure` set, and the structure units the other
+/// extractor produced are still real evidence about real bytes; refusing them
+/// too would discard a document's index because a parser disagreed with its
+/// code fences. What is never done is the middle case the grammar itself
+/// refuses — a *shorter* symbol list, indistinguishable from a complete one
+/// (see [`super::syntax`]).
+pub fn extract_resource(
+    claims: Claims,
+    text: &str,
+    content_id: &str,
+    keys: KeySpace,
+) -> ResourceExtraction {
+    let mut out = ResourceExtraction {
+        extractor: claims.structure,
+        key: keys.key(content_id, claims.structure),
+        units: extract_units(text, claims.structure),
+        syntax: None,
+        identities: vec![claims.structure.to_string()],
+        failure: None,
+    };
+    let Some(language) = claims.language else {
+        return out;
+    };
+    let extractor = language.extractor_identity();
+    match crate::runtime::atlas::syntax::extract(language, text.as_bytes()) {
+        Ok(facts) => {
+            out.syntax = Some(ScannedSyntax {
+                language: language.name(),
+                syntax_key: keys.key(content_id, &extractor),
+                symbols: facts
+                    .symbols
+                    .into_iter()
+                    .enumerate()
+                    .map(|(ordinal, symbol)| ScannedSymbol {
+                        ordinal: ordinal as u64,
+                        label: symbol.label,
+                        name: symbol.name,
+                        byte_start: symbol.byte_start as u64,
+                        byte_end: symbol.byte_end as u64,
+                    })
+                    .collect(),
+                edges: facts
+                    .imports
+                    .into_iter()
+                    .enumerate()
+                    .map(|(ordinal, import)| ScannedEdge {
+                        ordinal: ordinal as u64,
+                        kind: EDGE_IMPORT,
+                        target: import.target,
+                        byte_start: import.byte_start as u64,
+                        byte_end: import.byte_end as u64,
+                    })
+                    .collect(),
+                extractor: extractor.clone(),
+            });
+            out.identities.push(extractor);
+        }
+        Err(error) => out.failure = Some(format!("{extractor}: {error}")),
+    }
+    out
 }
 
 /// Run one extractor over decoded text and number its units.
@@ -541,9 +843,17 @@ mod tests {
         assert_eq!(row(&scan, "keys/server.pem").status, Coverage::Excluded);
         assert_eq!(row(&scan, "notes").status, Coverage::Discovered);
 
+        // Both routing tables ran. A Markdown file is claimed by the structure
+        // extractor *and* by the Markdown grammar, and that is two extractions
+        // of one blob with two F7 keys — never one extraction that could have
+        // been done two ways (X3b).
         assert_eq!(
             scan.extractors,
-            BTreeSet::from([MARKDOWN_EXTRACTOR.to_string(), TEXT_EXTRACTOR.to_string()])
+            BTreeSet::from([
+                MARKDOWN_EXTRACTOR.to_string(),
+                TEXT_EXTRACTOR.to_string(),
+                SyntaxLanguage::Markdown.extractor_identity(),
+            ])
         );
     }
 

--- a/src/runtime/atlas/syntax.rs
+++ b/src/runtime/atlas/syntax.rs
@@ -123,6 +123,19 @@ impl SyntaxLanguage {
         }
     }
 
+    /// Every label this language's grammar can produce, in table order.
+    ///
+    /// The *complete* set of what [`extract`] may put on a [`Symbol`] for this
+    /// language — which is what makes A1-09 checkable downstream rather than
+    /// merely asserted here: a consumer can compare the labels it stored
+    /// against this and see that nothing was classified, inferred or resolved
+    /// on the way. Duplicates are kept (several Rust node kinds are all
+    /// `function`), because this answers "what may a label be?" and not "how
+    /// many kinds are there?".
+    pub fn labels(self) -> impl Iterator<Item = &'static str> {
+        self.symbol_kinds().iter().map(|(_, label)| *label)
+    }
+
     fn grammar(self) -> tree_sitter::Language {
         match self {
             SyntaxLanguage::Rust => tree_sitter_rust::LANGUAGE.into(),

--- a/src/runtime/atlas/syntax.rs
+++ b/src/runtime/atlas/syntax.rs
@@ -205,9 +205,10 @@ impl SyntaxLanguage {
 
     /// Node kinds inspected for an import.
     ///
-    /// A kind listed here is a *candidate*: [`import_target`] returns `None`
-    /// for a node that turns out not to be one (every Bash `command` is a
-    /// candidate; only `source` and `.` are imports).
+    /// A kind listed here is a *candidate*: [`imports_in`] returns an empty
+    /// list for a node that turns out not to be one (every Bash `command` is a
+    /// candidate; only `source` and `.` are imports). It may also return
+    /// *several* — one Python `import_statement` can name a whole comma list.
     fn import_kinds(self) -> &'static [&'static str] {
         match self {
             SyntaxLanguage::Rust => &["use_declaration", "extern_crate_declaration"],
@@ -349,14 +350,12 @@ pub fn extract(language: SyntaxLanguage, bytes: &[u8]) -> Result<SyntaxFacts, Sy
                         byte_end: node.end_byte(),
                     });
                 }
-            } else if import_kinds.contains(&kind)
-                && let Some(target) = import_target(language, node, text)
-            {
-                facts.imports.push(Import {
-                    target,
-                    byte_start: node.start_byte(),
-                    byte_end: node.end_byte(),
-                });
+            } else if import_kinds.contains(&kind) {
+                // `extend`, not `push`: one candidate node can name more than
+                // one import (`import os, sys`), and a signature that could
+                // only answer once would drop the rest silently — the partial
+                // answer this module's own doctrine refuses.
+                facts.imports.extend(imports_in(language, node, text));
             }
         }
 
@@ -434,34 +433,88 @@ fn symbol_name(language: SyntaxLanguage, node: Node<'_>, text: &str) -> Option<S
     }
 }
 
-/// The target an import node names, or `None` when the candidate node is not
-/// an import after all.
-fn import_target(language: SyntaxLanguage, node: Node<'_>, text: &str) -> Option<String> {
+/// Every import one candidate node names, in source order.
+///
+/// **A list, not an `Option`.** A single node can name several imports —
+/// Python's `import os, sys` is one `import_statement` carrying two `name`
+/// fields — and a signature that can answer only once turns "two imports" into
+/// "one import" with nothing downstream able to tell. That is a silent partial
+/// extraction of a claimed node, which is the same thing the module docs refuse
+/// for a partial parse, so it gets the same treatment: every name the node
+/// wrote becomes a row, or the extraction is wrong.
+///
+/// Empty is the honest answer for a candidate that is not an import after all
+/// (every Bash `command` is a candidate; only `source` and `.` are imports).
+/// Empty is never the answer for a node that *is* one.
+fn imports_in(language: SyntaxLanguage, node: Node<'_>, text: &str) -> Vec<Import> {
     match (language, node.kind()) {
-        (SyntaxLanguage::Rust, "use_declaration") => named_field(node, "argument", text),
-        (SyntaxLanguage::Rust, "extern_crate_declaration") => named_field(node, "name", text),
-        (SyntaxLanguage::Python, "import_from_statement") => named_field(node, "module_name", text),
+        (SyntaxLanguage::Rust, "use_declaration") => one(node, named_field(node, "argument", text)),
+        (SyntaxLanguage::Rust, "extern_crate_declaration") => {
+            one(node, named_field(node, "name", text))
+        }
+        (SyntaxLanguage::Python, "import_from_statement") => {
+            one(node, named_field(node, "module_name", text))
+        }
         (SyntaxLanguage::Python, "import_statement") => {
-            let name = node.child_by_field_name("name")?;
-            if name.kind() == "aliased_import" {
-                named_field(name, "name", text)
-            } else {
-                node_text(name, text)
-            }
+            // tree-sitter-python attaches the `name` field to EVERY entry of
+            // the comma list, so this iterates the field rather than asking for
+            // it once (`child_by_field_name` answers with the first only).
+            // Each entry carries its own span: two names in one statement are
+            // two facts written at two places, and giving both the statement's
+            // span would make them indistinguishable by position.
+            let mut cursor = node.walk();
+            node.children_by_field_name("name", &mut cursor)
+                .filter_map(|entry| {
+                    let target = if entry.kind() == "aliased_import" {
+                        named_field(entry, "name", text)?
+                    } else {
+                        node_text(entry, text)?
+                    };
+                    Some(at(entry, target))
+                })
+                .collect()
         }
         (SyntaxLanguage::JavaScript | SyntaxLanguage::TypeScript, "import_statement") => {
-            Some(unquote(named_field(node, "source", text)?))
+            // The ordinary form puts the module string on the statement's own
+            // `source` field. TypeScript's legacy CommonJS-interop form —
+            // `import foo = require("./x")` — is the same node kind with no
+            // `source` field of its own: the string sits inside an
+            // `import_require_clause` child. Both are unambiguously imports, so
+            // both produce an edge; only a node matching neither shape (which
+            // this grammar does not produce) answers empty.
+            let source = named_field(node, "source", text).or_else(|| {
+                let mut cursor = node.walk();
+                let clause = node
+                    .named_children(&mut cursor)
+                    .find(|child| child.kind() == "import_require_clause")?;
+                named_field(clause, "source", text)
+            });
+            one(node, source.map(unquote))
         }
         (SyntaxLanguage::Bash, "command") => {
             // Only `source X` and `. X` are imports; every other command is a
-            // candidate that answers `None`.
-            let name = named_field(node, "name", text)?;
-            if name != "source" && name != "." {
-                return None;
-            }
-            Some(unquote(named_field(node, "argument", text)?))
+            // candidate that answers empty.
+            let target = named_field(node, "name", text)
+                .filter(|name| name == "source" || name == ".")
+                .and_then(|_| named_field(node, "argument", text))
+                .map(unquote);
+            one(node, target)
         }
-        _ => None,
+        _ => Vec::new(),
+    }
+}
+
+/// The zero-or-one case of [`imports_in`], spanning the whole candidate node.
+fn one(node: Node<'_>, target: Option<String>) -> Vec<Import> {
+    target.map(|target| at(node, target)).into_iter().collect()
+}
+
+/// One import, positioned at `node`.
+fn at(node: Node<'_>, target: String) -> Import {
+    Import {
+        target,
+        byte_start: node.start_byte(),
+        byte_end: node.end_byte(),
     }
 }
 
@@ -536,6 +589,66 @@ mod tests {
                 }
             ),
             "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn every_name_in_a_python_comma_import_becomes_its_own_edge() {
+        let source = b"import os, sys\nimport a.b as ab, c\n";
+        let facts = extract(SyntaxLanguage::Python, source).expect("parses");
+        let targets: Vec<&str> = facts.imports.iter().map(|i| i.target.as_str()).collect();
+        assert_eq!(
+            targets,
+            vec!["os", "sys", "a.b", "c"],
+            "a comma list must not lose every name after the first"
+        );
+        // And each one is positioned at the name it was written as, not at the
+        // statement, so two names in one statement are two distinguishable
+        // facts.
+        for import in &facts.imports {
+            let slice = std::str::from_utf8(&source[import.byte_start..import.byte_end])
+                .expect("span is UTF-8");
+            assert!(slice.contains(&import.target), "{slice:?}");
+        }
+        assert_ne!(
+            (facts.imports[0].byte_start, facts.imports[0].byte_end),
+            (facts.imports[1].byte_start, facts.imports[1].byte_end)
+        );
+    }
+
+    #[test]
+    fn a_typescript_import_require_is_an_edge_not_a_silent_drop() {
+        let source = b"import foo = require(\"./x\");\nimport bar from \"node:fs\";\n";
+        let facts = extract(SyntaxLanguage::TypeScript, source).expect("parses");
+        let targets: Vec<&str> = facts.imports.iter().map(|i| i.target.as_str()).collect();
+        assert_eq!(
+            targets,
+            vec!["./x", "node:fs"],
+            "the CommonJS-interop form is claimed as an import_statement and must yield an edge"
+        );
+    }
+
+    #[test]
+    fn a_command_that_is_not_source_is_not_an_import() {
+        let facts = extract(
+            SyntaxLanguage::Bash,
+            b"set -euo pipefail\nsource ./lib.sh\n",
+        )
+        .expect("parses");
+        let targets: Vec<&str> = facts.imports.iter().map(|i| i.target.as_str()).collect();
+        assert_eq!(targets, vec!["./lib.sh"]);
+    }
+
+    #[test]
+    fn multi_byte_text_before_a_name_does_not_shift_its_span() {
+        let source = "// 日本語のコメント — em dash too\npub fn café_fn() {}\n".as_bytes();
+        let facts = extract(SyntaxLanguage::Rust, source).expect("parses");
+        assert_eq!(facts.symbols.len(), 1);
+        let symbol = &facts.symbols[0];
+        assert_eq!(symbol.name, "café_fn");
+        assert_eq!(
+            std::str::from_utf8(&source[symbol.byte_start..symbol.byte_end]).expect("UTF-8"),
+            "pub fn café_fn() {}"
         );
     }
 

--- a/src/runtime/atlas/syntax.rs
+++ b/src/runtime/atlas/syntax.rs
@@ -1,0 +1,536 @@
+//! Syntax-derived symbols and imports — **pure functions over bytes** (F6's
+//! adapter-shape mandate), one tree-sitter grammar per language this build
+//! claims.
+//!
+//! Nothing here opens a file, touches a database, reads a clock, or knows a
+//! source exists. [`extract`] takes a language and bytes and returns owned
+//! facts. Same property, same reason, as [`super::text`]: extraction stays
+//! reviewable and unit-testable without a daemon, and the DB glue that will
+//! carry these rows adds nothing a reader has to take on trust.
+//!
+//! # Syntax, not semantics (A1-09)
+//!
+//! Every label here is what the *grammar* called the node — `function`,
+//! `struct`, `class`, `heading`. Nothing resolves a name to a definition,
+//! follows a re-export, or decides which `count` a call meant. An [`Import`]'s
+//! `target` is the text the file wrote, not a resolved module. That is the
+//! whole claim, and it is deliberately smaller than the claim a language
+//! server makes: these rows are evidence about syntax, and a consumer that
+//! treats them as a resolved symbol graph is reading a promise this module
+//! never made.
+//!
+//! # Two routing tables, not one overriding the other
+//!
+//! [`super::text::extractor_for`] routes bytes to a *structure-unit*
+//! extractor (Document/Section spans, for retrieval). [`language_for`] here
+//! routes bytes to a *symbol* extractor. A Markdown file is claimed by both,
+//! and that is not a conflict: F7 keys derived rows on content identity **plus
+//! extractor identity**, so two extractors over one blob are two extractions
+//! with two keys, never one extraction that could have been done two ways.
+//! The invariant `text` states — identical bytes plus identical extractor
+//! identity are one extraction — is preserved exactly.
+//!
+//! # Provenance is byte offsets into the original
+//!
+//! Every [`Symbol`] and [`Import`] carries `byte_start`/`byte_end` into the
+//! bytes it was extracted from, so A1 §3's provenance question is answered by
+//! slicing the original (A1-12), same rule as [`super::text`].
+//!
+//! # A parse error is an error, never a partial answer
+//!
+//! tree-sitter is error-tolerant by design: given malformed input it returns a
+//! tree with `ERROR` nodes and whatever it could still recognize. This module
+//! refuses that middle ground — [`extract`] returns [`SyntaxError::Parse`] for
+//! any tree containing an error or a missing node, and returns **no** partial
+//! symbol list alongside it. A file that parsed badly is coverage-reported as
+//! `error` (F8); it is never reported as indexed-with-fewer-symbols, because
+//! "fewer symbols" and "all the symbols" are indistinguishable to every
+//! downstream consumer. F5's corpus gate is the standing proof that this path
+//! is reachable rather than vacuous.
+
+use tree_sitter::{Node, Parser};
+
+/// Version component of every extractor identity in this module (F7's second
+/// cache-key input).
+///
+/// Bump this when what [`extract`] produces changes — a new node kind in a
+/// symbol table, a different name rule, a changed label. Bumping it changes
+/// every derived key, which is what makes a re-extraction happen instead of a
+/// stale reuse.
+pub const SYNTAX_EXTRACTOR_VERSION: &str = "v1";
+
+/// A language this build claims for symbol extraction.
+///
+/// Exactly the six families F5 names, and no more. `.tsx` is deliberately
+/// absent: it needs the TSX grammar rather than the TypeScript one, and a
+/// language with no fixture in the corpus would be a claim nothing checks —
+/// so a `.tsx` file routes to `None` and is honestly coverage-reported
+/// `unsupported` (F8) rather than parsed by an almost-right grammar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SyntaxLanguage {
+    Rust,
+    Toml,
+    Markdown,
+    Python,
+    JavaScript,
+    TypeScript,
+    Bash,
+}
+
+impl SyntaxLanguage {
+    /// Every claimed language, in a stable order.
+    pub const ALL: &'static [SyntaxLanguage] = &[
+        SyntaxLanguage::Rust,
+        SyntaxLanguage::Toml,
+        SyntaxLanguage::Markdown,
+        SyntaxLanguage::Python,
+        SyntaxLanguage::JavaScript,
+        SyntaxLanguage::TypeScript,
+        SyntaxLanguage::Bash,
+    ];
+
+    /// The language's manifest/coverage name.
+    pub fn name(self) -> &'static str {
+        match self {
+            SyntaxLanguage::Rust => "rust",
+            SyntaxLanguage::Toml => "toml",
+            SyntaxLanguage::Markdown => "markdown",
+            SyntaxLanguage::Python => "python",
+            SyntaxLanguage::JavaScript => "javascript",
+            SyntaxLanguage::TypeScript => "typescript",
+            SyntaxLanguage::Bash => "bash",
+        }
+    }
+
+    /// This language's extractor identity — F7's second cache-key input.
+    ///
+    /// Per language, not one identity for the module: changing the Rust symbol
+    /// table must not invalidate every extracted Python file.
+    pub fn extractor_identity(self) -> String {
+        format!("syntax-{}/{SYNTAX_EXTRACTOR_VERSION}", self.name())
+    }
+
+    /// Extensions routed to this language, lowercase, without the dot.
+    pub fn extensions(self) -> &'static [&'static str] {
+        match self {
+            SyntaxLanguage::Rust => &["rs"],
+            SyntaxLanguage::Toml => &["toml"],
+            SyntaxLanguage::Markdown => &["md", "markdown"],
+            SyntaxLanguage::Python => &["py"],
+            SyntaxLanguage::JavaScript => &["js", "mjs", "cjs", "jsx"],
+            SyntaxLanguage::TypeScript => &["ts", "mts", "cts"],
+            SyntaxLanguage::Bash => &["sh", "bash"],
+        }
+    }
+
+    fn grammar(self) -> tree_sitter::Language {
+        match self {
+            SyntaxLanguage::Rust => tree_sitter_rust::LANGUAGE.into(),
+            SyntaxLanguage::Toml => tree_sitter_toml_ng::LANGUAGE.into(),
+            SyntaxLanguage::Markdown => tree_sitter_md::LANGUAGE.into(),
+            SyntaxLanguage::Python => tree_sitter_python::LANGUAGE.into(),
+            SyntaxLanguage::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+            SyntaxLanguage::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            SyntaxLanguage::Bash => tree_sitter_bash::LANGUAGE.into(),
+        }
+    }
+
+    /// Node kinds that are symbols, paired with the label they carry.
+    ///
+    /// Read this as the definition of "symbol" for the language — the corpus
+    /// manifest's hand-verified counts are counts of exactly these kinds, and
+    /// nothing outside this table is a symbol however much it looks like one
+    /// (a `const` bound to an arrow function in JavaScript is a lexical
+    /// binding; an `impl` block in Rust has no name to be a symbol of).
+    fn symbol_kinds(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            SyntaxLanguage::Rust => &[
+                ("function_item", "function"),
+                ("function_signature_item", "function"),
+                ("struct_item", "struct"),
+                ("enum_item", "enum"),
+                ("union_item", "union"),
+                ("trait_item", "trait"),
+                ("mod_item", "module"),
+                ("const_item", "const"),
+                ("static_item", "static"),
+                ("type_item", "type"),
+                ("macro_definition", "macro"),
+            ],
+            SyntaxLanguage::Toml => &[
+                ("table", "table"),
+                ("table_array_element", "table_array"),
+                ("pair", "key"),
+            ],
+            SyntaxLanguage::Markdown => {
+                &[("atx_heading", "heading"), ("setext_heading", "heading")]
+            }
+            SyntaxLanguage::Python => &[
+                ("function_definition", "function"),
+                ("class_definition", "class"),
+            ],
+            SyntaxLanguage::JavaScript => &[
+                ("function_declaration", "function"),
+                ("generator_function_declaration", "function"),
+                ("class_declaration", "class"),
+                ("method_definition", "method"),
+            ],
+            SyntaxLanguage::TypeScript => &[
+                ("function_declaration", "function"),
+                ("generator_function_declaration", "function"),
+                ("class_declaration", "class"),
+                ("abstract_class_declaration", "class"),
+                ("method_definition", "method"),
+                ("method_signature", "method"),
+                ("interface_declaration", "interface"),
+                ("type_alias_declaration", "type"),
+                ("enum_declaration", "enum"),
+            ],
+            SyntaxLanguage::Bash => &[("function_definition", "function")],
+        }
+    }
+
+    /// Node kinds inspected for an import.
+    ///
+    /// A kind listed here is a *candidate*: [`import_target`] returns `None`
+    /// for a node that turns out not to be one (every Bash `command` is a
+    /// candidate; only `source` and `.` are imports).
+    fn import_kinds(self) -> &'static [&'static str] {
+        match self {
+            SyntaxLanguage::Rust => &["use_declaration", "extern_crate_declaration"],
+            // Neither format has an import construct. Zero is the honest
+            // answer, not an unimplemented one.
+            SyntaxLanguage::Toml | SyntaxLanguage::Markdown => &[],
+            SyntaxLanguage::Python => &["import_statement", "import_from_statement"],
+            SyntaxLanguage::JavaScript | SyntaxLanguage::TypeScript => &["import_statement"],
+            SyntaxLanguage::Bash => &["command"],
+        }
+    }
+}
+
+/// The language claimed for a path, or `None` for a family this build does
+/// not claim (coverage: `unsupported`).
+///
+/// Extension-driven and nothing else, for the same reason
+/// [`super::text::extractor_for`] is: content sniffing would mean reading
+/// bytes to decide whether to read bytes, and routing has to be one function
+/// per question or the same blob could be extracted differently depending on
+/// where it was acquired.
+pub fn language_for(relative: &str) -> Option<SyntaxLanguage> {
+    let extension = std::path::Path::new(relative)
+        .extension()
+        .and_then(|e| e.to_str())?
+        .to_ascii_lowercase();
+    SyntaxLanguage::ALL
+        .iter()
+        .copied()
+        .find(|language| language.extensions().contains(&extension.as_str()))
+}
+
+/// One syntax-derived symbol, positioned in the original bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Symbol {
+    /// What the grammar called it — `function`, `struct`, `heading`, … Never
+    /// a semantic classification (A1-09).
+    pub label: &'static str,
+    /// The name as written. Not resolved, not qualified, not deduplicated:
+    /// two `count` methods in one file are two symbols named `count`.
+    pub name: String,
+    /// Inclusive start offset into the original bytes.
+    pub byte_start: usize,
+    /// Exclusive end offset into the original bytes.
+    pub byte_end: usize,
+}
+
+/// One syntax-derived import, positioned in the original bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Import {
+    /// The import target exactly as the file wrote it — `node:fs`,
+    /// `std::collections::HashMap`, `./lib/common.sh`. Unresolved by
+    /// construction.
+    pub target: String,
+    /// Inclusive start offset into the original bytes.
+    pub byte_start: usize,
+    /// Exclusive end offset into the original bytes.
+    pub byte_end: usize,
+}
+
+/// Everything one extraction produced, in document order.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SyntaxFacts {
+    pub symbols: Vec<Symbol>,
+    pub imports: Vec<Import>,
+}
+
+/// Why an extraction produced nothing rather than something partial.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SyntaxError {
+    /// Bytes were not valid UTF-8. Strict, like [`super::text::as_text`]: a
+    /// lossy decode would shift every byte offset this module promises.
+    #[error("not valid UTF-8")]
+    NotUtf8,
+    /// The compiled grammar was rejected by the runtime — an ABI mismatch
+    /// between the `tree-sitter` crate and a grammar crate. Not reachable
+    /// through a bad input; reachable through a bad dependency bump, which is
+    /// exactly why it is a named variant rather than a panic.
+    #[error("grammar for {language} rejected by the tree-sitter runtime: {detail}")]
+    Grammar {
+        language: &'static str,
+        detail: String,
+    },
+    /// The parse produced a tree containing an error or missing node. No
+    /// partial results accompany this: see the module docs.
+    #[error("{language}: parse failed at byte {byte_start}")]
+    Parse {
+        language: &'static str,
+        byte_start: usize,
+    },
+    /// The parser returned no tree at all (cancellation or timeout — neither
+    /// is set by this call, so this is defensive).
+    #[error("{language}: parser returned no tree")]
+    NoTree { language: &'static str },
+}
+
+/// Extract symbols and imports from `bytes` as `language`.
+///
+/// Pure: no I/O, no state, no clock. Deterministic for a given
+/// (language, bytes) pair — which is what lets F7 key the result on content
+/// identity plus [`SyntaxLanguage::extractor_identity`] and reuse it.
+pub fn extract(language: SyntaxLanguage, bytes: &[u8]) -> Result<SyntaxFacts, SyntaxError> {
+    let text = std::str::from_utf8(bytes).map_err(|_| SyntaxError::NotUtf8)?;
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&language.grammar())
+        .map_err(|error| SyntaxError::Grammar {
+            language: language.name(),
+            detail: error.to_string(),
+        })?;
+    let tree = parser.parse(text, None).ok_or(SyntaxError::NoTree {
+        language: language.name(),
+    })?;
+
+    let root = tree.root_node();
+    if root.has_error() {
+        return Err(SyntaxError::Parse {
+            language: language.name(),
+            byte_start: first_error_byte(root),
+        });
+    }
+
+    let mut facts = SyntaxFacts::default();
+    let symbol_kinds = language.symbol_kinds();
+    let import_kinds = language.import_kinds();
+
+    let mut cursor = root.walk();
+    'walk: loop {
+        let node = cursor.node();
+        if node.is_named() {
+            let kind = node.kind();
+            if let Some((_, label)) = symbol_kinds.iter().find(|(k, _)| *k == kind) {
+                if let Some(name) = symbol_name(language, node, text) {
+                    facts.symbols.push(Symbol {
+                        label,
+                        name,
+                        byte_start: node.start_byte(),
+                        byte_end: node.end_byte(),
+                    });
+                }
+            } else if import_kinds.contains(&kind)
+                && let Some(target) = import_target(language, node, text)
+            {
+                facts.imports.push(Import {
+                    target,
+                    byte_start: node.start_byte(),
+                    byte_end: node.end_byte(),
+                });
+            }
+        }
+
+        if cursor.goto_first_child() {
+            continue;
+        }
+        loop {
+            if cursor.goto_next_sibling() {
+                continue 'walk;
+            }
+            if !cursor.goto_parent() {
+                break 'walk;
+            }
+        }
+    }
+
+    Ok(facts)
+}
+
+/// The first error-or-missing node's start byte, for the refusal's message.
+fn first_error_byte(root: Node<'_>) -> usize {
+    let mut cursor = root.walk();
+    'walk: loop {
+        let node = cursor.node();
+        if node.is_error() || node.is_missing() {
+            return node.start_byte();
+        }
+        if node.has_error() && cursor.goto_first_child() {
+            continue;
+        }
+        loop {
+            if cursor.goto_next_sibling() {
+                continue 'walk;
+            }
+            if !cursor.goto_parent() {
+                break 'walk;
+            }
+        }
+    }
+    root.start_byte()
+}
+
+fn node_text(node: Node<'_>, text: &str) -> Option<String> {
+    text.get(node.start_byte()..node.end_byte())
+        .map(str::to_owned)
+}
+
+fn named_field(node: Node<'_>, field: &str, text: &str) -> Option<String> {
+    node_text(node.child_by_field_name(field)?, text)
+}
+
+/// The name a symbol node carries.
+///
+/// A `None` here drops the node from the output entirely — deliberate for the
+/// two cases where a grammar produces a symbol-kind node with no name (an
+/// anonymous TOML `pair` cannot occur; a nameless Rust item cannot either),
+/// and the corpus manifest's exact counts are the check that this is not
+/// silently dropping real symbols.
+fn symbol_name(language: SyntaxLanguage, node: Node<'_>, text: &str) -> Option<String> {
+    match language {
+        SyntaxLanguage::Markdown => {
+            let content = node.child_by_field_name("heading_content")?;
+            Some(node_text(content, text)?.trim().to_owned())
+        }
+        SyntaxLanguage::Toml => {
+            // `table`, `table_array_element` and `pair` all name themselves
+            // with their first key child rather than a `name` field.
+            let mut child_cursor = node.walk();
+            let key = node
+                .named_children(&mut child_cursor)
+                .find(|child| matches!(child.kind(), "bare_key" | "dotted_key" | "quoted_key"))?;
+            Some(unquote(node_text(key, text)?))
+        }
+        _ => named_field(node, "name", text),
+    }
+}
+
+/// The target an import node names, or `None` when the candidate node is not
+/// an import after all.
+fn import_target(language: SyntaxLanguage, node: Node<'_>, text: &str) -> Option<String> {
+    match (language, node.kind()) {
+        (SyntaxLanguage::Rust, "use_declaration") => named_field(node, "argument", text),
+        (SyntaxLanguage::Rust, "extern_crate_declaration") => named_field(node, "name", text),
+        (SyntaxLanguage::Python, "import_from_statement") => named_field(node, "module_name", text),
+        (SyntaxLanguage::Python, "import_statement") => {
+            let name = node.child_by_field_name("name")?;
+            if name.kind() == "aliased_import" {
+                named_field(name, "name", text)
+            } else {
+                node_text(name, text)
+            }
+        }
+        (SyntaxLanguage::JavaScript | SyntaxLanguage::TypeScript, "import_statement") => {
+            Some(unquote(named_field(node, "source", text)?))
+        }
+        (SyntaxLanguage::Bash, "command") => {
+            // Only `source X` and `. X` are imports; every other command is a
+            // candidate that answers `None`.
+            let name = named_field(node, "name", text)?;
+            if name != "source" && name != "." {
+                return None;
+            }
+            Some(unquote(named_field(node, "argument", text)?))
+        }
+        _ => None,
+    }
+}
+
+/// Strip one layer of matching ASCII quotes, if present.
+fn unquote(value: String) -> String {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2
+        && (bytes[0] == b'"' || bytes[0] == b'\'')
+        && bytes[bytes.len() - 1] == bytes[0]
+    {
+        return value[1..value.len() - 1].to_owned();
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routing_claims_exactly_the_six_families_and_refuses_tsx() {
+        assert_eq!(language_for("src/main.rs"), Some(SyntaxLanguage::Rust));
+        assert_eq!(language_for("Cargo.toml"), Some(SyntaxLanguage::Toml));
+        assert_eq!(language_for("README.MD"), Some(SyntaxLanguage::Markdown));
+        assert_eq!(language_for("a/b.py"), Some(SyntaxLanguage::Python));
+        assert_eq!(language_for("a/b.mjs"), Some(SyntaxLanguage::JavaScript));
+        assert_eq!(language_for("a/b.ts"), Some(SyntaxLanguage::TypeScript));
+        assert_eq!(language_for("a/b.bash"), Some(SyntaxLanguage::Bash));
+        assert_eq!(language_for("a/b.tsx"), None);
+        assert_eq!(language_for("LICENSE"), None);
+    }
+
+    #[test]
+    fn extractor_identity_is_per_language_and_versioned() {
+        assert_eq!(SyntaxLanguage::Rust.extractor_identity(), "syntax-rust/v1");
+        assert_eq!(
+            SyntaxLanguage::TypeScript.extractor_identity(),
+            "syntax-typescript/v1"
+        );
+        let mut identities: Vec<String> = SyntaxLanguage::ALL
+            .iter()
+            .map(|l| l.extractor_identity())
+            .collect();
+        identities.sort();
+        identities.dedup();
+        assert_eq!(identities.len(), SyntaxLanguage::ALL.len());
+    }
+
+    #[test]
+    fn a_symbol_slices_back_out_of_the_original_bytes() {
+        let source = b"pub fn only() {}\n";
+        let facts = extract(SyntaxLanguage::Rust, source).expect("parses");
+        assert_eq!(facts.symbols.len(), 1);
+        let symbol = &facts.symbols[0];
+        assert_eq!(symbol.name, "only");
+        assert_eq!(
+            &source[symbol.byte_start..symbol.byte_end],
+            b"pub fn only() {}"
+        );
+    }
+
+    #[test]
+    fn malformed_input_is_an_error_and_carries_no_partial_symbols() {
+        let error = extract(SyntaxLanguage::Rust, b"pub fn ok() {}\npub fn broken( {\n")
+            .expect_err("must not parse");
+        assert!(
+            matches!(
+                error,
+                SyntaxError::Parse {
+                    language: "rust",
+                    ..
+                }
+            ),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn non_utf8_bytes_are_refused_rather_than_lossily_decoded() {
+        assert_eq!(
+            extract(SyntaxLanguage::Rust, &[0xff, 0xfe]).unwrap_err(),
+            SyntaxError::NotUtf8
+        );
+    }
+}

--- a/src/runtime/atlas/syntax.rs
+++ b/src/runtime/atlas/syntax.rs
@@ -66,6 +66,14 @@ pub const SYNTAX_EXTRACTOR_VERSION: &str = "v1";
 /// language with no fixture in the corpus would be a claim nothing checks —
 /// so a `.tsx` file routes to `None` and is honestly coverage-reported
 /// `unsupported` (F8) rather than parsed by an almost-right grammar.
+///
+/// `.jsx`/`.mjs`/`.cjs` sit on the other side of that line: they ARE
+/// claimed by the JavaScript family, so a file whose syntax the JS grammar
+/// cannot parse (real JSX above all) reports `error` coverage with zero
+/// symbols — a claimed-but-failed parse, not an unclaimed extension. That
+/// is F8's honest-error rule doing its job, but it makes JavaScript's
+/// claimed surface broader than what the grammar parses cleanly; narrowing
+/// `.jsx` out (or adopting the TSX grammar) is a later wave's call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SyntaxLanguage {
     Rust,

--- a/tests/fixtures/tslp_corpus/SPIKE-F5.md
+++ b/tests/fixtures/tslp_corpus/SPIKE-F5.md
@@ -118,7 +118,8 @@ advisories ok, bans ok, licenses FAILED, sources ok
 ```
 
 Recorded honestly and completely: with `default-features = false` the `dirs`
-subtree disappears (136 → 135 third-party crates) and the same probe returns
+subtree disappears (the probe's lockfile goes 144 → 136 entries, i.e. 143 →
+135 third-party crates) and the same probe returns
 `advisories ok, bans ok, licenses ok, sources ok`. So TSLP is not
 categorically deniable — it is deniable *as it ships*, and the features that
 cause the denial (`download`, `dynamic-loading`) are exactly the ones this
@@ -132,9 +133,208 @@ is unchanged by this wave.
 
 ## (b) Fixture corpus — hand-verified counts, exact match
 
-See `manifest.toml` beside this file and the corpus suite
-`tests/x3b_tslp_corpus.rs`. Results recorded below once run.
+**Result: PASS, first run, with no adjustment to the manifest.**
+
+Seven fixtures covering the six families F5 names, checked in beside this
+file, plus two malformed fixtures. `manifest.toml` states every expectation;
+`tests/x3b_tslp_corpus.rs` is the gate. The extractor is
+`src/runtime/atlas/syntax.rs` — a pure function over bytes, no DB handle, no
+daemon state (F6's adapter-shape mandate, citable at this PR).
+
+| Fixture | Language | Symbols | Imports |
+|---|---|---:|---:|
+| `rust/sample.rs` | rust | 16 | 2 |
+| `toml/sample.toml` | toml | 11 | 0 |
+| `markdown/sample.md` | markdown | 4 | 0 |
+| `python/sample.py` | python | 8 | 4 |
+| `javascript/sample.js` | javascript | 6 | 2 |
+| `typescript/sample.ts` | typescript | 8 | 2 |
+| `shell/sample.sh` | bash | 3 | 2 |
+
+The counts were written into `manifest.toml` by reading each fixture against
+`syntax.rs`'s `symbol_kinds`/`import_kinds` tables **before** the suite was
+ever executed, and the first execution matched all seven exactly. That
+ordering is the whole value of the criterion, so it is recorded rather than
+left implicit: nothing here was reconciled by re-recording what the extractor
+happened to say.
+
+What "exact" means here is stronger than the criterion asked for — the suite
+compares ordered symbol **names**, ordered **labels**, and ordered import
+**targets**, not just the two totals, and separately asserts that the
+manifest's own lists and counts agree with each other:
+
+```
+$ TMPDIR=/var/tmp/sgt-test-tmp cargo nextest run --locked --test x3b_tslp_corpus
+    Starting 4 tests across 1 binary
+        PASS [   0.006s] sergeant-rs::x3b_tslp_corpus the_corpus_covers_every_language_this_build_claims
+        PASS [   0.006s] sergeant-rs::x3b_tslp_corpus malformed_fixtures_error_rather_than_returning_a_partial_parse
+        PASS [   0.009s] sergeant-rs::x3b_tslp_corpus every_fixture_matches_its_hand_verified_counts_exactly
+        PASS [   0.009s] sergeant-rs::x3b_tslp_corpus every_symbol_and_import_slices_back_out_of_the_original_bytes
+     Summary [   0.010s] 4 tests run: 4 passed, 0 skipped
+```
+
+Three deliberate design points behind that result:
+
+* **A parse error is a fail, not a skip.** `extract` returns
+  `SyntaxError::Parse` for any tree containing an error or missing node and
+  returns *no* partial symbol list beside it — tree-sitter's error tolerance
+  is exactly the silent-partial-parse failure mode F5 forbids, so it is
+  refused at the module boundary. The suite has no `SKIPPED-ENV` escape and
+  none may be added: parsing bytes depends on nothing the two-environment
+  rule is about.
+* **The malformed fixtures exist so property one is falsifiable.** A corpus of
+  only-valid files would pass against an extractor whose error detection
+  never fires. `malformed/broken.rs` and `malformed/broken.py` are asserted to
+  *fail*.
+* **The fixtures include deliberate non-symbols** — a JS arrow function bound
+  to a `const`, a TS class field, Rust `impl` blocks, a Python module-level
+  assignment, a `#`-prefixed line inside a fenced Markdown code block, and
+  shell commands that are not `source`/`.`. Each is listed in the manifest
+  header. They are what make the counts a test of the definition rather than
+  of the parser's willingness to find something.
+
+Unit tests in `syntax.rs` cover the same contract at module level (5 tests,
+all passing), including the non-UTF-8 refusal and the round-trip that a
+symbol's byte span slices back out of the original bytes (A1-12 provenance).
+
+The new suite is wired into `scripts/coverage/c2-suites.sh` in the same
+commit — #231(b)'s `coverage_stage_membership` guard caught it as an orphan
+on the first full run, which is the guard doing exactly its job. It sits in
+C2, not C3: it reads checked-in fixture bytes and spawns nothing.
 
 ## (c) Footprint — measured delta vs the #299-lean baseline
 
-Recorded below once measured.
+**Result: PASS.** Both legs measured in this lane by this spike, on the same
+host, with the same commands, into two fresh target directories, run **one at
+a time** (a concurrent cold build inflates the other's wall time by up to
+~75% per CONTRIBUTING's own note, which would have made the build-time delta
+meaningless).
+
+The plan states no numeric ceiling, and none is invented here: the criterion
+is a measured, provenanced delta, and that is what follows.
+
+### Method
+
+```sh
+# BEFORE: Cargo.toml/Cargo.lock checked out at 299c8b8b (no tree-sitter);
+# src/ untouched, because no extraction code existed yet when this ran.
+export TMPDIR=/var/tmp/sgt-test-tmp
+export CARGO_TARGET_DIR=/var/tmp/hats3/x3b-target-base   # rm -rf'd first
+time cargo build --locked --tests      # the cold measurement CONTRIBUTING names
+time cargo build --locked              # produces target/debug/sgt
+du -sb "$CARGO_TARGET_DIR"; stat -c %s "$CARGO_TARGET_DIR/debug/sgt"
+
+# AFTER: identical commands, CARGO_TARGET_DIR=/var/tmp/hats3/x3b-target-after,
+# with the eight crates declared AND referenced by src/runtime/atlas/syntax.rs.
+```
+
+Scripts kept verbatim at `/var/tmp/hats3/x3b-evidence/measure-{baseline,after}.sh`;
+raw output at `footprint-{before,after}.txt` beside them. Host: 20 cores,
+30 GB RAM, `rustc 1.98.0 (88d9e12ae 2026-08-18)`. Baseline ran 09:51Z, after
+ran 10:03Z, same session, same machine, nothing else building.
+
+### The delta
+
+| Measure | Before (#299-lean) | After | Delta |
+|---|---:|---:|---:|
+| `Cargo.lock` packages | 432 | 442 | **+10** |
+| cold `cargo build --locked --tests` | 136 s | 138 s | **+2 s (+1.5%)** |
+| cold total (`--tests` then bin) | 152 s | 154 s | **+2 s (+1.3%)** |
+| `target/` after both builds | 14,573,170,440 B (14G) | 14,772,108,500 B (14G) | **+198,938,060 B (+0.185 GiB, +1.37%)** |
+| `target/debug/sgt` | 259,639,792 B (247M) | 259,758,608 B (248M) | +118,816 B (+0.05%) — **but see below** |
+
+For provenance against the brief's remembered baseline (~238M debug `sgt`,
+~12G fresh target): this lane measured its own before-numbers as 247M and 14G.
+The remembered figures are in the right neighbourhood but are not what this
+host produced today, which is exactly why the criterion demands the spike
+produce its own.
+
+The `target/` delta decomposes, and most of it is not the grammars: the new
+`x3b_tslp_corpus` test binary is **129,049,544 B** of the +198,938,060 B on
+its own, because every test binary in this repo links the whole dependency
+graph (that is the cost #299 already addressed by stripping dependency DWARF,
+not a new cost this wave introduced). The remaining ~70 MB is the grammar
+crates' own rlibs and C objects. Wiring X3b's writer will add no further test
+binary of this size unless it adds another suite.
+
+### The binary-size number needs a correction, stated plainly
+
+That +0.05% is **misleadingly small and must not be quoted on its own.** The
+grammars are C parser tables reached only through `syntax::extract`, and
+nothing on the `sgt` binary's reachable path calls it yet — the linker
+therefore dropped every grammar object from the binary. Verified:
+
+```
+$ nm /var/tmp/hats3/x3b-target-after/debug/sgt | grep -c 'tree_sitter_rust\|tree_sitter_python\|tree_sitter_bash'
+0
+```
+
+So the honest question — what will the binary cost once X3b's writer calls
+the extractor from the daemon — was measured directly, by temporarily forcing
+a reference from `main.rs`, rebuilding, and reverting it (the revert is
+confirmed: the binary returned byte-for-byte to 259,758,608):
+
+```
+$ nm .../sgt | grep -c 'tree_sitter_rust\|tree_sitter_python\|tree_sitter_bash'
+18
+forced-reference sgt bytes: 265,256,152
+```
+
+**Linked binary-size delta vs the #299-lean baseline: +5,616,360 B
+(+5.36 MiB, +2.16%)** — 265,256,152 against 259,639,792. That is the number
+to carry into X5's combined-delta re-measurement (F4's compounding rule),
+not the +118,816 B the unreferenced build reports today.
+
+### Not measured, and named rather than glossed
+
+Release-profile binary size. Both legs are dev-profile, which is what the
+#299 baseline the criterion names is about (#299 is a `profile.dev` decision,
+and the brief's baseline figures are debug figures). A release-profile delta
+is a different number and this spike did not produce it; X5's combined
+re-measurement is the natural place for it if the program wants one.
+
+## Verdict — (d) adopt
+
+All three criteria passed, in order, each before the next was begun. Under
+F5(d) and ruling 6 this is **adoption without escalation (J2)**: the plan
+delegated exactly this class of decision to the spike against exactly these
+pre-agreed criteria, and the criteria were met rather than argued around.
+Nothing here was partially adopted, vendored, forked, or allowlisted past.
+
+Riding the adoption, per F5(d)/A1-27: `rust-version` 1.89.0 → 1.98.0, with
+ci.yml's `env.MSRV` in the same commit — the two cannot move independently,
+because cargo refuses to build a package whose `rust-version` exceeds the
+compiler invoked. One consequence is flagged for review in ci.yml rather than
+decided here: the MSRV floor now equals `rust-toolchain.toml`'s pin, so that
+job has become a duplicate check of the pinned compiler. Retiring it, or
+re-establishing a genuinely older measured floor, is not this wave's call.
+
+## Final gate state on this lane
+
+Run after the whole change was in place (adoption, extractor, corpus,
+rust-version bump, coverage wiring):
+
+```
+$ cargo fmt --check                                     # clean
+$ cargo clippy --locked --all-targets -- -D warnings    # clean
+$ find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=error   # clean
+$ cargo nextest run --locked
+     Summary [ 330.995s] 2025 tests run: 2025 passed (1 slow), 38 skipped
+
+# exactly the dependency-policy job's own flags (ci.yml)
+$ cargo metadata --locked --format-version 1 >/dev/null                      # ok
+$ cargo deny --all-features --locked check bans licenses sources
+bans ok, licenses ok, sources ok
+$ cargo deny --all-features --locked check          # release-time Gate E shape
+advisories ok, bans ok, licenses ok, sources ok
+```
+
+## What this spike did NOT do
+
+The spike is F5(a)-(d) and stops there. X3b's remaining wiring —
+`source.symbols` / `source.occurrences` / `source.edges` DDL and their writer
+in `runtime/atlas/db.rs` (empty-table doctrine: each table lands with its
+writer), the F7-keyed cache glue joining X3a's batched blob reads, extraction
+under the F6 intelligence-lane permit, and the `unsupported` coverage rows
+(F8) — is not in this record and not in these commits. `syntax.rs` is
+deliberately shaped to be called by that glue rather than to contain it.

--- a/tests/fixtures/tslp_corpus/SPIKE-F5.md
+++ b/tests/fixtures/tslp_corpus/SPIKE-F5.md
@@ -338,3 +338,71 @@ writer), the F7-keyed cache glue joining X3a's batched blob reads, extraction
 under the F6 intelligence-lane permit, and the `unsupported` coverage rows
 (F8) — is not in this record and not in these commits. `syntax.rs` is
 deliberately shaped to be called by that glue rather than to contain it.
+
+---
+
+# The wiring, and what it measured (X3b, 2026-08-27)
+
+The section above closes with a list of what the spike deliberately did not
+do. All of it is now done, and this section records the two things the wiring
+*measured* — because both are facts about real input that no amount of
+fixture-corpus green would have produced.
+
+## Self-scan of this repository
+
+One `scan_estate_git` + `record_scan` of sergeant-rs at
+`b6192480` (the spike's own head), on this host, measured by a throwaway test
+that was deleted after it answered:
+
+```text
+files         249            (acquired resources)
+bytes       8,654,274        (their content, as read)
+units             559        (source.units — one Document per code file,
+                              plus Markdown sections)
+symbols         6,819        (source.occurrences — symbol *sites*)
+distinct        5,401        (source.symbols — the index the sites roll up to)
+edges           1,409        (source.edges — imports)
+coverage          376 rows:  indexed 246, unsupported 70, discovered 52,
+                              excluded 4, error 3, unavailable 1
+scan            2,239 ms     (git ls-tree + batched cat-file + all extraction)
+write           7,452 ms     (one transaction, 8,800-odd rows)
+```
+
+**The write cost is the honest number, and it moved during this wave.** The
+first measurement was **17,493 ms**, because every insert went through
+`Connection::execute`, which prepares its SQL afresh each call — the
+connection's prepared-statement cache was configured in X2 and then used by
+nothing. Routing the six per-row inserts through `prepare_cached` took it to
+7,452 ms on the same input: **2.3x, no semantic change, one transaction
+still.** What remains is DuckDB's own per-row `INSERT` cost (~0.85 ms/row);
+this is an analytical engine, and its documented bulk path is the Appender.
+That is **not** taken here: the Appender's interaction with the explicit
+transaction F1's crash window is stated over is not something this wave
+verified, and trading that invariant for a second speedup at wave close is
+the wrong order. It is a named, measured follow-up with a number attached,
+not an unexamined gap.
+
+Scanning happens under an intelligence-lane permit on the blocking pool (F6),
+so neither figure is on a path that can slow Work execution.
+
+## A real-world grammar limitation, reported rather than smoothed over
+
+Three files in this repository fail their grammar. Two are the corpus's own
+deliberately malformed fixtures, which is the point of them. The third is
+real:
+
+```text
+scripts/perf/common.sh   syntax-bash/v1: bash: parse failed at byte 24149
+```
+
+Byte 24149 is `stat="$(< "/proc/$pid/stat")"` — bash's redirection-only
+command substitution, which `tree-sitter-bash` 0.25.1 does not accept. The
+file is therefore coverage-reported `error` and contributes **no** symbols,
+rather than contributing the symbols the parser found before it gave up. That
+is F5's no-silent-partial-parse rule doing its job on input nobody chose for
+it, which is better evidence than the malformed fixtures are: those prove the
+refusal is reachable, this proves it is *load-bearing*.
+
+The structure unit for that file is still written. The failure belongs to one
+extractor, not to the resource — and `text/v1; syntax-bash/v1: …` in its
+coverage detail says exactly that.

--- a/tests/fixtures/tslp_corpus/SPIKE-F5.md
+++ b/tests/fixtures/tslp_corpus/SPIKE-F5.md
@@ -1,0 +1,140 @@
+# F5 spike record — tree-sitter adoption (S3 X3b)
+
+Sprint plan `sprint-plan-2026-08-27.md`, decision **F5** (J2, ruling 6). The
+three criteria run **in order**, each gate before the next; any failure stops
+the spike and escalates. This file is the durable record of what was actually
+run and what it printed.
+
+Lane: worktree `/var/tmp/hats3/x3b`, branch `hats3/x3b-tslp`, base
+`299c8b8b` (integration after X3a/#318). Host: 20 cores, 30 GB RAM,
+`/var/tmp` on a 935 GB volume. Toolchain `rustc 1.98.0 (88d9e12ae 2026-08-18)`
+/ `cargo 1.98.0 (797e8a9bc 2026-08-05)` (pinned by `rust-toolchain.toml`).
+`cargo-deny 0.20.2`. Every command ran with `TMPDIR=/var/tmp/sgt-test-tmp`.
+
+## (a) Deny gate — RUN FIRST, BEFORE ANY EXTRACTION CODE
+
+**Result: PASS.**
+
+### The crate set actually proposed for adoption
+
+Eight direct crates, all crates.io-published, all `license = "MIT"`, no git
+dependency anywhere:
+
+| Crate | Version | License |
+|---|---|---|
+| `tree-sitter` | 0.26.13 | MIT |
+| `tree-sitter-rust` | 0.24.2 | MIT |
+| `tree-sitter-toml-ng` | 0.7.0 | MIT |
+| `tree-sitter-md` | 0.5.3 | MIT |
+| `tree-sitter-python` | 0.25.0 | MIT |
+| `tree-sitter-javascript` | 0.25.0 | MIT |
+| `tree-sitter-typescript` | 0.23.2 | MIT |
+| `tree-sitter-bash` | 0.25.1 | MIT |
+
+`cargo add` locked **10** new packages (the eight above plus their two shared
+transitive deps):
+
+```
+     Locking 10 packages to latest Rust 1.89.0 compatible versions
+      Adding streaming-iterator v0.1.9
+      Adding tree-sitter v0.26.13
+      Adding tree-sitter-bash v0.25.1
+      Adding tree-sitter-javascript v0.25.0
+      Adding tree-sitter-language v0.1.7
+      Adding tree-sitter-md v0.5.3
+      Adding tree-sitter-python v0.25.0
+      Adding tree-sitter-rust v0.24.2
+      Adding tree-sitter-toml-ng v0.7.0
+      Adding tree-sitter-typescript v0.23.2
+```
+
+(`tree-sitter-toml-ng` is the maintained TOML grammar under the
+`tree-sitter-grammars` org; the older `tree-sitter-toml` 0.20.0 —
+`Mathspy/tree-sitter-toml` — is a dead fork against a pre-`LanguageFn` ABI.)
+
+### Verbatim results
+
+Baseline, clean tree at `299c8b8b`, before any Cargo.toml edit:
+
+```
+$ TMPDIR=/var/tmp/sgt-test-tmp cargo deny check
+advisories ok, bans ok, licenses ok, sources ok
+```
+
+With the eight crates added (this is the gate):
+
+```
+$ TMPDIR=/var/tmp/sgt-test-tmp cargo deny check
+advisories ok, bans ok, licenses ok, sources ok
+(exit 0)
+```
+
+The subset CI actually runs on routine PRs (`deny.toml` header):
+
+```
+$ TMPDIR=/var/tmp/sgt-test-tmp cargo deny check bans licenses sources
+bans ok, licenses ok, sources ok
+```
+
+The `warning[duplicate]` list is **byte-identical** before and after — the
+addition introduces no new duplicate-version warning:
+
+```
+$ diff <(grep -E '^warning\[' deny-baseline.txt) \
+       <(grep -E '^warning\[' deny-with-treesitter.txt) && echo IDENTICAL-WARNINGS
+IDENTICAL-WARNINGS
+```
+
+### Why not TSLP (`tree-sitter-language-pack`) — measured, not assumed
+
+The brief's stated risk was that TSLP's ~100 grammar crates would trip
+`unknown-git`. Measured in a scratch probe crate outside this worktree, with
+this repo's `deny.toml` copied in verbatim: **that specific risk did not
+materialise — TSLP has no git sources at all** (`grep 'source = "git' Cargo.lock`
+→ no matches; 143 crates, all crates.io). It fails the gate for a different
+reason, on **licenses**:
+
+```
+$ TMPDIR=/var/tmp/sgt-test-tmp cargo deny check     # tree-sitter-language-pack 1.15.8, default features
+error[rejected]: failed to satisfy license requirements
+   ┌─ /home/miztertea/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/option-ext-0.2.0/Cargo.toml:21:12
+   │
+21 │ license = "MPL-2.0"
+   │            ━━━━━━━
+   │            │
+   │            rejected: license is not explicitly allowed
+   │
+   ├ MPL-2.0 - Mozilla Public License 2.0:
+   ├   - OSI approved
+   ├   - FSF Free/Libre
+   ├   - Copyleft
+   ├ option-ext v0.2.0
+     └── dirs-sys v0.5.0
+         └── dirs v6.0.0
+             └── tree-sitter-language-pack v1.15.8
+
+advisories ok, bans ok, licenses FAILED, sources ok
+(exit 4)
+```
+
+Recorded honestly and completely: with `default-features = false` the `dirs`
+subtree disappears (136 → 135 third-party crates) and the same probe returns
+`advisories ok, bans ok, licenses ok, sources ok`. So TSLP is not
+categorically deniable — it is deniable *as it ships*, and the features that
+cause the denial (`download`, `dynamic-loading`) are exactly the ones this
+repo would refuse on posture grounds anyway: `download` fetches parsers over
+the network at runtime, which is the DuckDB-extension-autoload posture F4
+forbids. The lean eight-crate set is chosen on R1/R7 (six languages indexed,
+not 371) and on that posture, **not** on a deny failure it did not have.
+
+No vendoring, no fork, no allowlist edit was performed or needed. `deny.toml`
+is unchanged by this wave.
+
+## (b) Fixture corpus — hand-verified counts, exact match
+
+See `manifest.toml` beside this file and the corpus suite
+`tests/x3b_tslp_corpus.rs`. Results recorded below once run.
+
+## (c) Footprint — measured delta vs the #299-lean baseline
+
+Recorded below once measured.

--- a/tests/fixtures/tslp_corpus/javascript/sample.js
+++ b/tests/fixtures/tslp_corpus/javascript/sample.js
@@ -1,0 +1,31 @@
+// Hand-counted JavaScript fixture for the F5 corpus gate.
+import fs from "node:fs";
+import { join, resolve } from "node:path";
+
+export const LIMIT = 8;
+
+// An arrow function bound to a const is deliberately NOT a symbol under this
+// extractor's syntax-only rule (A1-09): the declaration is a lexical binding,
+// not a function declaration. The manifest's count depends on that.
+export const double = (x) => x * 2;
+
+export function topLevel(value) {
+  function inner(x) {
+    return x + 1;
+  }
+  return inner(value);
+}
+
+export class Counter {
+  constructor() {
+    this.hits = 0;
+  }
+
+  bump() {
+    this.hits += 1;
+  }
+}
+
+export default function main() {
+  return [fs, join, resolve, LIMIT, double, topLevel, new Counter()];
+}

--- a/tests/fixtures/tslp_corpus/malformed/broken.py
+++ b/tests/fixtures/tslp_corpus/malformed/broken.py
@@ -1,0 +1,4 @@
+# Deliberately unparseable Python, for the corpus gate's red side. See
+# broken.rs beside it for why a malformed fixture is part of the criterion.
+def broken(:
+    return ]

--- a/tests/fixtures/tslp_corpus/malformed/broken.rs
+++ b/tests/fixtures/tslp_corpus/malformed/broken.rs
@@ -1,0 +1,9 @@
+// Deliberately unparseable Rust, for the corpus gate's red side.
+//
+// F5's criterion is "a parse error on any fixture is a FAIL, not a skip". A
+// suite that only ever asserts "no fixture errored" is vacuous unless
+// something proves the extractor can still say "this errored" — that is what
+// this file, and its sibling broken.py, are for.
+pub fn broken( {
+    let = ;
+}

--- a/tests/fixtures/tslp_corpus/manifest.toml
+++ b/tests/fixtures/tslp_corpus/manifest.toml
@@ -21,6 +21,18 @@
 #   * markdown/sample.md `# not a heading` inside a fenced code block.
 #   * shell/sample.sh `set -euo pipefail` and `main "$@"` — commands that are
 #     not `source`/`.`, so not imports.
+#
+# Shapes the corpus deliberately includes because the extractor was once wrong
+# about them, and a corpus of only comfortable inputs makes "EXACT match" a
+# narrower guarantee than it reads:
+#   * python/multi_import.py — a comma list is ONE `import_statement` naming
+#     several modules; each name is its own edge.
+#   * typescript/import_require.ts — `import x = require("...")` is an
+#     `import_statement` whose source hides in an `import_require_clause`.
+#   * markdown/setext.md — `setext_heading` is a claimed kind, so it needs an
+#     instance.
+#   * rust/unicode.rs — multi-byte characters before AND inside extracted
+#     names, so the byte-offset provenance test slices non-trivial UTF-8.
 
 [[fixture]]
 path = "rust/sample.rs"
@@ -38,6 +50,17 @@ symbol_labels = [
   "struct", "macro", "function",
 ]
 import_targets = ["std::collections::HashMap", "std::fmt::{self, Display}"]
+
+# Multi-byte characters ahead of and inside every name here. A byte offset
+# mistaken for a character count lands mid-character and the slice fails.
+[[fixture]]
+path = "rust/unicode.rs"
+language = "rust"
+symbols = 3
+imports = 0
+symbol_names = ["Zähler", "café_fn", "GRÜSSE"]
+symbol_labels = ["struct", "function", "const"]
+import_targets = []
 
 [[fixture]]
 path = "toml/sample.toml"
@@ -65,6 +88,19 @@ symbol_names = [
 symbol_labels = ["heading", "heading", "heading", "heading"]
 import_targets = []
 
+# Two setext headings and one ATX heading. `setext_heading` is claimed by the
+# symbol table; without this fixture nothing exercised it.
+[[fixture]]
+path = "markdown/setext.md"
+language = "markdown"
+symbols = 3
+imports = 0
+symbol_names = [
+  "Setext Title", "Setext Subsection", "An ATX heading, for contrast",
+]
+symbol_labels = ["heading", "heading", "heading"]
+import_targets = []
+
 [[fixture]]
 path = "python/sample.py"
 language = "python"
@@ -79,6 +115,18 @@ symbol_labels = [
   "function", "function",
 ]
 import_targets = ["os", "sys", "collections", "typing"]
+
+# Five imports written across three statements: two comma lists (two names
+# each) and one `from` import (whose module is one name however many symbols it
+# binds). An extractor that answers once per statement records three.
+[[fixture]]
+path = "python/multi_import.py"
+language = "python"
+symbols = 1
+imports = 5
+symbol_names = ["uses"]
+symbol_labels = ["function"]
+import_targets = ["os", "sys", "json", "csv", "collections"]
 
 [[fixture]]
 path = "javascript/sample.js"
@@ -103,6 +151,17 @@ symbol_labels = [
   "function",
 ]
 import_targets = ["node:stream", "node:events"]
+
+# The CommonJS-interop import form beside an ordinary one, so the fixture
+# proves the two are both edges rather than proving only that the file parses.
+[[fixture]]
+path = "typescript/import_require.ts"
+language = "typescript"
+symbols = 1
+imports = 2
+symbol_names = ["reader"]
+symbol_labels = ["function"]
+import_targets = ["node:fs/promises", "node:events"]
 
 [[fixture]]
 path = "shell/sample.sh"

--- a/tests/fixtures/tslp_corpus/manifest.toml
+++ b/tests/fixtures/tslp_corpus/manifest.toml
@@ -1,0 +1,124 @@
+# F5 corpus manifest — HAND-VERIFIED expectations, not recorded output.
+#
+# Every number and every name below was counted by reading the fixture, before
+# the extractor was run against it, against the symbol/import definitions
+# stated in `src/runtime/atlas/syntax.rs` (`symbol_kinds` / `import_kinds` —
+# those tables ARE the definition of "symbol" and "import" here). If a fixture
+# and this manifest ever disagree, exactly one of them is wrong and the suite
+# fails; it never reconciles by re-recording what the extractor said.
+#
+# The gate (`tests/x3b_tslp_corpus.rs`) is EXACT match per fixture — counts,
+# ordered names, ordered labels, ordered import targets. A parse error on any
+# fixture below is a FAIL, never a skip.
+#
+# Deliberate non-symbols, chosen to make the definitions bite:
+#   * javascript/sample.js `export const double = (x) => x * 2` — a lexical
+#     binding, not a function declaration.
+#   * typescript/sample.ts `private hits = 0` — a class field.
+#   * rust/sample.rs `impl` blocks — no name to be a symbol of (their
+#     contained functions are counted).
+#   * python/sample.py `LIMIT = 8` — a module-level assignment.
+#   * markdown/sample.md `# not a heading` inside a fenced code block.
+#   * shell/sample.sh `set -euo pipefail` and `main "$@"` — commands that are
+#     not `source`/`.`, so not imports.
+
+[[fixture]]
+path = "rust/sample.rs"
+language = "rust"
+symbols = 16
+imports = 2
+symbol_names = [
+  "LIMIT", "NAME", "Pairs", "Counter", "Outcome", "Countable", "count",
+  "new", "bump", "count", "fmt", "nested", "helper", "Inner", "twice",
+  "main_like",
+]
+symbol_labels = [
+  "const", "static", "type", "struct", "enum", "trait", "function",
+  "function", "function", "function", "function", "module", "function",
+  "struct", "macro", "function",
+]
+import_targets = ["std::collections::HashMap", "std::fmt::{self, Display}"]
+
+[[fixture]]
+path = "toml/sample.toml"
+language = "toml"
+symbols = 11
+imports = 0
+symbol_names = [
+  "schema", "name", "server", "host", "port", "server.tls", "enabled",
+  "repo", "name", "repo", "name",
+]
+symbol_labels = [
+  "key", "key", "table", "key", "key", "table", "key", "table_array", "key",
+  "table_array", "key",
+]
+import_targets = []
+
+[[fixture]]
+path = "markdown/sample.md"
+language = "markdown"
+symbols = 4
+imports = 0
+symbol_names = [
+  "Fixture corpus", "Counting rules", "Nested detail", "Second section",
+]
+symbol_labels = ["heading", "heading", "heading", "heading"]
+import_targets = []
+
+[[fixture]]
+path = "python/sample.py"
+language = "python"
+symbols = 8
+imports = 4
+symbol_names = [
+  "top_level", "inner", "Counter", "__init__", "bump", "Nested", "deep",
+  "fetch",
+]
+symbol_labels = [
+  "function", "function", "class", "function", "function", "class",
+  "function", "function",
+]
+import_targets = ["os", "sys", "collections", "typing"]
+
+[[fixture]]
+path = "javascript/sample.js"
+language = "javascript"
+symbols = 6
+imports = 2
+symbol_names = ["topLevel", "inner", "Counter", "constructor", "bump", "main"]
+symbol_labels = ["function", "function", "class", "method", "method", "function"]
+import_targets = ["node:fs", "node:path"]
+
+[[fixture]]
+path = "typescript/sample.ts"
+language = "typescript"
+symbols = 8
+imports = 2
+symbol_names = [
+  "Pair", "Countable", "count", "Outcome", "Counter", "count", "bump",
+  "build",
+]
+symbol_labels = [
+  "type", "interface", "method", "enum", "class", "method", "method",
+  "function",
+]
+import_targets = ["node:stream", "node:events"]
+
+[[fixture]]
+path = "shell/sample.sh"
+language = "bash"
+symbols = 3
+imports = 2
+symbol_names = ["greet", "farewell", "main"]
+symbol_labels = ["function", "function", "function"]
+import_targets = ["./lib/common.sh", "./lib/extra.sh"]
+
+# The red side. Without these, "no fixture produced a parse error" is a claim
+# nothing could ever falsify.
+[[malformed]]
+path = "malformed/broken.rs"
+language = "rust"
+
+[[malformed]]
+path = "malformed/broken.py"
+language = "python"

--- a/tests/fixtures/tslp_corpus/markdown/sample.md
+++ b/tests/fixtures/tslp_corpus/markdown/sample.md
@@ -1,0 +1,22 @@
+# Fixture corpus
+
+Intro paragraph with a [link](https://example.invalid).
+
+## Counting rules
+
+Some text that mentions `# not a heading` inline.
+
+### Nested detail
+
+- a list item
+- another
+
+## Second section
+
+```rust
+// A fenced code block. The next line is NOT a heading, and the corpus
+// gate exists partly to prove the parser agrees.
+# not a heading
+```
+
+Final paragraph.

--- a/tests/fixtures/tslp_corpus/markdown/setext.md
+++ b/tests/fixtures/tslp_corpus/markdown/setext.md
@@ -1,0 +1,15 @@
+Setext Title
+============
+
+An H1 written with an underline rather than a `#`. `setext_heading` is a kind
+the symbol table claims, so it needs a fixture instance or the claim is one
+nothing checks.
+
+Setext Subsection
+-----------------
+
+Body paragraph.
+
+## An ATX heading, for contrast
+
+Final paragraph.

--- a/tests/fixtures/tslp_corpus/python/multi_import.py
+++ b/tests/fixtures/tslp_corpus/python/multi_import.py
@@ -1,0 +1,15 @@
+"""Comma-list imports — one statement, several names.
+
+Hand-counted for the corpus gate. This shape is the reason `imports_in`
+returns a list: tree-sitter-python attaches the `name` field to EVERY entry
+below, so an extractor that asks for the field once records `os` and silently
+drops `sys`.
+"""
+
+import os, sys
+import json as encoder, csv
+from collections import OrderedDict, defaultdict
+
+
+def uses() -> tuple:
+    return (os, sys, encoder, csv, OrderedDict, defaultdict)

--- a/tests/fixtures/tslp_corpus/python/sample.py
+++ b/tests/fixtures/tslp_corpus/python/sample.py
@@ -1,0 +1,34 @@
+"""Hand-counted Python fixture for the F5 corpus gate."""
+
+import os
+import sys as system
+from collections import OrderedDict
+from typing import Iterable, Optional
+
+LIMIT = 8
+
+
+def top_level(value: int) -> int:
+    def inner(x: int) -> int:
+        return x + 1
+
+    return inner(value)
+
+
+class Counter:
+    """Counts things."""
+
+    def __init__(self) -> None:
+        self.hits = 0
+
+    def bump(self) -> None:
+        self.hits += 1
+
+    class Nested:
+        def deep(self) -> str:
+            return "deep"
+
+
+async def fetch(url: str) -> Optional[str]:
+    _ = (os, system, OrderedDict, Iterable, LIMIT, url)
+    return None

--- a/tests/fixtures/tslp_corpus/rust/sample.rs
+++ b/tests/fixtures/tslp_corpus/rust/sample.rs
@@ -1,0 +1,72 @@
+//! Hand-counted Rust fixture for the F5 corpus gate.
+//!
+//! Not compiled by anything: `tests/fixtures/` is not a cargo target root, so
+//! this file is bytes the corpus suite reads, never a module.
+
+use std::collections::HashMap;
+use std::fmt::{self, Display};
+
+pub const LIMIT: usize = 8;
+static NAME: &str = "fixture";
+
+pub type Pairs = HashMap<String, usize>;
+
+pub struct Counter {
+    hits: usize,
+}
+
+pub enum Outcome {
+    Hit,
+    Miss,
+}
+
+pub trait Countable {
+    fn count(&self) -> usize;
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Counter { hits: 0 }
+    }
+
+    pub fn bump(&mut self) {
+        self.hits += 1;
+    }
+}
+
+impl Countable for Counter {
+    fn count(&self) -> usize {
+        self.hits
+    }
+}
+
+impl Display for Outcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Outcome::Hit => write!(f, "hit"),
+            Outcome::Miss => write!(f, "miss"),
+        }
+    }
+}
+
+pub mod nested {
+    pub fn helper() -> u8 {
+        1
+    }
+
+    pub struct Inner;
+}
+
+macro_rules! twice {
+    ($e:expr) => {
+        $e + $e
+    };
+}
+
+pub fn main_like() -> usize {
+    let mut c = Counter::new();
+    c.bump();
+    let _ = NAME;
+    let _ = LIMIT;
+    twice!(c.count())
+}

--- a/tests/fixtures/tslp_corpus/rust/unicode.rs
+++ b/tests/fixtures/tslp_corpus/rust/unicode.rs
@@ -1,0 +1,17 @@
+//! Multi-byte bytes before and inside extracted names — hand-counted so the
+//! provenance test slices at non-trivial UTF-8 offsets.
+//!
+//! 日本語のコメント — three-byte characters and an em dash, both sitting ahead
+//! of every symbol below, so a byte offset that was really a character count
+//! would land mid-character and fail the slice rather than pass by luck.
+
+/// Führt eine Zählung durch — Ümlaute im Doc-Kommentar.
+pub struct Zähler {
+    treffer: usize,
+}
+
+pub fn café_fn(zähler: &Zähler) -> usize {
+    zähler.treffer
+}
+
+pub const GRÜSSE: &str = "Grüße, 世界";

--- a/tests/fixtures/tslp_corpus/shell/sample.sh
+++ b/tests/fixtures/tslp_corpus/shell/sample.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Hand-counted shell fixture for the F5 corpus gate. Never executed — read as
+# bytes by the corpus suite. Lives outside scripts/, so ci.yml's ShellCheck
+# job (which globs scripts/ only) does not lint it.
+set -euo pipefail
+
+source ./lib/common.sh
+. ./lib/extra.sh
+
+LIMIT=8
+
+greet() {
+  echo "hello $1"
+}
+
+function farewell {
+  echo "bye $1"
+}
+
+main() {
+  greet world
+  farewell world
+  echo "$LIMIT"
+}
+
+main "$@"

--- a/tests/fixtures/tslp_corpus/toml/sample.toml
+++ b/tests/fixtures/tslp_corpus/toml/sample.toml
@@ -1,0 +1,16 @@
+# Hand-counted TOML fixture for the F5 corpus gate.
+schema = 1
+name = "fixture"
+
+[server]
+host = "127.0.0.1"
+port = 8080
+
+[server.tls]
+enabled = false
+
+[[repo]]
+name = "alpha"
+
+[[repo]]
+name = "beta"

--- a/tests/fixtures/tslp_corpus/typescript/import_require.ts
+++ b/tests/fixtures/tslp_corpus/typescript/import_require.ts
@@ -1,0 +1,13 @@
+// The legacy CommonJS-interop import form, hand-counted for the corpus gate.
+//
+// `import x = require("...")` is parsed by tree-sitter-typescript as an
+// `import_statement` with no `source` field of its own — the module string
+// sits inside an `import_require_clause`. It is unambiguously an import, so it
+// is unambiguously an edge.
+import fsp = require("node:fs/promises");
+import { EventEmitter } from "node:events";
+
+export function reader(): EventEmitter {
+  void fsp;
+  return new EventEmitter();
+}

--- a/tests/fixtures/tslp_corpus/typescript/sample.ts
+++ b/tests/fixtures/tslp_corpus/typescript/sample.ts
@@ -1,0 +1,33 @@
+// Hand-counted TypeScript fixture for the F5 corpus gate.
+import type { Readable } from "node:stream";
+import { EventEmitter } from "node:events";
+
+export type Pair = [string, number];
+
+export interface Countable {
+  count(): number;
+}
+
+export enum Outcome {
+  Hit,
+  Miss,
+}
+
+export class Counter extends EventEmitter implements Countable {
+  // A class field is not a symbol under this extractor's rule; the manifest's
+  // count depends on that.
+  private hits = 0;
+
+  count(): number {
+    return this.hits;
+  }
+
+  bump(): void {
+    this.hits += 1;
+  }
+}
+
+export function build(stream?: Readable): [Counter, Pair, Outcome] {
+  void stream;
+  return [new Counter(), ["fixture", 1], Outcome.Hit];
+}

--- a/tests/x2_knowledge_sources.rs
+++ b/tests/x2_knowledge_sources.rs
@@ -403,7 +403,13 @@ fn the_scan_summary_is_one_compact_event_with_provenance_and_no_path_list() {
         .iter()
         .map(|v| v.as_str().expect("str"))
         .collect();
-    assert_eq!(extractors, vec!["markdown/v1", "text/v1"]);
+    // The Markdown grammar joined the structure extractors in X3b: a `.md`
+    // blob is claimed by both routing tables, which F7 makes two extractions
+    // with two keys rather than one ambiguous extraction.
+    assert_eq!(
+        extractors,
+        vec!["markdown/v1", "syntax-markdown/v1", "text/v1"]
+    );
 
     // Compact: the summary names counts, not paths. The unit-level detail
     // lives in the table that can be queried.

--- a/tests/x3a_scan_uses_only_local_reads.rs
+++ b/tests/x3a_scan_uses_only_local_reads.rs
@@ -132,7 +132,11 @@ fn an_atlas_scan_runs_only_read_only_git_and_changes_nothing() {
     unsafe { std::env::remove_var(GIT_BIN_ENV) };
 
     let scanned = scanned.expect("the scan must succeed for the recording to mean anything");
-    assert_eq!(scanned.scan.files.len(), 3, "three extractable resources");
+    // Four since X3b: `src/main.rs` is claimed by a grammar, so it is an
+    // extractable resource rather than an unsupported one — and the extra
+    // resource is read out of the object store like the other three, which is
+    // exactly what this suite exists to keep true.
+    assert_eq!(scanned.scan.files.len(), 4, "four extractable resources");
     assert!(scanned.drift.is_none(), "HEAD never moved");
 
     // The committed bytes, not the working tree's.

--- a/tests/x3b_syntax_wiring.rs
+++ b/tests/x3b_syntax_wiring.rs
@@ -1,0 +1,641 @@
+//! S3 X3b acceptance: language-aware extraction, wired onto X3a's plumbing.
+//!
+//! The spike (`x3b_tslp_corpus.rs`) proved the *extractor* — that
+//! `runtime::atlas::syntax` produces exactly the hand-verified symbols and
+//! imports for a checked-in corpus, and refuses a malformed file outright.
+//! That suite stays the extractor's regression suite and this one does not
+//! duplicate it. What this suite proves is the **wiring**, and only the
+//! claims that could actually stop being true:
+//!
+//! * **The three tables land with their writer** (empty-table doctrine).
+//!   `source.symbols`, `source.occurrences` and `source.edges` hold rows after
+//!   a real scan of a real repository, reached through the ordinary
+//!   `scan_and_record_estate_git` path — not through a hand-built fixture.
+//! * **F7 keys the syntax extraction separately.** A blob read by the
+//!   structure extractor and by a grammar is two extractions with two keys,
+//!   both derived from the blob OID Git already computed and never from a
+//!   second hash of the same bytes.
+//! * **F8 counts honestly.** A file a grammar claims is `indexed` rather than
+//!   `unsupported`; a file nothing claims is `unsupported` and says so; a file
+//!   a grammar claimed and could not parse is `error` and contributes **no**
+//!   partial symbol list.
+//! * **A1-09: syntax, not semantics.** Every label written is one the grammar
+//!   itself produced, and an edge's target is the text the file wrote.
+//! * **F6: it runs on the intelligence lane**, over X3a's batched blobs.
+//! * **F1/ruling §4: the rows live and die with their generation.**
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::domain::source::{Coverage, KIND_SOURCE_SCANNED, estate_git_key};
+use sergeant_rs::runtime::atlas::db::AtlasDb;
+use sergeant_rs::runtime::atlas::git::{EstateGitSource, scan_estate_git};
+use sergeant_rs::runtime::atlas::lane::scan_estate_git_on_lane;
+use sergeant_rs::runtime::atlas::record::{ScanRecord, record_scan, scan_and_record_estate_git};
+use sergeant_rs::runtime::atlas::scan::{EDGE_IMPORT, KnowledgeSource, scan_local_knowledge};
+use sergeant_rs::runtime::atlas::syntax::SyntaxLanguage;
+use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+use sergeant_rs::runtime::engine::Engine;
+use sergeant_rs::runtime::git::git;
+use sergeant_rs::runtime::journal::Journal;
+
+// ---------------------------------------------------------------- fixtures
+
+/// A repository with one commit holding `files`, and its SHA.
+fn repo(files: &[(&str, &str)]) -> (TempDir, PathBuf, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mount = dir.path().join("mount");
+    std::fs::create_dir_all(&mount).expect("mkdir");
+    git(&mount, &["init", "--initial-branch=main"]).expect("init");
+    git(&mount, &["config", "user.email", "t@example.com"]).expect("email");
+    git(&mount, &["config", "user.name", "T"]).expect("name");
+    let sha = commit(&mount, files, "one");
+    (dir, mount, sha)
+}
+
+fn commit(mount: &Path, files: &[(&str, &str)], message: &str) -> String {
+    for (path, body) in files {
+        let full = mount.join(path);
+        std::fs::create_dir_all(full.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&full, body).expect("write");
+    }
+    git(mount, &["add", "-A"]).expect("add");
+    git(mount, &["commit", "-m", message]).expect("commit");
+    git(mount, &["rev-parse", "HEAD"]).expect("rev-parse")
+}
+
+fn source(mount: &Path, sha: &str) -> EstateGitSource {
+    EstateGitSource {
+        name: "product".to_string(),
+        mount: mount.to_path_buf(),
+        pinned_sha: sha.to_string(),
+        ignore: Vec::new(),
+    }
+}
+
+/// An Atlas store and a journal over one temp data dir.
+fn store(data: &Path) -> (AtlasDb, Journal) {
+    (
+        AtlasDb::open(data).expect("atlas"),
+        Journal::open(data).expect("journal"),
+    )
+}
+
+/// A small polyglot repository: one file per claimed family that has symbols
+/// to find, plus one file nothing claims.
+const POLYGLOT: &[(&str, &str)] = &[
+    (
+        "src/main.rs",
+        "use std::collections::HashMap;\n\npub struct Counter {\n    hits: u64,\n}\n\n\
+         pub fn count() -> u64 {\n    0\n}\n",
+    ),
+    (
+        "tool/run.py",
+        "import os\nfrom pathlib import Path\n\n\nclass Runner:\n    def count(self):\n        return 0\n",
+    ),
+    ("Cargo.toml", "[package]\nname = \"demo\"\n"),
+    ("README.md", "# Demo\n\nbody\n\n## Usage\n\nmore\n"),
+    (
+        "logo.png",
+        "\u{feff}not really a png but an unclaimed extension\n",
+    ),
+];
+
+/// Scan the polyglot repository and record it, returning the store, the
+/// generation id, and the mount.
+fn recorded_polyglot() -> (TempDir, TempDir, PathBuf, AtlasDb, String) {
+    let (repo_dir, mount, sha) = repo(POLYGLOT);
+    let data = tempfile::tempdir().expect("data");
+    let (mut db, mut journal) = store(data.path());
+    let (record, _) =
+        scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None)
+            .expect("record");
+    let ScanRecord::Recorded { generation_id, .. } = record else {
+        panic!("expected a recorded generation, got {record:?}");
+    };
+    (repo_dir, data, mount, db, generation_id)
+}
+
+// ------------------------------------------- the three tables and their writer
+
+/// **The whole of the empty-table doctrine for this wave**: the three tables
+/// arrive with a writer that actually fills them, through the ordinary
+/// recording path, from a real repository's Git objects.
+#[test]
+fn a_recorded_scan_writes_symbols_occurrences_and_edges() {
+    let (_repo, _data, _mount, db, _generation) = recorded_polyglot();
+
+    let symbols = db.symbols("product", 500).expect("symbols");
+    let occurrences = db.occurrences("product", 500).expect("occurrences");
+    let edges = db.edges("product", 500).expect("edges");
+    assert!(!symbols.is_empty(), "no symbol rows");
+    assert!(!occurrences.is_empty(), "no occurrence rows");
+    assert!(!edges.is_empty(), "no edge rows");
+
+    // Rust: the struct and the function, both by the grammar's own labels.
+    let rust: Vec<(&str, &str)> = occurrences
+        .iter()
+        .filter(|o| o.relative_path == "src/main.rs")
+        .map(|o| (o.label.as_str(), o.name.as_str()))
+        .collect();
+    assert_eq!(rust, vec![("struct", "Counter"), ("function", "count")]);
+
+    // Python: the class and its method are what *that* grammar names, and
+    // "method" is not invented for it — `symbol_kinds` calls a Python method a
+    // function, because the grammar does.
+    let python: Vec<(&str, &str)> = occurrences
+        .iter()
+        .filter(|o| o.relative_path == "tool/run.py")
+        .map(|o| (o.label.as_str(), o.name.as_str()))
+        .collect();
+    assert_eq!(python, vec![("class", "Runner"), ("function", "count")]);
+
+    // TOML and Markdown are claimed too, and by their own grammars.
+    assert!(
+        occurrences
+            .iter()
+            .any(|o| o.relative_path == "Cargo.toml" && o.label == "table" && o.name == "package"),
+        "{occurrences:#?}"
+    );
+    assert!(
+        occurrences
+            .iter()
+            .any(|o| o.relative_path == "README.md" && o.label == "heading" && o.name == "Demo"),
+        "{occurrences:#?}"
+    );
+
+    // Edges are imports, unresolved, exactly as written.
+    let mut targets: Vec<(&str, &str)> = edges
+        .iter()
+        .map(|e| (e.relative_path.as_str(), e.target.as_str()))
+        .collect();
+    targets.sort_unstable();
+    assert_eq!(
+        targets,
+        vec![
+            ("src/main.rs", "std::collections::HashMap"),
+            ("tool/run.py", "os"),
+            ("tool/run.py", "pathlib"),
+        ]
+    );
+    assert!(
+        edges.iter().all(|e| e.kind == EDGE_IMPORT),
+        "an edge kind this build cannot derive appeared: {edges:#?}"
+    );
+}
+
+/// A symbol row is the *index*; an occurrence row is a *site*. Two files
+/// defining `count` are one symbol with two occurrences — and that is a
+/// syntactic rollup over `(language, label, name)`, never a claim that the two
+/// sites define the same thing (A1-09).
+#[test]
+fn symbols_roll_up_the_sites_that_wrote_them() {
+    let (_repo, _data, _mount, db, _generation) = recorded_polyglot();
+    let symbols = db.symbols("product", 500).expect("symbols");
+
+    let rust_count = symbols
+        .iter()
+        .find(|s| s.language == "rust" && s.name == "count")
+        .expect("the Rust `count` function");
+    assert_eq!(rust_count.label, "function");
+    assert_eq!(rust_count.occurrences, 1);
+
+    // Python's `count` is a *different* symbol: the language is part of the
+    // identity, so two languages that happen to spell a name the same way are
+    // never merged.
+    let python_count = symbols
+        .iter()
+        .find(|s| s.language == "python" && s.name == "count")
+        .expect("the Python `count` method");
+    assert_eq!(python_count.occurrences, 1);
+
+    // Every symbol's occurrence count matches the sites actually stored.
+    let occurrences = db.occurrences("product", 500).expect("occurrences");
+    for symbol in &symbols {
+        let sites = occurrences
+            .iter()
+            .filter(|o| {
+                o.language == symbol.language && o.label == symbol.label && o.name == symbol.name
+            })
+            .count() as u64;
+        assert_eq!(
+            symbol.occurrences, sites,
+            "the index disagrees with the sites for {symbol:?}"
+        );
+    }
+}
+
+/// The same name in two files is one symbol and two sites — the property the
+/// rollup exists for, stated where a single-file fixture could not show it.
+#[test]
+fn one_name_in_two_files_is_one_symbol_and_two_occurrences() {
+    let (_repo, mount, sha) = repo(&[
+        ("a.rs", "pub fn shared() {}\n"),
+        ("b/c.rs", "pub fn shared() {}\n"),
+    ]);
+    let data = tempfile::tempdir().expect("data");
+    let (mut db, mut journal) = store(data.path());
+    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+
+    let symbols = db.symbols("product", 100).expect("symbols");
+    let shared: Vec<_> = symbols.iter().filter(|s| s.name == "shared").collect();
+    assert_eq!(shared.len(), 1, "{symbols:#?}");
+    assert_eq!(shared[0].occurrences, 2);
+
+    let sites: BTreeSet<String> = db
+        .occurrences("product", 100)
+        .expect("occurrences")
+        .into_iter()
+        .filter(|o| o.name == "shared")
+        .map(|o| o.relative_path)
+        .collect();
+    assert_eq!(
+        sites,
+        BTreeSet::from(["a.rs".to_string(), "b/c.rs".to_string()])
+    );
+}
+
+// ----------------------------------------------------------- F7, the keys
+
+/// **F7 on the syntax half.** The key is the blob OID Git already computed,
+/// composed with the *grammar's* identity — a second, separate extraction of
+/// the same bytes, with a key of its own. Never a second hash of the blob.
+#[test]
+fn the_syntax_extraction_is_keyed_on_the_blob_oid_and_the_grammar() {
+    let (_repo, _data, mount, db, _generation) = recorded_polyglot();
+    let oid = git(&mount, &["rev-parse", "HEAD:README.md"]).expect("rev-parse");
+
+    let readme = db
+        .occurrences("product", 500)
+        .expect("occurrences")
+        .into_iter()
+        .find(|o| o.relative_path == "README.md")
+        .expect("a README occurrence");
+    assert_eq!(
+        readme.extractor,
+        SyntaxLanguage::Markdown.extractor_identity()
+    );
+    assert_eq!(
+        readme.syntax_key,
+        estate_git_key(&oid, &SyntaxLanguage::Markdown.extractor_identity()),
+        "the syntax key is the blob OID composed with the grammar's identity"
+    );
+
+    // And the structure extraction of the *same blob* has a different key,
+    // because it is a different extraction (F7's second input).
+    assert_ne!(
+        readme.syntax_key,
+        estate_git_key(&oid, MARKDOWN_EXTRACTOR),
+        "one blob read by two extractors must not share one key"
+    );
+    let units = db.units("product", 500).expect("units");
+    let unit = units
+        .iter()
+        .find(|u| u.relative_path == "README.md")
+        .expect("a README unit");
+    assert_eq!(unit.local_key, estate_git_key(&oid, MARKDOWN_EXTRACTOR));
+    assert_ne!(unit.local_key, readme.syntax_key);
+}
+
+/// The local key space is the one a filesystem source uses, and the same
+/// separation holds there — the shared extractor cannot blur the two spaces.
+#[test]
+fn a_local_knowledge_scan_keys_its_syntax_extraction_locally() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("lib.py"), "def only():\n    return 1\n").expect("write");
+    let scan = scan_local_knowledge(&KnowledgeSource {
+        name: "notes".to_string(),
+        root: dir.path().to_path_buf(),
+        ignore: Vec::new(),
+    })
+    .expect("scan");
+
+    let file = &scan.files[0];
+    let syntax = file.syntax.as_ref().expect("python is claimed");
+    assert_eq!(syntax.language, "python");
+    assert_eq!(
+        syntax.syntax_key,
+        sergeant_rs::domain::source::local_key(&file.content_hash, &syntax.extractor)
+    );
+    assert_ne!(
+        syntax.syntax_key,
+        estate_git_key(&file.content_hash, &syntax.extractor),
+        "the two key spaces are domain-separated"
+    );
+    assert_eq!(syntax.symbols.len(), 1);
+    assert_eq!(syntax.symbols[0].name, "only");
+}
+
+// -------------------------------------------------------- F8, honest counts
+
+/// F8, both directions at once: a file a grammar claims stops being
+/// `unsupported` and becomes `indexed`, and a file **nothing** claims is still
+/// `unsupported` — named as such, and counted.
+#[test]
+fn a_claimed_language_is_indexed_and_an_unclaimed_one_is_still_counted() {
+    let (_repo, _data, _mount, db, _generation) = recorded_polyglot();
+    let coverage = db.coverage("product", 500).expect("coverage");
+    let status = |path: &str| {
+        coverage
+            .iter()
+            .find(|c| c.row.path.as_deref() == Some(path))
+            .unwrap_or_else(|| panic!("no coverage row for {path}"))
+            .clone()
+    };
+
+    // X3a reported `src/main.rs` unsupported, because no extractor claimed
+    // `.rs`. A grammar claims it now, and the honest answer changed with it.
+    assert_eq!(status("src/main.rs").row.status, Coverage::Indexed);
+    assert_eq!(status("Cargo.toml").row.status, Coverage::Indexed);
+    assert_eq!(status("tool/run.py").row.status, Coverage::Indexed);
+
+    // The detail names *both* extractors that produced rows, so "which parser
+    // produced this?" is answerable from coverage alone (A1 §3).
+    let detail = status("src/main.rs").row.detail.expect("detail");
+    assert!(detail.contains("text/v1"), "{detail}");
+    assert!(
+        detail.contains(&SyntaxLanguage::Rust.extractor_identity()),
+        "{detail}"
+    );
+
+    // And nothing became indexed by accident.
+    let unclaimed = status("logo.png");
+    assert_eq!(unclaimed.row.status, Coverage::Unsupported);
+    let detail = unclaimed.row.detail.expect("detail");
+    assert!(detail.contains("grammar"), "{detail}");
+
+    let counts = db.coverage_counts("product").expect("counts");
+    assert_eq!(counts.get(Coverage::Indexed.as_str()), Some(&4));
+    assert_eq!(counts.get(Coverage::Unsupported.as_str()), Some(&1));
+}
+
+/// `.tsx` is the honest gap the spike named: this build has the TypeScript
+/// grammar and not the TSX one, so a `.tsx` file is `unsupported` rather than
+/// parsed by an almost-right grammar.
+#[test]
+fn a_language_this_build_does_not_claim_is_unsupported_not_almost_parsed() {
+    let (_repo, mount, sha) = repo(&[
+        ("app.tsx", "export function App() { return null; }\n"),
+        ("app.ts", "export function App(): null { return null; }\n"),
+    ]);
+    let data = tempfile::tempdir().expect("data");
+    let (mut db, mut journal) = store(data.path());
+    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+
+    let coverage = db.coverage("product", 100).expect("coverage");
+    let tsx = coverage
+        .iter()
+        .find(|c| c.row.path.as_deref() == Some("app.tsx"))
+        .expect("a tsx row");
+    assert_eq!(tsx.row.status, Coverage::Unsupported);
+    assert!(
+        !db.occurrences("product", 100)
+            .expect("occurrences")
+            .iter()
+            .any(|o| o.relative_path == "app.tsx"),
+        "an unclaimed language produced symbols anyway"
+    );
+    // The claimed sibling did index, so the refusal is about the grammar and
+    // not about the fixture.
+    assert!(
+        db.occurrences("product", 100)
+            .expect("occurrences")
+            .iter()
+            .any(|o| o.relative_path == "app.ts" && o.name == "App")
+    );
+}
+
+/// A parse failure is an `error` coverage row and **no partial symbols** — the
+/// spike's refusal, carried through the wiring. The structure units the other
+/// extractor produced survive, because they are real evidence about real
+/// bytes; what is never written is a shorter symbol list nothing can
+/// distinguish from a complete one.
+#[test]
+fn a_file_a_grammar_cannot_parse_is_an_error_row_with_no_partial_symbols() {
+    let (_repo, mount, sha) = repo(&[
+        ("good.rs", "pub fn fine() {}\n"),
+        ("broken.rs", "pub fn ok() {}\npub fn broken( {\n"),
+    ]);
+    let data = tempfile::tempdir().expect("data");
+    let (mut db, mut journal) = store(data.path());
+    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+
+    let coverage = db.coverage("product", 100).expect("coverage");
+    let broken = coverage
+        .iter()
+        .find(|c| c.row.path.as_deref() == Some("broken.rs"))
+        .expect("a broken.rs row");
+    assert_eq!(broken.row.status, Coverage::Error);
+    let detail = broken.row.detail.clone().expect("detail");
+    assert!(detail.contains("parse failed"), "{detail}");
+    assert!(
+        detail.contains(&SyntaxLanguage::Rust.extractor_identity()),
+        "the failing extractor is named: {detail}"
+    );
+
+    let occurrences = db.occurrences("product", 100).expect("occurrences");
+    assert!(
+        !occurrences.iter().any(|o| o.relative_path == "broken.rs"),
+        "a failed parse wrote a partial symbol list: {occurrences:#?}"
+    );
+    assert!(
+        occurrences.iter().any(|o| o.relative_path == "good.rs"),
+        "one bad file stopped a good one from indexing"
+    );
+    // The bytes were still acquired and their structure unit written: the
+    // failure is one extractor's, not the resource's.
+    assert!(
+        db.units("product", 100)
+            .expect("units")
+            .iter()
+            .any(|u| u.relative_path == "broken.rs")
+    );
+
+    // And the journal summary names only extractors that produced rows.
+    let extractors: BTreeSet<String> = journal
+        .replay_from_floor()
+        .expect("replay")
+        .filter_map(Result::ok)
+        .filter(|e| e.kind == KIND_SOURCE_SCANNED)
+        .flat_map(|e| {
+            e.payload["extractors"]
+                .as_array()
+                .expect("extractors")
+                .iter()
+                .map(|v| v.as_str().expect("string").to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    assert!(extractors.contains(&SyntaxLanguage::Rust.extractor_identity()));
+}
+
+/// The journal summary carries the new counts, so "how much was derived?" is
+/// answerable from the trail and not only from the database (F1).
+#[test]
+fn the_scan_summary_counts_symbols_and_edges() {
+    let (_repo, mount, sha) = repo(POLYGLOT);
+    let data = tempfile::tempdir().expect("data");
+    let (mut db, mut journal) = store(data.path());
+    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+
+    let summary = journal
+        .replay_from_floor()
+        .expect("replay")
+        .filter_map(Result::ok)
+        .find(|e| e.kind == KIND_SOURCE_SCANNED)
+        .expect("a summary");
+    let symbols = summary.payload["symbols"].as_u64().expect("symbols");
+    let edges = summary.payload["edges"].as_u64().expect("edges");
+    assert_eq!(
+        symbols,
+        db.occurrences("product", 500).expect("occurrences").len() as u64
+    );
+    assert_eq!(edges, db.edges("product", 500).expect("edges").len() as u64);
+}
+
+// ---------------------------------------------------------- A1-09, syntax only
+
+/// Every label written is one a grammar's own symbol table produced. Nothing
+/// resolves, classifies, or infers — so the set of labels in the store is a
+/// subset of the set the extractor can emit, checked rather than asserted in
+/// prose.
+#[test]
+fn every_label_written_is_one_a_grammar_produced() {
+    let (_repo, _data, _mount, db, _generation) = recorded_polyglot();
+    let allowed: BTreeSet<&'static str> = SyntaxLanguage::ALL
+        .iter()
+        .flat_map(|language| language.labels())
+        .collect();
+    for occurrence in db.occurrences("product", 500).expect("occurrences") {
+        assert!(
+            allowed.contains(occurrence.label.as_str()),
+            "label {:?} is not one any grammar in this build emits",
+            occurrence.label
+        );
+    }
+    for symbol in db.symbols("product", 500).expect("symbols") {
+        assert!(allowed.contains(symbol.label.as_str()), "{symbol:?}");
+    }
+}
+
+// ------------------------------------------------ F6, on the intelligence lane
+
+/// F6: the extraction that now produces symbols is the same one X3a put on the
+/// intelligence lane — it did not quietly acquire a second path to run on.
+#[tokio::test]
+async fn extraction_on_the_intelligence_lane_produces_the_same_symbols() {
+    let (_repo, mount, sha) = repo(POLYGLOT);
+    let data = tempfile::tempdir().expect("data");
+    let engine = Engine::new(Arc::new(BackendRegistry::new()), None, data.path())
+        .with_intelligence_lane_cap(2);
+    let src = source(&mount, &sha);
+
+    let direct = scan_estate_git(&src).expect("direct");
+    let on_lane = scan_estate_git_on_lane(&engine, src.clone())
+        .await
+        .expect("on the lane");
+    assert_eq!(on_lane.scan.files, direct.scan.files);
+    assert!(
+        on_lane.scan.symbol_count() > 0,
+        "the lane's consumer produced no symbols"
+    );
+    assert_eq!(on_lane.scan.symbol_count(), direct.scan.symbol_count());
+    assert_eq!(on_lane.scan.edge_count(), direct.scan.edge_count());
+    assert_eq!(
+        engine.intelligence_lane.available_permits(),
+        2,
+        "the permit was not returned"
+    );
+
+    // And the rows the lane's scan produces record exactly as the direct one's
+    // do — one writer, whichever route the scan took.
+    let (mut db, mut journal) = store(data.path());
+    record_scan(&mut db, &mut journal, &on_lane.scan, None).expect("record");
+    assert!(!db.symbols("product", 500).expect("symbols").is_empty());
+}
+
+// ------------------------------------- F1 / ruling §4, the generation lifetime
+
+/// Derived syntax rows are a generation's, and an eviction takes them with it —
+/// no orphan symbols outliving the world they describe.
+#[test]
+fn evicting_a_generation_takes_its_syntax_rows_with_it() {
+    let (_repo, mount, sha) = repo(&[("a.rs", "pub fn first() {}\n")]);
+    let data = tempfile::tempdir().expect("data");
+    let (mut db, mut journal) = store(data.path());
+    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+    assert_eq!(db.symbols("product", 100).expect("symbols").len(), 1);
+
+    // A second commit changes the bytes, so ruling §4 evicts the predecessor.
+    let next = commit(&mount, &[("a.rs", "pub fn second() {}\n")], "two");
+    let (record, _) =
+        scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &next), None)
+            .expect("record");
+    let ScanRecord::Recorded { evicted, .. } = record else {
+        panic!("expected a recorded generation, got {record:?}");
+    };
+    assert!(evicted.is_some(), "the predecessor was not superseded");
+
+    let names: Vec<String> = db
+        .symbols("product", 100)
+        .expect("symbols")
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+    assert_eq!(
+        names,
+        vec!["second".to_string()],
+        "an evicted symbol survived"
+    );
+    assert_eq!(
+        db.occurrences("product", 100).expect("occurrences").len(),
+        1
+    );
+    assert!(
+        db.edges("product", 100).expect("edges").is_empty(),
+        "no imports were written in either commit"
+    );
+}
+
+/// F1's persistence rule, extended to this wave's rows: a symbol derived
+/// before a restart is still there after one. Atlas's file is not a
+/// projection, and these rows are not re-foldable from the journal.
+#[test]
+fn syntax_rows_survive_reopening_the_store() {
+    let (_repo, mount, sha) = repo(&[("a.rs", "use std::io;\npub fn kept() {}\n")]);
+    let data = tempfile::tempdir().expect("data");
+    {
+        let (mut db, mut journal) = store(data.path());
+        scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None)
+            .expect("record");
+    }
+    let db = AtlasDb::open(data.path()).expect("reopen");
+    let symbols = db.symbols("product", 100).expect("symbols");
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "kept");
+    assert_eq!(
+        db.edges("product", 100).expect("edges")[0].target,
+        "std::io"
+    );
+}
+
+/// F12: every read of these tables is bounded, and a caller cannot ask for
+/// "all".
+#[test]
+fn every_syntax_read_is_bounded() {
+    let (_repo, _data, _mount, db, _generation) = recorded_polyglot();
+    assert_eq!(db.symbols("product", 1).expect("symbols").len(), 1);
+    assert_eq!(db.occurrences("product", 2).expect("occurrences").len(), 2);
+    assert!(db.edges("product", 1).expect("edges").len() <= 1);
+    // And an absurd request is capped rather than honoured.
+    assert!(
+        db.occurrences("product", usize::MAX)
+            .expect("occurrences")
+            .len()
+            <= sergeant_rs::runtime::atlas::db::MAX_ROWS
+    );
+}

--- a/tests/x3b_tslp_corpus.rs
+++ b/tests/x3b_tslp_corpus.rs
@@ -1,0 +1,232 @@
+//! F5 criterion (b) — the fixture corpus gate.
+//!
+//! A checked-in multi-language corpus (Rust, TOML, Markdown, Python, JS, TS,
+//! shell) with **hand-verified** symbol and import counts in
+//! `tests/fixtures/tslp_corpus/manifest.toml`. Pass is EXACT match per
+//! fixture — counts, ordered names, ordered labels, ordered import targets.
+//!
+//! Three properties this suite exists to keep true, each of which the obvious
+//! lazy version of it would lose:
+//!
+//! 1. **A parse error is a FAIL, not a skip.** No `SKIPPED-ENV` escape hatch
+//!    exists here and none may be added: nothing about parsing bytes depends
+//!    on the two environments CONTRIBUTING's two-environment rule is about
+//!    (no permission bits, no filesystem behaviour, no network), so a failure
+//!    here is a real failure on any runner.
+//! 2. **Exact, not "at least".** A `>=` assertion passes for an extractor
+//!    that silently found half the symbols, which is precisely the silent
+//!    partial parse F5 forbids.
+//! 3. **The malformed fixtures must still error.** Otherwise property 1 is
+//!    unfalsifiable — a corpus of only-valid files would pass against an
+//!    extractor whose error detection never fires.
+
+use std::path::{Path, PathBuf};
+
+use sergeant_rs::runtime::atlas::syntax::{self, SyntaxError, SyntaxLanguage};
+
+#[derive(serde::Deserialize)]
+struct Manifest {
+    fixture: Vec<Fixture>,
+    malformed: Vec<Malformed>,
+}
+
+#[derive(serde::Deserialize)]
+struct Fixture {
+    path: String,
+    language: String,
+    symbols: usize,
+    imports: usize,
+    symbol_names: Vec<String>,
+    symbol_labels: Vec<String>,
+    import_targets: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct Malformed {
+    path: String,
+    language: String,
+}
+
+fn corpus_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/tslp_corpus")
+}
+
+fn manifest() -> Manifest {
+    let path = corpus_root().join("manifest.toml");
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    toml::from_str(&text).unwrap_or_else(|e| panic!("parsing {}: {e}", path.display()))
+}
+
+fn language(name: &str) -> SyntaxLanguage {
+    SyntaxLanguage::ALL
+        .iter()
+        .copied()
+        .find(|l| l.name() == name)
+        .unwrap_or_else(|| panic!("manifest names an unclaimed language: {name}"))
+}
+
+#[test]
+fn the_corpus_covers_every_language_this_build_claims() {
+    let manifest = manifest();
+    let mut covered: Vec<&str> = manifest
+        .fixture
+        .iter()
+        .map(|f| language(&f.language).name())
+        .collect();
+    covered.sort_unstable();
+    covered.dedup();
+
+    let mut claimed: Vec<&str> = SyntaxLanguage::ALL.iter().map(|l| l.name()).collect();
+    claimed.sort_unstable();
+
+    assert_eq!(
+        covered, claimed,
+        "every language `SyntaxLanguage::ALL` claims needs a corpus fixture — \
+         an unfixtured language is a claim nothing checks"
+    );
+}
+
+#[test]
+fn every_fixture_matches_its_hand_verified_counts_exactly() {
+    let manifest = manifest();
+    assert!(
+        !manifest.fixture.is_empty(),
+        "the manifest lists no fixtures"
+    );
+
+    for fixture in &manifest.fixture {
+        let path = corpus_root().join(&fixture.path);
+        let bytes =
+            std::fs::read(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+        let language = language(&fixture.language);
+
+        // Routing is part of the claim: a fixture the extractor would never
+        // be handed is not evidence that the extractor works.
+        assert_eq!(
+            syntax::language_for(&fixture.path),
+            Some(language),
+            "{} routes to the wrong language",
+            fixture.path
+        );
+
+        // A parse error here is a FAIL, and this is the line that makes it
+        // one — `expect` rather than a `continue`.
+        let facts = syntax::extract(language, &bytes).unwrap_or_else(|e| {
+            panic!(
+                "{} must parse cleanly — F5 forbids a partial parse: {e}",
+                fixture.path
+            )
+        });
+
+        let names: Vec<String> = facts.symbols.iter().map(|s| s.name.clone()).collect();
+        let labels: Vec<String> = facts.symbols.iter().map(|s| s.label.to_string()).collect();
+        let targets: Vec<String> = facts.imports.iter().map(|i| i.target.clone()).collect();
+
+        assert_eq!(
+            names, fixture.symbol_names,
+            "{}: symbol names differ from the hand-verified list",
+            fixture.path
+        );
+        assert_eq!(
+            labels, fixture.symbol_labels,
+            "{}: symbol labels differ from the hand-verified list",
+            fixture.path
+        );
+        assert_eq!(
+            targets, fixture.import_targets,
+            "{}: import targets differ from the hand-verified list",
+            fixture.path
+        );
+
+        // The counts the manifest states in their own right, so a manifest
+        // whose list and count disagree fails rather than half-checking.
+        assert_eq!(
+            facts.symbols.len(),
+            fixture.symbols,
+            "{}: symbol COUNT differs",
+            fixture.path
+        );
+        assert_eq!(
+            facts.imports.len(),
+            fixture.imports,
+            "{}: import COUNT differs",
+            fixture.path
+        );
+        assert_eq!(
+            fixture.symbol_names.len(),
+            fixture.symbols,
+            "{}: the manifest's own name list and count disagree",
+            fixture.path
+        );
+        assert_eq!(
+            fixture.symbol_labels.len(),
+            fixture.symbols,
+            "{}: the manifest's own label list and count disagree",
+            fixture.path
+        );
+        assert_eq!(
+            fixture.import_targets.len(),
+            fixture.imports,
+            "{}: the manifest's own target list and count disagree",
+            fixture.path
+        );
+    }
+}
+
+#[test]
+fn every_symbol_and_import_slices_back_out_of_the_original_bytes() {
+    for fixture in &manifest().fixture {
+        let path = corpus_root().join(&fixture.path);
+        let bytes = std::fs::read(&path).expect("fixture readable");
+        let facts = syntax::extract(language(&fixture.language), &bytes).expect("parses");
+
+        for symbol in &facts.symbols {
+            let slice = bytes
+                .get(symbol.byte_start..symbol.byte_end)
+                .unwrap_or_else(|| {
+                    panic!("{}: {} has an out-of-range span", fixture.path, symbol.name)
+                });
+            let slice = std::str::from_utf8(slice).expect("span is UTF-8");
+            assert!(
+                slice.contains(symbol.name.as_str()),
+                "{}: the span for {} does not contain its own name — provenance is broken",
+                fixture.path,
+                symbol.name
+            );
+        }
+        for import in &facts.imports {
+            let slice = bytes
+                .get(import.byte_start..import.byte_end)
+                .unwrap_or_else(|| panic!("{}: import span out of range", fixture.path));
+            let slice = std::str::from_utf8(slice).expect("span is UTF-8");
+            assert!(
+                slice.contains(import.target.as_str()),
+                "{}: the span for import {} does not contain its own target",
+                fixture.path,
+                import.target
+            );
+        }
+    }
+}
+
+#[test]
+fn malformed_fixtures_error_rather_than_returning_a_partial_parse() {
+    let manifest = manifest();
+    assert!(
+        !manifest.malformed.is_empty(),
+        "without a malformed fixture, the clean-parse assertion above is unfalsifiable"
+    );
+
+    for malformed in &manifest.malformed {
+        let path = corpus_root().join(&malformed.path);
+        let bytes =
+            std::fs::read(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+        let error = syntax::extract(language(&malformed.language), &bytes).unwrap_err();
+        assert!(
+            matches!(error, SyntaxError::Parse { .. }),
+            "{} should fail as a parse error, got {error:?}",
+            malformed.path
+        );
+    }
+}


### PR DESCRIPTION
Wave X3b of S3 (Atlas core) — the spike half of the panel-split X3. Plan: workspace `host-atlas-s3-series/sprint-plan-2026-08-27.md` (amended); F5 = J2 adoption against pre-agreed criteria (ruling 6).

**F5 spike, in order, all PASS (adopted):**
- **(a) Deny gate FIRST** (commit order proves it — `8a68c4a0` touches only Cargo.toml/lock + evidence, before any extraction code): 8 crates.io MIT crates (tree-sitter 0.26.13 + rust/toml-ng/md/python/js-ts/bash grammars), cargo-deny green.
- **(b) Fixture corpus**: multi-language corpus with hand-verified symbol/import counts written BEFORE first execution; exact-match assertions, parse error = fail; first run matched with no manifest adjustment.
- **(c) Footprint**: measured solo both legs — +2s cold build (+1.5%), **+5.36 MiB linked debug binary (+2.16%)** — the naive +118 KiB was a linker artifact (grammar objects dropped while unreferenced; corrected by forced-reference measurement). Evidence: workspace `knowledge/evidence/perf/tslp-footprint-delta-2026-08-27.md`. Feeds X5's F4 combined-delta rule.
- **(d)** `rust-version` 1.89 → 1.98.0 (A1-27). Side-effect: the msrv CI job now duplicates the pin — recorded as #319, not acted on in-wave.

**Wiring:** `source.symbols/occurrences/edges` DDL + writer land together (empty-table doctrine); syntax-derived labels only (A1-09), versioned extractor identity (`syntax-<lang>/v1`) in every F7 key so a grammar bump stages a new generation and eviction sweeps all three tables; pure-function extractors over bytes joined onto X3a's batched-blob/lane-permit plumbing; strict UTF-8 + `has_error()` rejection (no partial rows); `.tsx` honestly `unsupported`, `.jsx` claimed-but-error documented (aria seat).

Gates: wave workflow wf_f8301aea — 8 panel findings, 4 confirmed, fixed (incl. a real silent-drop bug: `import os, sys` yielded one edge); the fix agent's stream died mid-response and the verify gate absorbed, cleaned, and committed its completed work (`1d91f606` — aria independently confirmed nothing half-finished landed); verify green (nextest 2043/2043, clippy/fmt, cargo-deny). Aria seat SOUND (independently re-ran 18/18 corpus + 32/32 affected suites); both findings dispositioned (#319; doc commit). Rung citations in commit bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4