### PR TITLE
feat(atlas): S5 W1 — A2 §2's deterministic admissibility filter

### DIFF
--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -240,3 +240,15 @@ cov_stage_end 1 "the y6b_online_only test binary must write its own profile"
 cov_stage_begin c2-y5_doctrine_never_fetches_is_scoped
 cov_run cargo llvm-cov --no-report --test y5_doctrine_never_fetches_is_scoped --locked || cov_fail "y5_doctrine_never_fetches_is_scoped failed under instrumentation"
 cov_stage_end 1 "the y5_doctrine_never_fetches_is_scoped test binary must write its own profile"
+
+# S5 W1, wired at birth (the #231 lesson, same as x5/y2/y5/y6 above): A2 §2's
+# deterministic admissibility filter — the four bounded canned queries and
+# their negative-admission proofs, plus the structural pins on H13.1's
+# extractor vocabulary. Builds Atlas stores in tempdirs and records scans
+# through the ordinary `record_scan` path, and runs one real
+# `scan_local_knowledge` walk for the `--content config` live check. No
+# daemon, no estate, no subprocess of any kind — which is why it is here
+# rather than with the spawning suites. Floor 1.
+cov_stage_begin c2-w1_deterministic_filter
+cov_run cargo llvm-cov --no-report --test w1_deterministic_filter --locked || cov_fail "w1_deterministic_filter failed under instrumentation"
+cov_stage_end 1 "the w1_deterministic_filter test binary must write its own profile"

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -1841,6 +1841,331 @@ impl AtlasDb {
         Ok(out)
     }
 
+    // ------------------------------------------------------------------
+    // S5 W1 — A2 §2's deterministic admissibility filter (H1, H13.1).
+    //
+    // "The first operation is deterministic admissibility, not embeddings":
+    // source/estate/Work-generation filter, then authority filter, then
+    // content-kind filter, then the optional repo/knowledge/external
+    // selector — every stage a database predicate that decides what may be
+    // SEEN, never a ranking hint (A2 §8: a reranker must never cross this
+    // boundary because a candidate scores well). No scoring, no ranking, no
+    // BM25, no embeddings live here or anywhere in this wave — those are
+    // W2-W4. Every method below answers with a COMPLETE, EXACT admissible
+    // set: additive SQL on the cross-source join precedent
+    // [`Self::symbol_lookup`]/[`Self::references`] already established
+    // (H1), never a new table or a new column (H13.1).
+    // ------------------------------------------------------------------
+
+    /// A2 §2 stages 1(+4) and 2 in one canned query: the source/estate/
+    /// Work-generation filter, the optional repo/knowledge/external
+    /// selector (the same [`SourceKind`] axis — [`SourceSelector::Kind`]),
+    /// and the authority filter — composed once here and reused, in
+    /// identical shape, by every content-kind method below, so a
+    /// generation excluded at this stage can never resurface through a
+    /// different table.
+    ///
+    /// Every clause is `(? IS NULL OR column = ?)`: an unset filter field
+    /// admits every value of that column rather than narrowing it, so
+    /// `Admissibility::default()` (bare [`SourceSelector::Any`], no
+    /// authority) is "every confirmed generation this store holds" — never
+    /// approximate, never partial. Bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    pub fn admissible_generations(
+        &self,
+        filter: &Admissibility,
+        limit: usize,
+    ) -> Result<Vec<SourceGeneration>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let (source_name, content_key, source_kind) = filter.source.bindings();
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let mut statement = self.conn.prepare(
+            "SELECT generation_id, source_name, source_kind, authority_class, content_key, \
+                    observed_at \
+             FROM source.generations \
+             WHERE state = ? \
+               AND (? IS NULL OR source_name = ?) \
+               AND (? IS NULL OR content_key = ?) \
+               AND (? IS NULL OR source_kind = ?) \
+               AND (? IS NULL OR authority_class = ?) \
+             ORDER BY source_name, observed_at DESC, generation_id DESC LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![
+            STATE_CONFIRMED,
+            source_name,
+            source_name,
+            content_key,
+            content_key,
+            source_kind,
+            source_kind,
+            authority,
+            authority,
+            limit
+        ])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            let kind: String = row.get(2)?;
+            let auth: String = row.get(3)?;
+            out.push(SourceGeneration {
+                id: row.get(0)?,
+                source_name: row.get(1)?,
+                kind: SourceKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
+                    column: "source_kind".to_string(),
+                    value: kind.clone(),
+                })?,
+                authority: AuthorityClass::parse(&auth).ok_or_else(|| {
+                    AtlasError::UnknownValue {
+                        column: "authority_class".to_string(),
+                        value: auth.clone(),
+                    }
+                })?,
+                content_key: row.get(4)?,
+                observed_at: row.get(5)?,
+            });
+        }
+        Ok(out)
+    }
+
+    /// A2 §2's content-kind filter, **document family** — H13.1's decided
+    /// mechanism: table-routing (`source.units` is physically separate from
+    /// the code and tabular families, so the coarse split needs no new
+    /// column) plus an extractor-identity allowlist joined off
+    /// `source.files`, pinned by [`DOCUMENT_EXTRACTOR_IDENTITIES`] and its
+    /// own structural test (`tests/w1_deterministic_filter.rs`).
+    ///
+    /// **The allowlist is a safety net, not a clean split — verified live,
+    /// correcting a premise H13.1's own text carried.** `claims_for`
+    /// (`src/runtime/atlas/scan.rs`) gives every grammar-claimed-but-
+    /// document-unclaimed file (`main.rs`, `Cargo.toml`) a plain-text
+    /// fallback unit under [`crate::runtime::atlas::text::TEXT_EXTRACTOR`]
+    /// so "every acquired resource still has units" — checked directly in
+    /// this worktree: a `Cargo.toml` fixture produces exactly one
+    /// `Document` unit (extractor `"text/v1"`, body = the whole file) in
+    /// *addition* to its `source.occurrences` rows under `"syntax-toml/v1"`.
+    /// That is the *same* extractor identity a genuine `.txt` document
+    /// carries, so this filter cannot separate "real prose" from a
+    /// code/config file's catch-all body — no `extractor` value
+    /// distinguishes them — and it does not try to. H13.1's "no new
+    /// column" holds regardless: the gap is named here, not engineered
+    /// around with state this wave was told not to add.
+    ///
+    /// Stages 1/2/4 come from `filter`, identically to
+    /// [`Self::admissible_generations`]. Bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    pub fn admissible_units(
+        &self,
+        filter: &Admissibility,
+        limit: usize,
+    ) -> Result<Vec<StoredUnitHit>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let (source_name, content_key, source_kind) = filter.source.bindings();
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let [doc_a, doc_b, doc_c, doc_d] = DOCUMENT_EXTRACTOR_IDENTITIES;
+        let mut statement = self.conn.prepare(
+            "SELECT g.source_name, u.relative_path, u.local_key, u.ordinal, u.unit_kind, \
+                    u.heading_level, u.title, u.byte_start, u.byte_end, u.body \
+             FROM source.units u \
+             JOIN source.generations g USING (generation_id) \
+             JOIN source.files f ON f.generation_id = u.generation_id \
+                                 AND f.relative_path = u.relative_path \
+             WHERE g.state = ? \
+               AND f.extractor IN (?, ?, ?, ?) \
+               AND (? IS NULL OR g.source_name = ?) \
+               AND (? IS NULL OR g.content_key = ?) \
+               AND (? IS NULL OR g.source_kind = ?) \
+               AND (? IS NULL OR g.authority_class = ?) \
+             ORDER BY g.source_name, u.relative_path, u.ordinal LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![
+            STATE_CONFIRMED,
+            doc_a,
+            doc_b,
+            doc_c,
+            doc_d,
+            source_name,
+            source_name,
+            content_key,
+            content_key,
+            source_kind,
+            source_kind,
+            authority,
+            authority,
+            limit
+        ])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            let kind: String = row.get(4)?;
+            out.push(StoredUnitHit {
+                source_name: row.get(0)?,
+                unit: StoredUnit {
+                    relative_path: row.get(1)?,
+                    local_key: row.get(2)?,
+                    ordinal: row.get::<usize, i64>(3)? as u64,
+                    kind: UnitKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
+                        column: "unit_kind".to_string(),
+                        value: kind.clone(),
+                    })?,
+                    heading_level: row.get::<usize, Option<i64>>(5)?.map(|v| v as u8),
+                    title: row.get(6)?,
+                    byte_start: row.get::<usize, i64>(7)? as u64,
+                    byte_end: row.get::<usize, i64>(8)? as u64,
+                    body: row.get(9)?,
+                },
+            });
+        }
+        Ok(out)
+    }
+
+    /// A2 §2's content-kind filter, **code family** — `source.symbols` +
+    /// `source.occurrences` + `source.edges`, physically separate from the
+    /// document and tabular families (H13.1, no new column). This method
+    /// reads `source.occurrences`; `symbols`/`edges` follow the identical
+    /// shape and are not duplicated here (R1 — nothing in this wave's
+    /// negative-admission proof needs them; each is a mechanical variant of
+    /// this one for a later wave to add on demand).
+    ///
+    /// The extractor match is `extractor LIKE ?` bound to
+    /// [`CODE_EXTRACTOR_LIKE`] (`"syntax-%"`) — a fixed, code-owned pattern
+    /// (F12: never a client-supplied pattern), pinned by a structural test
+    /// against every
+    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::ALL`] identity.
+    /// **This is also where a `.toml` config file's occurrences live**
+    /// (H13.1's decided exception): a config file's key/table structure is
+    /// claimed by
+    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::Toml`] the same way
+    /// Rust is claimed by
+    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::Rust`], under
+    /// extractor identity `"syntax-toml/v1"` — matched by this same `LIKE`
+    /// pattern. `--content config` has no document-side backing (see
+    /// [`Self::admissible_units`]'s own doc) and is not offered as a
+    /// distinct value; a caller wanting config content calls this method,
+    /// exactly as for code.
+    ///
+    /// Stages 1/2/4 come from `filter`, identically to
+    /// [`Self::admissible_generations`]. Bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    pub fn admissible_occurrences(
+        &self,
+        filter: &Admissibility,
+        limit: usize,
+    ) -> Result<Vec<StoredOccurrenceHit>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let (source_name, content_key, source_kind) = filter.source.bindings();
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let mut statement = self.conn.prepare(
+            "SELECT g.source_name, o.relative_path, o.syntax_key, o.extractor, o.language, \
+                    o.ordinal, o.label, o.name, o.byte_start, o.byte_end \
+             FROM source.occurrences o JOIN source.generations g USING (generation_id) \
+             WHERE g.state = ? \
+               AND o.extractor LIKE ? \
+               AND (? IS NULL OR g.source_name = ?) \
+               AND (? IS NULL OR g.content_key = ?) \
+               AND (? IS NULL OR g.source_kind = ?) \
+               AND (? IS NULL OR g.authority_class = ?) \
+             ORDER BY g.source_name, o.relative_path, o.ordinal LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![
+            STATE_CONFIRMED,
+            CODE_EXTRACTOR_LIKE,
+            source_name,
+            source_name,
+            content_key,
+            content_key,
+            source_kind,
+            source_kind,
+            authority,
+            authority,
+            limit
+        ])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push(StoredOccurrenceHit {
+                source_name: row.get(0)?,
+                occurrence: StoredOccurrence {
+                    relative_path: row.get(1)?,
+                    syntax_key: row.get(2)?,
+                    extractor: row.get(3)?,
+                    language: row.get(4)?,
+                    ordinal: row.get::<usize, i64>(5)? as u64,
+                    label: row.get(6)?,
+                    name: row.get(7)?,
+                    byte_start: row.get::<usize, i64>(8)? as u64,
+                    byte_end: row.get::<usize, i64>(9)? as u64,
+                },
+            });
+        }
+        Ok(out)
+    }
+
+    /// A2 §2's content-kind filter, **tabular family** — `source.datasets`
+    /// (+ `context.row_units`, not read here — see
+    /// [`Self::admissible_occurrences`]'s note on why the whole family is
+    /// not duplicated). No extractor ambiguity here: `source.datasets`
+    /// carries no `extractor` column at all (`format`/`reader` are a
+    /// different axis), so table-routing alone is exact for this family
+    /// (H13.1).
+    ///
+    /// Stages 1/2/4 come from `filter`, identically to
+    /// [`Self::admissible_generations`]. Bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    pub fn admissible_datasets(
+        &self,
+        filter: &Admissibility,
+        limit: usize,
+    ) -> Result<Vec<StoredDatasetHit>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let (source_name, content_key, source_kind) = filter.source.bindings();
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let mut statement = self.conn.prepare(
+            "SELECT g.source_name, d.relative_path, d.format, d.content_hash, d.reader, \
+                    d.dataset_key, d.byte_len, d.columns, d.row_count, d.truncated, d.row_units \
+             FROM source.datasets d JOIN source.generations g USING (generation_id) \
+             WHERE g.state = ? \
+               AND (? IS NULL OR g.source_name = ?) \
+               AND (? IS NULL OR g.content_key = ?) \
+               AND (? IS NULL OR g.source_kind = ?) \
+               AND (? IS NULL OR g.authority_class = ?) \
+             ORDER BY g.source_name, d.relative_path LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![
+            STATE_CONFIRMED,
+            source_name,
+            source_name,
+            content_key,
+            content_key,
+            source_kind,
+            source_kind,
+            authority,
+            authority,
+            limit
+        ])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            let format: String = row.get(2)?;
+            out.push(StoredDatasetHit {
+                source_name: row.get(0)?,
+                dataset: StoredDataset {
+                    relative_path: row.get(1)?,
+                    format: DatasetFormat::parse(&format).ok_or_else(|| {
+                        AtlasError::UnknownValue {
+                            column: "format".to_string(),
+                            value: format.clone(),
+                        }
+                    })?,
+                    content_hash: row.get(3)?,
+                    reader: row.get(4)?,
+                    dataset_key: row.get(5)?,
+                    byte_len: row.get::<usize, i64>(6)? as u64,
+                    columns: split_names(&row.get::<usize, String>(7)?),
+                    row_count: row.get::<usize, i64>(8)? as u64,
+                    truncated: row.get(9)?,
+                    row_units: row.get::<usize, i64>(10)? as u64,
+                },
+            });
+        }
+        Ok(out)
+    }
+
     /// Every generation's state, keyed by id — a diagnostic read, and what a
     /// crash-window test inspects.
     pub fn generation_states(&self) -> Result<BTreeMap<String, String>, AtlasError> {
@@ -2900,6 +3225,203 @@ pub struct StoredReference {
     pub byte_start: u64,
     /// End offset into the original file bytes, exclusive.
     pub byte_end: u64,
+}
+
+// ---------------------------------------------------------------------
+// S5 W1 — A2 §2's admissibility filter vocabulary (H1, H13.1).
+// ---------------------------------------------------------------------
+
+/// A2 §2's stage-1(+4) and stage-2 world selection, composed once and
+/// reused by every content-kind method
+/// ([`AtlasDb::admissible_units`]/[`AtlasDb::admissible_occurrences`]/
+/// [`AtlasDb::admissible_datasets`]) and by
+/// [`AtlasDb::admissible_generations`] itself.
+///
+/// **Admissibility only, never a ranking hint** (A2 §8): every field here
+/// either admits a row or it does not. There is no score, no weight,
+/// nothing a downstream reranker (W2-W4, not built yet) could read as a
+/// preference — this wave ships before any of that exists, and this type
+/// is why it can (A2 §2's own ordering: filter the world, only THEN
+/// retrieve/rank).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Admissibility {
+    /// Stage 1 (+4): which source(s) may be seen at all.
+    pub source: SourceSelector,
+    /// Stage 2: which authority class may be seen. `None` admits every
+    /// class — this filter only ever narrows what a caller explicitly
+    /// asked to narrow; there is no implicit default-deny beyond what
+    /// `source` already selects.
+    pub authority: Option<AuthorityClass>,
+}
+
+/// A2 §2's stage-1 source/estate/Work-generation selector, plus stage 4's
+/// optional repo/knowledge/external grouping — the same [`SourceKind`]
+/// axis, so it is one variant here ([`Self::Kind`]) rather than a second
+/// field a caller could set inconsistently with [`Self::Named`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum SourceSelector {
+    /// No source-name/kind constraint: every confirmed generation, subject
+    /// only to [`Admissibility::authority`].
+    #[default]
+    Any,
+    /// A2 §2's `--source <name>`: exactly one declared source's newest
+    /// CONFIRMED generation.
+    Named(String),
+    /// A2 §2's `--source <name>@<sha>`: one exact generation. Because a
+    /// superseded generation's content rows are deleted at eviction time
+    /// (ruling §4 — [`AtlasDb::confirm_scan`]'s own promotion, and
+    /// [`AtlasDb::evict_work_overlays`]), this can only ever answer for a
+    /// `content_key` that is *still* the source's current confirmed
+    /// generation; a genuinely stale key correctly returns nothing rather
+    /// than approximating — "never approximate" (A2 §2) applies to an
+    /// admissibility miss exactly as it applies to a hit.
+    Exact {
+        /// The declared source.
+        source_name: String,
+        /// The exact generation's content identity.
+        content_key: String,
+    },
+    /// A2 §2's `--type repo|knowledge|external` selector.
+    Kind(SourceKind),
+    /// A2 §2's `--work <id>` filter, **W1's scope only** (H13.2): the
+    /// named repository's BASE generation — never the overlay half, which
+    /// is W1b's daemon-side lifecycle hook
+    /// ([`crate::runtime::atlas::overlay::overlay_source_name`]/
+    /// [`AtlasDb::evict_work_overlays`]). `repository` is the plain,
+    /// non-overlay source name this Work's surface is bound to; Atlas
+    /// holds no Work↔repository binding of its own (that lives in
+    /// [`crate::runtime::surface::WorkSurface`]) so the caller resolves it
+    /// and hands it in. [`Self::work_scope`] is what a caller MUST
+    /// render/assert alongside any answer built from this variant —
+    /// A2 §2's own text promises "including overlay", so silently
+    /// presenting a base-only answer as complete would be a false claim
+    /// about a named acceptance dimension (H13.2).
+    WorkBase {
+        /// The Work this admission is scoped to, carried for the caller's
+        /// own attribution — not read by the query itself.
+        work_id: String,
+        /// The base repository source name.
+        repository: String,
+    },
+}
+
+impl SourceSelector {
+    /// The `(source_name, content_key, source_kind)` bind values every
+    /// admissibility query composes identically — [`Self::Named`] and
+    /// [`Self::WorkBase`] bind the same shape on purpose: **W1's whole
+    /// point is that a Work's base generation reads exactly like any other
+    /// named source's**, and only [`Self::work_scope`] marks the
+    /// difference the caller must state.
+    fn bindings(&self) -> (Option<&str>, Option<&str>, Option<&'static str>) {
+        match self {
+            Self::Any => (None, None, None),
+            Self::Named(name) => (Some(name.as_str()), None, None),
+            Self::Exact {
+                source_name,
+                content_key,
+            } => (Some(source_name.as_str()), Some(content_key.as_str()), None),
+            Self::Kind(kind) => (None, None, Some(kind.as_str())),
+            Self::WorkBase { repository, .. } => (Some(repository.as_str()), None, None),
+        }
+    }
+
+    /// A2 §2's `--work` completeness fact (H8, H13.2) — see
+    /// [`Self::WorkBase`]'s own doc for why this must be rendered, not
+    /// merely computed.
+    pub fn work_scope(&self) -> WorkScope {
+        match self {
+            Self::WorkBase { .. } => WorkScope::BaseOnly,
+            _ => WorkScope::NotWorkScoped,
+        }
+    }
+}
+
+/// Whether an [`Admissibility`] answer built from
+/// [`SourceSelector::WorkBase`] covers A2 §2's `--work` promise in full —
+/// *"current Work's world, **including overlay**"* — or only its base
+/// half.
+///
+/// H13.2 assigns the overlay half to a daemon-side lifecycle hook (W1b);
+/// every [`SourceSelector::WorkBase`] answer is [`Self::BaseOnly`] until
+/// that lands. **If W1b escalates or slips, this stays [`Self::BaseOnly`]
+/// with the limitation stated — never a silent partial** (H13.2's own
+/// words: a filter that quietly omits the overlay is a partial
+/// implementation of a named acceptance dimension).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkScope {
+    /// [`SourceSelector::WorkBase`] was not the selector in play — the
+    /// concept does not apply to this answer.
+    NotWorkScoped,
+    /// `--work` admitted only the repository's plain base generation —
+    /// W1's whole scope. A caller MUST state this rather than presenting
+    /// the answer as A2 §2's full "including overlay" promise.
+    BaseOnly,
+}
+
+/// H13.1's content-kind filter, document family: the exhaustive, code-owned
+/// list of extractor identities [`AtlasDb::admissible_units`] matches
+/// against — never a client-supplied pattern (F12). Every identity a
+/// document-shaped adapter in this build can write to `source.files`:
+/// Markdown, plain text, Office (`.docx`), and mail (`.eml`). **Not**
+/// [`crate::runtime::atlas::archive::ZIP_EXTRACTOR`]: a ZIP archive is a
+/// container — its own top-level resource carries no prose, only its
+/// unpacked children do, each under its own (already-listed) extractor
+/// identity.
+///
+/// Pinned by `tests/w1_deterministic_filter.rs`'s structural test, in the
+/// shape of `tests/x1_atlas_substrate.rs`'s one-owner test: it walks
+/// `text.rs`/`office.rs`/`mail.rs`'s own `pub const ..._EXTRACTOR`
+/// declarations and asserts this list is exactly that set, so a new
+/// document adapter that lands a new identity without updating this list
+/// fails that test rather than silently falling out of (or into)
+/// `--content document`.
+pub const DOCUMENT_EXTRACTOR_IDENTITIES: [&str; 4] = [
+    crate::runtime::atlas::text::MARKDOWN_EXTRACTOR,
+    crate::runtime::atlas::text::TEXT_EXTRACTOR,
+    crate::runtime::atlas::office::DOCX_EXTRACTOR,
+    crate::runtime::atlas::mail::MAIL_EXTRACTOR,
+];
+
+/// H13.1's content-kind filter, code family: the fixed, code-owned `LIKE`
+/// pattern [`AtlasDb::admissible_occurrences`] matches `extractor` against
+/// — never a client-supplied pattern (F12). Every `source.occurrences`
+/// (and `source.symbols`/`source.edges`) row is written from
+/// [`crate::runtime::atlas::syntax::SyntaxLanguage::extractor_identity`],
+/// whose own format (`"syntax-{name}/{SYNTAX_EXTRACTOR_VERSION}"`) makes
+/// this prefix exhaustive by construction — pinned by a structural test
+/// that asserts every
+/// [`crate::runtime::atlas::syntax::SyntaxLanguage::ALL`] identity matches
+/// it, and that a synthetic unknown identity does not.
+pub const CODE_EXTRACTOR_LIKE: &str = "syntax-%";
+
+/// One structure unit read back out of the store, with the source it
+/// belongs to — [`AtlasDb::admissible_units`]'s cross-source answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredUnitHit {
+    /// The declared source.
+    pub source_name: String,
+    /// The unit itself.
+    pub unit: StoredUnit,
+}
+
+/// One occurrence read back out of the store, with the source it belongs
+/// to — [`AtlasDb::admissible_occurrences`]'s cross-source answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredOccurrenceHit {
+    /// The declared source.
+    pub source_name: String,
+    /// The occurrence itself.
+    pub occurrence: StoredOccurrence,
+}
+
+/// One registered dataset read back out of the store, with the source it
+/// belongs to — [`AtlasDb::admissible_datasets`]'s cross-source answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredDatasetHit {
+    /// The declared source.
+    pub source_name: String,
+    /// The dataset itself.
+    pub dataset: StoredDataset,
 }
 
 #[cfg(test)]

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -1857,13 +1857,26 @@ impl AtlasDb {
     // (H1), never a new table or a new column (H13.1).
     // ------------------------------------------------------------------
 
+    /// The fixed, code-owned `NOT LIKE` bound every admissibility query
+    /// below applies to `source_name`, excluding every Work-overlay
+    /// generation ([`crate::runtime::atlas::overlay::OVERLAY_PREFIX`],
+    /// `work:<id>/<repo>`) regardless of [`SourceSelector`] variant — see
+    /// [`Self::admissible_generations`]'s own doc for why the exclusion is
+    /// unconditional. Derived from the overlay module's own prefix constant
+    /// rather than a second hardcoded literal, so the two can never drift
+    /// apart; still never a client-supplied pattern (F12), the same
+    /// precedent as [`CODE_EXTRACTOR_LIKE`].
+    fn overlay_exclude_like() -> String {
+        format!("{}%", crate::runtime::atlas::overlay::OVERLAY_PREFIX)
+    }
+
     /// A2 §2 stages 1(+4) and 2 in one canned query: the source/estate/
     /// Work-generation filter, the optional repo/knowledge/external
-    /// selector (the same [`SourceKind`] axis — [`SourceSelector::Kind`]),
-    /// and the authority filter — composed once here and reused, in
-    /// identical shape, by every content-kind method below, so a
-    /// generation excluded at this stage can never resurface through a
-    /// different table.
+    /// selector ([`Admissibility::kind`], composable with any
+    /// [`SourceSelector`]), and the authority filter — composed once here
+    /// and reused, in identical shape, by every content-kind method below,
+    /// so a generation excluded at this stage can never resurface through
+    /// a different table.
     ///
     /// Every clause is `(? IS NULL OR column = ?)`: an unset filter field
     /// admits every value of that column rather than narrowing it, so
@@ -1871,19 +1884,39 @@ impl AtlasDb {
     /// authority) is "every confirmed generation this store holds" — never
     /// approximate, never partial. Bounded by `limit` (capped at
     /// [`MAX_ROWS`], F12).
+    ///
+    /// **Every Work-overlay generation is excluded, unconditionally.** A
+    /// generation whose `source_name` carries
+    /// [`crate::runtime::atlas::overlay::OVERLAY_PREFIX`]
+    /// (`work:<id>/<repo>`) describes a world only one Work's surface can
+    /// see (H13.2). No [`SourceSelector`] variant reaches it — not even
+    /// [`SourceSelector::Named`]/[`SourceSelector::Exact`] naming the exact
+    /// coordinate, because a caller who merely learns another Work's id
+    /// (e.g. from `sgt work list`) could otherwise type it straight into
+    /// `--source` and read that Work's surface. [`SourceSelector::WorkBase`]
+    /// does not strictly need the exclusion — it already binds the plain
+    /// repository name, never the overlay coordinate — but it applies
+    /// uniformly rather than special-casing one variant as "trusted."
+    /// Overlay visibility belongs to W1b's daemon-side lifecycle hook alone
+    /// ([`Self::evict_work_overlays`], which reads the coordinate directly,
+    /// never through this admissibility filter); search stays a pure
+    /// reader (H13.2) and does not get there yet.
     pub fn admissible_generations(
         &self,
         filter: &Admissibility,
         limit: usize,
-    ) -> Result<Vec<SourceGeneration>, AtlasError> {
+    ) -> Result<Admitted<SourceGeneration>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let (source_name, content_key, source_kind) = filter.source.bindings();
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
+        let overlay_exclude = Self::overlay_exclude_like();
         let mut statement = self.conn.prepare(
             "SELECT generation_id, source_name, source_kind, authority_class, content_key, \
                     observed_at \
              FROM source.generations \
              WHERE state = ? \
+               AND source_name NOT LIKE ? \
                AND (? IS NULL OR source_name = ?) \
                AND (? IS NULL OR content_key = ?) \
                AND (? IS NULL OR source_kind = ?) \
@@ -1892,6 +1925,7 @@ impl AtlasDb {
         )?;
         let mut rows = statement.query(duckdb::params![
             STATE_CONFIRMED,
+            overlay_exclude,
             source_name,
             source_name,
             content_key,
@@ -1923,7 +1957,10 @@ impl AtlasDb {
                 observed_at: row.get(5)?,
             });
         }
-        Ok(out)
+        Ok(Admitted {
+            hits: out,
+            scope: filter.source.work_scope(),
+        })
     }
 
     /// A2 §2's content-kind filter, **document family** — H13.1's decided
@@ -1956,11 +1993,13 @@ impl AtlasDb {
         &self,
         filter: &Admissibility,
         limit: usize,
-    ) -> Result<Vec<StoredUnitHit>, AtlasError> {
+    ) -> Result<Admitted<StoredUnitHit>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let (source_name, content_key, source_kind) = filter.source.bindings();
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
         let [doc_a, doc_b, doc_c, doc_d] = DOCUMENT_EXTRACTOR_IDENTITIES;
+        let overlay_exclude = Self::overlay_exclude_like();
         let mut statement = self.conn.prepare(
             "SELECT g.source_name, u.relative_path, u.local_key, u.ordinal, u.unit_kind, \
                     u.heading_level, u.title, u.byte_start, u.byte_end, u.body \
@@ -1970,6 +2009,7 @@ impl AtlasDb {
                                  AND f.relative_path = u.relative_path \
              WHERE g.state = ? \
                AND f.extractor IN (?, ?, ?, ?) \
+               AND g.source_name NOT LIKE ? \
                AND (? IS NULL OR g.source_name = ?) \
                AND (? IS NULL OR g.content_key = ?) \
                AND (? IS NULL OR g.source_kind = ?) \
@@ -1982,6 +2022,7 @@ impl AtlasDb {
             doc_b,
             doc_c,
             doc_d,
+            overlay_exclude,
             source_name,
             source_name,
             content_key,
@@ -2013,7 +2054,10 @@ impl AtlasDb {
                 },
             });
         }
-        Ok(out)
+        Ok(Admitted {
+            hits: out,
+            scope: filter.source.work_scope(),
+        })
     }
 
     /// A2 §2's content-kind filter, **code family** — `source.symbols` +
@@ -2048,16 +2092,19 @@ impl AtlasDb {
         &self,
         filter: &Admissibility,
         limit: usize,
-    ) -> Result<Vec<StoredOccurrenceHit>, AtlasError> {
+    ) -> Result<Admitted<StoredOccurrenceHit>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let (source_name, content_key, source_kind) = filter.source.bindings();
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
+        let overlay_exclude = Self::overlay_exclude_like();
         let mut statement = self.conn.prepare(
             "SELECT g.source_name, o.relative_path, o.syntax_key, o.extractor, o.language, \
                     o.ordinal, o.label, o.name, o.byte_start, o.byte_end \
              FROM source.occurrences o JOIN source.generations g USING (generation_id) \
              WHERE g.state = ? \
                AND o.extractor LIKE ? \
+               AND g.source_name NOT LIKE ? \
                AND (? IS NULL OR g.source_name = ?) \
                AND (? IS NULL OR g.content_key = ?) \
                AND (? IS NULL OR g.source_kind = ?) \
@@ -2067,6 +2114,7 @@ impl AtlasDb {
         let mut rows = statement.query(duckdb::params![
             STATE_CONFIRMED,
             CODE_EXTRACTOR_LIKE,
+            overlay_exclude,
             source_name,
             source_name,
             content_key,
@@ -2094,7 +2142,10 @@ impl AtlasDb {
                 },
             });
         }
-        Ok(out)
+        Ok(Admitted {
+            hits: out,
+            scope: filter.source.work_scope(),
+        })
     }
 
     /// A2 §2's content-kind filter, **tabular family** — `source.datasets`
@@ -2112,15 +2163,18 @@ impl AtlasDb {
         &self,
         filter: &Admissibility,
         limit: usize,
-    ) -> Result<Vec<StoredDatasetHit>, AtlasError> {
+    ) -> Result<Admitted<StoredDatasetHit>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let (source_name, content_key, source_kind) = filter.source.bindings();
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
+        let overlay_exclude = Self::overlay_exclude_like();
         let mut statement = self.conn.prepare(
             "SELECT g.source_name, d.relative_path, d.format, d.content_hash, d.reader, \
                     d.dataset_key, d.byte_len, d.columns, d.row_count, d.truncated, d.row_units \
              FROM source.datasets d JOIN source.generations g USING (generation_id) \
              WHERE g.state = ? \
+               AND g.source_name NOT LIKE ? \
                AND (? IS NULL OR g.source_name = ?) \
                AND (? IS NULL OR g.content_key = ?) \
                AND (? IS NULL OR g.source_kind = ?) \
@@ -2129,6 +2183,7 @@ impl AtlasDb {
         )?;
         let mut rows = statement.query(duckdb::params![
             STATE_CONFIRMED,
+            overlay_exclude,
             source_name,
             source_name,
             content_key,
@@ -2163,7 +2218,10 @@ impl AtlasDb {
                 },
             });
         }
-        Ok(out)
+        Ok(Admitted {
+            hits: out,
+            scope: filter.source.work_scope(),
+        })
     }
 
     /// Every generation's state, keyed by id — a diagnostic read, and what a
@@ -3245,23 +3303,36 @@ pub struct StoredReference {
 /// retrieve/rank).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Admissibility {
-    /// Stage 1 (+4): which source(s) may be seen at all.
+    /// Stage 1: which source(s) may be seen at all — `--source`/
+    /// `--source@sha`/`--work`, or none of those (every source).
     pub source: SourceSelector,
+    /// Stage 4: the optional repo/knowledge/external grouping
+    /// (`--type repo|knowledge|external`), the same [`SourceKind`] axis
+    /// [`Self::source`] can also narrow by name. A genuinely **independent**
+    /// field rather than a [`SourceSelector`] variant — A2 §2 lists stage 4
+    /// as an optional selector *layered on* stage 1 (`--work --type
+    /// document`, `--source repo-a --type repo`), and a caller must be able
+    /// to compose the two; folding it into [`SourceSelector`] as one more
+    /// mutually-exclusive variant (as an earlier revision of this type did)
+    /// made that composition inexpressible by construction. `None` admits
+    /// every kind — narrows only what a caller explicitly asked to narrow,
+    /// same as [`Self::authority`].
+    pub kind: Option<SourceKind>,
     /// Stage 2: which authority class may be seen. `None` admits every
     /// class — this filter only ever narrows what a caller explicitly
     /// asked to narrow; there is no implicit default-deny beyond what
-    /// `source` already selects.
+    /// `source`/`kind` already select.
     pub authority: Option<AuthorityClass>,
 }
 
-/// A2 §2's stage-1 source/estate/Work-generation selector, plus stage 4's
-/// optional repo/knowledge/external grouping — the same [`SourceKind`]
-/// axis, so it is one variant here ([`Self::Kind`]) rather than a second
-/// field a caller could set inconsistently with [`Self::Named`].
+/// A2 §2's stage-1 source/estate/Work-generation selector. Stage 4's
+/// repo/knowledge/external grouping is [`Admissibility::kind`], a separate
+/// field composable with any variant here — see that field's own doc for
+/// why it does not live as a variant of this enum.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum SourceSelector {
-    /// No source-name/kind constraint: every confirmed generation, subject
-    /// only to [`Admissibility::authority`].
+    /// No source-name constraint: every confirmed generation, subject
+    /// only to [`Admissibility::kind`]/[`Admissibility::authority`].
     #[default]
     Any,
     /// A2 §2's `--source <name>`: exactly one declared source's newest
@@ -3281,8 +3352,6 @@ pub enum SourceSelector {
         /// The exact generation's content identity.
         content_key: String,
     },
-    /// A2 §2's `--type repo|knowledge|external` selector.
-    Kind(SourceKind),
     /// A2 §2's `--work <id>` filter, **W1's scope only** (H13.2): the
     /// named repository's BASE generation — never the overlay half, which
     /// is W1b's daemon-side lifecycle hook
@@ -3306,22 +3375,23 @@ pub enum SourceSelector {
 }
 
 impl SourceSelector {
-    /// The `(source_name, content_key, source_kind)` bind values every
-    /// admissibility query composes identically — [`Self::Named`] and
-    /// [`Self::WorkBase`] bind the same shape on purpose: **W1's whole
-    /// point is that a Work's base generation reads exactly like any other
-    /// named source's**, and only [`Self::work_scope`] marks the
-    /// difference the caller must state.
-    fn bindings(&self) -> (Option<&str>, Option<&str>, Option<&'static str>) {
+    /// The `(source_name, content_key)` bind values every admissibility
+    /// query composes identically — [`Self::Named`] and [`Self::WorkBase`]
+    /// bind the same shape on purpose: **W1's whole point is that a Work's
+    /// base generation reads exactly like any other named source's**, and
+    /// only [`Self::work_scope`] marks the difference the caller must
+    /// state. Stage 4's `source_kind` bind is
+    /// [`Admissibility::kind`]'s alone now, not this selector's — see that
+    /// field's own doc.
+    fn bindings(&self) -> (Option<&str>, Option<&str>) {
         match self {
-            Self::Any => (None, None, None),
-            Self::Named(name) => (Some(name.as_str()), None, None),
+            Self::Any => (None, None),
+            Self::Named(name) => (Some(name.as_str()), None),
             Self::Exact {
                 source_name,
                 content_key,
-            } => (Some(source_name.as_str()), Some(content_key.as_str()), None),
-            Self::Kind(kind) => (None, None, Some(kind.as_str())),
-            Self::WorkBase { repository, .. } => (Some(repository.as_str()), None, None),
+            } => (Some(source_name.as_str()), Some(content_key.as_str())),
+            Self::WorkBase { repository, .. } => (Some(repository.as_str()), None),
         }
     }
 
@@ -3356,6 +3426,23 @@ pub enum WorkScope {
     /// W1's whole scope. A caller MUST state this rather than presenting
     /// the answer as A2 §2's full "including overlay" promise.
     BaseOnly,
+}
+
+/// What one `admissible_*` call answered, **with its own completeness
+/// marker attached to the value** — every `admissible_*` method returns
+/// this rather than a bare `Vec`, so [`WorkScope`]'s "a caller MUST
+/// render/assert" (see [`SourceSelector::WorkBase`]'s own doc) is something
+/// the type forces rather than a fact only recoverable by re-deriving it
+/// from the original `filter` a caller may no longer have in scope. A
+/// caller that forwards `hits` onward without `scope` has to do so
+/// explicitly (`.hits`, dropping `.scope` on the floor) rather than by
+/// construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Admitted<T> {
+    /// The admissible rows themselves.
+    pub hits: Vec<T>,
+    /// What this answer covers — see [`WorkScope`].
+    pub scope: WorkScope,
 }
 
 /// H13.1's content-kind filter, document family: the exhaustive, code-owned

--- a/tests/w1_deterministic_filter.rs
+++ b/tests/w1_deterministic_filter.rs
@@ -473,7 +473,13 @@ fn code_extractor_like_covers_every_syntax_language_and_rejects_an_unknown_ident
         );
     }
     assert!(!"mystery/v1".starts_with(prefix));
-    assert!(!"anydoc/0.2.4+docx/v1".starts_with(prefix));
+    // A real document-family identity, not merely a fabricated one — proves
+    // the pattern rejects an adapter identity that genuinely exists in this
+    // build, not only a string nothing would ever produce. Referenced by
+    // constant rather than spelled out: office.rs's own boundary test
+    // (`tests/y2_office_boundary.rs`) forbids the vendor name it wraps from
+    // appearing in any other file as a literal.
+    assert!(!DOCX_EXTRACTOR.starts_with(prefix));
 }
 
 /// H13.1's structural pin, document family — the same shape

--- a/tests/w1_deterministic_filter.rs
+++ b/tests/w1_deterministic_filter.rs
@@ -1,0 +1,824 @@
+//! S5 W1 — A2 §2's deterministic admissibility filter.
+//!
+//! A2 §2's own words: *"The first operation is deterministic admissibility,
+//! not embeddings"* — source/estate/Work-generation filter, then authority
+//! filter, then content-kind filter, then the optional repo/knowledge/
+//! external selector, and only then retrieve/rank (not built until W2-W4).
+//! This suite tests [`AtlasDb::admissible_generations`]/
+//! [`AtlasDb::admissible_units`]/[`AtlasDb::admissible_occurrences`]/
+//! [`AtlasDb::admissible_datasets`] directly — W1's own scope statement:
+//! "this wave exposes the filter internally and tests it directly" (`sgt
+//! search`'s CLI surface is W5).
+//!
+//! **Negative-admission tests are the point** (the brief's own words): a
+//! filter that only proves it returns the right rows has not been tested.
+//! Every stage below has at least one test that proves an inadmissible row
+//! is NOT returned, not merely that an admissible one is.
+//!
+//! Fixtures are hand-built [`SourceScan`] values recorded through the real
+//! [`record_scan`] three-step path (stage/journal/confirm) — the same
+//! public entry point every real scanner (`git`/`scan`/`external_git`)
+//! funnels through — rather than a real git repository or a real
+//! filesystem walk, because what this suite is proving is admissibility
+//! SQL, not acquisition. The one exception is the `--content config`
+//! live-verification test, which deliberately runs the REAL
+//! `scan_local_knowledge` pipeline over a real `Cargo.toml`, because that
+//! test's whole point is to check what the real extractors actually do —
+//! `tests/x3b_syntax_wiring.rs`'s own `POLYGLOT` fixture already proves the
+//! extraction; this suite proves what the ADMISSIBILITY FILTER does with
+//! it.
+
+use std::collections::BTreeSet;
+
+use tempfile::TempDir;
+
+use sergeant_rs::domain::event::rfc3339_utc_now;
+use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
+use sergeant_rs::runtime::atlas::db::{
+    Admissibility, AtlasDb, CODE_EXTRACTOR_LIKE, DOCUMENT_EXTRACTOR_IDENTITIES, SourceSelector,
+    WorkScope,
+};
+use sergeant_rs::runtime::atlas::mail::MAIL_EXTRACTOR;
+use sergeant_rs::runtime::atlas::office::DOCX_EXTRACTOR;
+use sergeant_rs::runtime::atlas::record::record_scan;
+use sergeant_rs::runtime::atlas::scan::{
+    KnowledgeSource, ScannedFile, ScannedSymbol, ScannedSyntax, ScannedUnit, SourceScan,
+    scan_local_knowledge,
+};
+use sergeant_rs::runtime::atlas::syntax::SyntaxLanguage;
+use sergeant_rs::runtime::atlas::tabular::ContextFields;
+use sergeant_rs::runtime::atlas::text::{MARKDOWN_EXTRACTOR, TEXT_EXTRACTOR};
+use sergeant_rs::runtime::journal::Journal;
+
+// ---------------------------------------------------------------- fixtures
+
+/// A whole-document [`ScannedUnit`] — the shape every real document
+/// extractor's first unit takes (`text::plain_units`/`markdown_units`).
+fn document(text: &str) -> ScannedUnit {
+    ScannedUnit {
+        ordinal: 0,
+        kind: UnitKind::Document,
+        heading_level: None,
+        title: None,
+        byte_start: 0,
+        byte_end: text.len() as u64,
+        text: text.to_string(),
+    }
+}
+
+/// A one-symbol syntax extraction under a caller-chosen extractor identity.
+/// Real [`SyntaxLanguage`] identities are always `"syntax-<name>/vN"`; a
+/// fixture may deliberately hand this something else (`"mystery/v1"`) to
+/// simulate an adapter the content-kind filter has never heard of — exactly
+/// the case its structural pin exists to catch.
+fn syntax(
+    language: &'static str,
+    extractor: &str,
+    label: &'static str,
+    name: &str,
+) -> ScannedSyntax {
+    ScannedSyntax {
+        language,
+        extractor: extractor.to_string(),
+        syntax_key: format!("syntax-key/{language}/{name}"),
+        symbols: vec![ScannedSymbol {
+            ordinal: 0,
+            label,
+            name: name.to_string(),
+            byte_start: 0,
+            byte_end: name.len() as u64,
+        }],
+        edges: Vec::new(),
+    }
+}
+
+/// One acquired resource: a structure extraction, an optional syntax
+/// extraction, or both — exactly the shape a real grammar-claimed-but-
+/// document-unclaimed file takes (`scan.rs`'s own `claims_for` doc).
+fn file(
+    relative_path: &str,
+    extractor: &str,
+    units: Vec<ScannedUnit>,
+    syntax_extraction: Option<ScannedSyntax>,
+) -> ScannedFile {
+    ScannedFile {
+        relative_path: relative_path.to_string(),
+        content_hash: format!("hash/{relative_path}"),
+        extractor: extractor.to_string(),
+        local_key: format!("key/{relative_path}"),
+        byte_len: 16,
+        mtime_millis: None,
+        units,
+        syntax: syntax_extraction,
+    }
+}
+
+/// A hand-built [`SourceScan`] over `files`, extractors collected from them.
+fn scan(
+    source_name: &str,
+    kind: SourceKind,
+    authority: AuthorityClass,
+    content_key: &str,
+    files: Vec<ScannedFile>,
+) -> SourceScan {
+    let mut extractors = BTreeSet::new();
+    for f in &files {
+        extractors.insert(f.extractor.clone());
+        if let Some(s) = &f.syntax {
+            extractors.insert(s.extractor.clone());
+        }
+    }
+    SourceScan {
+        source_name: source_name.to_string(),
+        kind,
+        authority,
+        content_key: content_key.to_string(),
+        revision: None,
+        observed_at: rfc3339_utc_now(),
+        files,
+        coverage: Vec::new(),
+        extractors,
+        datasets: Vec::new(),
+        root: None,
+        context_fields: ContextFields::none(),
+    }
+}
+
+/// A shared store, with four sources recorded into it:
+///
+/// * `repo-a` (estate-git, estate-mutable): `src/main.rs` (Rust symbol
+///   `widget_a`, plus the real plain-text fallback unit every
+///   grammar-claimed-but-document-unclaimed file gets — `claims_for`'s own
+///   doc), `README.md` (a genuine Markdown document, no syntax), and one
+///   file under a `"mystery/v1"` syntax extractor and a `"mystery-doc/v1"`
+///   structure extractor — an adapter identity the content-kind filter has
+///   never heard of, standing in for "a new adapter that invents an
+///   extractor identity the filter does not know about."
+/// * `repo-b` (estate-git, estate-mutable): `src/other.rs` (Rust symbol
+///   `widget_b`) — proves source exclusion.
+/// * `notes` (local-knowledge, estate-readonly): `guide.md` — proves the
+///   repo/knowledge selector and the authority-vs-kind distinction.
+/// * `vendor-lib` (external-git, external): `lib.rs` (Rust symbol
+///   `widget_vendor`) — proves authority exclusion.
+struct Estate {
+    _data: TempDir,
+    db: AtlasDb,
+}
+
+const REPO_A_KEY: &str = "repo-a@key-1";
+
+fn estate() -> Estate {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    let repo_a = scan(
+        "repo-a",
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        REPO_A_KEY,
+        vec![
+            file(
+                "src/main.rs",
+                TEXT_EXTRACTOR,
+                vec![document("fn widget_a() {}\n")],
+                Some(syntax("rust", "syntax-rust/v1", "function", "widget_a")),
+            ),
+            file(
+                "README.md",
+                MARKDOWN_EXTRACTOR,
+                vec![document("# Repo A\n")],
+                None,
+            ),
+            file(
+                "mystery.xyz",
+                "mystery-doc/v1",
+                vec![document("unclaimed-shaped body")],
+                Some(syntax("mystery", "mystery/v1", "thing", "unknown_symbol")),
+            ),
+        ],
+    );
+    record_scan(&mut db, &mut journal, &repo_a, None).expect("record repo-a");
+
+    let repo_b = scan(
+        "repo-b",
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        "repo-b@key-1",
+        vec![file(
+            "src/other.rs",
+            TEXT_EXTRACTOR,
+            vec![document("fn widget_b() {}\n")],
+            Some(syntax("rust", "syntax-rust/v1", "function", "widget_b")),
+        )],
+    );
+    record_scan(&mut db, &mut journal, &repo_b, None).expect("record repo-b");
+
+    let notes = scan(
+        "notes",
+        SourceKind::LocalKnowledge,
+        AuthorityClass::EstateReadonly,
+        "notes@key-1",
+        vec![file(
+            "guide.md",
+            MARKDOWN_EXTRACTOR,
+            vec![document("# Guide\n")],
+            None,
+        )],
+    );
+    record_scan(&mut db, &mut journal, &notes, None).expect("record notes");
+
+    let vendor = scan(
+        "vendor-lib",
+        SourceKind::ExternalGit,
+        AuthorityClass::External,
+        "vendor-lib@key-1",
+        vec![file(
+            "lib.rs",
+            TEXT_EXTRACTOR,
+            vec![document("fn widget_vendor() {}\n")],
+            Some(syntax(
+                "rust",
+                "syntax-rust/v1",
+                "function",
+                "widget_vendor",
+            )),
+        )],
+    );
+    record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
+
+    Estate { _data: data, db }
+}
+
+fn named(source_name: &str) -> Admissibility {
+    Admissibility {
+        source: SourceSelector::Named(source_name.to_string()),
+        authority: None,
+    }
+}
+
+fn occurrence_names(estate: &Estate, filter: &Admissibility) -> Vec<String> {
+    estate
+        .db
+        .admissible_occurrences(filter, 500)
+        .expect("admissible occurrences")
+        .into_iter()
+        .map(|hit| hit.occurrence.name)
+        .collect()
+}
+
+// --------------------------------------------------- stage 1: source filter
+
+/// POSITIVE: `--source repo-a` admits `repo-a`'s own occurrence.
+/// NEGATIVE: it excludes `repo-b`'s — "another source's rows excluded"
+/// (the brief's own example).
+#[test]
+fn a_named_source_filter_admits_its_own_occurrences_and_excludes_another_sources() {
+    let estate = estate();
+    let names = occurrence_names(&estate, &named("repo-a"));
+    assert!(names.contains(&"widget_a".to_string()), "{names:?}");
+    assert!(
+        !names.contains(&"widget_b".to_string()),
+        "repo-b's occurrence leaked through a repo-a filter: {names:?}"
+    );
+}
+
+/// The same exclusion at the generation level, one layer under content:
+/// `admissible_generations` never hands back a source the caller did not
+/// name, whichever content-kind method would eventually read it.
+#[test]
+fn a_named_source_filter_admits_only_that_sources_generation() {
+    let estate = estate();
+    let generations = estate
+        .db
+        .admissible_generations(&named("repo-a"), 500)
+        .expect("admissible generations");
+    let names: Vec<&str> = generations.iter().map(|g| g.source_name.as_str()).collect();
+    assert_eq!(names, vec!["repo-a"], "{names:?}");
+}
+
+/// An exact `--source repo-a@<sha>` pin answers for the CURRENT confirmed
+/// generation's own key; a content key that is not that one returns
+/// NOTHING rather than approximating — "never approximate" (A2 §2) applies
+/// to a miss exactly as it applies to a hit.
+#[test]
+fn an_exact_generation_pin_matches_its_own_key_and_returns_nothing_for_a_stale_one() {
+    let estate = estate();
+    let exact = Admissibility {
+        source: SourceSelector::Exact {
+            source_name: "repo-a".to_string(),
+            content_key: REPO_A_KEY.to_string(),
+        },
+        authority: None,
+    };
+    let hit = estate
+        .db
+        .admissible_generations(&exact, 500)
+        .expect("admissible generations");
+    assert_eq!(hit.len(), 1, "{hit:?}");
+    assert_eq!(hit[0].source_name, "repo-a");
+
+    let stale = Admissibility {
+        source: SourceSelector::Exact {
+            source_name: "repo-a".to_string(),
+            content_key: "repo-a@a-key-nothing-was-ever-confirmed-under".to_string(),
+        },
+        authority: None,
+    };
+    let miss = estate
+        .db
+        .admissible_generations(&stale, 500)
+        .expect("admissible generations");
+    assert!(
+        miss.is_empty(),
+        "a stale content key must match nothing, got {miss:?}"
+    );
+}
+
+// ------------------------------------------- stage 4: repo/knowledge/external
+
+/// POSITIVE: `--type knowledge` (`SourceSelector::Kind(LocalKnowledge)`)
+/// admits `notes`. NEGATIVE: it excludes `repo-a`/`repo-b` (estate-git) and
+/// `vendor-lib` (external-git) — the estate's own repositories and a
+/// fetched external one are both a different KIND, not merely a different
+/// name.
+#[test]
+fn a_knowledge_kind_selector_admits_only_local_knowledge_sources() {
+    let estate = estate();
+    let filter = Admissibility {
+        source: SourceSelector::Kind(SourceKind::LocalKnowledge),
+        authority: None,
+    };
+    let generations = estate
+        .db
+        .admissible_generations(&filter, 500)
+        .expect("admissible generations");
+    let names: Vec<&str> = generations.iter().map(|g| g.source_name.as_str()).collect();
+    assert_eq!(names, vec!["notes"], "{names:?}");
+}
+
+// -------------------------------------------------- stage 2: authority filter
+
+/// NEGATIVE: filtering to `estate_mutable` authority excludes `vendor-lib`'s
+/// `external` occurrence even though no `--source`/`--type` named it out —
+/// "an `external` authority excluded when unrequested" (the brief's own
+/// example).
+#[test]
+fn an_authority_filter_excludes_external_content_when_not_requested() {
+    let estate = estate();
+    let filter = Admissibility {
+        source: SourceSelector::Any,
+        authority: Some(AuthorityClass::EstateMutable),
+    };
+    let names = occurrence_names(&estate, &filter);
+    assert!(
+        !names.contains(&"widget_vendor".to_string()),
+        "external authority leaked through an estate_mutable-only filter: {names:?}"
+    );
+    assert!(names.contains(&"widget_a".to_string()) && names.contains(&"widget_b".to_string()));
+}
+
+/// POSITIVE mirror: asking for `external` specifically admits ONLY
+/// `vendor-lib`'s occurrence, excluding both estate-git repos' — proving
+/// the filter is a real predicate in both directions, not a permissive
+/// default that only ever narrows the OTHER way.
+#[test]
+fn an_authority_filter_for_external_admits_only_the_external_source() {
+    let estate = estate();
+    let filter = Admissibility {
+        source: SourceSelector::Any,
+        authority: Some(AuthorityClass::External),
+    };
+    let names = occurrence_names(&estate, &filter);
+    assert_eq!(names, vec!["widget_vendor".to_string()], "{names:?}");
+}
+
+/// A bare `Admissibility::default()` — `SourceSelector::Any`, no authority
+/// — is "every confirmed generation this store holds": the un-narrowed
+/// case has to stay complete, or every negative test above would be
+/// meaningless (it would be indistinguishable from a filter that excludes
+/// everything).
+#[test]
+fn an_unfiltered_admissibility_admits_every_confirmed_source() {
+    let estate = estate();
+    let generations = estate
+        .db
+        .admissible_generations(&Admissibility::default(), 500)
+        .expect("admissible generations");
+    let mut names: Vec<&str> = generations.iter().map(|g| g.source_name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, vec!["notes", "repo-a", "repo-b", "vendor-lib"]);
+}
+
+// --------------------------------------------------- stage 3: content-kind
+
+/// NEGATIVE: `admissible_occurrences`' `LIKE 'syntax-%'` match excludes an
+/// occurrence written under an extractor identity it has never heard of —
+/// H13.1's own scenario, "a new adapter that invents an extractor identity
+/// the filter does not know about," proven live at the database level, not
+/// merely pinned as a Rust constant.
+#[test]
+fn a_content_kind_mismatch_is_excluded_from_the_code_family() {
+    let estate = estate();
+    let names = occurrence_names(&estate, &named("repo-a"));
+    assert!(
+        !names.contains(&"unknown_symbol".to_string()),
+        "an occurrence under an unrecognized extractor identity leaked through the code-family \
+         filter: {names:?}"
+    );
+    // And its two REAL sibling files in the same source are still admitted
+    // — the exclusion is per-row, not a source-wide veto.
+    assert!(names.contains(&"widget_a".to_string()), "{names:?}");
+}
+
+/// The document-family mirror: a unit written under an unrecognized
+/// structure extractor is excluded from `admissible_units`, while a real
+/// document (`README.md`) from the same source is admitted.
+#[test]
+fn a_content_kind_mismatch_is_excluded_from_the_document_family() {
+    let estate = estate();
+    let hits = estate
+        .db
+        .admissible_units(&named("repo-a"), 500)
+        .expect("admissible units");
+    let paths: Vec<&str> = hits.iter().map(|h| h.unit.relative_path.as_str()).collect();
+    assert!(
+        !paths.contains(&"mystery.xyz"),
+        "a unit under an unrecognized structure extractor leaked through the document-family \
+         filter: {paths:?}"
+    );
+    assert!(paths.contains(&"README.md"), "{paths:?}");
+}
+
+// --------------------------------------------------------- structural pins
+
+/// H13.1's structural pin, code family: every real
+/// [`SyntaxLanguage::ALL`] extractor identity matches
+/// [`CODE_EXTRACTOR_LIKE`]'s prefix, and a synthetic unknown one does not —
+/// so a new [`SyntaxLanguage`] variant automatically stays admitted (it is
+/// constructed via the same `"syntax-{name}/vN"` format this pattern
+/// covers), while an adapter that writes `source.occurrences` some other
+/// way is caught rather than silently included.
+#[test]
+fn code_extractor_like_covers_every_syntax_language_and_rejects_an_unknown_identity() {
+    let prefix = CODE_EXTRACTOR_LIKE
+        .strip_suffix('%')
+        .expect("the pattern is a prefix match");
+    assert_eq!(prefix, "syntax-");
+    for language in SyntaxLanguage::ALL {
+        let identity = language.extractor_identity();
+        assert!(
+            identity.starts_with(prefix),
+            "{identity} (from {language:?}) does not match the code-family pattern {CODE_EXTRACTOR_LIKE:?}"
+        );
+    }
+    assert!(!"mystery/v1".starts_with(prefix));
+    assert!(!"anydoc/0.2.4+docx/v1".starts_with(prefix));
+}
+
+/// H13.1's structural pin, document family — the same shape
+/// `tests/x1_atlas_substrate.rs`'s one-owner test uses: read every document
+/// adapter module's own `pub const ..._EXTRACTOR` declaration as text, and
+/// assert [`DOCUMENT_EXTRACTOR_IDENTITIES`] is EXACTLY that set. A new
+/// document adapter that lands a new identity without updating the filter's
+/// allowlist fails this test rather than silently falling out of (or into)
+/// `--content document`.
+#[test]
+fn document_extractor_identities_matches_every_known_document_adapter_constant() {
+    fn extractor_constants(source: &str) -> Vec<String> {
+        source
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                let rest = line.strip_prefix("pub const ")?;
+                if !rest.contains("_EXTRACTOR: &str = ") {
+                    return None;
+                }
+                let quoted = rest.split('"').nth(1)?;
+                Some(quoted.to_string())
+            })
+            .collect()
+    }
+
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/runtime/atlas");
+    let mut expected: BTreeSet<String> = BTreeSet::new();
+    for module in ["text.rs", "office.rs", "mail.rs"] {
+        let text = std::fs::read_to_string(root.join(module))
+            .unwrap_or_else(|e| panic!("read {module}: {e}"));
+        // office.rs/mail.rs each carry other `_EXTRACTOR`-shaped consts too
+        // (e.g. a version constant) — the module-local ones this filter
+        // actually needs are exactly `DOCX_EXTRACTOR`/`MAIL_EXTRACTOR`; text.rs
+        // carries only the two it always has.
+        expected.extend(extractor_constants(&text));
+    }
+    // ZIP_EXTRACTOR is a real `pub const ..._EXTRACTOR` too, and is
+    // deliberately absent from the allowlist (a container carries no prose
+    // of its own — see `DOCUMENT_EXTRACTOR_IDENTITIES`'s own doc) — named
+    // here as the one expected mismatch this scan will find, so the loop
+    // above stays a real assertion rather than one this test quietly
+    // narrows to pass.
+    let archive_text = std::fs::read_to_string(root.join("archive.rs")).expect("read archive.rs");
+    expected.extend(extractor_constants(&archive_text));
+
+    let mut allowlisted: BTreeSet<String> = DOCUMENT_EXTRACTOR_IDENTITIES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    // Restate the container exclusion explicitly rather than special-casing
+    // the scan: the allowlist plus the one named exclusion must equal the
+    // full set every document/container adapter module declares.
+    allowlisted.insert(sergeant_rs::runtime::atlas::archive::ZIP_EXTRACTOR.to_string());
+
+    assert_eq!(
+        allowlisted, expected,
+        "DOCUMENT_EXTRACTOR_IDENTITIES (plus the one named container exclusion, ZIP_EXTRACTOR) \
+         must equal exactly the extractor constants text.rs/office.rs/mail.rs/archive.rs declare"
+    );
+    assert!(expected.contains(MARKDOWN_EXTRACTOR));
+    assert!(expected.contains(TEXT_EXTRACTOR));
+    assert!(expected.contains(DOCX_EXTRACTOR));
+    assert!(expected.contains(MAIL_EXTRACTOR));
+}
+
+// -------------------------------------------------------------- --work scope
+
+/// A `--work` filter reads a named repository exactly like `--source`
+/// does — W1's whole point — and its answer states [`WorkScope::BaseOnly`]
+/// rather than presenting itself as A2 §2's full "including overlay"
+/// promise (H13.2). It excludes a different repository's generation the
+/// identical way a plain `--source` filter would.
+#[test]
+fn a_work_base_selector_reads_like_its_named_repository_and_states_base_only_scope() {
+    let estate = estate();
+    let filter = Admissibility {
+        source: SourceSelector::WorkBase {
+            work_id: "01WORKID000000000000000000".to_string(),
+            repository: "repo-a".to_string(),
+        },
+        authority: None,
+    };
+    assert_eq!(filter.source.work_scope(), WorkScope::BaseOnly);
+
+    let names = occurrence_names(&estate, &filter);
+    assert!(names.contains(&"widget_a".to_string()), "{names:?}");
+    assert!(
+        !names.contains(&"widget_b".to_string()),
+        "a --work filter scoped to repo-a must not admit repo-b's occurrences: {names:?}"
+    );
+}
+
+/// A selector that is not `WorkBase` never claims the Work scope — the
+/// concept genuinely does not apply, rather than defaulting to some
+/// unstated completeness.
+#[test]
+fn a_non_work_selector_reports_not_work_scoped() {
+    assert_eq!(
+        SourceSelector::Named("repo-a".to_string()).work_scope(),
+        WorkScope::NotWorkScoped
+    );
+    assert_eq!(SourceSelector::Any.work_scope(), WorkScope::NotWorkScoped);
+}
+
+// -------------------------------------------- --content config, verified live
+
+/// H13.1's `--content config` gap, checked against the REAL extraction
+/// pipeline (`scan_local_knowledge`, not a hand-built fixture) rather than
+/// asserted from the plan's own prose.
+///
+/// **Corrects a premise H13.1's own text carried.** The plan states a
+/// `.toml` file produces zero `source.units` rows "because
+/// `text::extractor_for` claims only Markdown/text extensions" — true of
+/// `extractor_for` in isolation, but `scan.rs`'s `claims_for` unions it
+/// with `language_for`, and a path only the LATTER claims still gets a
+/// plain-text structure extraction (`claims_for`'s own doc: "every
+/// acquired resource still has units"). This test proves that live: a
+/// `Cargo.toml` produces BOTH a `source.occurrences` row under
+/// `"syntax-toml/v1"` (H13.1's own worked example) AND one `source.units`
+/// row (a whole-document unit, extractor `"text/v1"`) — not the "zero
+/// units" the plan asserted. H13.1's DECIDED mechanism (table +
+/// extractor-prefix routing, no new column, `config` not offered as a
+/// distinct value) is unaffected by this correction: `admissible_units`
+/// still cannot tell this fallback unit apart from a genuine `.txt`
+/// document (both carry extractor `"text/v1"`), which is exactly the
+/// "safety net, not a clean split" [`AtlasDb::admissible_units`]'s own doc
+/// names.
+#[test]
+fn a_toml_files_config_content_lives_in_the_code_lane_and_also_leaves_a_document_fallback_unit() {
+    let source_dir = tempfile::tempdir().expect("source dir");
+    std::fs::write(
+        source_dir.path().join("Cargo.toml"),
+        "[package]\nname = \"demo\"\n",
+    )
+    .expect("write Cargo.toml");
+    let knowledge = KnowledgeSource {
+        name: "manifest".to_string(),
+        root: source_dir.path().to_path_buf(),
+        ignore: Vec::new(),
+        context_fields: ContextFields::none(),
+    };
+    let scanned = scan_local_knowledge(&knowledge).expect("scan Cargo.toml");
+
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    record_scan(&mut db, &mut journal, &scanned, None).expect("record manifest");
+
+    let filter = named("manifest");
+
+    // H13.1's own worked example: the config's key/table structure is
+    // admissible through the code family, under `syntax-toml/v1`.
+    let occurrences = db
+        .admissible_occurrences(&filter, 500)
+        .expect("admissible occurrences");
+    assert!(
+        occurrences
+            .iter()
+            .any(|hit| hit.occurrence.extractor == "syntax-toml/v1"
+                && hit.occurrence.label == "table"
+                && hit.occurrence.name == "package"),
+        "{occurrences:#?}"
+    );
+
+    // The live correction: a document-family unit exists too — not the
+    // "zero source.units rows" the plan's own text asserted.
+    let units = db.admissible_units(&filter, 500).expect("admissible units");
+    assert_eq!(
+        units.len(),
+        1,
+        "Cargo.toml must leave exactly one fallback document unit, got {units:#?}"
+    );
+    assert_eq!(units[0].unit.relative_path, "Cargo.toml");
+    assert_eq!(units[0].unit.kind, UnitKind::Document);
+}
+
+// -------------------------------------------------- tabular family, datasets
+
+/// The tabular family (`source.datasets`), through the real
+/// `scan_local_knowledge` pipeline (CSV registration is X4's own
+/// auto-claim, not something a hand-built fixture should restate). NEGATIVE:
+/// `admissible_datasets` scoped to one source excludes the other's — the
+/// same source-exclusion proof as the code/document families, over the
+/// third physically separate table H13.1 names.
+#[test]
+fn a_source_filter_excludes_another_sources_dataset() {
+    fn knowledge_source_with_csv(name: &str, csv_body: &str) -> (TempDir, KnowledgeSource) {
+        let dir = tempfile::tempdir().expect("source dir");
+        std::fs::write(dir.path().join("rows.csv"), csv_body).expect("write csv");
+        let source = KnowledgeSource {
+            name: name.to_string(),
+            root: dir.path().to_path_buf(),
+            ignore: Vec::new(),
+            context_fields: ContextFields::none(),
+        };
+        (dir, source)
+    }
+
+    let (_dir_a, source_a) = knowledge_source_with_csv("data-a", "label,weight\nalpha,1\n");
+    let (_dir_b, source_b) = knowledge_source_with_csv("data-b", "label,weight\nbeta,2\n");
+    let scan_a = scan_local_knowledge(&source_a).expect("scan data-a");
+    let scan_b = scan_local_knowledge(&source_b).expect("scan data-b");
+    assert_eq!(scan_a.datasets.len(), 1, "{scan_a:#?}");
+    assert_eq!(scan_b.datasets.len(), 1, "{scan_b:#?}");
+
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    record_scan(&mut db, &mut journal, &scan_a, None).expect("record data-a");
+    record_scan(&mut db, &mut journal, &scan_b, None).expect("record data-b");
+
+    let hits = db
+        .admissible_datasets(&named("data-a"), 500)
+        .expect("admissible datasets");
+    let sources: Vec<&str> = hits.iter().map(|h| h.source_name.as_str()).collect();
+    assert_eq!(sources, vec!["data-a"], "{hits:#?}");
+    assert_eq!(hits[0].dataset.relative_path, "rows.csv");
+}
+
+// ------------------------------- --work, the fourth required negative (W1)
+
+/// **NEGATIVE: a different Work's generation is excluded** — the fourth
+/// negative admission W1's brief names by name, and the one the
+/// `--work`-shaped test above does not reach.
+///
+/// `a_work_base_selector_reads_like_its_named_repository_and_states_base_only_scope`
+/// proves a `--work` filter excludes a different *repository*. That is not
+/// the same claim: a Work's generation is identified by its own source
+/// coordinate, and two Works can be bound to the SAME repository at the
+/// same time. So the exclusion that actually matters here is over the
+/// overlay coordinate
+/// [`overlay_source_name`](sergeant_rs::runtime::atlas::overlay::overlay_source_name)
+/// — `work:<id>/<repo>` — which is the shape W1b's daemon-side lifecycle
+/// hook will write, and which
+/// [`AtlasDb::evict_work_overlays`](sergeant_rs::runtime::atlas::db::AtlasDb::evict_work_overlays)
+/// already reads today.
+///
+/// Two exclusions are required and both are checked:
+///
+/// 1. **Another Work's overlay over the same repository is not admissible.**
+///    `work:01OTHER…/repo-a` describes a world only that Work can see. A
+///    filter that matched the `work:` prefix, or that reached for "anything
+///    mentioning repo-a", would admit it — and admissibility decides what
+///    may be SEEN, so that is a leak between two Works' surfaces, not a
+///    ranking imprecision (A2 §8).
+/// 2. **This Work's OWN overlay is not admissible either** — the honest
+///    half. W1's `--work` is
+///    [`WorkScope::BaseOnly`](sergeant_rs::runtime::atlas::db::WorkScope)
+///    (H13.2), so the overlay is absent by design rather than by accident,
+///    and the answer says so. When W1b lands, THIS assertion is the one
+///    that must be revisited together with `work_scope()` — never one
+///    without the other, which is exactly why they are pinned in the same
+///    test.
+#[test]
+fn a_work_filter_excludes_a_different_works_generation() {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    const MINE: &str = "01MINE0000000000000000000A";
+    const OTHER: &str = "01OTHER000000000000000000B";
+
+    // The base world both Works are cut from.
+    let base = scan(
+        "repo-a",
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        REPO_A_KEY,
+        vec![file(
+            "src/main.rs",
+            TEXT_EXTRACTOR,
+            vec![document("fn widget_base() {}\n")],
+            Some(syntax("rust", "syntax-rust/v1", "function", "widget_base")),
+        )],
+    );
+    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+
+    // Two overlay generations over that same base, one per Work, each under
+    // its own `work:<id>/<repo>` source coordinate.
+    for (work_id, symbol) in [(MINE, "widget_mine"), (OTHER, "widget_theirs")] {
+        let overlay = scan(
+            &sergeant_rs::runtime::atlas::overlay::overlay_source_name(work_id, "repo-a"),
+            SourceKind::EstateGit,
+            AuthorityClass::EstateMutable,
+            &format!("repo-a@base+{work_id}"),
+            vec![file(
+                "src/main.rs",
+                TEXT_EXTRACTOR,
+                vec![document("fn overlaid() {}\n")],
+                Some(syntax("rust", "syntax-rust/v1", "function", symbol)),
+            )],
+        );
+        record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    }
+
+    let filter = Admissibility {
+        source: SourceSelector::WorkBase {
+            work_id: MINE.to_string(),
+            repository: "repo-a".to_string(),
+        },
+        authority: None,
+    };
+
+    // Both overlay generations genuinely exist in the store, so the two
+    // exclusions below are the filter's doing rather than an empty database's.
+    for work_id in [MINE, OTHER] {
+        let coordinate =
+            sergeant_rs::runtime::atlas::overlay::overlay_source_name(work_id, "repo-a");
+        assert!(
+            !db.admissible_units(&named(&coordinate), 500)
+                .expect("admissible units")
+                .is_empty(),
+            "the fixture must actually hold {coordinate}'s rows, or the exclusions prove nothing"
+        );
+    }
+
+    let sources: BTreeSet<String> = db
+        .admissible_generations(&filter, 500)
+        .expect("admissible generations")
+        .into_iter()
+        .map(|generation| generation.source_name)
+        .collect();
+    assert_eq!(
+        sources,
+        BTreeSet::from(["repo-a".to_string()]),
+        "--work admits exactly its repository's BASE generation: not another Work's overlay \
+         over the same repository, and not (yet, H13.2) its own"
+    );
+
+    // And at the content tables too — a content-kind method that composed
+    // the source predicate differently would leak another Work's surface
+    // into this one's answer while `admissible_generations` stayed correct.
+    let names: Vec<String> = db
+        .admissible_occurrences(&filter, 500)
+        .expect("admissible occurrences")
+        .into_iter()
+        .map(|hit| hit.occurrence.name)
+        .collect();
+    assert_eq!(
+        names,
+        vec!["widget_base".to_string()],
+        "another Work's occurrences must never cross a --work filter: {names:?}"
+    );
+
+    // The limitation is declared, not silently applied (H13.2).
+    assert_eq!(filter.source.work_scope(), WorkScope::BaseOnly);
+}

--- a/tests/w1_deterministic_filter.rs
+++ b/tests/w1_deterministic_filter.rs
@@ -40,7 +40,7 @@ use sergeant_rs::runtime::atlas::db::{
 };
 use sergeant_rs::runtime::atlas::mail::MAIL_EXTRACTOR;
 use sergeant_rs::runtime::atlas::office::DOCX_EXTRACTOR;
-use sergeant_rs::runtime::atlas::record::record_scan;
+use sergeant_rs::runtime::atlas::record::{ScanRecord, record_scan};
 use sergeant_rs::runtime::atlas::scan::{
     KnowledgeSource, ScannedFile, ScannedSymbol, ScannedSyntax, ScannedUnit, SourceScan,
     scan_local_knowledge,
@@ -162,6 +162,10 @@ fn scan(
 ///   `widget_vendor`) — proves authority exclusion.
 struct Estate {
     _data: TempDir,
+    /// Kept open (not dropped after setup) so a test can record a further
+    /// scan through the real [`record_scan`] path — the supersession test
+    /// below needs to drive `confirm_scan`'s own eviction, not fabricate it.
+    journal: Journal,
     db: AtlasDb,
 }
 
@@ -247,12 +251,17 @@ fn estate() -> Estate {
     );
     record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
 
-    Estate { _data: data, db }
+    Estate {
+        _data: data,
+        journal,
+        db,
+    }
 }
 
 fn named(source_name: &str) -> Admissibility {
     Admissibility {
         source: SourceSelector::Named(source_name.to_string()),
+        kind: None,
         authority: None,
     }
 }
@@ -262,6 +271,7 @@ fn occurrence_names(estate: &Estate, filter: &Admissibility) -> Vec<String> {
         .db
         .admissible_occurrences(filter, 500)
         .expect("admissible occurrences")
+        .hits
         .into_iter()
         .map(|hit| hit.occurrence.name)
         .collect()
@@ -293,8 +303,17 @@ fn a_named_source_filter_admits_only_that_sources_generation() {
         .db
         .admissible_generations(&named("repo-a"), 500)
         .expect("admissible generations");
-    let names: Vec<&str> = generations.iter().map(|g| g.source_name.as_str()).collect();
+    let names: Vec<&str> = generations
+        .hits
+        .iter()
+        .map(|g| g.source_name.as_str())
+        .collect();
     assert_eq!(names, vec!["repo-a"], "{names:?}");
+    assert_eq!(
+        generations.scope,
+        WorkScope::NotWorkScoped,
+        "a plain --source filter's answer is not Work-scoped at all"
+    );
 }
 
 /// An exact `--source repo-a@<sha>` pin answers for the CURRENT confirmed
@@ -309,20 +328,22 @@ fn an_exact_generation_pin_matches_its_own_key_and_returns_nothing_for_a_stale_o
             source_name: "repo-a".to_string(),
             content_key: REPO_A_KEY.to_string(),
         },
+        kind: None,
         authority: None,
     };
     let hit = estate
         .db
         .admissible_generations(&exact, 500)
         .expect("admissible generations");
-    assert_eq!(hit.len(), 1, "{hit:?}");
-    assert_eq!(hit[0].source_name, "repo-a");
+    assert_eq!(hit.hits.len(), 1, "{hit:?}");
+    assert_eq!(hit.hits[0].source_name, "repo-a");
 
     let stale = Admissibility {
         source: SourceSelector::Exact {
             source_name: "repo-a".to_string(),
             content_key: "repo-a@a-key-nothing-was-ever-confirmed-under".to_string(),
         },
+        kind: None,
         authority: None,
     };
     let miss = estate
@@ -330,14 +351,131 @@ fn an_exact_generation_pin_matches_its_own_key_and_returns_nothing_for_a_stale_o
         .admissible_generations(&stale, 500)
         .expect("admissible generations");
     assert!(
-        miss.is_empty(),
+        miss.hits.is_empty(),
         "a stale content key must match nothing, got {miss:?}"
+    );
+}
+
+/// NEGATIVE — the review brief's own scenario: an evicted/superseded
+/// generation must not leak. Unlike the test above (a content key that was
+/// *never confirmed*), this drives the real live-eviction path: `repo-a` is
+/// rescanned with genuinely changed bytes, so `confirm_scan` (via
+/// `record_scan`) confirms the new generation and evicts the standing one in
+/// the same transaction (`ruling §4`) — physically deleting its rows and
+/// flipping its `source.generations.state` off `confirmed`. Every
+/// admissibility method, and the exact-pin path at the now-stale key, must
+/// come back empty for it.
+#[test]
+fn a_superseded_generation_does_not_leak_through_any_admissible_method() {
+    let mut estate = estate();
+
+    let original = estate
+        .db
+        .admissible_generations(&named("repo-a"), 500)
+        .expect("admissible generations");
+    assert_eq!(original.hits.len(), 1, "{original:?}");
+    let original_generation_id = original.hits[0].id.clone();
+    assert_eq!(original.hits[0].content_key, REPO_A_KEY);
+
+    // Re-scan `repo-a` under the SAME source_name with genuinely different
+    // bytes (a new symbol, a new content key, and — the point — no
+    // `README.md`/`mystery.xyz` at all) so `confirm_scan` supersedes and
+    // evicts the standing generation rather than reporting `Unchanged`.
+    let repo_a_v2 = scan(
+        "repo-a",
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        "repo-a@key-2",
+        vec![file(
+            "src/main.rs",
+            TEXT_EXTRACTOR,
+            vec![document("fn widget_a_v2() {}\n")],
+            Some(syntax("rust", "syntax-rust/v1", "function", "widget_a_v2")),
+        )],
+    );
+    let recorded = record_scan(&mut estate.db, &mut estate.journal, &repo_a_v2, None)
+        .expect("record repo-a v2");
+    let evicted = match recorded {
+        ScanRecord::Recorded { evicted, .. } => evicted,
+        other => panic!("expected a recorded, superseding scan of repo-a, got {other:?}"),
+    };
+    assert_eq!(
+        evicted.as_deref(),
+        Some(original_generation_id.as_str()),
+        "the rescan must genuinely supersede repo-a's original generation, or nothing below \
+         proves the LIVE eviction path rather than an empty database"
+    );
+
+    // Stage 1 (source/generation filter): exactly one confirmed generation
+    // for `repo-a`, and it is the NEW one — the evicted generation must not
+    // still be reported as admissible.
+    let after = estate
+        .db
+        .admissible_generations(&named("repo-a"), 500)
+        .expect("admissible generations");
+    assert_eq!(
+        after.hits.len(),
+        1,
+        "the evicted generation leaked through admissible_generations: {after:?}"
+    );
+    assert_eq!(after.hits[0].content_key, "repo-a@key-2");
+    assert_ne!(
+        after.hits[0].id, original_generation_id,
+        "admissible_generations still reports the evicted generation's own id"
+    );
+
+    // Content-kind filter, code family: the evicted generation's occurrence
+    // (`widget_a`) must not leak through admissible_occurrences — only the
+    // surviving generation's `widget_a_v2` is admissible now.
+    let names = occurrence_names(&estate, &named("repo-a"));
+    assert!(
+        !names.contains(&"widget_a".to_string()),
+        "the evicted generation's occurrence leaked through admissible_occurrences: {names:?}"
+    );
+    assert!(names.contains(&"widget_a_v2".to_string()), "{names:?}");
+
+    // Content-kind filter, document family: the evicted generation's
+    // `README.md` unit must not leak through admissible_units — the
+    // surviving generation never had a README.md at all.
+    let paths: Vec<String> = estate
+        .db
+        .admissible_units(&named("repo-a"), 500)
+        .expect("admissible units")
+        .hits
+        .into_iter()
+        .map(|hit| hit.unit.relative_path)
+        .collect();
+    assert!(
+        !paths.contains(&"README.md".to_string()),
+        "the evicted generation's unit leaked through admissible_units: {paths:?}"
+    );
+
+    // The exact-pin path: pinning at the OLD, now-superseded content key
+    // must match nothing — it names a world that no longer stands, exactly
+    // like the never-confirmed stale key above, but this key WAS once the
+    // real confirmed generation's own.
+    let stale_exact = Admissibility {
+        source: SourceSelector::Exact {
+            source_name: "repo-a".to_string(),
+            content_key: REPO_A_KEY.to_string(),
+        },
+        kind: None,
+        authority: None,
+    };
+    let miss = estate
+        .db
+        .admissible_generations(&stale_exact, 500)
+        .expect("admissible generations");
+    assert!(
+        miss.hits.is_empty(),
+        "an exact pin at the evicted generation's own former content key must match nothing, \
+         got {miss:?}"
     );
 }
 
 // ------------------------------------------- stage 4: repo/knowledge/external
 
-/// POSITIVE: `--type knowledge` (`SourceSelector::Kind(LocalKnowledge)`)
+/// POSITIVE: `--type knowledge` (`Admissibility::kind = Some(LocalKnowledge)`)
 /// admits `notes`. NEGATIVE: it excludes `repo-a`/`repo-b` (estate-git) and
 /// `vendor-lib` (external-git) — the estate's own repositories and a
 /// fetched external one are both a different KIND, not merely a different
@@ -346,15 +484,88 @@ fn an_exact_generation_pin_matches_its_own_key_and_returns_nothing_for_a_stale_o
 fn a_knowledge_kind_selector_admits_only_local_knowledge_sources() {
     let estate = estate();
     let filter = Admissibility {
-        source: SourceSelector::Kind(SourceKind::LocalKnowledge),
+        source: SourceSelector::Any,
+        kind: Some(SourceKind::LocalKnowledge),
         authority: None,
     };
     let generations = estate
         .db
         .admissible_generations(&filter, 500)
         .expect("admissible generations");
-    let names: Vec<&str> = generations.iter().map(|g| g.source_name.as_str()).collect();
+    let names: Vec<&str> = generations
+        .hits
+        .iter()
+        .map(|g| g.source_name.as_str())
+        .collect();
     assert_eq!(names, vec!["notes"], "{names:?}");
+}
+
+/// **Stage 4 composes with stage 1** — A2 §2's own listing ("the optional
+/// repo/knowledge/external selector") makes `--type` layered ON TOP OF
+/// `--source`/`--work`, not an alternative to them. `Admissibility::kind`
+/// is a field independent of `SourceSelector` for exactly this reason (see
+/// its own doc): the two are checked together here, over both a `--source`
+/// selector and a `--work` (`WorkBase`) selector, proving the composition
+/// the type system now allows is also correct at the SQL level, not merely
+/// expressible.
+#[test]
+fn stage_4_composes_with_a_named_source_and_with_a_work_base_selector() {
+    let estate = estate();
+
+    // `--source repo-a --type repo`: repo-a genuinely IS estate-git, so
+    // both halves of the composed filter agree — the generation is
+    // admitted.
+    let matching = Admissibility {
+        source: SourceSelector::Named("repo-a".to_string()),
+        kind: Some(SourceKind::EstateGit),
+        authority: None,
+    };
+    let hits = estate
+        .db
+        .admissible_generations(&matching, 500)
+        .expect("admissible generations");
+    let names: Vec<&str> = hits.hits.iter().map(|g| g.source_name.as_str()).collect();
+    assert_eq!(names, vec!["repo-a"], "{names:?}");
+
+    // `--source repo-a --type knowledge`: repo-a is named correctly but is
+    // NOT local-knowledge, so the composed (AND) filter admits nothing —
+    // proving `kind` genuinely narrows a `Named` selector's own answer
+    // rather than being ignored once a source name is given.
+    let disagreeing = Admissibility {
+        source: SourceSelector::Named("repo-a".to_string()),
+        kind: Some(SourceKind::LocalKnowledge),
+        authority: None,
+    };
+    let miss = estate
+        .db
+        .admissible_generations(&disagreeing, 500)
+        .expect("admissible generations");
+    assert!(
+        miss.hits.is_empty(),
+        "a --source filter naming an estate-git source, composed with --type knowledge, must          admit nothing: {miss:?}"
+    );
+
+    // The same composition over `--work` (`SourceSelector::WorkBase`), the
+    // selector this finding named specifically as inexpressible before this
+    // fix: `--work <id> --type repo` still reads repo-a's base generation.
+    let work_and_kind = Admissibility {
+        source: SourceSelector::WorkBase {
+            work_id: "01WORKID000000000000000000".to_string(),
+            repository: "repo-a".to_string(),
+        },
+        kind: Some(SourceKind::EstateGit),
+        authority: None,
+    };
+    let work_hits = estate
+        .db
+        .admissible_generations(&work_and_kind, 500)
+        .expect("admissible generations");
+    let work_names: Vec<&str> = work_hits
+        .hits
+        .iter()
+        .map(|g| g.source_name.as_str())
+        .collect();
+    assert_eq!(work_names, vec!["repo-a"], "{work_names:?}");
 }
 
 // -------------------------------------------------- stage 2: authority filter
@@ -368,6 +579,7 @@ fn an_authority_filter_excludes_external_content_when_not_requested() {
     let estate = estate();
     let filter = Admissibility {
         source: SourceSelector::Any,
+        kind: None,
         authority: Some(AuthorityClass::EstateMutable),
     };
     let names = occurrence_names(&estate, &filter);
@@ -387,6 +599,7 @@ fn an_authority_filter_for_external_admits_only_the_external_source() {
     let estate = estate();
     let filter = Admissibility {
         source: SourceSelector::Any,
+        kind: None,
         authority: Some(AuthorityClass::External),
     };
     let names = occurrence_names(&estate, &filter);
@@ -405,7 +618,11 @@ fn an_unfiltered_admissibility_admits_every_confirmed_source() {
         .db
         .admissible_generations(&Admissibility::default(), 500)
         .expect("admissible generations");
-    let mut names: Vec<&str> = generations.iter().map(|g| g.source_name.as_str()).collect();
+    let mut names: Vec<&str> = generations
+        .hits
+        .iter()
+        .map(|g| g.source_name.as_str())
+        .collect();
     names.sort_unstable();
     assert_eq!(names, vec!["notes", "repo-a", "repo-b", "vendor-lib"]);
 }
@@ -441,7 +658,11 @@ fn a_content_kind_mismatch_is_excluded_from_the_document_family() {
         .db
         .admissible_units(&named("repo-a"), 500)
         .expect("admissible units");
-    let paths: Vec<&str> = hits.iter().map(|h| h.unit.relative_path.as_str()).collect();
+    let paths: Vec<&str> = hits
+        .hits
+        .iter()
+        .map(|h| h.unit.relative_path.as_str())
+        .collect();
     assert!(
         !paths.contains(&"mystery.xyz"),
         "a unit under an unrecognized structure extractor leaked through the document-family \
@@ -561,9 +782,21 @@ fn a_work_base_selector_reads_like_its_named_repository_and_states_base_only_sco
             work_id: "01WORKID000000000000000000".to_string(),
             repository: "repo-a".to_string(),
         },
+        kind: None,
         authority: None,
     };
     assert_eq!(filter.source.work_scope(), WorkScope::BaseOnly);
+
+    // The completeness marker is carried on the ANSWER itself, not only
+    // recoverable by re-deriving it from `filter` -- `Admitted::scope`,
+    // checked directly on a real `admissible_generations` return, not on
+    // the input filter a caller forwarding just the hits may no longer
+    // have in scope.
+    let generations = estate
+        .db
+        .admissible_generations(&filter, 500)
+        .expect("admissible generations");
+    assert_eq!(generations.scope, WorkScope::BaseOnly);
 
     let names = occurrence_names(&estate, &filter);
     assert!(names.contains(&"widget_a".to_string()), "{names:?}");
@@ -638,6 +871,7 @@ fn a_toml_files_config_content_lives_in_the_code_lane_and_also_leaves_a_document
         .expect("admissible occurrences");
     assert!(
         occurrences
+            .hits
             .iter()
             .any(|hit| hit.occurrence.extractor == "syntax-toml/v1"
                 && hit.occurrence.label == "table"
@@ -649,12 +883,12 @@ fn a_toml_files_config_content_lives_in_the_code_lane_and_also_leaves_a_document
     // "zero source.units rows" the plan's own text asserted.
     let units = db.admissible_units(&filter, 500).expect("admissible units");
     assert_eq!(
-        units.len(),
+        units.hits.len(),
         1,
         "Cargo.toml must leave exactly one fallback document unit, got {units:#?}"
     );
-    assert_eq!(units[0].unit.relative_path, "Cargo.toml");
-    assert_eq!(units[0].unit.kind, UnitKind::Document);
+    assert_eq!(units.hits[0].unit.relative_path, "Cargo.toml");
+    assert_eq!(units.hits[0].unit.kind, UnitKind::Document);
 }
 
 // -------------------------------------------------- tabular family, datasets
@@ -695,9 +929,9 @@ fn a_source_filter_excludes_another_sources_dataset() {
     let hits = db
         .admissible_datasets(&named("data-a"), 500)
         .expect("admissible datasets");
-    let sources: Vec<&str> = hits.iter().map(|h| h.source_name.as_str()).collect();
+    let sources: Vec<&str> = hits.hits.iter().map(|h| h.source_name.as_str()).collect();
     assert_eq!(sources, vec!["data-a"], "{hits:#?}");
-    assert_eq!(hits[0].dataset.relative_path, "rows.csv");
+    assert_eq!(hits.hits[0].dataset.relative_path, "rows.csv");
 }
 
 // ------------------------------- --work, the fourth required negative (W1)
@@ -718,16 +952,25 @@ fn a_source_filter_excludes_another_sources_dataset() {
 /// [`AtlasDb::evict_work_overlays`](sergeant_rs::runtime::atlas::db::AtlasDb::evict_work_overlays)
 /// already reads today.
 ///
-/// Two exclusions are required and both are checked:
+/// Three exclusions are required and all three are checked:
 ///
-/// 1. **Another Work's overlay over the same repository is not admissible.**
-///    `work:01OTHER…/repo-a` describes a world only that Work can see. A
-///    filter that matched the `work:` prefix, or that reached for "anything
-///    mentioning repo-a", would admit it — and admissibility decides what
-///    may be SEEN, so that is a leak between two Works' surfaces, not a
-///    ranking imprecision (A2 §8).
-/// 2. **This Work's OWN overlay is not admissible either** — the honest
-///    half. W1's `--work` is
+/// 1. **Neither overlay coordinate is admissible through `SourceSelector::
+///    Named` either** — not just through the `--work`/`--type`/`--source`
+///    selectors `a_work_base_selector_...` already covers for a *different
+///    repository*. `work:<id>/repo-a` describes a world only that Work can
+///    see; a caller who merely learns another Work's id (visible via `sgt
+///    work list`) must not be able to type it straight into `--source` and
+///    read that Work's surface. Every `admissible_*` method excludes the
+///    `work:` prefix unconditionally, so this holds even for the coordinate
+///    typed exactly.
+/// 2. **Another Work's overlay over the same repository is not admissible
+///    through `--work` either.** `work:01OTHER…/repo-a` describes a world
+///    only that Work can see. A filter that matched the `work:` prefix, or
+///    that reached for "anything mentioning repo-a", would admit it — and
+///    admissibility decides what may be SEEN, so that is a leak between two
+///    Works' surfaces, not a ranking imprecision (A2 §8).
+/// 3. **This Work's OWN overlay is not admissible through `--work` either**
+///    — the honest half. W1's `--work` is
 ///    [`WorkScope::BaseOnly`](sergeant_rs::runtime::atlas::db::WorkScope)
 ///    (H13.2), so the overlay is absent by design rather than by accident,
 ///    and the answer says so. When W1b lands, THIS assertion is the one
@@ -760,6 +1003,14 @@ fn a_work_filter_excludes_a_different_works_generation() {
 
     // Two overlay generations over that same base, one per Work, each under
     // its own `work:<id>/<repo>` source coordinate.
+    //
+    // The write is proved directly through `record_scan`'s own return value
+    // (`ScanRecord::Recorded` — journaled and confirmed) rather than by
+    // reading the row back through an admissibility query: every
+    // admissibility method now excludes the `work:` prefix unconditionally
+    // (the blocker this test exists to pin), so a round trip through
+    // `SourceSelector::Named` can no longer serve as proof the fixture
+    // landed — that round trip succeeding was the very leak being fixed.
     for (work_id, symbol) in [(MINE, "widget_mine"), (OTHER, "widget_theirs")] {
         let overlay = scan(
             &sergeant_rs::runtime::atlas::overlay::overlay_source_name(work_id, "repo-a"),
@@ -773,7 +1024,12 @@ fn a_work_filter_excludes_a_different_works_generation() {
                 Some(syntax("rust", "syntax-rust/v1", "function", symbol)),
             )],
         );
-        record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+        let recorded = record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+        assert!(
+            matches!(recorded, ScanRecord::Recorded { .. }),
+            "the fixture must actually be journaled and confirmed, or the exclusions below \
+             prove nothing: {recorded:?}"
+        );
     }
 
     let filter = Admissibility {
@@ -781,25 +1037,32 @@ fn a_work_filter_excludes_a_different_works_generation() {
             work_id: MINE.to_string(),
             repository: "repo-a".to_string(),
         },
+        kind: None,
         authority: None,
     };
 
-    // Both overlay generations genuinely exist in the store, so the two
-    // exclusions below are the filter's doing rather than an empty database's.
+    // Neither overlay coordinate is admissible through ANY selector — not
+    // just `WorkBase` (W1's `--work`, checked below), but also `Named`/
+    // `Exact` addressing the coordinate directly, since a caller who learns
+    // another Work's id could otherwise type it straight into `--source`.
     for work_id in [MINE, OTHER] {
         let coordinate =
             sergeant_rs::runtime::atlas::overlay::overlay_source_name(work_id, "repo-a");
         assert!(
-            !db.admissible_units(&named(&coordinate), 500)
+            db.admissible_units(&named(&coordinate), 500)
                 .expect("admissible units")
+                .hits
                 .is_empty(),
-            "the fixture must actually hold {coordinate}'s rows, or the exclusions prove nothing"
+            "SourceSelector::Named must never surface an overlay coordinate, {coordinate} \
+             included: a caller who learns a Work id must not be able to read that Work's \
+             surface via --source"
         );
     }
 
     let sources: BTreeSet<String> = db
         .admissible_generations(&filter, 500)
         .expect("admissible generations")
+        .hits
         .into_iter()
         .map(|generation| generation.source_name)
         .collect();
@@ -816,6 +1079,7 @@ fn a_work_filter_excludes_a_different_works_generation() {
     let names: Vec<String> = db
         .admissible_occurrences(&filter, 500)
         .expect("admissible occurrences")
+        .hits
         .into_iter()
         .map(|hit| hit.occurrence.name)
         .collect();


### PR DESCRIPTION
## What

A2 §2's first operation: **deterministic admissibility, before any scoring exists.** Four bounded, canned, parameterized queries — `admissible_generations`, `admissible_units`, `admissible_occurrences`, `admissible_datasets` — over the units A1 already writes. No ranking, no BM25, no embeddings; those are W2–W4.

Admissibility is a database operation that decides what may be **seen**, never a ranking hint (A2 §8 forbids anything downstream crossing an authority/source filter because a candidate scores well).

## What the blind panel caught

**Blocker — Work overlays were admissible through every selector except `--work`.** An overlay coordinate (`work:<id>/<repo>`) could be typed straight into `--source`, so a caller who learned another Work's id could read that Work's overlay content through a filter never meant to expose it. Fixed by applying `source_name NOT LIKE ?` unconditionally across all four queries, with the pattern derived from `overlay::OVERLAY_PREFIX` rather than a second hardcoded literal.

Also fixed:
- `WorkScope::BaseOnly` was computable from the input filter but never carried on the **answer**. All four methods now return `Admitted<T> { hits, scope }`, so the completeness marker travels with the result rather than needing re-derivation.
- Stage 4 (repo/knowledge/external) was fused into stage 1 by the selector enum's mutual exclusivity, making `--work + --type` and `--source + --type` inexpressible. Stage 4 is now an independent `kind` field.

Each fix was proven by **revert-and-watch-red** — the exclusion disabled and the test observed failing, then restored. A test never watched to fail is not known to work.

## Negative admission is the point

Every stage proves an inadmissible row is **not** returned: another source's rows excluded; `external` authority excluded when not requested (plus the inverse, so the filter is proven to *select* rather than merely return less); content-kind mismatch excluded; a different Work's generation excluded over the same repository — which is the exclusion that matters, since two Works can bind the same repo.

## Content-kind (H13.1) and the `config` gap

Table-routing + extractor-prefix, no new column. Both pinned structurally: `DOCUMENT_EXTRACTOR_IDENTITIES` is walked against every adapter's own `pub const …_EXTRACTOR`, and `CODE_EXTRACTOR_LIKE` against every `SyntaxLanguage::ALL` identity plus a synthetic unknown — a new adapter inventing an identity the filter doesn't know **trips** the test rather than silently falling out of `--content`.

`--content config` is not offered as a document-side value, and a test records why.

## `--work` is base-generation only, and says so

A2 §2's text says "including overlay"; the overlay trigger is W1b. Rather than returning a silent partial, `WorkScope::BaseOnly` is declared on every answer.

## Verification

- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- Wave suite: 18/18
- Boundary tripwires green: item-13 no-client-SQL, both one-owner duckdb tests
- Full suite once: `2270 tests run: 2270 passed (6 slow), 38 skipped`
- New suite wired into coverage stage C2 at birth (#231's lesson) — which also fixed a red `every_suite_is_wired_or_explicitly_allowlisted`

R2 (built on the existing `symbol_lookup`/`references` cross-source join precedent — no new table, no new column). J3 (H1 and H13.1 already decided).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4