### PR TITLE
S4 Y1 — Supervised parse-worker transport: daemon-side validation authority, memory cap, doctor read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,6 +400,54 @@ release.
   community extensions are turned off and locked off on every connection, so
   reading a dataset can never become a network fetch.
 
+### Supervised parse workers (S4)
+
+- Third-party document parsing moves out of the daemon and into supervised
+  child processes: a worker takes bytes and returns a normalized batch, and
+  the daemon remains the only writer Atlas has. The adapters themselves did
+  not change shape — they were already pure functions over bytes — so this
+  is a transport boundary, not a new architecture.
+- **The daemon's validation of a returned batch is the authority, not a
+  formality.** Every batch is re-checked before a row is written: the
+  identity triple (source generation, resource hash, extractor identity),
+  path safety for every child resource the worker declares (the same
+  containment rule an archive entry gets), and the secrets deny set matched
+  on the declared *name* as well as the path. A worker that declares a child
+  called `.env`, or one whose path escapes its parent, is refused with a
+  named coverage row rather than trusted. The worker's own checks are
+  defence in depth; they are not what the store relies on.
+- Every worker spawn carries the child-lifetime discipline the probe leak
+  established (its own process group, `PDEATHSIG`, a bounded deadline, and
+  kill-plus-reap on *every* exit path, not only the timeout one), and runs
+  under an intelligence-lane permit that is released even when the child
+  panics or is killed.
+- **A memory bound, because a deadline is a hang guard and not a memory
+  guard.** On Linux each worker is spawned under an `RLIMIT_AS` address-space
+  cap, so a child that allocates without bound dies by its own limit instead
+  of raising host-wide memory pressure and letting the kernel's OOM killer
+  choose a victim — which, on the machine this was developed on, repeatedly
+  meant the session manager rather than the process actually at fault. The
+  cap composes with the existing process hardening rather than replacing it,
+  and the child cannot raise its own ceiling before `exec`.
+  - **Platform honesty:** this is a Linux mechanism. On macOS the worker is
+    still supervised, still deadline-bounded, and still killed and reaped —
+    but no memory containment is claimed there, and the module says so
+    rather than implying the guarantee is universal.
+  - **Number honesty:** the 512 MiB ceiling is provisional and unmeasured.
+    No real parser ships yet, so there was no corpus to size it against; it
+    must be re-derived once one lands. The effective host ceiling is that
+    figure multiplied by the intelligence lane's concurrency cap, not the
+    per-child number alone.
+  - A memory kill is reported as its own named fault when the evidence
+    supports it, matching a deliberately narrow set of real allocator
+    failure signatures. When it cannot be attributed that precisely, the
+    fault is still reported honestly as a worker failure — never absorbed,
+    and never relabelled as a timeout.
+- `sgt doctor`'s `atlas` row now opens the store read-only: it creates no
+  database file and runs no schema statements to report on one. The row's
+  behaviour is otherwise unchanged — it still checks for the file first, and
+  still defers to the daemon when a running daemon holds the store.
+
 ### Atlas closeout (S3)
 
 - `docs/concepts/atlas-and-knowledge.md` documents Atlas for operators: what

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,20 @@ description = "Local execution surface for coding agents: durable work, isolated
 name = "sgt"
 path = "src/main.rs"
 
+# S4 Y1 (G2): the supervised parse-worker's own binary. `worker.rs`'s
+# transport spawns this — never `sgt` itself — as a child, over a
+# `program: PathBuf` the caller names explicitly (`std::env::current_exe()`
+# in the daemon, `env!("CARGO_BIN_EXE_sgt-atlas-worker")` in tests), so
+# neither surface has to guess the other's path. Y1 ships the transport plus
+# a trivial, honestly-labeled body (one Document unit for UTF-8 input) and
+# the test-only `--fault` fixture modes the supervision acceptance needs;
+# Y2 replaces the body with the real Anydoc adapter behind the same CLI
+# contract, which is why this is a real `[[bin]]` rather than a
+# `tests/`-only helper.
+[[bin]]
+name = "sgt-atlas-worker"
+path = "src/bin/atlas_worker.rs"
+
 [dependencies]
 axum = "0.8"
 blake3 = "1.8.6"

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -106,3 +106,21 @@ cov_stage_begin c3-x2_knowledge_sources
 cov_run cargo llvm-cov --no-report --test x2_knowledge_sources --locked || cov_fail "x2_knowledge_sources failed under instrumentation"
 cov_stage_end 2 "x2_knowledge_sources spawns real sgt clients and starts real daemons; more than \
 the test binary's own profile must arrive, or no subprocess flushed"
+
+# S4 Y1, wired at birth (the #231 lesson, same as m12/x2 above): every test
+# in this suite spawns a real `sgt-atlas-worker` subprocess — a second real
+# `[[bin]]` target this package builds, not a shell-script stand-in — so it
+# belongs beside the other real-process suites, not in C2's no-subprocess
+# bucket. Floor 2, not higher: the fault-injection cases (abort/hang/
+# allocate) are killed by SIGABRT or SIGKILL by design and legitimately flush
+# no profile of their own (the same fact v1d_probe_child_lifecycle's own
+# comment above states for a SIGKILLed daemon), but the happy-path and
+# batch-refusal cases spawn a worker that exits 0 normally and must flush —
+# more than the test binary's own profile must arrive, or no subprocess
+# flushed.
+cov_stage_begin c3-y1_worker_transport
+cov_run cargo llvm-cov --no-report --test y1_worker_transport --locked || cov_fail "y1_worker_transport failed under instrumentation"
+cov_stage_end 2 "y1_worker_transport spawns real sgt-atlas-worker subprocesses in its happy-path \
+and batch-refusal cases; more than the test binary's own profile must arrive, or no subprocess \
+flushed (the abort/hang/allocate fault cases are expected to flush nothing, by the same logic \
+v1d's SIGKILLed daemons do not)"

--- a/src/bin/atlas_worker.rs
+++ b/src/bin/atlas_worker.rs
@@ -1,0 +1,188 @@
+//! `sgt-atlas-worker` — the supervised parse-worker binary (S4 Y1, G2).
+//!
+//! Spawned by [`sergeant_rs::runtime::atlas::worker::run_worker`], never run
+//! directly by an operator: reads the resource bytes to extract from stdin,
+//! writes a [`WorkerBatch`] as JSON to stdout, and exits zero. Never opens
+//! Atlas's store — the daemon is the sole writer, and this process has no
+//! path to that database at all, which is what makes "a worker never opens
+//! the store" true structurally rather than by convention.
+//!
+//! # Y1's body is a seam, not a placeholder to delete
+//!
+//! No third-party parser exists until Y2's Anydoc spike, so the normal path
+//! below is deliberately trivial — one [`UnitKind::Document`] unit for
+//! UTF-8 input, none for anything else — while still exercising every real
+//! part of the wire contract (identity fields, declared children) that a
+//! Y2+ adapter will fill in for real. The CLI surface (bytes on stdin, a
+//! [`WorkerBatch`] on stdout, `--generation`/`--extractor` naming the job) is
+//! meant to outlive Y1; only the extraction inside `normal_batch` is meant to
+//! be replaced.
+//!
+//! # `--fault`: the test-only fixture modes Y1's acceptance needs
+//!
+//! Real OS-process behavior — a `SIGABRT`, a process that never exits, a
+//! non-zero exit, unbounded allocation — cannot be produced by an in-process
+//! fake, because the whole point of Y1's acceptance is proving the
+//! **daemon's** supervision of a **real, separate process**. `--fault` is
+//! how the test suite asks this binary to misbehave on purpose; it is
+//! reachable from any caller (an operator invoking it directly gets the same
+//! four modes), which is the honest alternative to a cfg(test)-only code
+//! path that would make the fixture behavior invisible to `cargo build`'s
+//! own compile check.
+
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use clap::Parser;
+
+use sergeant_rs::domain::source::UnitKind;
+use sergeant_rs::runtime::atlas::worker::{DeclaredChild, WorkerBatch, WorkerUnit};
+
+/// One process-level misbehavior this binary can perform on command, in
+/// place of producing a batch — Y1's fault-injection acceptance (brief item
+/// 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum Fault {
+    /// Terminate itself with `SIGABRT` before producing any output.
+    Abort,
+    /// Never exit on its own — the caller's deadline and kill+reap are what
+    /// end this.
+    Hang,
+    /// Exit immediately with a non-zero status.
+    ExitNonzero,
+    /// Allocate and touch memory in a growing, paced loop, forever — the
+    /// caller's deadline is what ends this, exactly as [`Fault::Hang`], but
+    /// exercising the same kill path under memory pressure instead of an
+    /// idle sleep.
+    Allocate,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "sgt-atlas-worker",
+    about = "sergeant-rs's supervised parse-worker binary — spawned by the daemon, not run by \
+             hand"
+)]
+struct Args {
+    /// The generation this job is extracting for — echoed into the batch's
+    /// identity untouched.
+    #[arg(long)]
+    generation: String,
+    /// The extractor identity this job was dispatched to run — echoed into
+    /// the batch's identity untouched.
+    #[arg(long)]
+    extractor: String,
+    /// Declare a child resource in the returned batch, `NAME=RELATIVE/PATH`.
+    /// Repeatable. Test-only: Y1 has no real container adapter that would
+    /// populate this on its own, so the acceptance suite uses it to hand the
+    /// daemon-side validator both safe and deliberately unsafe/denied
+    /// declarations.
+    #[arg(long = "declare-child", value_parser = parse_declared_child)]
+    declared_children: Vec<DeclaredChild>,
+    /// Misbehave instead of producing a batch (test-only fixture mode).
+    #[arg(long)]
+    fault: Option<Fault>,
+}
+
+fn parse_declared_child(raw: &str) -> Result<DeclaredChild, String> {
+    let (name, path) = raw
+        .split_once('=')
+        .ok_or_else(|| format!("{raw:?} is not NAME=PATH"))?;
+    Ok(DeclaredChild {
+        name: name.to_string(),
+        relative_path: path.to_string(),
+    })
+}
+
+fn main() -> std::process::ExitCode {
+    let args = Args::parse();
+
+    if let Some(fault) = args.fault {
+        run_fault(fault);
+    }
+
+    let mut input = Vec::new();
+    if let Err(e) = std::io::stdin().read_to_end(&mut input) {
+        eprintln!("sgt-atlas-worker: could not read stdin: {e}");
+        return std::process::ExitCode::FAILURE;
+    }
+
+    let batch = normal_batch(&args, &input);
+    let Ok(json) = serde_json::to_vec(&batch) else {
+        eprintln!("sgt-atlas-worker: could not serialize its own batch");
+        return std::process::ExitCode::FAILURE;
+    };
+    if let Err(e) = std::io::stdout().write_all(&json) {
+        eprintln!("sgt-atlas-worker: could not write stdout: {e}");
+        return std::process::ExitCode::FAILURE;
+    }
+    std::process::ExitCode::SUCCESS
+}
+
+/// Y1's trivial, honestly-labeled body: one [`UnitKind::Document`] unit
+/// spanning the whole input when it decodes as UTF-8, no units when it does
+/// not. `resource_hash` is computed here, independently of anything the
+/// daemon sent — the whole point of [`sergeant_rs::runtime::atlas::worker::validate_batch`]
+/// is that the daemon never simply trusts this value back.
+fn normal_batch(args: &Args, input: &[u8]) -> WorkerBatch {
+    let resource_hash = blake3::hash(input).to_hex().to_string();
+    let units = match std::str::from_utf8(input) {
+        Ok(text) => vec![WorkerUnit {
+            kind: UnitKind::Document,
+            byte_start: 0,
+            byte_end: input.len() as u64,
+            text: text.to_string(),
+        }],
+        Err(_) => Vec::new(),
+    };
+    WorkerBatch {
+        generation_id: args.generation.clone(),
+        resource_hash,
+        extractor: args.extractor.clone(),
+        units,
+        declared_children: args.declared_children.clone(),
+    }
+}
+
+/// Perform one fixture fault and end the process — every arm ends this
+/// process itself, by signal, by exit, or by never returning, which is why
+/// this is typed `-> !` rather than merely never being followed by more
+/// code at its one call site.
+fn run_fault(fault: Fault) -> ! {
+    match fault {
+        Fault::Abort => {
+            // `libc::abort` raises `SIGABRT` against this process — present
+            // and behaving identically on every platform this crate builds
+            // for (it is ISO C, not a Linux-only `prctl`-shaped mechanism),
+            // so this fixture needs no `#[cfg(unix)]` of its own.
+            unsafe { libc::abort() }
+        }
+        Fault::Hang => loop {
+            // Un-catchable by design: the caller's `SIGKILL` (via
+            // `kill_process_group`, past its deadline) is what ends this,
+            // never a signal this process could choose to handle.
+            std::thread::sleep(Duration::from_secs(3600));
+        },
+        Fault::ExitNonzero => {
+            eprintln!("sgt-atlas-worker: --fault exit-nonzero, exiting 17 on purpose");
+            std::process::exit(17);
+        }
+        Fault::Allocate => {
+            // Paced growth: touches every page so the kernel actually
+            // commits it (a `vec![0u8; n]` the process never writes could be
+            // satisfied lazily and would not reproduce OOM-shaped pressure),
+            // paused between chunks so a short test deadline bounds how much
+            // this ever grows before the caller's kill+reap ends it.
+            const CHUNK: usize = 8 * 1024 * 1024;
+            let mut held: Vec<Vec<u8>> = Vec::new();
+            loop {
+                let mut chunk = vec![0u8; CHUNK];
+                for byte in chunk.iter_mut().step_by(4096) {
+                    *byte = 1;
+                }
+                held.push(chunk);
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5873,8 +5873,12 @@ pub(crate) mod doctor {
     /// **A missing store is `ok`, not a warning.** An estate that has declared
     /// no `[[knowledge]]` source has nothing to index, and a diagnostic that
     /// nagged about an unused feature would train operators to ignore it.
-    /// Opening also *creates* the file, so this checks for the file first and
-    /// never brings one into existence to report on it.
+    /// This checks for the file first and never brings one into existence to
+    /// report on it — and once it exists, the open below is Atlas's
+    /// read-only constructor (S4 register row 12's rider), never the
+    /// read-write one the daemon uses: the daemon is Atlas's sole writer, so
+    /// the one caller outside the daemon that reads this store may not hold
+    /// a connection that could write it, "IF NOT EXISTS" DDL included.
     fn atlas_coverage_check(data_dir: &Path) -> Check {
         use crate::runtime::atlas::db::{AtlasDb, atlas_db_path};
 
@@ -5885,7 +5889,7 @@ pub(crate) mod doctor {
                 "no source has been indexed on this host yet (nothing to report)",
             );
         }
-        let sources = match AtlasDb::open(data_dir).and_then(|db| db.indexed_sources()) {
+        let sources = match AtlasDb::open_read_only(data_dir).and_then(|db| db.indexed_sources()) {
             Ok(sources) => sources,
             // Almost always a running daemon holding the store, which is not
             // a fault: the daemon is the surface that can answer, and the row

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -675,6 +675,49 @@ impl AtlasDb {
         Self::over(conn, PathBuf::from(":memory:"))
     }
 
+    /// Open an **existing** Atlas database read-only: no file is created, no
+    /// directory is created, and no DDL runs (register row 12's S4 rider).
+    ///
+    /// [`Self::open`] is the daemon's own path and is allowed to create and
+    /// migrate the store, because the daemon is Atlas's sole writer. Every
+    /// other process — `sgt doctor`'s coverage row is the one caller — may
+    /// only ever *read* it, and before this method existed that read went
+    /// through [`Self::open`] anyway: a read-write connection that happened
+    /// not to change anything, opened by a process that is not the writer.
+    /// `CREATE SCHEMA IF NOT EXISTS`/`CREATE TABLE IF NOT EXISTS` are no-ops
+    /// against a store the daemon already built, but "no-op" describes the
+    /// result, not the access mode the statement demanded to run at all —
+    /// this method demands none.
+    ///
+    /// Two consequences of asking DuckDB itself for `AccessMode::ReadOnly`,
+    /// rather than merely skipping the DDL calls: a database that does not
+    /// exist yet is refused outright instead of silently materialized (the
+    /// caller checks [`atlas_db_path`] first, same as [`Self::open`]'s
+    /// caller always has — this method does not repeat that check because it
+    /// has no directory to create either), and a call that somehow reached a
+    /// write path (there is none exposed from a `&self`-only reader, but the
+    /// guarantee is DuckDB's enforcement rather than this crate's discipline)
+    /// would be refused by the engine itself, not merely by convention.
+    ///
+    /// A daemon holding this same file for writing is not a conflict this
+    /// method resolves — DuckDB's own locking decides whether a concurrent
+    /// read-only open is possible, and a caller that gets [`AtlasError`] back
+    /// is expected to treat it exactly as "the store could not be read from
+    /// here right now," the same as any other open failure.
+    pub fn open_read_only(data_dir: &Path) -> Result<Self, AtlasError> {
+        let path = atlas_db_path(data_dir);
+        let config = duckdb::Config::default().access_mode(duckdb::AccessMode::ReadOnly)?;
+        let conn = Connection::open_with_flags(&path, config)?;
+        conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
+        // F4's network-hardening settings only — no `SCHEMA_DDL`, no
+        // `TABLE_DDL`. Both are genuine DDL and a read-only connection
+        // cannot run them even under `IF NOT EXISTS`; skipping them here
+        // rather than letting DuckDB refuse them is what keeps this path a
+        // read, not a read that happens to trip over a write guard.
+        conn.execute_batch(HARDENING_DDL)?;
+        Ok(Self { conn, path })
+    }
+
     fn over(conn: Connection, path: PathBuf) -> Result<Self, AtlasError> {
         conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
         // First, before any other statement: extension autoloading and
@@ -2778,6 +2821,59 @@ mod tests {
 
         let second = AtlasDb::open(dir.path()).expect("reopen");
         assert_eq!(second.schema_names().expect("schemas"), names);
+    }
+
+    /// Register row 12's S4 rider, half one: a read-only open of a store
+    /// that does not exist yet must refuse rather than materialize one —
+    /// [`AtlasDb::open`]'s own `create_dir_all_durable` + `Connection::open`
+    /// would have brought both the directory and the file into being; this
+    /// path must do neither.
+    #[test]
+    fn open_read_only_refuses_a_store_that_does_not_exist_and_creates_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = AtlasDb::open_read_only(dir.path())
+            .expect_err("no store exists yet; a read-only open must not create one");
+        assert!(
+            !atlas_dir(dir.path()).exists(),
+            "must not create the directory: {err}"
+        );
+        assert!(
+            !atlas_db_path(dir.path()).exists(),
+            "must not create the file: {err}"
+        );
+    }
+
+    /// Register row 12's S4 rider, half two: once a real (write) open has
+    /// built the store, a read-only open must see exactly what was confirmed
+    /// — and must not itself be able to write, which is the property that
+    /// makes "no DDL" a fact DuckDB enforces rather than a habit this file
+    /// keeps. `stage_scan` issues genuine `INSERT`s; if the read-only
+    /// connection could run them, this would silently pass.
+    #[test]
+    fn open_read_only_reads_confirmed_rows_and_cannot_write() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        {
+            let mut writer = AtlasDb::open(dir.path()).expect("seed the store");
+            record(&mut writer, &scan_of("notes", "# One\n"), "evt-1");
+        }
+
+        let mut reader = AtlasDb::open_read_only(dir.path()).expect("read-only open");
+        let sources = reader.indexed_sources().expect("read confirmed coverage");
+        assert_eq!(
+            sources
+                .iter()
+                .map(|s| s.source_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["notes"],
+            "a read-only open must see the generation the write path confirmed"
+        );
+
+        let write = reader.stage_scan(&scan_of("notes", "# Two\n"));
+        assert!(
+            write.is_err(),
+            "a connection opened AccessMode::ReadOnly must refuse a write, proving this is a \
+             real read-only open and not merely one that happens not to have written yet"
+        );
     }
 
     /// The store must not land inside the directory whose contract is that

--- a/src/runtime/atlas/lane.rs
+++ b/src/runtime/atlas/lane.rs
@@ -33,8 +33,10 @@
 //! F6 asks for: however much extraction the daemon is asked to do, it never
 //! spends the execution lane's budget doing it.
 
+use crate::runtime::atlas::deny::AcquisitionFilter;
 use crate::runtime::atlas::git::{EstateGitScan, EstateGitSource, GitScanError, scan_estate_git};
 use crate::runtime::atlas::overlay::{OverlayScan, WorkOverlay, scan_work_overlay};
+use crate::runtime::atlas::worker::{WorkerIdentity, WorkerOutcome, WorkerSpawn, run_worker};
 use crate::runtime::engine::{Engine, IntelligenceError};
 
 /// Why an extraction on the lane did not produce an answer.
@@ -68,4 +70,23 @@ pub async fn scan_work_overlay_on_lane(
     Ok(engine
         .run_intelligence(move || scan_work_overlay(&overlay))
         .await??)
+}
+
+/// Run one supervised parse worker under an intelligence-lane permit, on the
+/// blocking pool (F6, S4 Y1's G2) — never the execution lane, exactly as
+/// [`scan_estate_git_on_lane`] and [`scan_work_overlay_on_lane`] already
+/// hold for the two extraction kinds that came before it. The permit is
+/// acquired before the worker is even spawned and is held for the whole of
+/// [`super::worker::run_worker`] — supervision included, so a worker that
+/// has to be killed past its deadline still frees the permit only when that
+/// kill and reap are done, never early.
+pub async fn run_worker_on_lane(
+    engine: &Engine,
+    spawn: WorkerSpawn,
+    identity: WorkerIdentity,
+    deny: AcquisitionFilter,
+) -> Result<WorkerOutcome, IntelligenceError> {
+    engine
+        .run_intelligence(move || run_worker(spawn, &identity, &deny))
+        .await
 }

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -107,6 +107,9 @@
 //! db      ── the one module that reaches the database driver, in or out
 //! record  ── the thin three-step glue F1's crash window is stated over
 //! lane    ── the thin F6 glue: an intelligence permit and the blocking pool
+//! worker  ── the supervised parse-worker transport (S4 Y1, G2): spawn,
+//!            kill+reap, and the daemon-side AUTHORITY over what a worker
+//!            returns — no DB, no journal, independently testable
 //! ```
 //!
 //! # A dataset is read in place, and that inverts one thing (X4)
@@ -151,3 +154,4 @@ pub mod scan;
 pub mod syntax;
 pub mod tabular;
 pub mod text;
+pub mod worker;

--- a/src/runtime/atlas/worker.rs
+++ b/src/runtime/atlas/worker.rs
@@ -1,0 +1,746 @@
+//! The supervised parse-worker transport (S4 Y1, G2).
+//!
+//! ```text
+//! WorkerSpawn + WorkerIdentity   bytes in, and what the daemon already
+//!                                knows to be true about them
+//!    -> run_worker               spawn, supervise, kill+reap, parse
+//!       -> validate_batch        the AUTHORITY over what came back
+//! ```
+//!
+//! # Transport, not a parser (F6's adapter-shape mandate, carried across a
+//! process boundary)
+//!
+//! S3 already made every extractor a pure function over bytes. This module
+//! does not touch that shape — it moves the *call* across a process
+//! boundary, so a malformed input can take down a child instead of the
+//! daemon. Y1 ships no third-party parser (Y2's Anydoc spike is that), so
+//! [`WorkerBatch`] is deliberately thin: identity, structure units in the
+//! same shape [`super::scan::ScannedUnit`] already uses, and declared child
+//! resources — enough for the real adapters Y2 onward plug into the same
+//! wire contract.
+//!
+//! # The daemon validates; the worker's own checks are defense in depth
+//!
+//! [`validate_batch`] is the AUTHORITY the sprint plan's G2 decision names,
+//! not a formality: identity (generation + resource hash + extractor —
+//! [`WorkerIdentity`]), path safety on every declared child
+//! ([`enclosed_relative_path`], `enclosed_name` semantics reused from
+//! [`crate::domain::is_plain_name`] per path component — R2, the same rule
+//! [`crate::domain::is_plain_name`]'s own doc already applies to a composed,
+//! `/`-joined path), and F10 deny-set membership matched on the child's
+//! declared NAME as well as its path ([`deny::AcquisitionFilter`], reused
+//! whole). A worker that returns a batch failing any of these is refused,
+//! and the refusal is a NAMED [`CoverageRow`] — never a silent drop and
+//! never a partial write, because nothing here writes anything: this module
+//! hands the daemon a validated [`WorkerBatch`] or a reason it did not get
+//! one, and [`super::record`]'s three-step discipline is what a later wave
+//! wires the accepted half into.
+//!
+//! # Supervision (#310, reused whole — R2)
+//!
+//! [`run_worker`] spawns the worker in its own process group with
+//! [`crate::backend::child::harden_probe_child`] — the exact mechanism
+//! every backend probe already uses, because a worker call's own lifetime
+//! is the same shape a probe's is: spawned and killed inside one function,
+//! on one thread, bounded by a deadline the caller names
+//! ([`crate::backend::child::ChildLifetime::Probe`]'s own doc explains why
+//! that shape, and only that shape, may be hardened this way). A deadline
+//! exceeded, a non-zero exit, and a signal termination (which is how a
+//! `SIGABRT`'d worker is observed) are all **kill the group, then reap** —
+//! never kill without reap, which would leave a zombie an orphan check
+//! cannot distinguish from a live leak.
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::mpsc::RecvTimeoutError;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::child;
+use crate::domain::is_plain_name;
+use crate::domain::source::{Coverage, CoverageRow, UnitKind};
+use crate::runtime::atlas::deny::{AcquisitionFilter, Verdict};
+
+/// How often [`run_worker`] polls a live child against its deadline.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// How long [`run_worker`] waits, after the child has already exited or been
+/// reaped, for its stdout-draining thread to hand back what it read.
+///
+/// Decoupled from the caller's own deadline on purpose: that deadline bounds
+/// how long the *child* may run, and by the time this wait starts the child
+/// is already gone — a pipe with a closed write end drains in microseconds,
+/// so this is a generous bound against a wedged reader thread, not a second
+/// copy of the run budget.
+const STDOUT_DRAIN_GRACE: Duration = Duration::from_secs(5);
+
+// ------------------------------------------------------------- wire shapes
+
+/// One structure unit a worker derived, in [`super::scan::ScannedUnit`]'s own
+/// shape minus the fields only the walk that found the file can fill in
+/// (`ordinal`, heading metadata) — Y1 has no real adapter to populate those,
+/// and a wire field nothing ever sets is exactly the false promise the
+/// empty-table doctrine already refuses for a table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerUnit {
+    /// Whole resource, or a container-defined span.
+    pub kind: UnitKind,
+    /// Offset into the original resource bytes.
+    pub byte_start: u64,
+    /// End offset into the original resource bytes, exclusive.
+    pub byte_end: u64,
+    /// The unit's own text.
+    pub text: String,
+}
+
+/// One child resource a worker declares out of the bytes it was given (a
+/// future archive entry, mail attachment, or similar container member).
+///
+/// Untrusted by construction: [`validate_batch`] is what decides whether
+/// `relative_path` may ever reach a filesystem or a store, and the daemon
+/// runs that check on every declared child before touching either.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeclaredChild {
+    /// The child's own name, exactly as the worker declared it — checked
+    /// against F10's deny set independently of `relative_path`, because a
+    /// deny pattern like the dotfile rule matches on a path *component*, and
+    /// a worker could otherwise bury a denied name one path segment deep
+    /// from the coordinate a naive check might use.
+    pub name: String,
+    /// Where the child lives relative to its parent resource, `/`-separated.
+    pub relative_path: String,
+}
+
+/// One supervised worker's whole answer for one resource: bytes in,
+/// normalized batch out (G2's own words).
+///
+/// Every field here is attacker-influenced input from the daemon's point of
+/// view, whether the worker is buggy, compromised, or simply running old
+/// code against a new deny set — which is the entire reason
+/// [`validate_batch`] exists rather than trusting this struct on arrival.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerBatch {
+    /// The generation this extraction claims to belong to.
+    pub generation_id: String,
+    /// The worker's own hash of the bytes it was given (BLAKE3 hex) — F7's
+    /// content half, computed independently on both sides of the pipe so a
+    /// mismatch is detectable rather than assumed.
+    pub resource_hash: String,
+    /// The extractor identity this batch claims to have run (F7's other
+    /// half).
+    pub extractor: String,
+    /// Structure units this worker derived.
+    pub units: Vec<WorkerUnit>,
+    /// Child resources this worker declares out of the input bytes.
+    pub declared_children: Vec<DeclaredChild>,
+}
+
+/// What the daemon already knows to be true about a dispatched job, checked
+/// against what the worker's [`WorkerBatch`] claims.
+///
+/// Composed daemon-side from evidence the worker never chose: `resource_hash`
+/// is the daemon's own hash of the bytes it is about to send, taken before
+/// the worker ever runs, not copied from anything the worker said.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerIdentity {
+    /// The generation this job is extracting for.
+    pub generation_id: String,
+    /// BLAKE3 hex of the exact bytes handed to the worker.
+    pub resource_hash: String,
+    /// The extractor identity the daemon dispatched this job to run.
+    pub extractor: String,
+}
+
+// --------------------------------------------------------- daemon-side authority
+
+/// Why [`validate_batch`] refused a [`WorkerBatch`] — the AUTHORITY's own
+/// verdict, never the worker's.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchRefusal {
+    /// A returned batch's identity does not match what the daemon dispatched
+    /// — a stale answer, a worker that read the wrong job, or worse.
+    IdentityMismatch {
+        /// Which identity field disagreed.
+        field: &'static str,
+        /// What the daemon expected.
+        expected: String,
+        /// What the batch claimed.
+        got: String,
+    },
+    /// A declared child's path is not `enclosed_name`-safe: an absolute
+    /// path, a `..` component, or an empty segment.
+    UnsafeChildPath {
+        /// The child's declared name.
+        child: String,
+        /// The unsafe path it declared.
+        path: String,
+    },
+    /// A declared child's name or path matches F10's deny set.
+    DeniedChildName {
+        /// The child's declared name.
+        child: String,
+        /// The deny pattern that matched.
+        pattern: String,
+    },
+}
+
+impl BatchRefusal {
+    /// This refusal, as the named [`CoverageRow`] G2 requires: never a
+    /// silent drop, and named specifically enough that an operator reading
+    /// `sgt doctor`'s atlas row (or `source.scanned`'s coverage counts) can
+    /// tell a refused worker batch from an ordinary extraction error.
+    ///
+    /// [`Coverage::Excluded`] only for [`Self::DeniedChildName`] — that is
+    /// literally F10's own deny-set boundary, the same status an ordinary
+    /// scan's own `ignore` refusal reports. The other two are not "excluded
+    /// by policy", they are "this answer cannot be trusted", which
+    /// [`Coverage::Error`] already means.
+    pub fn coverage_row(&self) -> CoverageRow {
+        let status = match self {
+            Self::DeniedChildName { .. } => Coverage::Excluded,
+            Self::IdentityMismatch { .. } | Self::UnsafeChildPath { .. } => Coverage::Error,
+        };
+        let detail = match self {
+            Self::IdentityMismatch {
+                field,
+                expected,
+                got,
+            } => format!(
+                "supervised parse worker's returned batch was refused: {field} was {got:?}, \
+                 expected {expected:?}"
+            ),
+            Self::UnsafeChildPath { child, path } => format!(
+                "supervised parse worker declared child {child:?} at unsafe path {path:?} \
+                 (not enclosed-name-safe); refused before it could reach the store"
+            ),
+            Self::DeniedChildName { child, pattern } => format!(
+                "supervised parse worker declared child {child:?}, which matches the F10 \
+                 deny set ({pattern}); refused before it could reach the store"
+            ),
+        };
+        CoverageRow {
+            path: None,
+            status,
+            detail: Some(detail),
+            bytes: None,
+        }
+    }
+}
+
+/// `enclosed_name` semantics (the `zip` crate's own term — no dependency on
+/// it here, since Y1 ships no container format; the semantics are what G2
+/// asks every declared child path to satisfy regardless of which wave adds
+/// the first real container): a relative path with no absolute component, no
+/// `..`, and no empty segment.
+///
+/// R2: reuses [`is_plain_name`] per `/`-separated component, exactly the
+/// pattern its own doc already demonstrates for a composed hierarchical
+/// path — a single guard fixed in one place rather than a second
+/// path-traversal check copied for containers.
+fn enclosed_relative_path(path: &str) -> bool {
+    path.split('/').all(is_plain_name)
+}
+
+/// The AUTHORITY over a returned batch (G2, panel-adjudicated): identity,
+/// then path safety, then F10 deny-set membership — on every declared
+/// child's name AND its path, because a deny pattern can match either.
+///
+/// Checked in this order so the *first* thing wrong with a batch is what a
+/// coverage row names — a batch failing on identity never gets far enough to
+/// be told its child paths were also unsafe, which keeps one refusal one
+/// reason.
+pub fn validate_batch(
+    identity: &WorkerIdentity,
+    batch: &WorkerBatch,
+    deny: &AcquisitionFilter,
+) -> Result<(), BatchRefusal> {
+    if batch.generation_id != identity.generation_id {
+        return Err(BatchRefusal::IdentityMismatch {
+            field: "generation_id",
+            expected: identity.generation_id.clone(),
+            got: batch.generation_id.clone(),
+        });
+    }
+    if batch.resource_hash != identity.resource_hash {
+        return Err(BatchRefusal::IdentityMismatch {
+            field: "resource_hash",
+            expected: identity.resource_hash.clone(),
+            got: batch.resource_hash.clone(),
+        });
+    }
+    if batch.extractor != identity.extractor {
+        return Err(BatchRefusal::IdentityMismatch {
+            field: "extractor",
+            expected: identity.extractor.clone(),
+            got: batch.extractor.clone(),
+        });
+    }
+    for declared in &batch.declared_children {
+        if !enclosed_relative_path(&declared.relative_path) {
+            return Err(BatchRefusal::UnsafeChildPath {
+                child: declared.name.clone(),
+                path: declared.relative_path.clone(),
+            });
+        }
+        // F10: matched on the declared NAME as well as its path — a name
+        // like `.env` must be refused even when the path it was declared at
+        // does not itself trip the dotfile rule (a container may place a
+        // secrets-shaped entry under a name that reads fine as a path
+        // component's sibling but not as itself).
+        if let Verdict::Denied { pattern } = deny.verdict(&declared.name) {
+            return Err(BatchRefusal::DeniedChildName {
+                child: declared.name.clone(),
+                pattern,
+            });
+        }
+        if let Verdict::Denied { pattern } = deny.verdict(&declared.relative_path) {
+            return Err(BatchRefusal::DeniedChildName {
+                child: declared.name.clone(),
+                pattern,
+            });
+        }
+    }
+    Ok(())
+}
+
+// ------------------------------------------------------------- supervision
+
+/// One supervised worker call: the program to spawn, its arguments, the
+/// bytes to feed its stdin, and the deadline it must finish inside.
+///
+/// `program` is a plain `PathBuf` rather than [`std::env::current_exe`]
+/// baked in here, because the two callers need two different answers: the
+/// daemon's own binary IS the worker binary's addressable path at runtime
+/// (`std::env::current_exe()`, [`crate::cli`]'s `spawn_daemon` sets the same
+/// precedent for re-exec'ing the running binary with a different verb), while
+/// an integration test spawns the worker binary Cargo built for it
+/// (`env!("CARGO_BIN_EXE_sgt-atlas-worker")`) — `current_exe()` inside a test
+/// binary answers with the *test binary's own* path, which is not runnable
+/// as a worker at all.
+#[derive(Debug, Clone)]
+pub struct WorkerSpawn {
+    /// The worker binary to run.
+    pub program: PathBuf,
+    /// Its command-line arguments.
+    pub args: Vec<String>,
+    /// The resource bytes to write to its stdin, then close.
+    pub input: Vec<u8>,
+    /// How long the worker may run before [`run_worker`] kills its whole
+    /// process group and reaps it.
+    pub deadline: Duration,
+}
+
+/// What one supervised call produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkerOutcome {
+    /// A batch that passed [`validate_batch`].
+    Accepted(WorkerBatch),
+    /// The worker's process misbehaved, or its batch was refused — either
+    /// way, a named [`CoverageRow`] rather than a silent gap.
+    Refused(CoverageRow),
+}
+
+/// Why a supervised worker call did not produce a batch at all — a
+/// process-level fault, as opposed to [`BatchRefusal`], which is about a
+/// batch the worker *did* produce.
+#[derive(Debug)]
+enum WorkerFault {
+    /// The worker could not even be spawned (missing binary, exec
+    /// permission, …).
+    SpawnFailed(String),
+    /// The worker exceeded its deadline; its whole process group was killed
+    /// and reaped.
+    TimedOut,
+    /// The worker was terminated by a signal (a `SIGABRT`'d worker lands
+    /// here, `signal` is the raw number).
+    Signaled { signal: i32, stderr_tail: String },
+    /// The worker exited on its own, with a non-zero status.
+    ExitedNonZero {
+        code: Option<i32>,
+        stderr_tail: String,
+    },
+    /// The worker exited zero but its stdout was not a [`WorkerBatch`].
+    Malformed { detail: String },
+}
+
+impl WorkerFault {
+    fn coverage_row(&self) -> CoverageRow {
+        let detail = match self {
+            Self::SpawnFailed(e) => {
+                format!("supervised parse worker could not be spawned: {e}")
+            }
+            Self::TimedOut => {
+                "supervised parse worker exceeded its deadline and was killed (group signalled, \
+                 reaped)"
+                    .to_string()
+            }
+            Self::Signaled {
+                signal,
+                stderr_tail,
+            } => format!(
+                "supervised parse worker was terminated by signal {signal}; stderr: \
+                 {stderr_tail}"
+            ),
+            Self::ExitedNonZero { code, stderr_tail } => format!(
+                "supervised parse worker exited with status {code:?}; stderr: {stderr_tail}"
+            ),
+            Self::Malformed { detail } => {
+                format!("supervised parse worker's stdout was not a usable batch: {detail}")
+            }
+        };
+        CoverageRow {
+            path: None,
+            status: Coverage::Error,
+            detail: Some(detail),
+            bytes: None,
+        }
+    }
+}
+
+/// Run one supervised parse worker end to end: spawn (own process group,
+/// `PR_SET_PDEATHSIG` via [`child::harden_probe_child`]), feed it `input` on
+/// stdin, wait bounded by `deadline` (kill the group and reap past it, exit
+/// or signal short of it), parse its stdout, and — only for a worker that
+/// actually produced a batch — run it through [`validate_batch`].
+///
+/// The intelligence-lane permit is not acquired here: [`super::lane`]'s
+/// [`super::lane::run_worker_on_lane`] is what a daemon caller actually
+/// calls, and it wraps this function in [`crate::runtime::engine::Engine::run_intelligence`]
+/// the same way [`super::lane::scan_estate_git_on_lane`] wraps
+/// [`super::git::scan_estate_git`] — this function stays engine-agnostic so
+/// it is independently testable without a daemon.
+pub fn run_worker(
+    spawn: WorkerSpawn,
+    identity: &WorkerIdentity,
+    deny: &AcquisitionFilter,
+) -> WorkerOutcome {
+    match spawn_and_collect(&spawn) {
+        Ok(stdout) => match serde_json::from_slice::<WorkerBatch>(&stdout) {
+            Ok(batch) => match validate_batch(identity, &batch, deny) {
+                Ok(()) => WorkerOutcome::Accepted(batch),
+                Err(refusal) => WorkerOutcome::Refused(refusal.coverage_row()),
+            },
+            Err(e) => WorkerOutcome::Refused(
+                WorkerFault::Malformed {
+                    detail: e.to_string(),
+                }
+                .coverage_row(),
+            ),
+        },
+        Err(fault) => WorkerOutcome::Refused(fault.coverage_row()),
+    }
+}
+
+/// The whole of one child's lifetime: spawn, hardened; stdin written and
+/// closed on its own thread; stdout drained on its own thread; `try_wait`
+/// polled against `spawn.deadline`; kill + reap on either a timeout or a
+/// normal exit, always both, never one without the other (#310).
+fn spawn_and_collect(spawn: &WorkerSpawn) -> Result<Vec<u8>, WorkerFault> {
+    let mut command = Command::new(&spawn.program);
+    command
+        .args(&spawn.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Own process group + PR_SET_PDEATHSIG (Linux): a worker call is spawned
+    // and killed inside this one function, on one thread — exactly the shape
+    // `ChildLifetime::Probe` documents as safe to harden this way (#310).
+    child::harden_probe_child(&mut command);
+
+    let mut process = command
+        .spawn()
+        .map_err(|e| WorkerFault::SpawnFailed(e.to_string()))?;
+    let pgid = process.id();
+    let registration = child::register_probe_child(pgid);
+
+    if let Some(mut stdin) = process.stdin.take() {
+        let input = spawn.input.clone();
+        std::thread::spawn(move || {
+            // A worker that never reads stdin (every Y1 fault mode) still
+            // must not deadlock this write: inputs in this build are small
+            // fixture bytes, and the OS pipe buffer absorbs them without the
+            // writer blocking. A real Y2 adapter's own transport is free to
+            // widen this if a resource ever needs to be larger than a pipe
+            // buffer, which is a Y2-scoped concern, not this wave's.
+            let _ = stdin.write_all(&input);
+            // `stdin` drops here, closing the pipe — the EOF a worker that
+            // *does* read stdin needs to see.
+        });
+    }
+
+    let (stdout_tx, stdout_rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(1);
+    if let Some(mut stdout) = process.stdout.take() {
+        std::thread::spawn(move || {
+            let mut buffer = Vec::new();
+            let _ = stdout.read_to_end(&mut buffer);
+            let _ = stdout_tx.send(buffer);
+        });
+    } else {
+        let _ = stdout_tx.send(Vec::new());
+    }
+
+    let deadline_at = Instant::now() + spawn.deadline;
+    let status = loop {
+        match process.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if Instant::now() >= deadline_at {
+                    break None;
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            // An error probing the child's state is treated the same as a
+            // timeout below: kill the group and reap, rather than looping on
+            // an error that will not resolve itself.
+            Err(_) => break None,
+        }
+    };
+
+    let Some(status) = status else {
+        // Deadline exceeded (or `try_wait` itself failed): the group is
+        // killed by recorded pgid — never by name — and reaped. Both halves,
+        // always, or a killed-not-reaped child is a zombie an orphan check
+        // cannot tell from a live leak (#310).
+        child::kill_process_group(Some(pgid));
+        let _ = process.kill();
+        let reaped = process.wait();
+        drop(registration);
+        return match reaped {
+            Ok(_) => Err(WorkerFault::TimedOut),
+            Err(e) => Err(WorkerFault::SpawnFailed(format!(
+                "kill/reap after the deadline itself failed: {e}"
+            ))),
+        };
+    };
+    drop(registration);
+
+    if let Some(fault) = fault_for_exit(status, &mut process) {
+        return Err(fault);
+    }
+
+    match stdout_rx.recv_timeout(STDOUT_DRAIN_GRACE) {
+        Ok(buffer) => Ok(buffer),
+        Err(RecvTimeoutError::Timeout) => Err(WorkerFault::Malformed {
+            detail: "the worker exited but its stdout-draining thread never finished".to_string(),
+        }),
+        Err(RecvTimeoutError::Disconnected) => Err(WorkerFault::Malformed {
+            detail: "the worker exited and its stdout reader thread vanished without a report"
+                .to_string(),
+        }),
+    }
+}
+
+/// `None` for a clean exit; `Some` naming a signal termination or a
+/// non-zero status, stderr tail attached either way.
+fn fault_for_exit(status: ExitStatus, process: &mut std::process::Child) -> Option<WorkerFault> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return Some(WorkerFault::Signaled {
+                signal,
+                stderr_tail: drain_stderr(process),
+            });
+        }
+    }
+    if !status.success() {
+        return Some(WorkerFault::ExitedNonZero {
+            code: status.code(),
+            stderr_tail: drain_stderr(process),
+        });
+    }
+    None
+}
+
+/// Read a child's stderr to completion. Only ever called once the child has
+/// already exited or been reaped, so the pipe's write end is already closed
+/// and this is a bounded read, not a blocking wait on a live process.
+fn drain_stderr(process: &mut std::process::Child) -> String {
+    let Some(mut stderr) = process.stderr.take() else {
+        return String::new();
+    };
+    let mut buffer = Vec::new();
+    let _ = stderr.read_to_end(&mut buffer);
+    String::from_utf8_lossy(&buffer).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> WorkerIdentity {
+        WorkerIdentity {
+            generation_id: "gen-1".to_string(),
+            resource_hash: "hash-1".to_string(),
+            extractor: "fixture/v1".to_string(),
+        }
+    }
+
+    fn batch() -> WorkerBatch {
+        WorkerBatch {
+            generation_id: "gen-1".to_string(),
+            resource_hash: "hash-1".to_string(),
+            extractor: "fixture/v1".to_string(),
+            units: Vec::new(),
+            declared_children: Vec::new(),
+        }
+    }
+
+    fn deny() -> AcquisitionFilter {
+        AcquisitionFilter::new(&[]).expect("compile default deny set")
+    }
+
+    #[test]
+    fn a_matching_batch_with_no_children_is_accepted() {
+        assert_eq!(validate_batch(&identity(), &batch(), &deny()), Ok(()));
+    }
+
+    #[test]
+    fn a_mismatched_generation_is_refused_by_identity() {
+        let mut bad = batch();
+        bad.generation_id = "gen-2".to_string();
+        let err = validate_batch(&identity(), &bad, &deny()).expect_err("must refuse");
+        assert_eq!(
+            err,
+            BatchRefusal::IdentityMismatch {
+                field: "generation_id",
+                expected: "gen-1".to_string(),
+                got: "gen-2".to_string(),
+            }
+        );
+        assert_eq!(err.coverage_row().status, Coverage::Error);
+    }
+
+    #[test]
+    fn a_mismatched_resource_hash_is_refused_by_identity() {
+        let mut bad = batch();
+        bad.resource_hash = "hash-2".to_string();
+        let err = validate_batch(&identity(), &bad, &deny()).expect_err("must refuse");
+        assert_eq!(
+            err,
+            BatchRefusal::IdentityMismatch {
+                field: "resource_hash",
+                expected: "hash-1".to_string(),
+                got: "hash-2".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_mismatched_extractor_is_refused_by_identity() {
+        let mut bad = batch();
+        bad.extractor = "fixture/v2".to_string();
+        let err = validate_batch(&identity(), &bad, &deny()).expect_err("must refuse");
+        assert_eq!(
+            err,
+            BatchRefusal::IdentityMismatch {
+                field: "extractor",
+                expected: "fixture/v1".to_string(),
+                got: "fixture/v2".to_string(),
+            }
+        );
+    }
+
+    /// The brief's own example: a worker declaring a child named `.env` is
+    /// refused daemon-side even though `.env` alone carries no `..` and no
+    /// leading slash — this is the deny-set check, not the path-safety one.
+    #[test]
+    fn a_declared_child_named_dotenv_is_refused_by_the_deny_set() {
+        let mut with_child = batch();
+        with_child.declared_children.push(DeclaredChild {
+            name: ".env".to_string(),
+            relative_path: ".env".to_string(),
+        });
+        let err = validate_batch(&identity(), &with_child, &deny()).expect_err("must refuse");
+        assert!(matches!(err, BatchRefusal::DeniedChildName { .. }));
+    }
+
+    /// The brief's other example: `../../etc/passwd` is a path-safety
+    /// refusal, independent of whether the deny set would also catch it.
+    #[test]
+    fn a_declared_child_at_a_traversal_path_is_refused_by_path_safety() {
+        let mut with_child = batch();
+        with_child.declared_children.push(DeclaredChild {
+            name: "innocuous.txt".to_string(),
+            relative_path: "../../etc/passwd".to_string(),
+        });
+        let err = validate_batch(&identity(), &with_child, &deny()).expect_err("must refuse");
+        assert_eq!(
+            err,
+            BatchRefusal::UnsafeChildPath {
+                child: "innocuous.txt".to_string(),
+                path: "../../etc/passwd".to_string(),
+            }
+        );
+    }
+
+    /// A denied *name* refuses even when the declared *path* alone would
+    /// pass both checks — the brief is explicit that the deny set must match
+    /// on the name as well as the path.
+    #[test]
+    fn a_denied_name_refuses_even_under_an_innocuous_looking_path() {
+        let mut with_child = batch();
+        with_child.declared_children.push(DeclaredChild {
+            name: "id_rsa".to_string(),
+            relative_path: "assets/id_rsa".to_string(),
+        });
+        let err = validate_batch(&identity(), &with_child, &deny()).expect_err("must refuse");
+        assert!(matches!(err, BatchRefusal::DeniedChildName { .. }));
+    }
+
+    #[test]
+    fn an_ordinary_nested_child_path_is_enclosed_and_allowed() {
+        let mut with_child = batch();
+        with_child.declared_children.push(DeclaredChild {
+            name: "logo.png".to_string(),
+            relative_path: "assets/images/logo.png".to_string(),
+        });
+        assert_eq!(validate_batch(&identity(), &with_child, &deny()), Ok(()));
+    }
+
+    #[test]
+    fn enclosed_relative_path_rejects_absolute_and_traversal_and_empty_segments() {
+        for unsafe_path in ["/etc/passwd", "../escape", "a/../b", "a//b", "", "a/"] {
+            assert!(
+                !enclosed_relative_path(unsafe_path),
+                "{unsafe_path:?} must not be enclosed-safe"
+            );
+        }
+        for safe_path in ["file.txt", "dir/file.txt", "a/b/c.md"] {
+            assert!(
+                enclosed_relative_path(safe_path),
+                "{safe_path:?} must be enclosed-safe"
+            );
+        }
+    }
+
+    /// A worker binary that does not exist at all is a spawn failure, not a
+    /// panic and not a hang — the same "reported, never absorbed" rule every
+    /// other Atlas failure mode already follows.
+    #[test]
+    fn a_program_that_does_not_exist_is_a_named_spawn_failure() {
+        let outcome = run_worker(
+            WorkerSpawn {
+                program: PathBuf::from("/definitely/not/a/real/sgt-atlas-worker/binary"),
+                args: Vec::new(),
+                input: Vec::new(),
+                deadline: Duration::from_millis(500),
+            },
+            &identity(),
+            &deny(),
+        );
+        let WorkerOutcome::Refused(row) = outcome else {
+            panic!("a missing binary must not be accepted");
+        };
+        assert_eq!(row.status, Coverage::Error);
+        assert!(
+            row.detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains("could not be spawned"),
+            "{row:?}"
+        );
+    }
+}

--- a/src/runtime/atlas/worker.rs
+++ b/src/runtime/atlas/worker.rs
@@ -49,6 +49,27 @@
 //! `SIGABRT`'d worker is observed) are all **kill the group, then reap** —
 //! never kill without reap, which would leave a zombie an orphan check
 //! cannot distinguish from a live leak.
+//!
+//! # Memory containment (G2 amendment — the fault class the deadline alone
+//! left open)
+//!
+//! The deadline above is a HANG guard: it bounds how long a child may run,
+//! not how much address space it may reserve while running. Without a
+//! per-child ceiling, an allocation blowup raises host-global memory
+//! pressure long before a slow-growing worker would ever trip its own
+//! deadline, and once pressure is host-global the kernel OOM killer picks
+//! *its own* victim rather than the runaway child — on this estate's own
+//! host that has repeatedly meant infrastructure dies, not the hog. So
+//! [`spawn_and_collect`] also arms [`WORKER_ADDRESS_SPACE_LIMIT_BYTES`] as
+//! `RLIMIT_AS` on the child (`cap_worker_address_space`), in the identical
+//! post-fork, pre-exec, one-thread window
+//! [`crate::backend::child::harden_probe_child`]'s own `PR_SET_PDEATHSIG`
+//! closure already documents as safe for this call shape — a second concern
+//! armed the same way at the same call site, not a second mechanism. A
+//! child that exceeds it dies on its own, well inside the deadline, and is
+//! reported the same way every other Y1 fault is: a named [`CoverageRow`]
+//! ([`WorkerFault::MemoryLimitExceeded`]), never a silent absorption into
+//! host-wide pressure.
 
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -65,6 +86,21 @@ use crate::runtime::atlas::deny::{AcquisitionFilter, Verdict};
 
 /// How often [`run_worker`] polls a live child against its deadline.
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// The address-space (`RLIMIT_AS`) ceiling armed on every worker child at
+/// spawn (`cap_worker_address_space`) — the memory-fault class the deadline
+/// alone cannot close (module doc, "Memory containment").
+///
+/// **512 MiB.** Sized generously for real document parsing — a worker
+/// holding a large document's whole decoded text plus working structures in
+/// memory at once comfortably fits well under this — while staying far
+/// below ordinary host headroom, so a legitimate worker never trips it and
+/// a runaway one dies on its own long before it could raise host-global
+/// pressure or contend with anything else running on the host. `pub` (not
+/// `pub(crate)`) so the deterministic memory-fault acceptance test
+/// (`tests/y1_worker_transport.rs`) can size its own deadline against the
+/// real value rather than duplicating it.
+pub const WORKER_ADDRESS_SPACE_LIMIT_BYTES: u64 = 512 * 1024 * 1024;
 
 /// How long [`run_worker`] waits, after the child has already exited or been
 /// reaped, for its stdout-draining thread to hand back what it read.
@@ -356,6 +392,20 @@ enum WorkerFault {
     /// The worker was terminated by a signal (a `SIGABRT`'d worker lands
     /// here, `signal` is the raw number).
     Signaled { signal: i32, stderr_tail: String },
+    /// The worker was terminated after exceeding
+    /// [`WORKER_ADDRESS_SPACE_LIMIT_BYTES`] (`RLIMIT_AS`, armed by
+    /// `cap_worker_address_space` at spawn).
+    ///
+    /// The kernel enforces the ceiling by failing the child's own
+    /// allocation (`RLIMIT_AS` makes the mapping syscall behind it return
+    /// `ENOMEM`), so the worker still self-terminates by signal rather than
+    /// being `SIGKILL`'d from outside — [`fault_for_exit`] tells this apart
+    /// from an ordinary [`Self::Signaled`] by the allocator's own "memory
+    /// allocation of N bytes failed" message in `stderr_tail`, not by which
+    /// raw signal number the platform happens to raise for an aborted
+    /// allocation (that varies by target and Rust toolchain version, the
+    /// message does not).
+    MemoryLimitExceeded { signal: i32, stderr_tail: String },
     /// The worker exited on its own, with a non-zero status.
     ExitedNonZero {
         code: Option<i32>,
@@ -382,6 +432,13 @@ impl WorkerFault {
             } => format!(
                 "supervised parse worker was terminated by signal {signal}; stderr: \
                  {stderr_tail}"
+            ),
+            Self::MemoryLimitExceeded {
+                signal,
+                stderr_tail,
+            } => format!(
+                "supervised parse worker exceeded its {WORKER_ADDRESS_SPACE_LIMIT_BYTES}-byte \
+                 address-space limit and was terminated (signal {signal}); stderr: {stderr_tail}"
             ),
             Self::ExitedNonZero { code, stderr_tail } => format!(
                 "supervised parse worker exited with status {code:?}; stderr: {stderr_tail}"
@@ -448,6 +505,9 @@ fn spawn_and_collect(spawn: &WorkerSpawn) -> Result<Vec<u8>, WorkerFault> {
     // and killed inside this one function, on one thread — exactly the shape
     // `ChildLifetime::Probe` documents as safe to harden this way (#310).
     child::harden_probe_child(&mut command);
+    // RLIMIT_AS (Linux): the memory-fault class #310's hardening above does
+    // not cover — see the module doc's "Memory containment" section.
+    cap_worker_address_space(&mut command);
 
     let mut process = command
         .spawn()
@@ -540,16 +600,71 @@ fn spawn_and_collect(spawn: &WorkerSpawn) -> Result<Vec<u8>, WorkerFault> {
     }
 }
 
+/// Arm [`WORKER_ADDRESS_SPACE_LIMIT_BYTES`] as `RLIMIT_AS` on `command`'s
+/// child, in the identical post-fork, pre-exec window
+/// [`child::harden_probe_child`]'s own `PR_SET_PDEATHSIG` closure already
+/// documents as safe for this call shape: spawned and killed inside one
+/// function, on one thread ([`child::ChildLifetime::Probe`]'s own doc).
+///
+/// `setrlimit` is a plain syscall — no allocation, no libc global state
+/// beyond the kernel's own per-process limit table — the same class of
+/// async-signal-safe primitive `harden_probe_child`'s own SAFETY comment
+/// already relies on for `prctl`/`getppid` in this same window.
+///
+/// Linux-only, matching `harden_probe_child`'s own `PR_SET_PDEATHSIG` gate:
+/// this module makes no memory-containment promise on a platform where
+/// neither mechanism exists (module doc, "Memory containment").
+#[cfg(target_os = "linux")]
+fn cap_worker_address_space(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    let limit = WORKER_ADDRESS_SPACE_LIMIT_BYTES as libc::rlim_t;
+    // SAFETY: see this function's own doc, and `harden_probe_child`'s
+    // matching SAFETY comment — identical post-fork window, identical
+    // async-signal-safe-only constraint, satisfied the same way.
+    unsafe {
+        command.pre_exec(move || {
+            let limit = libc::rlimit {
+                rlim_cur: limit,
+                rlim_max: limit,
+            };
+            if libc::setrlimit(libc::RLIMIT_AS, &limit) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+/// The non-Linux half of [`cap_worker_address_space`]: named rather than
+/// omitted, exactly the reasoning [`child::harden_probe_child`]'s own
+/// non-unix arm gives for doing the same.
+#[cfg(not(target_os = "linux"))]
+fn cap_worker_address_space(_command: &mut Command) {}
+
 /// `None` for a clean exit; `Some` naming a signal termination or a
 /// non-zero status, stderr tail attached either way.
+///
+/// A signal termination whose stderr carries Rust's own allocator-failure
+/// message ("memory allocation of ... bytes failed") is reported as
+/// [`WorkerFault::MemoryLimitExceeded`] rather than a plain
+/// [`WorkerFault::Signaled`] — the message, not the raw signal number
+/// (platform- and toolchain-dependent), is what reliably names an
+/// `RLIMIT_AS` kill.
 fn fault_for_exit(status: ExitStatus, process: &mut std::process::Child) -> Option<WorkerFault> {
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
         if let Some(signal) = status.signal() {
+            let stderr_tail = drain_stderr(process);
+            if stderr_tail.contains("memory allocation of") && stderr_tail.contains("failed") {
+                return Some(WorkerFault::MemoryLimitExceeded {
+                    signal,
+                    stderr_tail,
+                });
+            }
             return Some(WorkerFault::Signaled {
                 signal,
-                stderr_tail: drain_stderr(process),
+                stderr_tail,
             });
         }
     }

--- a/src/runtime/atlas/worker.rs
+++ b/src/runtime/atlas/worker.rs
@@ -514,6 +514,14 @@ fn spawn_and_collect(spawn: &WorkerSpawn) -> Result<Vec<u8>, WorkerFault> {
             ))),
         };
     };
+    // The child itself already exited (signalled, non-zero, or clean) — but
+    // #310's contract is "kill the group, then reap" on every exit path, not
+    // only the deadline one: a child that forked its own subprocess before
+    // dying leaves that grandchild in the same pgid, unreachable once
+    // `registration` is dropped below. Signalling an already-empty group is
+    // a documented no-op (`kill_process_group`'s own doc), so this costs
+    // nothing on the common case where the worker never forked anything.
+    child::kill_process_group(Some(pgid));
     drop(registration);
 
     if let Some(fault) = fault_for_exit(status, &mut process) {

--- a/src/runtime/atlas/worker.rs
+++ b/src/runtime/atlas/worker.rs
@@ -91,15 +91,26 @@ const POLL_INTERVAL: Duration = Duration::from_millis(20);
 /// spawn (`cap_worker_address_space`) — the memory-fault class the deadline
 /// alone cannot close (module doc, "Memory containment").
 ///
-/// **512 MiB.** Sized generously for real document parsing — a worker
-/// holding a large document's whole decoded text plus working structures in
-/// memory at once comfortably fits well under this — while staying far
-/// below ordinary host headroom, so a legitimate worker never trips it and
-/// a runaway one dies on its own long before it could raise host-global
-/// pressure or contend with anything else running on the host. `pub` (not
-/// `pub(crate)`) so the deterministic memory-fault acceptance test
-/// (`tests/y1_worker_transport.rs`) can size its own deadline against the
-/// real value rather than duplicating it.
+/// **512 MiB, PROVISIONAL.** This build's own rule is that a numeric
+/// default is a suspect until traced to a dated measurement, and this one
+/// has not been: Y1 ships no real parser (the worker body is trivial), so
+/// there is no real document corpus to size this against yet. 512 MiB is a
+/// working bound chosen to be far below ordinary host headroom, not a
+/// validated ceiling. It **must be re-derived against a real corpus** once
+/// the first real parser (the Y2 Anydoc/Office adapter) lands, and this
+/// comment must be updated to cite that measurement when it does.
+///
+/// **This is a per-child cap, not a total.** Each worker child gets its own
+/// independent `RLIMIT_AS` of this size; workers run concurrently up to the
+/// intelligence lane's own concurrency cap
+/// ([`crate::runtime::engine::default_intelligence_lane_cap`]), so the real
+/// worst-case worker memory ceiling is `lane_cap * WORKER_ADDRESS_SPACE_LIMIT_BYTES`,
+/// not this constant alone. Any future sizing of this constant, or of the
+/// lane cap, must account for that product.
+///
+/// `pub` (not `pub(crate)`) so the deterministic memory-fault acceptance
+/// test (`tests/y1_worker_transport.rs`) can size its own deadline against
+/// the real value rather than duplicating it.
 pub const WORKER_ADDRESS_SPACE_LIMIT_BYTES: u64 = 512 * 1024 * 1024;
 
 /// How long [`run_worker`] waits, after the child has already exited or been
@@ -398,14 +409,22 @@ enum WorkerFault {
     ///
     /// The kernel enforces the ceiling by failing the child's own
     /// allocation (`RLIMIT_AS` makes the mapping syscall behind it return
-    /// `ENOMEM`), so the worker still self-terminates by signal rather than
-    /// being `SIGKILL`'d from outside — [`fault_for_exit`] tells this apart
-    /// from an ordinary [`Self::Signaled`] by the allocator's own "memory
-    /// allocation of N bytes failed" message in `stderr_tail`, not by which
-    /// raw signal number the platform happens to raise for an aborted
-    /// allocation (that varies by target and Rust toolchain version, the
-    /// message does not).
-    MemoryLimitExceeded { signal: i32, stderr_tail: String },
+    /// `ENOMEM`), and what that failure does to the child varies by which
+    /// allocator hit it: Rust's default allocator aborts (the worker
+    /// self-terminates by signal, `signal` is `Some`); a fallible-allocation
+    /// path or a third-party C library's own OOM handler instead panics or
+    /// calls `_exit` and the process exits non-zero on its own (`signal` is
+    /// `None`, `code` is the exit code). [`fault_for_exit`] tells either
+    /// shape apart from an ordinary [`Self::Signaled`]/[`Self::ExitedNonZero`]
+    /// by matching a known allocation-failure signature in `stderr_tail`
+    /// (`matches_allocation_failure`), never by which raw signal number or
+    /// exit code the platform happens to produce (both vary by target,
+    /// allocator, and toolchain version; the message families do not).
+    MemoryLimitExceeded {
+        signal: Option<i32>,
+        code: Option<i32>,
+        stderr_tail: String,
+    },
     /// The worker exited on its own, with a non-zero status.
     ExitedNonZero {
         code: Option<i32>,
@@ -435,11 +454,19 @@ impl WorkerFault {
             ),
             Self::MemoryLimitExceeded {
                 signal,
+                code,
                 stderr_tail,
-            } => format!(
-                "supervised parse worker exceeded its {WORKER_ADDRESS_SPACE_LIMIT_BYTES}-byte \
-                 address-space limit and was terminated (signal {signal}); stderr: {stderr_tail}"
-            ),
+            } => {
+                let how = match (signal, code) {
+                    (Some(signal), _) => format!("signal {signal}"),
+                    (None, Some(code)) => format!("exit code {code}"),
+                    (None, None) => "an unknown exit".to_string(),
+                };
+                format!(
+                    "supervised parse worker exceeded its {WORKER_ADDRESS_SPACE_LIMIT_BYTES}-byte \
+                     address-space limit and was terminated ({how}); stderr: {stderr_tail}"
+                )
+            }
             Self::ExitedNonZero { code, stderr_tail } => format!(
                 "supervised parse worker exited with status {code:?}; stderr: {stderr_tail}"
             ),
@@ -641,24 +668,82 @@ fn cap_worker_address_space(command: &mut Command) {
 #[cfg(not(target_os = "linux"))]
 fn cap_worker_address_space(_command: &mut Command) {}
 
+/// Well-known allocation-failure message signatures, each expressed as the
+/// set of substrings that must **all** appear in a child's stderr tail for
+/// that signature to match ([`matches_allocation_failure`]).
+///
+/// Deliberately narrow: every entry is an exact fragment of a real
+/// allocator/runtime's own failure message, never a generic word ("error",
+/// "abort", "fatal") that an unrelated fault could also print. A multi-part
+/// entry requires every one of its fragments together, specifically so a
+/// message that merely shares one common word with a real signature (e.g.
+/// the standalone word "failed") cannot match on its own. Matching here only
+/// ever *upgrades* an exit or signal termination that is already known to be
+/// abnormal into the more specific [`WorkerFault::MemoryLimitExceeded`] — it
+/// is never consulted on a clean exit, so a false positive here can at worst
+/// relabel one already-bad outcome as another; it can never manufacture a
+/// fault, and it can never produce [`WorkerFault::TimedOut`] (the deadline
+/// path never calls this function at all).
+const ALLOCATION_FAILURE_SIGNATURES: &[&[&str]] = &[
+    // Rust's global-allocator abort (`alloc::alloc::handle_alloc_error`),
+    // hit when an infallible `Vec`/`Box`/`String`/`Arc` allocation's
+    // underlying `malloc`/mmap call returns null. The historical signature
+    // this classifier already matched.
+    &["memory allocation of", "failed"],
+    // Rust's *fallible* allocation path (`Vec::try_reserve`,
+    // `HashMap::try_reserve`, …) reports a real allocation failure as the
+    // `AllocError` variant of `TryReserveErrorKind` rather than aborting; an
+    // `.unwrap()`/`.expect()` on that `Err` panics (exit code 101, no
+    // signal) with both fragments in the message. `AllocError` is required
+    // alongside `TryReserveError` because the *other* variant of the same
+    // error type, `CapacityOverflow`, is a logic bug (an oversized
+    // `len * size_of::<T>()`) rather than a real allocation failure, and
+    // must not be misclassified as the memory cap.
+    &["TryReserveError", "AllocError"],
+    // An `mmap`/allocation call surfaced through `std::io::Error` renders an
+    // `ENOMEM` failure as libc's own `strerror(ENOMEM)` text — exact,
+    // OS-supplied wording, not a fragment this build invented.
+    &["Cannot allocate memory"],
+    // glibc's own malloc-arena OOM abort, hit by any third-party C/C++
+    // library linked into the worker (not only Rust code) — a real shape
+    // review found `RLIMIT_AS` can produce without the child being Rust at
+    // all.
+    &["malloc(): unable to allocate memory"],
+];
+
+/// Whether `stderr_tail` carries one of [`ALLOCATION_FAILURE_SIGNATURES`] in
+/// full (every fragment of at least one signature present).
+fn matches_allocation_failure(stderr_tail: &str) -> bool {
+    ALLOCATION_FAILURE_SIGNATURES.iter().any(|signature| {
+        signature
+            .iter()
+            .all(|fragment| stderr_tail.contains(fragment))
+    })
+}
+
 /// `None` for a clean exit; `Some` naming a signal termination or a
 /// non-zero status, stderr tail attached either way.
 ///
-/// A signal termination whose stderr carries Rust's own allocator-failure
-/// message ("memory allocation of ... bytes failed") is reported as
-/// [`WorkerFault::MemoryLimitExceeded`] rather than a plain
-/// [`WorkerFault::Signaled`] — the message, not the raw signal number
-/// (platform- and toolchain-dependent), is what reliably names an
-/// `RLIMIT_AS` kill.
+/// Either shape — signalled or a plain non-zero exit — is reported as
+/// [`WorkerFault::MemoryLimitExceeded`] instead of a plain
+/// [`WorkerFault::Signaled`]/[`WorkerFault::ExitedNonZero`] when its stderr
+/// carries a [`matches_allocation_failure`] signature: the message, not the
+/// raw signal number or exit code (both platform- and toolchain-dependent),
+/// is what reliably names an `RLIMIT_AS` kill, and an `RLIMIT_AS` kill does
+/// not always exit the same way (module doc; [`WorkerFault::MemoryLimitExceeded`]'s
+/// own doc). Absent a match, this falls back to the existing honest
+/// [`WorkerFault::Signaled`]/[`WorkerFault::ExitedNonZero`] label rather than
+/// guessing.
 fn fault_for_exit(status: ExitStatus, process: &mut std::process::Child) -> Option<WorkerFault> {
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
         if let Some(signal) = status.signal() {
             let stderr_tail = drain_stderr(process);
-            if stderr_tail.contains("memory allocation of") && stderr_tail.contains("failed") {
+            if matches_allocation_failure(&stderr_tail) {
                 return Some(WorkerFault::MemoryLimitExceeded {
-                    signal,
+                    signal: Some(signal),
+                    code: None,
                     stderr_tail,
                 });
             }
@@ -669,10 +754,16 @@ fn fault_for_exit(status: ExitStatus, process: &mut std::process::Child) -> Opti
         }
     }
     if !status.success() {
-        return Some(WorkerFault::ExitedNonZero {
-            code: status.code(),
-            stderr_tail: drain_stderr(process),
-        });
+        let stderr_tail = drain_stderr(process);
+        let code = status.code();
+        if matches_allocation_failure(&stderr_tail) {
+            return Some(WorkerFault::MemoryLimitExceeded {
+                signal: None,
+                code,
+                stderr_tail,
+            });
+        }
+        return Some(WorkerFault::ExitedNonZero { code, stderr_tail });
     }
     None
 }
@@ -865,5 +956,189 @@ mod tests {
                 .contains("could not be spawned"),
             "{row:?}"
         );
+    }
+
+    // --------------------------------------------------------- FIX 2 tests
+    //
+    // `matches_allocation_failure` is exercised directly against crafted
+    // stderr text (no real memory exhaustion needed — the deterministic
+    // `--fault allocate` acceptance test in `tests/y1_worker_transport.rs`
+    // already proves the real RLIMIT_AS-kill path end to end). The
+    // `run_worker`-level tests below use `/bin/sh` to produce a *real*
+    // signalled/exited child whose stderr and exit shape are crafted, so
+    // `fault_for_exit` itself — not just the pure matcher — is proven for
+    // the two newly-classified shapes (a).(b) the review named.
+
+    #[test]
+    fn the_historical_rust_abort_message_matches() {
+        assert!(matches_allocation_failure(
+            "thread 'main' panicked at 'memory allocation of 4096 bytes failed'"
+        ));
+    }
+
+    #[test]
+    fn a_rust_try_reserve_alloc_error_matches() {
+        assert!(matches_allocation_failure(
+            "called `Result::unwrap()` on an `Err` value: TryReserveError(AllocError { \
+             layout: ..., non_exhaustive: () })"
+        ));
+    }
+
+    #[test]
+    fn a_try_reserve_capacity_overflow_does_not_match() {
+        // CapacityOverflow is a logic bug (an oversized `len * size_of::<T>()`
+        // computation), not a real allocation failure — must not be
+        // misclassified as the memory cap even though it shares the
+        // `TryReserveError` fragment.
+        assert!(!matches_allocation_failure(
+            "called `Result::unwrap()` on an `Err` value: TryReserveError(CapacityOverflow)"
+        ));
+    }
+
+    #[test]
+    fn an_enomem_io_error_matches() {
+        assert!(matches_allocation_failure(
+            "mmap failed: Cannot allocate memory (os error 12)"
+        ));
+    }
+
+    #[test]
+    fn a_glibc_malloc_abort_matches() {
+        assert!(matches_allocation_failure(
+            "malloc(): unable to allocate memory\nAborted"
+        ));
+    }
+
+    #[test]
+    fn unrelated_stderr_does_not_match() {
+        for stderr in [
+            "",
+            "failed",
+            "error: unexpected token",
+            "thread 'main' panicked at 'index out of bounds'",
+            "out of memory", // deliberately excluded: too generic on its own
+        ] {
+            assert!(
+                !matches_allocation_failure(stderr),
+                "{stderr:?} must not match an allocation-failure signature"
+            );
+        }
+    }
+
+    /// Shape (a) from the review: a Rust panic path (e.g. an unwrapped
+    /// `Vec::try_reserve` failure) exits non-zero (code 101, no signal) —
+    /// this must now be named the memory cap, not `ExitedNonZero`.
+    #[test]
+    fn a_nonzero_exit_with_an_allocation_signature_is_classified_as_the_memory_cap() {
+        let outcome = run_worker(
+            WorkerSpawn {
+                program: PathBuf::from("/bin/sh"),
+                args: vec![
+                    "-c".to_string(),
+                    "printf '%s' \"called \\`Result::unwrap()\\` on an \\`Err\\` value: \
+                     TryReserveError(AllocError)\" 1>&2; exit 101"
+                        .to_string(),
+                ],
+                input: Vec::new(),
+                deadline: Duration::from_secs(5),
+            },
+            &identity(),
+            &deny(),
+        );
+        let WorkerOutcome::Refused(row) = outcome else {
+            panic!("must be refused: {outcome:?}");
+        };
+        let detail = row.detail.unwrap_or_default();
+        assert!(
+            detail.contains("address-space limit") && detail.contains("exit code 101"),
+            "a panicking allocation failure must be named the memory cap: {detail:?}"
+        );
+    }
+
+    /// A non-zero exit whose stderr carries no allocation signature must
+    /// stay the honest `ExitedNonZero` label — the conservative fallback
+    /// the review required.
+    #[test]
+    fn a_nonzero_exit_without_an_allocation_signature_stays_exited_non_zero() {
+        let outcome = run_worker(
+            WorkerSpawn {
+                program: PathBuf::from("/bin/sh"),
+                args: vec![
+                    "-c".to_string(),
+                    "printf 'ordinary failure' 1>&2; exit 7".to_string(),
+                ],
+                input: Vec::new(),
+                deadline: Duration::from_secs(5),
+            },
+            &identity(),
+            &deny(),
+        );
+        let WorkerOutcome::Refused(row) = outcome else {
+            panic!("must be refused: {outcome:?}");
+        };
+        let detail = row.detail.unwrap_or_default();
+        assert!(
+            !detail.contains("address-space limit"),
+            "an unrelated non-zero exit must not be named the memory cap: {detail:?}"
+        );
+        assert!(detail.contains("exited with status"), "{detail:?}");
+    }
+
+    /// Shape (b) from the review: a third-party C library aborting on its
+    /// own OOM path with glibc's message, terminated by `SIGABRT` rather
+    /// than `RLIMIT_AS` directly — this must still be named the memory cap
+    /// when the evidence (the message) supports it.
+    #[test]
+    fn a_signalled_exit_with_a_glibc_allocation_signature_is_classified_as_the_memory_cap() {
+        let outcome = run_worker(
+            WorkerSpawn {
+                program: PathBuf::from("/bin/sh"),
+                args: vec![
+                    "-c".to_string(),
+                    "printf 'malloc(): unable to allocate memory' 1>&2; kill -ABRT $$".to_string(),
+                ],
+                input: Vec::new(),
+                deadline: Duration::from_secs(5),
+            },
+            &identity(),
+            &deny(),
+        );
+        let WorkerOutcome::Refused(row) = outcome else {
+            panic!("must be refused: {outcome:?}");
+        };
+        let detail = row.detail.unwrap_or_default();
+        assert!(
+            detail.contains("address-space limit") && detail.contains("signal"),
+            "a glibc allocation abort must be named the memory cap: {detail:?}"
+        );
+    }
+
+    /// A signalled exit whose stderr carries no allocation signature must
+    /// stay the honest `Signaled` label — same conservative fallback,
+    /// signal path this time.
+    #[test]
+    fn a_signalled_exit_without_an_allocation_signature_stays_signaled() {
+        let outcome = run_worker(
+            WorkerSpawn {
+                program: PathBuf::from("/bin/sh"),
+                args: vec![
+                    "-c".to_string(),
+                    "printf 'segfault, not an allocation failure' 1>&2; kill -SEGV $$".to_string(),
+                ],
+                input: Vec::new(),
+                deadline: Duration::from_secs(5),
+            },
+            &identity(),
+            &deny(),
+        );
+        let WorkerOutcome::Refused(row) = outcome else {
+            panic!("must be refused: {outcome:?}");
+        };
+        let detail = row.detail.unwrap_or_default();
+        assert!(
+            !detail.contains("address-space limit"),
+            "an unrelated signal must not be named the memory cap: {detail:?}"
+        );
+        assert!(detail.contains("terminated by signal"), "{detail:?}");
     }
 }

--- a/tests/x5_a1a_acceptance.rs
+++ b/tests/x5_a1a_acceptance.rs
@@ -43,7 +43,7 @@
 //! | 9 | image/scanned evidence enters the OCR fallback with page/region/engine provenance | deferred-s4 | — |
 //! | 10 | external Git acquisition resolves an exact commit in a no-Work-checkout cache | deferred-s4 | — |
 //! | 11 | source parsing uses content/extractor identity so unchanged resources reuse cached facts | met | `x2_knowledge_sources::a_scan_records_once_reuses_an_unchanged_generation_and_evicts_a_changed_one` |
-//! | 12 | daemon remains sole Atlas writer and worker failure cannot corrupt journal authority | met-with-deviation | `x5_a1a_acceptance::a1a_item_12_no_atlas_write_path_is_reachable_from_the_cli` |
+//! | 12 | daemon remains sole Atlas writer and worker failure cannot corrupt journal authority | met | `x5_a1a_acceptance::a1a_item_12_no_atlas_write_path_is_reachable_from_the_cli` |
 //! | 13 | `sgt map`/status surfaces expose source/generation/coverage rather than arbitrary SQL | met | `x5_a1a_acceptance::a1a_item_13_no_client_sql_reaches_the_store` |
 //! | 14 | all existing exact-root, Work-surface, distro-route/edition and split-hardening output-contract tests remain green | met | `x5_a1a_acceptance::a1a_item_14_the_inherited_contract_pins_still_exist` |
 //!
@@ -353,11 +353,19 @@ const WALK: &[Item] = &[
     },
     Item {
         number: 12,
-        verdict: Verdict::MetWithDeviation,
+        verdict: Verdict::Met,
         checks: &[
             at(
                 "tests/x5_a1a_acceptance.rs",
                 "a1a_item_12_no_atlas_write_path_is_reachable_from_the_cli",
+            ),
+            at(
+                "src/runtime/atlas/db.rs",
+                "open_read_only_refuses_a_store_that_does_not_exist_and_creates_nothing",
+            ),
+            at(
+                "src/runtime/atlas/db.rs",
+                "open_read_only_reads_confirmed_rows_and_cannot_write",
             ),
             at(
                 "tests/x1_atlas_substrate.rs",
@@ -375,14 +383,24 @@ const WALK: &[Item] = &[
                 "tests/x2_knowledge_sources.rs",
                 "a_crash_after_the_summary_but_before_confirmation_completes_the_scan",
             ),
+            at(
+                "tests/y1_worker_transport.rs",
+                "a_fault_worker_leaves_the_daemon_up_the_permit_freed_and_a_named_coverage_row",
+            ),
         ],
-        note: "RESIDUAL, named rather than glossed: `sgt doctor`'s atlas coverage row opens the \
-               store from the CLI process when no daemon holds the lock. It writes no fact — the \
-               open runs idempotent `IF NOT EXISTS` DDL and then reads — but it is a read-write \
-               open by a non-daemon process, so 'sole writer' is exact for facts and approximate \
-               for the file handle. DESTINATION: S4, as a read-only open. Everything else holds: \
-               no fact-writing path is reachable from the CLI at all, and a worker that dies \
-               mid-scan leaves the journal authoritative in both crash windows.",
+        note: "RESIDUAL CLOSED (S4 Y1, G2): the row-1 residual read 'DESTINATION: S4, as a \
+               read-only open' — `sgt doctor`'s atlas coverage row now opens the store through \
+               `AtlasDb::open_read_only`, which asks DuckDB itself for `AccessMode::ReadOnly` and \
+               runs no `CREATE SCHEMA`/`CREATE TABLE` DDL at all, idempotent or not. The two new \
+               db.rs checks pin both halves: a store that does not exist is refused rather than \
+               materialized, and a store that does exist is read but genuinely cannot be written \
+               through this connection (DuckDB refuses the write, not merely this crate declining \
+               to attempt one). G2 also widens what 'daemon remains sole Atlas writer' has to \
+               survive: a worker's returned batch is now itself untrusted input, validated \
+               daemon-side (identity, `enclosed_name` path safety, F10 deny-set membership on \
+               declared child names) before anything is written — the fault-injection check cited \
+               here is the SUPERVISION proof for that (Y2 carries the real-parser malformed-input \
+               proof); nothing here claims a third-party parser exists yet.",
     },
     Item {
         number: 13,
@@ -921,7 +939,9 @@ fn a1a_item_12_no_atlas_write_path_is_reachable_from_the_cli() {
         .collect();
     assert_eq!(
         opens,
-        vec!["let sources = match AtlasDb::open(data_dir).and_then(|db| db.indexed_sources()) {"],
+        vec![
+            "let sources = match AtlasDb::open_read_only(data_dir).and_then(|db| db.indexed_sources()) {"
+        ],
         "the CLI's only Atlas call is doctor's coverage read; a new one is a writer-boundary \
          decision, not a refactor"
     );

--- a/tests/y1_worker_transport.rs
+++ b/tests/y1_worker_transport.rs
@@ -1,0 +1,368 @@
+//! S4 Y1 acceptance: the supervised parse-worker transport (G2).
+//!
+//! **Proves the SUPERVISION CONTRACT, not a parser** (panel finding — no
+//! third-party parser exists until Y2's Anydoc spike, so there is nothing
+//! real to poison yet). Two halves:
+//!
+//! * A real worker binary ([`SGT_ATLAS_WORKER`]) returning a batch is
+//!   validated daemon-side as the AUTHORITY (identity, `enclosed_name` path
+//!   safety, F10 deny-set membership on declared child names) — proven
+//!   through the real supervised process, not only through
+//!   `runtime::atlas::worker`'s own pure-function unit tests.
+//! * Four process-level faults (abort, hang past deadline, non-zero exit,
+//!   allocate-until-killed) each leave the daemon (here: the [`Engine`])
+//!   up, the intelligence-lane permit freed, no partial Atlas rows, and a
+//!   named coverage row describing the failure — the acceptance
+//!   [`a_fault_worker_leaves_the_daemon_up_the_permit_freed_and_a_named_coverage_row`]
+//!   walks all four.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+use sergeant_rs::backend::BackendRegistry;
+use sergeant_rs::domain::source::Coverage;
+use sergeant_rs::runtime::atlas::db::AtlasDb;
+use sergeant_rs::runtime::atlas::deny::AcquisitionFilter;
+use sergeant_rs::runtime::atlas::lane::run_worker_on_lane;
+use sergeant_rs::runtime::atlas::worker::{WorkerIdentity, WorkerOutcome, WorkerSpawn, run_worker};
+use sergeant_rs::runtime::engine::Engine;
+
+/// The real worker binary Cargo built alongside this test binary (`sgt` is
+/// the other one, addressed the same way elsewhere in this suite).
+const SGT_ATLAS_WORKER: &str = env!("CARGO_BIN_EXE_sgt-atlas-worker");
+
+/// Generous enough that a healthy worker (spawn, run, exit) never trips it
+/// under either of the two-environment rule's hosts, short enough that the
+/// hang/allocate faults below do not slow the suite.
+const NORMAL_DEADLINE: Duration = Duration::from_secs(10);
+/// Deliberately short: this bounds how long the hang/allocate fault cases
+/// keep their worker alive before supervision kills it.
+const FAULT_DEADLINE: Duration = Duration::from_millis(400);
+/// The outer bound the whole test is wrapped in. If supervision's deadline
+/// enforcement were broken (a hung worker never actually killed), the
+/// per-case `FAULT_DEADLINE` above would never fire and this is what would
+/// catch it instead of the test hanging forever.
+const TEST_OUTER_BOUND: Duration = Duration::from_secs(20);
+
+fn deny() -> AcquisitionFilter {
+    AcquisitionFilter::new(&[]).expect("compile default deny set")
+}
+
+fn identity_for(input: &[u8]) -> WorkerIdentity {
+    WorkerIdentity {
+        generation_id: "gen-y1".to_string(),
+        resource_hash: blake3::hash(input).to_hex().to_string(),
+        extractor: "fixture/v1".to_string(),
+    }
+}
+
+fn spawn(args: Vec<String>, input: Vec<u8>, deadline: Duration) -> WorkerSpawn {
+    WorkerSpawn {
+        program: PathBuf::from(SGT_ATLAS_WORKER),
+        args,
+        input,
+        deadline,
+    }
+}
+
+// --------------------------------------------------------------- the happy path
+
+/// Bytes in, a normalized batch out, through a real subprocess — round-trips
+/// content through the real worker binary rather than only through
+/// `worker.rs`'s in-memory unit tests.
+#[test]
+fn a_worker_process_returns_units_that_pass_daemon_side_validation() {
+    let input = b"hello atlas".to_vec();
+    let identity = identity_for(&input);
+    let outcome = run_worker(
+        spawn(
+            vec![
+                "--generation".to_string(),
+                identity.generation_id.clone(),
+                "--extractor".to_string(),
+                identity.extractor.clone(),
+            ],
+            input.clone(),
+            NORMAL_DEADLINE,
+        ),
+        &identity,
+        &deny(),
+    );
+    let WorkerOutcome::Accepted(batch) = outcome else {
+        panic!("a well-formed worker run must be accepted: {outcome:?}");
+    };
+    assert_eq!(batch.generation_id, identity.generation_id);
+    assert_eq!(batch.resource_hash, identity.resource_hash);
+    assert_eq!(batch.units.len(), 1, "one Document unit for UTF-8 input");
+    assert_eq!(batch.units[0].text, "hello atlas");
+}
+
+/// The identity the daemon expects is composed from what the daemon itself
+/// knows — never from anything the worker said — so a worker that ran
+/// against the *wrong* bytes (or a stale job) is refused even though it
+/// exited cleanly and produced well-formed JSON.
+#[test]
+fn a_batch_computed_over_the_wrong_bytes_is_refused_by_identity_not_trusted() {
+    let true_input = b"the real bytes".to_vec();
+    // The daemon's own expectation is built over *different* bytes than what
+    // actually got sent — simulating a worker that (bug, or a compromised
+    // process) computed its hash over something else.
+    let identity = identity_for(b"not what was actually sent");
+    let outcome = run_worker(
+        spawn(
+            vec![
+                "--generation".to_string(),
+                identity.generation_id.clone(),
+                "--extractor".to_string(),
+                identity.extractor.clone(),
+            ],
+            true_input,
+            NORMAL_DEADLINE,
+        ),
+        &identity,
+        &deny(),
+    );
+    let WorkerOutcome::Refused(row) = outcome else {
+        panic!("an identity mismatch must be refused: {outcome:?}");
+    };
+    assert_eq!(row.status, Coverage::Error);
+    assert!(
+        row.detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("resource_hash"),
+        "{row:?}"
+    );
+}
+
+/// The brief's own example, through the real subprocess: a worker declaring
+/// a child named `.env` is refused daemon-side, with a named coverage row —
+/// worker-side, nothing stopped it; the daemon is the authority.
+#[test]
+fn a_real_worker_declaring_a_denied_child_name_is_refused_with_a_named_row() {
+    let input = b"body".to_vec();
+    let identity = identity_for(&input);
+    let outcome = run_worker(
+        spawn(
+            vec![
+                "--generation".to_string(),
+                identity.generation_id.clone(),
+                "--extractor".to_string(),
+                identity.extractor.clone(),
+                "--declare-child".to_string(),
+                ".env=.env".to_string(),
+            ],
+            input,
+            NORMAL_DEADLINE,
+        ),
+        &identity,
+        &deny(),
+    );
+    let WorkerOutcome::Refused(row) = outcome else {
+        panic!("a denied child name must be refused: {outcome:?}");
+    };
+    assert_eq!(row.status, Coverage::Excluded);
+    assert!(
+        row.detail.as_deref().unwrap_or_default().contains(".env"),
+        "{row:?}"
+    );
+}
+
+/// The brief's other example: a declared child at a traversal path is
+/// refused by path safety, through the real subprocess.
+#[test]
+fn a_real_worker_declaring_a_traversal_child_path_is_refused_with_a_named_row() {
+    let input = b"body".to_vec();
+    let identity = identity_for(&input);
+    let outcome = run_worker(
+        spawn(
+            vec![
+                "--generation".to_string(),
+                identity.generation_id.clone(),
+                "--extractor".to_string(),
+                identity.extractor.clone(),
+                "--declare-child".to_string(),
+                "evil=../../etc/passwd".to_string(),
+            ],
+            input,
+            NORMAL_DEADLINE,
+        ),
+        &identity,
+        &deny(),
+    );
+    let WorkerOutcome::Refused(row) = outcome else {
+        panic!("a traversal child path must be refused: {outcome:?}");
+    };
+    assert_eq!(row.status, Coverage::Error);
+    assert!(
+        row.detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("../../etc/passwd"),
+        "{row:?}"
+    );
+}
+
+// ------------------------------------------------------- the supervision contract
+
+/// One fault-injection case: the `--fault` mode this binary is asked to
+/// perform, and a substring the resulting coverage row's detail must name.
+struct FaultCase {
+    fault: &'static str,
+    names: &'static str,
+}
+
+const FAULT_CASES: &[FaultCase] = &[
+    FaultCase {
+        fault: "abort",
+        names: "signal",
+    },
+    FaultCase {
+        fault: "hang",
+        names: "deadline",
+    },
+    FaultCase {
+        fault: "exit-nonzero",
+        names: "status",
+    },
+    FaultCase {
+        fault: "allocate",
+        names: "deadline",
+    },
+];
+
+/// **The wave's own acceptance**: for each of the four fault-injection
+/// modes, the daemon (here, the [`Engine`] running the worker under a real
+/// intelligence-lane permit) stays up, the permit is freed, no partial Atlas
+/// rows appear, and a named coverage row lands describing the failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_fault_worker_leaves_the_daemon_up_the_permit_freed_and_a_named_coverage_row() {
+    tokio::time::timeout(TEST_OUTER_BOUND, async {
+        for case in FAULT_CASES {
+            let data = TempDir::new().expect("tempdir");
+            let engine = Engine::new(Arc::new(BackendRegistry::new()), None, data.path())
+                .with_intelligence_lane_cap(1);
+
+            // "No partial rows are written": Atlas has no writer for a
+            // worker's batch until a later wave wires `record`'s three-step
+            // discipline onto it, and this transport never opens the store
+            // at all (`AtlasDb` is not even reachable from `worker.rs`) — so
+            // the decisive, checkable form of the claim today is that an
+            // independent Atlas store is untouched by the call, before and
+            // after.
+            let atlas = AtlasDb::open_in_memory().expect("in-memory atlas");
+            assert!(atlas.indexed_sources().expect("read").is_empty());
+
+            let input = b"irrelevant for a fault run".to_vec();
+            let identity = identity_for(&input);
+            let outcome = run_worker_on_lane(
+                &engine,
+                spawn(
+                    vec![
+                        "--generation".to_string(),
+                        identity.generation_id.clone(),
+                        "--extractor".to_string(),
+                        identity.extractor.clone(),
+                        "--fault".to_string(),
+                        case.fault.to_string(),
+                    ],
+                    input,
+                    FAULT_DEADLINE,
+                ),
+                identity,
+                deny(),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("[{}] the lane call itself must not fail: {e}", case.fault));
+
+            let WorkerOutcome::Refused(row) = outcome else {
+                panic!(
+                    "[{}] a fault must be refused, not accepted: {outcome:?}",
+                    case.fault
+                );
+            };
+            assert_eq!(
+                row.status,
+                Coverage::Error,
+                "[{}] a process-level fault is Coverage::Error: {row:?}",
+                case.fault
+            );
+            let detail = row.detail.clone().unwrap_or_default();
+            assert!(
+                detail.contains(case.names),
+                "[{}] coverage detail {detail:?} must name {:?}",
+                case.fault,
+                case.names
+            );
+
+            assert_eq!(
+                engine.intelligence_lane.available_permits(),
+                1,
+                "[{}] the intelligence-lane permit must be freed",
+                case.fault
+            );
+
+            // "The daemon stays up": the engine that just supervised a
+            // killed/aborted/non-zero child still runs an ordinary job.
+            let still_alive: usize = engine.run_intelligence(|| 7).await.unwrap_or_else(|e| {
+                panic!("[{}] the engine must still be usable: {e}", case.fault)
+            });
+            assert_eq!(still_alive, 7);
+
+            assert!(
+                atlas.indexed_sources().expect("read").is_empty(),
+                "[{}] no partial rows may appear from a faulted worker",
+                case.fault
+            );
+        }
+    })
+    .await
+    .expect("the whole fault-injection walk must finish well inside its outer bound");
+}
+
+/// No `sgt`-shaped, `opencode`, or `codex` children may survive the suite
+/// (#310's four patterns) — this wave adds a fifth species, and it gets the
+/// same discipline: nothing named `sgt-atlas-worker` may still be running
+/// once every case above (including the two hang/allocate kills) has
+/// returned.
+#[test]
+fn no_worker_process_survives_the_fault_injection_walk() {
+    // A fresh probe, run after the async test above has already executed in
+    // this same binary (integration test binaries run all `#[test]`s in one
+    // process) is not orderable against it, so this asserts the one thing
+    // that is always true regardless of order: right now, nothing named
+    // `sgt-atlas-worker` is alive. Run last alphabetically is not guaranteed
+    // either, so the real proof is inside the fault walk's own per-case
+    // deadline enforcement above (kill + reap, synchronously, before
+    // `run_worker` returns) — this is a coarse whole-binary backstop, not
+    // the decisive check.
+    // Polled, not a single sample: `child.wait()` reaping inside this same
+    // process and a system-wide `pgrep` snapshot observing that reap are two
+    // different vantage points, and a process signalled microseconds ago can
+    // still show up in one `/proc` scan — the same reason `child.rs`'s own
+    // `wait_until_gone` polls rather than checking once.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let output = std::process::Command::new("pgrep")
+            .arg("-f")
+            .arg("sgt-atlas-worker")
+            .output();
+        let Ok(output) = output else {
+            // `pgrep` missing entirely is a probe-environment gap, not a
+            // failure — the decisive per-case kill+reap assertion above is
+            // what this suite actually relies on.
+            return;
+        };
+        let listing = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if listing.is_empty() {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("an sgt-atlas-worker process is still alive after the grace period: {listing}");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}

--- a/tests/y1_worker_transport.rs
+++ b/tests/y1_worker_transport.rs
@@ -27,7 +27,9 @@ use sergeant_rs::domain::source::Coverage;
 use sergeant_rs::runtime::atlas::db::AtlasDb;
 use sergeant_rs::runtime::atlas::deny::AcquisitionFilter;
 use sergeant_rs::runtime::atlas::lane::run_worker_on_lane;
-use sergeant_rs::runtime::atlas::worker::{WorkerIdentity, WorkerOutcome, WorkerSpawn, run_worker};
+use sergeant_rs::runtime::atlas::worker::{
+    WORKER_ADDRESS_SPACE_LIMIT_BYTES, WorkerIdentity, WorkerOutcome, WorkerSpawn, run_worker,
+};
 use sergeant_rs::runtime::engine::Engine;
 
 /// The real worker binary Cargo built alongside this test binary (`sgt` is
@@ -46,6 +48,18 @@ const FAULT_DEADLINE: Duration = Duration::from_millis(400);
 /// per-case `FAULT_DEADLINE` above would never fire and this is what would
 /// catch it instead of the test hanging forever.
 const TEST_OUTER_BOUND: Duration = Duration::from_secs(20);
+/// Deliberately generous, and used by exactly one test
+/// ([`an_allocating_worker_is_killed_by_its_address_space_cap_not_the_deadline`]):
+/// the `--fault allocate` mode grows by 8 MiB every 20ms
+/// (`src/bin/atlas_worker.rs`'s own `Fault::Allocate` doc), so it reaches
+/// [`WORKER_ADDRESS_SPACE_LIMIT_BYTES`] (512 MiB) in roughly 1.3s regardless
+/// of host memory pressure — `RLIMIT_AS` bounds virtual address space, not
+/// resident memory, so this is deterministic on any host. This deadline is
+/// wide enough that the address-space cap always wins the race, on purpose:
+/// a deadline short enough to also plausibly fire (like [`FAULT_DEADLINE`]
+/// above) would leave the test unable to tell "killed by the cap" apart from
+/// "killed by the clock".
+const MEMORY_CAP_TEST_DEADLINE: Duration = Duration::from_secs(8);
 
 fn deny() -> AcquisitionFilter {
     AcquisitionFilter::new(&[]).expect("compile default deny set")
@@ -228,6 +242,13 @@ const FAULT_CASES: &[FaultCase] = &[
         fault: "exit-nonzero",
         names: "status",
     },
+    // With FAULT_DEADLINE this short (400ms), the allocate fault reaches
+    // only ~160 MiB before the clock fires — well under
+    // WORKER_ADDRESS_SPACE_LIMIT_BYTES (512 MiB) — so this case is still the
+    // HANG-guard proof, same as it was before the memory cap existed. The
+    // memory-guard proof, with a deadline wide enough for the cap to win
+    // instead, is `an_allocating_worker_is_killed_by_its_address_space_cap_not_the_deadline`
+    // below.
     FaultCase {
         fault: "allocate",
         names: "deadline",
@@ -321,6 +342,72 @@ async fn a_fault_worker_leaves_the_daemon_up_the_permit_freed_and_a_named_covera
     })
     .await
     .expect("the whole fault-injection walk must finish well inside its outer bound");
+}
+
+/// **The memory-fault class the deadline alone left open (independent
+/// review finding, refuter-confirmed, folded into the plan as G2's
+/// amendment):** an allocation blowup must be killed by the address-space
+/// cap itself, deterministically, and distinguishably from the deadline —
+/// not merely "eventually killed by something". A deadline generous enough
+/// that the cap has to fire first ([`MEMORY_CAP_TEST_DEADLINE`]), plus an
+/// elapsed-time assertion showing the kill landed well before that deadline
+/// could have fired, is what makes this a proof of the memory guard rather
+/// than a second proof of the hang guard already covered above.
+#[test]
+fn an_allocating_worker_is_killed_by_its_address_space_cap_not_the_deadline() {
+    let input = b"irrelevant for a memory-fault run".to_vec();
+    let identity = identity_for(&input);
+
+    let started = std::time::Instant::now();
+    let outcome = run_worker(
+        spawn(
+            vec![
+                "--generation".to_string(),
+                identity.generation_id.clone(),
+                "--extractor".to_string(),
+                identity.extractor.clone(),
+                "--fault".to_string(),
+                "allocate".to_string(),
+            ],
+            input,
+            MEMORY_CAP_TEST_DEADLINE,
+        ),
+        &identity,
+        &deny(),
+    );
+    let elapsed = started.elapsed();
+
+    let WorkerOutcome::Refused(row) = outcome else {
+        panic!("an allocation past the address-space cap must be refused: {outcome:?}");
+    };
+    assert_eq!(row.status, Coverage::Error, "{row:?}");
+    let detail = row.detail.clone().unwrap_or_default();
+
+    // Distinguishes cap-kill from deadline-kill by what the row actually
+    // says, not by inference: `WorkerFault::TimedOut`'s own detail names
+    // "exceeded its deadline" and nothing else does.
+    assert!(
+        !detail.contains("exceeded its deadline"),
+        "must be killed by the address-space cap, not the wall-clock deadline: {detail:?}"
+    );
+    assert!(
+        detail.contains(&WORKER_ADDRESS_SPACE_LIMIT_BYTES.to_string())
+            && detail.contains("address-space"),
+        "coverage detail must name the address-space limit that killed it: {detail:?}"
+    );
+
+    // Distinguishes cap-kill from deadline-kill by *when* it happened, not
+    // only by what the row says: a deadline-kill could not possibly return
+    // before MEMORY_CAP_TEST_DEADLINE elapsed, so landing well inside half
+    // of it is proof the cap — not the clock — ended the child. RLIMIT_AS
+    // bounds virtual address space, not resident memory, so this timing is
+    // independent of host memory pressure and safe to assert without
+    // flaking under load.
+    assert!(
+        elapsed < MEMORY_CAP_TEST_DEADLINE / 2,
+        "the address-space cap must fire well inside the deadline budget, not race it: killed \
+         after {elapsed:?}, deadline was {MEMORY_CAP_TEST_DEADLINE:?}"
+    );
 }
 
 /// No `sgt`-shaped, `opencode`, or `codex` children may survive the suite


### PR DESCRIPTION
Wave Y1 of S4 (Atlas adapters). Plan: workspace `host-atlas-s4-series/sprint-plan-2026-08-27.md` (amended; G2 governs). This is the wave where S3's named F6 deviation comes due: A1 §12's worker boundary.

**The transport** (`src/runtime/atlas/worker.rs`, `src/bin/atlas_worker.rs`): a pure-function adapter runs in a supervised child — bytes in, normalized batch out. Every spawn carries the #310 ChildLifetime discipline (own process group, PDEATHSIG, kill+reap on every exit path, bounded deadline) and runs under an intelligence-lane permit. The worker never opens the store; `duckdb` stays confined to `atlas/db.rs` + `analytics.rs` and both structural tests stay green.

**Daemon-side validation is the AUTHORITY, not a formality** — every returned batch is re-validated before a row is written: identity (generation + resource hash + extractor identity), `enclosed_name` path safety, and F10 deny-set membership matched on the child-declared NAME as well as its path. A worker declaring a child named `.env` or `../../etc/passwd` is refused daemon-side with a named coverage row. Worker-side checks are defense in depth only.

**A memory cap, added after an independent seat found the hole.** The plan's headline promise is "a malformed document fails its worker, never the daemon" — but a wall-clock deadline is a *hang* guard, not a memory guard. Without an address-space limit, an allocation blowup raises host-global pressure and the kernel OOM killer picks its own victim; on this host that has repeatedly been infrastructure rather than the hog (#310's four session/host deaths). Every spawn now arms `RLIMIT_AS` on the child via `pre_exec`, composed with (not replacing) the existing PDEATHSIG hardening — Rust runs `pre_exec` closures in registration order, and the hard limit equals the soft one so the child cannot raise its own ceiling before `exec`.

The cap's acceptance is **deterministic, not racy**: the allocating fault runs under a deliberately wide deadline so only the cap can fire, and the test asserts the coverage detail names the address-space limit and does *not* contain "exceeded its deadline". Without the cap the fixture would need ~3.2 GiB to reach that deadline, and a host OOM kill would produce a plain signal fault — so the test cannot pass by either accident.

**Honesty about the constant**: 512 MiB is marked PROVISIONAL in its own doc comment — unmeasured, chosen while Y1 ships no real parser, and required to be re-derived against a real corpus when Y2's adapter lands (#325). The comment also states the real ceiling is `lane_cap × constant`, not the per-child number alone. Cap-kill detection matches a conservative set of allocation-failure signatures (Rust allocator abort, `TryReserveError`+`AllocError` — with `CapacityOverflow` explicitly excluded and pinned by a negative test, `strerror(ENOMEM)`, glibc's malloc abort) on both signalled and non-zero-exit deaths; every match only upgrades an already-abnormal exit to a more specific label, never manufactures a fault, and never touches the deadline path. Attribution from kernel accounting rather than message text is filed as #324.

**Doctor rider**: `sgt doctor`'s atlas row is now a read-only open (`AtlasDb::open_read_only`) — creates no file, runs no DDL. Acceptance register row 12's residual closes here (`met-with-deviation` → `met`).

Gates: wave workflow wf_3c73e238 (all-sonnet) — 1 panel finding, confirmed and fixed (kill the process group on every exit path, not only the deadline one); verify green. Post-wave adversarial review of the cap commit: SOUND, its two findings applied here. Final: nextest **2105 passed**, 38 skipped, exit code verified via PIPESTATUS; clippy zero warnings; fmt clean; no `sgt-atlas-worker` survivors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4