### PR TITLE
fix(deps): bump chacha20 to 0.10.2 — unblock the release gate (#328)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,9 +597,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## What

One-line `Cargo.lock` bump: `chacha20` 0.10.1 → 0.10.2.

## Why this was blocking

Gate E of the S4 close dry-run ([run 33250519400](https://github.com/miztertea/sergeant-rs/actions/runs/33250519400)) failed on **exactly one** error — the yanked `chacha20` 0.10.1. It is now reached by two paths:

- `ulid → rand → chacha20` (the original #328 path)
- `anydoc → pdf-inspector → lopdf → rand → chacha20` (new since S4)

so a single lockfile bump clears both. 0.10.2 is published and unyanked; no manifest constraint changes.

`cargo deny check` now exits 0:

```
advisories ok, bans ok, licenses ok, sources ok
```

That output also confirms the **scoped `RUSTSEC-2026-0192` exception** from the anydoc adoption ruling is holding narrowly rather than the gate being disabled — the advisory does not appear anywhere in the output.

## Verification

- `cargo deny check` → exit 0 (the full gate command, all four checks)
- `cargo check --all-targets` → exit 0, zero warnings

## Why it was mis-filed

#328 sat in the 0.3.0 plan under "category D — test/CI health, running alongside." It is not alongside anything: **Gate E is a release gate**, so 0.3.0 could not have shipped past it however S5 and S6 went. Re-categorised as release-blocking.

Closes #328.

R3 (use what the ecosystem already published — no code change needed).
J1 (local, reversible, non-contractual: a lockfile patch bump changing no public behaviour and no manifest constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4