### PR TITLE
feat(atlas): S5 W2 — lexical retrieval (BM25) over A1's existing units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1316,6 +1316,52 @@ them were dead code in every real installation.
   still said overlay indexing had no trigger at all, now say what the code
   does.
 
+### Lexical retrieval (S5)
+
+- **Atlas can now be searched by text.** A small local BM25 index over the
+  evidence units A1 already writes (A2 §5, decision A2-05 — no search server,
+  no new chunker), living in the one Atlas database as `context.lexical_units`
+  and `context.lexical_postings`. It is derived evidence, keyed by
+  SourceGeneration: a superseded generation's postings are evicted with it in
+  the same transaction as every other derived row, and the whole index is
+  rebuildable from the A1 rows alone (`AtlasDb::reindex_lexical`).
+- **The filter runs first and ranking never widens it.** Every lexical query
+  joins postings to `source.generations` through the same admissibility
+  predicate the W1 filter family applies, so a unit outside the caller's world
+  is unreachable rather than merely unranked — A2 §8's "the reranker must
+  never silently cross an authority/source filter merely because a candidate
+  scores well", enforced structurally. A planted document that is the best
+  lexical match in the store for every query the suite runs is proven to rank
+  first with no filter and to be absent under the authority, source and kind
+  filters
+  (`w2_lexical_retrieval::an_inadmissible_unit_with_a_perfect_lexical_match_is_never_returned`),
+  and one Work's overlay never surfaces through another's `--work`
+  (`::another_works_overlay_unit_never_surfaces_through_a_lexical_query`).
+- **All four unit families answer, with A1's own coordinates.** Code,
+  document, mail and selected-row-text (A2 §17 item 2), each with a test that
+  finds a unit of that kind and resolves its provenance — source, generation,
+  unit, and the byte range for the three families whose evidence is a
+  resource's bytes. Selected-row text carries A2 §3's structured-text
+  coordinate instead (`dataset/row-id/field-set`): a row is read in place and
+  never copied into Atlas, so there is no byte range to cite and none is
+  invented.
+- **Tokenization keeps the whole identifier as well as its parts.** A2 §5's
+  six named forms — `PaymentRetryPolicy`, `payment_retry_policy`,
+  `payment-retry-policy`, `Foo::bar`, `POST /payments`, `INC0012345` — are
+  six test cases, and searching `PaymentRetryPolicy` and searching `payment`
+  both find the unit that spells it. The code family indexes the identifiers a
+  grammar claimed; the document, mail and row families index the unit's own
+  prose, which is A2 §5's "document/mail retrieval additionally retains
+  ordinary natural-language tokens".
+- **Deterministic, including its ties.** Same query and same generations give
+  the same ordered result: score descending by total order, then the stated
+  key `(source_name, relative_path, ordinal, unit_key)` ascending, accumulated
+  through a `BTreeMap` rather than a hash map. A capped posting scan says so
+  on the answer rather than quietly returning different scores.
+- No CLI surface yet (that is a later wave), no semantic retrieval, no
+  fusion, and no ANN/vector index — A2 §16 lists that last one as an explicit
+  non-goal until measurements prove exact scanning inadequate.
+
 
 ## [0.2.4] - 2026-08-25
 

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -295,3 +295,16 @@ cov_stage_end 1 "the w1d_overlay_freshness test binary must write its own profil
 cov_stage_begin c2-f258_nextest_thread_budget
 cov_run cargo llvm-cov --no-report --test f258_nextest_thread_budget --locked || cov_fail "f258_nextest_thread_budget failed under instrumentation"
 cov_stage_end 1 "the f258_nextest_thread_budget test binary must write its own profile"
+# S5 W2, wired at birth (the #231 lesson, same as x5/y2/y5/y6/w1/w1b/w1c/w1d
+# above): A2 §5's lexical retrieval — the BM25 index over A1's existing
+# evidence units, its four unit families with A1 provenance (§17 item 2), and
+# the negative A2 §8 turns on (an inadmissible unit with a perfect lexical
+# match is never returned). Builds Atlas stores in tempdirs, runs one real
+# `scan_local_knowledge` walk for the code/document/row-text families, and
+# records the mail fixture through the ordinary `record_scan` path. No daemon,
+# no estate, no subprocess of any kind — the `.eml` worker is deliberately not
+# spawned (that is y4_mail_adapter's job), which is why this sits here rather
+# than with the spawning suites. Floor 1.
+cov_stage_begin c2-w2_lexical_retrieval
+cov_run cargo llvm-cov --no-report --test w2_lexical_retrieval --locked || cov_fail "w2_lexical_retrieval failed under instrumentation"
+cov_stage_end 1 "the w2_lexical_retrieval test binary must write its own profile"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -846,6 +846,39 @@ pub async fn start_with(
                          generation may remain unresolved (it stays unreadable)"
                     ),
                 }
+                // S5 W2 (F-SF-01): the lexical-index upgrade path. A store
+                // written before W2 has confirmed generations with rows but
+                // no postings — `reindex_lexical`'s own doc names this exact
+                // condition, but nothing invoked it. `lexical_index_needs_rebuild`
+                // is a cheap anti-join, so it is safe to check every startup
+                // rather than only once at a version boundary this crate has
+                // no other way to detect; the rebuild itself runs only when
+                // that check finds something to do.
+                match atlas.lexical_index_needs_rebuild() {
+                    Ok(true) => match atlas.reindex_lexical() {
+                        Ok(outcome) => tracing::debug!(
+                            target: "sergeant::atlas",
+                            indexed = outcome.indexed,
+                            truncated = outcome.truncated,
+                            "lexical index rebuilt at startup (S5 W2 upgrade path)"
+                        ),
+                        // Same reasoning as an unopenable store above:
+                        // derived evidence never costs the estate its daemon.
+                        Err(e) => tracing::warn!(
+                            target: "sergeant::atlas",
+                            error = %e,
+                            "lexical index could not be rebuilt at startup; \
+                             lexical_search may return empty for pre-existing \
+                             generations this run"
+                        ),
+                    },
+                    Ok(false) => {}
+                    Err(e) => tracing::warn!(
+                        target: "sergeant::atlas",
+                        error = %e,
+                        "could not check whether the lexical index needs a rebuild"
+                    ),
+                }
                 // S5 W1b: the Work-overlay eviction reconciliation sweep,
                 // first half — a terminal Work whose surface was ALREADY
                 // torn down before this restart.

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -136,6 +136,10 @@ use crate::domain::workflow::{
     KIND_STAGE_FAILED, KIND_STAGE_NEEDS_INPUT, KIND_STAGE_WAITING, KIND_WORKFLOW_BOUND,
 };
 use crate::runtime::atlas::external_git::ExternalGitProvenance;
+use crate::runtime::atlas::lexical::{
+    Bm25Corpus, LexicalFamily, LexicalHit, UnitCoordinate, bm25_contribution, query_terms,
+    rank_order, term_frequencies,
+};
 use crate::runtime::atlas::scan::{ScannedFile, ScannedSyntax, ScannedUnit, SourceScan};
 use crate::runtime::atlas::tabular::{
     DatasetFormat, RowKeyBasis, RowUnit, ScannedDataset, row_units,
@@ -368,6 +372,29 @@ SET lock_configuration = true;\n";
 ///   that source, and that is the refusal, not an oversight. `key_basis` says
 ///   whether `row_key` is content-derived or had to fold in the ordinal — see
 ///   [`crate::runtime::atlas::tabular`] for why an S5 consumer needs to know.
+///
+/// S5 W2's two, and why the lexical index is a table here rather than a
+/// service (A2 §5, decision A2-05):
+///
+/// * **`context.lexical_units` is one indexable unit's identity and length.**
+///   It lives in `context` for `context.row_units`'s own reason — it is
+///   retrieval-facing text assembled from a source — and it is **derived
+///   evidence over A1's existing units, not a second chunk universe** (A2
+///   §3/A2-02: "A2 does not invent an independent chunk universe"). Every row
+///   is derived from a `source.occurrences`, `source.units` or
+///   `context.row_units` row that already exists; W2 adds no chunker (R2).
+///   The coordinate columns are nullable by family, because A2 §3 gives each
+///   family a different coordinate and only three of the four are byte spans
+///   — see
+///   [`crate::runtime::atlas::lexical::UnitCoordinate`], which is the type
+///   this table is read back into.
+/// * **`context.lexical_postings` is the inverted index**: one row per
+///   (unit, term), with the term's frequency in that unit. Both tables are
+///   keyed by `generation_id` and both are deleted by [`evict`] with every
+///   other derived row, which is what makes "a superseded generation's
+///   postings are evicted with it" a property of the schema rather than a
+///   promise — and keeps the reported-never-silent eviction discipline
+///   identical to every other table's.
 const TABLE_DDL: &str = "\
 CREATE TABLE IF NOT EXISTS source.generations (\n\
   generation_id    TEXT NOT NULL,\n\
@@ -494,6 +521,30 @@ CREATE TABLE IF NOT EXISTS context.row_units (\n\
   key_basis     TEXT NOT NULL,\n\
   fields        TEXT NOT NULL,\n\
   body          TEXT NOT NULL\n\
+);\n\
+CREATE TABLE IF NOT EXISTS context.lexical_units (\n\
+  generation_id TEXT NOT NULL,\n\
+  source_name   TEXT NOT NULL,\n\
+  family        TEXT NOT NULL,\n\
+  unit_key      TEXT NOT NULL,\n\
+  relative_path TEXT NOT NULL,\n\
+  ordinal       BIGINT NOT NULL,\n\
+  title         TEXT,\n\
+  symbol        TEXT,\n\
+  language      TEXT,\n\
+  label         TEXT,\n\
+  dataset_key   TEXT,\n\
+  row_key       TEXT,\n\
+  fields        TEXT,\n\
+  byte_start    BIGINT,\n\
+  byte_end      BIGINT,\n\
+  token_count   BIGINT NOT NULL\n\
+);\n\
+CREATE TABLE IF NOT EXISTS context.lexical_postings (\n\
+  generation_id  TEXT NOT NULL,\n\
+  unit_key       TEXT NOT NULL,\n\
+  term           TEXT NOT NULL,\n\
+  term_frequency BIGINT NOT NULL\n\
 );\n";
 
 /// A generation whose rows are written but whose summary is not yet journaled
@@ -508,6 +559,82 @@ const STATE_CONFIRMED: &str = "confirmed";
 /// after a crash. Kept as a row (with its coverage row) rather than deleted,
 /// because "this world was observed and is no longer indexed" is evidence.
 const STATE_EVICTED: &str = "evicted";
+
+/// A2 §2's composed stage-1/2/4 admissibility predicate over the `g` alias,
+/// as a **compile-time literal** the three W2 statements below splice in with
+/// `concat!`.
+///
+/// A macro rather than a `const &str` because `concat!` takes literals, and a
+/// literal is the point: `tests/x5_a1a_acceptance.rs::
+/// a1a_item_13_no_client_sql_reaches_the_store` pins every interpolation in
+/// every SQL literal in this file, and lexical retrieval adds none. The
+/// clause order and shape are identical to the one
+/// [`AtlasDb::admissible_generations`] and its three content-kind siblings
+/// spell inline; the bind values are
+/// [`AtlasDb::admissibility_binds`], in this order:
+///
+/// ```text
+/// state, overlay-exclude LIKE, source_name x2, overlay-admit x2,
+/// content_key x2, source_kind x2, authority_class x2
+/// ```
+macro_rules! admissible_generations_where {
+    () => {
+        "g.state = ? \
+         AND ( (g.source_name NOT LIKE ? \
+                AND (? IS NULL OR g.source_name = ?)) \
+               OR (? IS NOT NULL AND g.source_name = ?) ) \
+         AND (? IS NULL OR g.content_key = ?) \
+         AND (? IS NULL OR g.source_kind = ?) \
+         AND (? IS NULL OR g.authority_class = ?)"
+    };
+}
+
+/// The join every W2 statement makes: postings to their unit, unit to its
+/// generation. A posting whose generation the admissibility predicate
+/// excludes is unreachable through it — which is what makes A2 §8's "never
+/// silently crossing an authority/source filter" structural here rather than
+/// procedural.
+macro_rules! lexical_posting_join {
+    () => {
+        "FROM context.lexical_postings p \
+         JOIN context.lexical_units l ON l.generation_id = p.generation_id \
+                                      AND l.unit_key = p.unit_key \
+         JOIN source.generations g ON g.generation_id = l.generation_id \
+         WHERE "
+    };
+}
+
+/// BM25's corpus statistics — `N` and the mean document length — measured
+/// over the admissible, family-filtered set and nothing wider.
+const LEXICAL_CORPUS_SQL: &str = concat!(
+    "SELECT count(*), coalesce(sum(l.token_count), 0) \
+     FROM context.lexical_units l \
+     JOIN source.generations g USING (generation_id) \
+     WHERE ",
+    admissible_generations_where!(),
+    " AND (? IS NULL OR l.family = ?)"
+);
+
+/// One term's document frequency over that same set.
+const LEXICAL_DOCUMENT_FREQUENCY_SQL: &str = concat!(
+    "SELECT count(*) ",
+    lexical_posting_join!(),
+    admissible_generations_where!(),
+    " AND (? IS NULL OR l.family = ?) AND p.term = ?"
+);
+
+/// One term's postings, with every coordinate column a hit has to cite.
+const LEXICAL_POSTINGS_SQL: &str = concat!(
+    "SELECT l.generation_id, l.source_name, g.content_key, l.family, l.unit_key, \
+            l.relative_path, l.ordinal, l.title, l.symbol, l.language, l.label, \
+            l.dataset_key, l.row_key, l.fields, l.byte_start, l.byte_end, \
+            l.token_count, p.term_frequency ",
+    lexical_posting_join!(),
+    admissible_generations_where!(),
+    " AND (? IS NULL OR l.family = ?) AND p.term = ? \
+      ORDER BY l.source_name, l.relative_path, l.ordinal, l.unit_key \
+      LIMIT ?"
+);
 
 /// The default row ceiling on a read from this store (F12).
 ///
@@ -1078,6 +1205,13 @@ impl AtlasDb {
                 ],
             )?;
         }
+        // S5 W2: the lexical index, derived inside the same transaction from
+        // the rows just written. Not from `scan` in memory — from the stored
+        // rows themselves, so the postings are an index over exactly the
+        // evidence a hit will cite, and there is no second derivation path
+        // that could disagree with the first (A2-02: no independent chunk
+        // universe). All-or-nothing with everything else the scan staged.
+        index_generation(&tx, &generation_id)?;
         tx.commit()?;
         Ok(ScanCommit::Staged { generation_id })
     }
@@ -2481,6 +2615,257 @@ impl AtlasDb {
         })
     }
 
+    // ------------------------------------------------------------------
+    // S5 W2 — A2 §5's lexical retrieval (decision A2-05).
+    //
+    // The filter runs FIRST and decides the world; BM25 ranks INSIDE it.
+    // That ordering is A2 §2's ("only then retrieve/rank") and A2 §8's
+    // prohibition — "the reranker must never silently cross an
+    // authority/source filter merely because a candidate scores well" — and
+    // here it is structural rather than procedural: every query below joins
+    // `context.lexical_units` to `source.generations` through the SAME
+    // composed admissibility predicate the `admissible_*` family applies, so
+    // an inadmissible generation's postings are unreachable from a search.
+    // There is no code path that scores a row first and filters it after,
+    // because there is no code path that can see the row at all.
+    // ------------------------------------------------------------------
+
+    /// A2 §2's composed stage-1/2/4 predicate's **bind values**, in the order
+    /// [`ADMISSIBLE_GENERATION_PREDICATE`] consumes them.
+    ///
+    /// The predicate text itself is a macro rather than a runtime `format!`,
+    /// and that is not a style choice: `tests/x5_a1a_acceptance.rs::
+    /// a1a_item_13_no_client_sql_reaches_the_store` pins the exhaustive list
+    /// of interpolations in every SQL literal in this file, and W2 adds none
+    /// — every statement below is a compile-time literal assembled by
+    /// `concat!`. Item 13 forbids handing the store a query; the cheapest way
+    /// to keep that true is to have no runtime string-building in the query
+    /// path at all.
+    ///
+    /// Required to agree with the W1 family's own inline predicate, and
+    /// pinned by `tests/w2_lexical_retrieval.rs::
+    /// every_generation_a_lexical_hit_cites_is_one_the_admissibility_filter_
+    /// admits`, which compares the two answers rather than the two strings (a
+    /// string comparison would pass on two queries that are identically
+    /// wrong).
+    fn admissibility_binds(filter: &Admissibility) -> Vec<Duck> {
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let overlay_admit = filter.source.overlay_admit_source_name();
+        vec![
+            Duck::Text(STATE_CONFIRMED.to_string()),
+            Duck::Text(Self::overlay_exclude_like()),
+            optional_text(source_name),
+            optional_text(source_name),
+            overlay_admit.clone().map_or(Duck::Null, Duck::Text),
+            overlay_admit.map_or(Duck::Null, Duck::Text),
+            optional_text(content_key),
+            optional_text(content_key),
+            optional_text(source_kind),
+            optional_text(source_kind),
+            optional_text(authority),
+            optional_text(authority),
+        ]
+    }
+
+    /// A2 §5's lexical retrieval: BM25 over the admissible set, deterministic
+    /// in its ties, every hit carrying A1's own coordinate.
+    ///
+    /// # What this does, in order
+    ///
+    /// 1. Tokenizes the query
+    ///    ([`crate::runtime::atlas::lexical::query_terms`]) — distinct terms,
+    ///    sorted, so the query itself contributes nothing order-dependent.
+    /// 2. Measures the corpus **inside the admissible set**: how many units it
+    ///    holds and their mean token count. A unit the caller may not see does
+    ///    not merely fail to appear in the results — it does not influence the
+    ///    IDF or the length normalization of the ones that do.
+    /// 3. Per term, reads that term's document frequency and then its
+    ///    postings, both over that same admissible set, and accumulates each
+    ///    unit's score
+    ///    ([`crate::runtime::atlas::lexical::bm25_contribution`]).
+    /// 4. Orders by [`crate::runtime::atlas::lexical::rank_order`].
+    ///
+    /// **Two statements per term rather than one `IN (...)` list**, because an
+    /// `IN` list's placeholders have to be built at runtime and item 13's
+    /// no-client-SQL pin (see [`Self::admissibility_binds`]) is worth more
+    /// than the round trips: a query's distinct-term count is small, and the
+    /// document frequency has to be its own exact count anyway — deriving it
+    /// from the (capped) posting scan would make a unit's IDF depend on how
+    /// many *other* units happened to fit under the cap.
+    ///
+    /// # Determinism
+    ///
+    /// Same query + same generations ⇒ same ordered result. Terms are visited
+    /// in sorted order, each statement carries its own `ORDER BY`, and
+    /// accumulation is a [`BTreeMap`] keyed by `(generation_id, unit_key)` —
+    /// never a hash map. The final order is score descending by
+    /// `f64::total_cmp`, then the stated tie-break key `(source_name,
+    /// relative_path, ordinal, unit_key)` ascending. Nothing in that chain
+    /// reads row arrival order.
+    ///
+    /// # Bounds, and saying so
+    ///
+    /// The posting scan is capped at [`MAX_ROWS`] postings across all terms
+    /// (F12). Because a cap on *postings* silently changes *scores* rather
+    /// than merely shortening a list, [`LexicalAnswer::truncated`] says when
+    /// it bit, and it is a field on the answer rather than a log line for the
+    /// same reason [`WorkScope`] is: a caller must be able to state what its
+    /// answer covers.
+    pub fn lexical_search(&self, query: &LexicalQuery<'_>) -> Result<LexicalAnswer, AtlasError> {
+        let scope = self.work_scope(query.filter, true)?;
+        let terms = query_terms(query.text);
+        let limit = query.limit.min(MAX_ROWS);
+        let empty = LexicalAnswer {
+            hits: Vec::new(),
+            scope: scope.clone(),
+            truncated: false,
+        };
+        if terms.is_empty() || limit == 0 {
+            return Ok(empty);
+        }
+        let family = query.family.map(LexicalFamily::as_str);
+        let admissibility = Self::admissibility_binds(query.filter);
+
+        // (2) the corpus, measured over the admissible, family-filtered set.
+        let mut binds = admissibility.clone();
+        binds.push(optional_text(family));
+        binds.push(optional_text(family));
+        let mut statement = self.conn.prepare(LEXICAL_CORPUS_SQL)?;
+        let mut rows = statement.query(duckdb::params_from_iter(binds))?;
+        let (units, tokens) = match rows.next()? {
+            Some(row) => (
+                row.get::<usize, i64>(0)? as u64,
+                row.get::<usize, i64>(1)? as u64,
+            ),
+            None => (0, 0),
+        };
+        drop(rows);
+        drop(statement);
+        if units == 0 {
+            return Ok(empty);
+        }
+        let corpus = Bm25Corpus {
+            units,
+            average_length: tokens as f64 / units as f64,
+        };
+
+        let mut scored: BTreeMap<(String, String), Scored> = BTreeMap::new();
+        let mut seen = 0usize;
+        let mut truncated = false;
+        'terms: for term in &terms {
+            // (3a) this term's document frequency, exact, over the admissible
+            // set — never counted off the capped scan below.
+            let mut binds = admissibility.clone();
+            binds.push(optional_text(family));
+            binds.push(optional_text(family));
+            binds.push(Duck::Text(term.clone()));
+            let mut statement = self.conn.prepare(LEXICAL_DOCUMENT_FREQUENCY_SQL)?;
+            let mut rows = statement.query(duckdb::params_from_iter(binds))?;
+            let document_frequency = match rows.next()? {
+                Some(row) => row.get::<usize, i64>(0)? as u64,
+                None => 0,
+            };
+            drop(rows);
+            drop(statement);
+            if document_frequency == 0 {
+                continue;
+            }
+
+            // (3b) this term's postings, bounded by what is left of the cap.
+            let remaining = MAX_ROWS.saturating_sub(seen);
+            let mut binds = admissibility.clone();
+            binds.push(optional_text(family));
+            binds.push(optional_text(family));
+            binds.push(Duck::Text(term.clone()));
+            binds.push(Duck::BigInt(remaining as i64 + 1));
+            let mut statement = self.conn.prepare(LEXICAL_POSTINGS_SQL)?;
+            let mut rows = statement.query(duckdb::params_from_iter(binds))?;
+            while let Some(row) = rows.next()? {
+                if seen >= MAX_ROWS {
+                    truncated = true;
+                    break 'terms;
+                }
+                seen += 1;
+                let generation_id: String = row.get(0)?;
+                let unit_key: String = row.get(4)?;
+                let token_count = row.get::<usize, i64>(16)? as u64;
+                let term_frequency = row.get::<usize, i64>(17)? as u64;
+                let entry = match scored.entry((generation_id.clone(), unit_key.clone())) {
+                    std::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
+                    std::collections::btree_map::Entry::Vacant(slot) => slot.insert(Scored {
+                        hit: LexicalHit {
+                            score: 0.0,
+                            source_name: row.get(1)?,
+                            generation_id,
+                            content_key: row.get(2)?,
+                            unit_key,
+                            coordinate: coordinate_of(row)?,
+                        },
+                        token_count,
+                    }),
+                };
+                entry.hit.score += bm25_contribution(
+                    corpus,
+                    document_frequency,
+                    term_frequency,
+                    entry.token_count,
+                );
+            }
+        }
+
+        let mut hits: Vec<LexicalHit> = scored.into_values().map(|s| s.hit).collect();
+        hits.sort_by(rank_order);
+        hits.truncate(limit);
+        Ok(LexicalAnswer {
+            hits,
+            scope,
+            truncated,
+        })
+    }
+
+    /// Rebuild the whole lexical index from the A1 rows it is derived from.
+    ///
+    /// The index is **derived evidence**: the journal, Git and the original
+    /// bytes remain authority (A1-01), so losing it costs nothing that cannot
+    /// be recomputed. This is what makes that claim checkable rather than
+    /// asserted — and it is the upgrade path for a store written before S5
+    /// W2, whose generations have rows but no postings.
+    ///
+    /// Every non-evicted generation is re-derived through the same
+    /// [`index_generation`] the staging transaction uses, in one transaction,
+    /// after its existing rows are cleared. Returns how many units were
+    /// indexed.
+    pub fn reindex_lexical(&mut self) -> Result<u64, AtlasError> {
+        let mut statement = self.conn.prepare(
+            "SELECT generation_id FROM source.generations WHERE state != ? \
+             ORDER BY observed_at, generation_id LIMIT ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![STATE_EVICTED, MAX_ROWS as i64])?;
+        let mut targets: Vec<String> = Vec::new();
+        while let Some(row) = rows.next()? {
+            targets.push(row.get(0)?);
+        }
+        drop(rows);
+        drop(statement);
+        let tx = self.conn.transaction()?;
+        let mut indexed = 0u64;
+        for generation_id in &targets {
+            tx.execute(
+                "DELETE FROM context.lexical_postings WHERE generation_id = ?",
+                duckdb::params![generation_id],
+            )?;
+            tx.execute(
+                "DELETE FROM context.lexical_units WHERE generation_id = ?",
+                duckdb::params![generation_id],
+            )?;
+            indexed += index_generation(&tx, generation_id)?;
+        }
+        tx.commit()?;
+        Ok(indexed)
+    }
+
     /// Every generation's state, keyed by id — a diagnostic read, and what a
     /// crash-window test inspects.
     pub fn generation_states(&self) -> Result<BTreeMap<String, String>, AtlasError> {
@@ -3125,6 +3510,291 @@ fn insert_row_unit(
     Ok(())
 }
 
+/// S5 W2 — derive one generation's lexical index from the rows it just
+/// staged (A2 §5, decision A2-05).
+///
+/// **Derived from the stored rows, not from the in-memory scan.** A hit cites
+/// a `source.occurrences`/`source.units`/`context.row_units` row; deriving
+/// the postings from those same rows is what makes the citation checkable
+/// rather than parallel. It also means [`AtlasDb::reindex_lexical`] and this
+/// call are the same derivation, so a rebuilt index cannot disagree with a
+/// freshly built one.
+///
+/// **The three families, and where each one's text comes from** (A2 §17 item
+/// 2's four, less the document/mail split that one query makes):
+///
+/// * [`LexicalFamily::Document`] / [`LexicalFamily::Mail`] — `source.units`,
+///   joined to `source.files` for the extractor identity that decides which
+///   of the two it is ([`DOCUMENT_EXTRACTOR_IDENTITIES`], with
+///   [`crate::runtime::atlas::mail::MAIL_EXTRACTOR`] the mail half). Indexed
+///   text is the unit's title and body — so these families carry every
+///   ordinary word of the prose, which is A2 §5's *"Document/mail retrieval
+///   additionally retains ordinary natural-language tokens"*.
+/// * [`LexicalFamily::Code`] — `source.occurrences`, the grammar-claimed
+///   definition sites, matched on [`CODE_EXTRACTOR_LIKE`] exactly as
+///   [`AtlasDb::admissible_occurrences`] matches them. Indexed text is the
+///   symbol name and nothing else: A2 §5's BM25 is *"tuned for
+///   identifier/document tokens"*, and [EXT-SEMBLE] validates it
+///   *"particularly for identifiers/API names"*. A code file's prose is not
+///   lost by that choice — `claims_for` gives every grammar-claimed file a
+///   plain-text fallback unit, which is indexed by the document family above.
+/// * [`LexicalFamily::RowText`] — `context.row_units`, A1's F10a-gated
+///   selected-row text. Indexed text is the assembled body.
+///
+/// **Unbounded on purpose, and this is the one read in this module that is.**
+/// [`MAX_ROWS`] is a refusal to build an unbounded result set for a *caller*;
+/// these three reads run inside the staging transaction over rows the same
+/// transaction just wrote from a scan whose units were already all in memory,
+/// so a cap here would add no new bound — it would only drop units out of the
+/// index silently, which is exactly the reported-never-silent discipline this
+/// wave is required to keep.
+fn index_generation(conn: &Connection, generation_id: &str) -> Result<u64, AtlasError> {
+    let mut units: Vec<IndexableUnit> = Vec::new();
+
+    let [doc_a, doc_b, doc_c, doc_d] = DOCUMENT_EXTRACTOR_IDENTITIES;
+    let mut statement = conn.prepare(
+        "SELECT u.source_name, u.relative_path, u.ordinal, u.title, u.byte_start, u.byte_end, \
+                u.body, f.extractor \
+         FROM source.units u \
+         JOIN source.files f ON f.generation_id = u.generation_id \
+                             AND f.relative_path = u.relative_path \
+         WHERE u.generation_id = ? AND f.extractor IN (?, ?, ?, ?) \
+         ORDER BY u.relative_path, u.ordinal",
+    )?;
+    let mut rows = statement.query(duckdb::params![generation_id, doc_a, doc_b, doc_c, doc_d])?;
+    while let Some(row) = rows.next()? {
+        let extractor: String = row.get(7)?;
+        let family = if extractor == crate::runtime::atlas::mail::MAIL_EXTRACTOR {
+            LexicalFamily::Mail
+        } else {
+            LexicalFamily::Document
+        };
+        let relative_path: String = row.get(1)?;
+        let ordinal = row.get::<usize, i64>(2)? as u64;
+        let title: Option<String> = row.get(3)?;
+        let body: String = row.get(6)?;
+        let text = match &title {
+            Some(title) => format!("{title}\n{body}"),
+            None => body,
+        };
+        units.push(IndexableUnit {
+            source_name: row.get(0)?,
+            family,
+            unit_key: unit_key(family, &relative_path, ordinal),
+            relative_path,
+            ordinal,
+            title,
+            symbol: None,
+            language: None,
+            label: None,
+            dataset_key: None,
+            row_key: None,
+            fields: None,
+            byte_start: Some(row.get::<usize, i64>(4)? as u64),
+            byte_end: Some(row.get::<usize, i64>(5)? as u64),
+            text,
+        });
+    }
+    drop(rows);
+    drop(statement);
+
+    let mut statement = conn.prepare(
+        "SELECT source_name, relative_path, ordinal, language, label, name, byte_start, byte_end \
+         FROM source.occurrences \
+         WHERE generation_id = ? AND extractor LIKE ? \
+         ORDER BY relative_path, ordinal",
+    )?;
+    let mut rows = statement.query(duckdb::params![generation_id, CODE_EXTRACTOR_LIKE])?;
+    while let Some(row) = rows.next()? {
+        let relative_path: String = row.get(1)?;
+        let ordinal = row.get::<usize, i64>(2)? as u64;
+        let name: String = row.get(5)?;
+        units.push(IndexableUnit {
+            source_name: row.get(0)?,
+            family: LexicalFamily::Code,
+            unit_key: unit_key(LexicalFamily::Code, &relative_path, ordinal),
+            relative_path,
+            ordinal,
+            title: None,
+            symbol: Some(name.clone()),
+            language: Some(row.get(3)?),
+            label: Some(row.get(4)?),
+            dataset_key: None,
+            row_key: None,
+            fields: None,
+            byte_start: Some(row.get::<usize, i64>(6)? as u64),
+            byte_end: Some(row.get::<usize, i64>(7)? as u64),
+            text: name,
+        });
+    }
+    drop(rows);
+    drop(statement);
+
+    let mut statement = conn.prepare(
+        "SELECT source_name, relative_path, dataset_key, ordinal, row_key, fields, body \
+         FROM context.row_units WHERE generation_id = ? ORDER BY relative_path, ordinal",
+    )?;
+    let mut rows = statement.query(duckdb::params![generation_id])?;
+    while let Some(row) = rows.next()? {
+        let relative_path: String = row.get(1)?;
+        let ordinal = row.get::<usize, i64>(3)? as u64;
+        units.push(IndexableUnit {
+            source_name: row.get(0)?,
+            family: LexicalFamily::RowText,
+            unit_key: unit_key(LexicalFamily::RowText, &relative_path, ordinal),
+            relative_path,
+            ordinal,
+            title: None,
+            symbol: None,
+            language: None,
+            label: None,
+            dataset_key: Some(row.get(2)?),
+            row_key: Some(row.get(4)?),
+            fields: Some(row.get(5)?),
+            byte_start: None,
+            byte_end: None,
+            text: row.get(6)?,
+        });
+    }
+    drop(rows);
+    drop(statement);
+
+    // The two batches, appended rather than inserted row by row. This file
+    // already carries the measurement that decides it (see [`Analytics`]'s
+    // own doc): on this container a single-row DuckDB `INSERT` costs ~1-2 ms
+    // and an appended row ~4 us. A real repository scan produces tens of
+    // thousands of postings, so row-at-a-time `INSERT` here turned an 11 s
+    // estate scan into one that blew a 100 s client timeout
+    // (`tests/y6a_estate_scoped_scan.rs`) before this was measured and fixed;
+    // the appender is R2 — the mechanism this file already owns, reused.
+    let mut unit_rows: Vec<Vec<Duck>> = Vec::with_capacity(units.len());
+    let mut posting_rows: Vec<Vec<Duck>> = Vec::new();
+    for unit in &units {
+        let (frequencies, token_count) = term_frequencies(&unit.text);
+        unit_rows.push(vec![
+            Duck::Text(generation_id.to_string()),
+            Duck::Text(unit.source_name.clone()),
+            Duck::Text(unit.family.as_str().to_string()),
+            Duck::Text(unit.unit_key.clone()),
+            Duck::Text(unit.relative_path.clone()),
+            Duck::BigInt(unit.ordinal as i64),
+            optional_text(unit.title.as_deref()),
+            optional_text(unit.symbol.as_deref()),
+            optional_text(unit.language.as_deref()),
+            optional_text(unit.label.as_deref()),
+            optional_text(unit.dataset_key.as_deref()),
+            optional_text(unit.row_key.as_deref()),
+            optional_text(unit.fields.as_deref()),
+            unit.byte_start
+                .map_or(Duck::Null, |v| Duck::BigInt(v as i64)),
+            unit.byte_end.map_or(Duck::Null, |v| Duck::BigInt(v as i64)),
+            Duck::BigInt(token_count as i64),
+        ]);
+        for (term, frequency) in &frequencies {
+            posting_rows.push(vec![
+                Duck::Text(generation_id.to_string()),
+                Duck::Text(unit.unit_key.clone()),
+                Duck::Text(term.clone()),
+                Duck::BigInt(*frequency as i64),
+            ]);
+        }
+    }
+    let indexed = unit_rows.len() as u64;
+    append_rows(conn, CONTEXT_SCHEMA, "lexical_units", unit_rows)?;
+    append_rows(conn, CONTEXT_SCHEMA, "lexical_postings", posting_rows)?;
+    Ok(indexed)
+}
+
+/// A2 §3's family-shaped coordinate, read off one
+/// [`LEXICAL_POSTINGS_SQL`] row.
+///
+/// The column set is one row shape for four coordinate shapes, because the
+/// families share a table; `family` decides which columns are meaningful, and
+/// the ones that are not are `NULL` by construction (see
+/// [`index_generation`], the only writer). A missing value defaults rather
+/// than failing: a coordinate is evidence about where a hit came from, and a
+/// row whose `language` is somehow absent should still cite its path and span
+/// rather than take the whole answer down.
+fn coordinate_of(row: &duckdb::Row<'_>) -> Result<UnitCoordinate, AtlasError> {
+    let family_name: String = row.get(3)?;
+    let family = LexicalFamily::parse(&family_name).ok_or_else(|| AtlasError::UnknownValue {
+        column: "family".to_string(),
+        value: family_name.clone(),
+    })?;
+    let relative_path: String = row.get(5)?;
+    let ordinal = row.get::<usize, i64>(6)? as u64;
+    let title: Option<String> = row.get(7)?;
+    let byte_start = row.get::<usize, Option<i64>>(14)?.unwrap_or(0) as u64;
+    let byte_end = row.get::<usize, Option<i64>>(15)?.unwrap_or(0) as u64;
+    Ok(match family {
+        LexicalFamily::Code => UnitCoordinate::Code {
+            relative_path,
+            language: row.get::<usize, Option<String>>(9)?.unwrap_or_default(),
+            label: row.get::<usize, Option<String>>(10)?.unwrap_or_default(),
+            symbol: row.get::<usize, Option<String>>(8)?.unwrap_or_default(),
+            ordinal,
+            byte_start,
+            byte_end,
+        },
+        LexicalFamily::Document => UnitCoordinate::Document {
+            relative_path,
+            ordinal,
+            title,
+            byte_start,
+            byte_end,
+        },
+        LexicalFamily::Mail => UnitCoordinate::Mail {
+            relative_path,
+            ordinal,
+            title,
+            byte_start,
+            byte_end,
+        },
+        LexicalFamily::RowText => UnitCoordinate::RowText {
+            relative_path,
+            dataset_key: row.get::<usize, Option<String>>(11)?.unwrap_or_default(),
+            ordinal,
+            row_key: row.get::<usize, Option<String>>(12)?.unwrap_or_default(),
+            fields: row
+                .get::<usize, Option<String>>(13)?
+                .as_deref()
+                .map(split_names)
+                .unwrap_or_default(),
+        },
+    })
+}
+
+/// The index's own per-generation unit identity: `<family>:<path>#<ordinal>`.
+///
+/// The family prefix is load-bearing rather than decorative — one `.rs` file
+/// produces both a `source.occurrences` row at ordinal 0 and (through
+/// `claims_for`'s plain-text fallback) a `source.units` row at ordinal 0, and
+/// without the prefix those two distinct pieces of evidence would collide on
+/// one key and one would silently overwrite the other's postings.
+fn unit_key(family: LexicalFamily, relative_path: &str, ordinal: u64) -> String {
+    format!("{}:{relative_path}#{ordinal}", family.as_str())
+}
+
+/// One unit on its way into the index — the stored row plus the text that
+/// row contributes.
+struct IndexableUnit {
+    source_name: String,
+    family: LexicalFamily,
+    unit_key: String,
+    relative_path: String,
+    ordinal: u64,
+    title: Option<String>,
+    symbol: Option<String>,
+    language: Option<String>,
+    label: Option<String>,
+    dataset_key: Option<String>,
+    row_key: Option<String>,
+    fields: Option<String>,
+    byte_start: Option<u64>,
+    byte_end: Option<u64>,
+    text: String,
+}
+
 /// Column/field names as one stored value: JSON, so a name containing a comma
 /// survives the round trip.
 fn join_names(names: &[String]) -> String {
@@ -3222,6 +3892,20 @@ fn evict(
     // the wider allowlist exposed.
     conn.execute(
         "DELETE FROM context.row_units WHERE generation_id = ?",
+        duckdb::params![generation_id],
+    )?;
+    // S5 W2: the lexical index is derived evidence over the rows deleted
+    // above, so it goes with them. This is the whole of "keyed by
+    // SourceGeneration, so a superseded generation's postings are evicted
+    // with it" — postings first, because a posting whose unit row is already
+    // gone is an orphan, and there is no window in which one exists (this
+    // runs inside the caller's transaction).
+    conn.execute(
+        "DELETE FROM context.lexical_postings WHERE generation_id = ?",
+        duckdb::params![generation_id],
+    )?;
+    conn.execute(
+        "DELETE FROM context.lexical_units WHERE generation_id = ?",
         duckdb::params![generation_id],
     )?;
     // A no-op DELETE for every non-`external_git` generation (the table has
@@ -3776,6 +4460,59 @@ pub struct Admitted<T> {
     pub scope: WorkScope,
 }
 
+/// One lexical query: A2 §5's text, inside A2 §2's world.
+///
+/// The filter is a **borrowed** [`Admissibility`] rather than an owned copy
+/// so a caller cannot end up ranking against a filter that differs from the
+/// one it already used to decide the world — there is one filter value, and
+/// both stages read it.
+#[derive(Debug, Clone)]
+pub struct LexicalQuery<'a> {
+    /// The raw query text, tokenized by
+    /// [`crate::runtime::atlas::lexical::query_terms`].
+    pub text: &'a str,
+    /// A2 §2's deterministic admissibility filter — applied FIRST, in SQL,
+    /// so ranking happens inside the admissible set and can never widen it
+    /// (A2 §8).
+    pub filter: &'a Admissibility,
+    /// Optionally narrow to one of A2 §17 item 2's four families. `None`
+    /// searches all four, which is the default a caller who asked for no
+    /// narrowing should get.
+    pub family: Option<LexicalFamily>,
+    /// How many hits to return, capped at [`MAX_ROWS`] (F12).
+    pub limit: usize,
+}
+
+/// What one [`AtlasDb::lexical_search`] answered, with everything a caller
+/// must be able to state about it.
+///
+/// Three fields, none decorative: the ranked hits, the [`WorkScope`] every
+/// `--work`-filtered answer has to render (see that type's own doc), and
+/// whether the posting scan hit its cap. A capped scan is not a shorter list
+/// — it is a list whose *scores* were computed over fewer postings than
+/// exist, so it is a different answer and says so.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexicalAnswer {
+    /// The ranked hits, best first, ties broken by
+    /// [`crate::runtime::atlas::lexical::LexicalHit::tie_break_key`].
+    pub hits: Vec<LexicalHit>,
+    /// What this answer covers — see [`WorkScope`].
+    pub scope: WorkScope,
+    /// Whether the posting scan reached [`MAX_ROWS`] and stopped.
+    pub truncated: bool,
+}
+
+/// One unit's accumulating score, with the length BM25 normalizes it by.
+struct Scored {
+    hit: LexicalHit,
+    token_count: u64,
+}
+
+/// A bind value for a `(? IS NULL OR column = ?)` clause.
+fn optional_text(value: Option<&str>) -> Duck {
+    value.map_or(Duck::Null, |text| Duck::Text(text.to_string()))
+}
+
 /// H13.1's content-kind filter, document family: the exhaustive, code-owned
 /// list of extractor identities [`AtlasDb::admissible_units`] matches
 /// against — never a client-supplied pattern (F12). Every identity a
@@ -3911,6 +4648,10 @@ pub enum AnalyticsError {
 /// Physical qualification only — nothing this module reports changes name
 /// because of it. See the module doc.
 const OPS_SCHEMA: &str = "ops";
+
+/// The schema S5 W2's lexical index lives in — retrieval-facing derived
+/// text, `context.row_units`'s own namespace.
+const CONTEXT_SCHEMA: &str = "context";
 
 /// One operations table, qualified and quoted for SQL.
 ///
@@ -5344,10 +6085,24 @@ const TABLES: &[&str] = &[
 /// this container, a single-row `INSERT` costs ~1 ms and an appended row
 /// ~4 µs. An empty batch is a no-op rather than an open-and-close.
 fn append_all(conn: &Connection, table: &str, rows: Vec<Vec<Duck>>) -> Result<(), AnalyticsError> {
+    append_rows(conn, OPS_SCHEMA, table, rows)?;
+    Ok(())
+}
+
+/// [`append_all`] over any schema — the same appender, reused by S5 W2's
+/// lexical index in `context` (R2). Kept as one function rather than two
+/// because the measurement that justifies the appender is a property of
+/// DuckDB, not of the `ops` schema.
+fn append_rows(
+    conn: &Connection,
+    schema: &str,
+    table: &str,
+    rows: Vec<Vec<Duck>>,
+) -> Result<(), duckdb::Error> {
     if rows.is_empty() {
         return Ok(());
     }
-    let mut appender = conn.appender_to_db(table, OPS_SCHEMA)?;
+    let mut appender = conn.appender_to_db(table, schema)?;
     for values in rows {
         appender.append_row(duckdb::appender_params_from_iter(values))?;
     }

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -2871,6 +2871,29 @@ impl AtlasDb {
         Ok(ReindexOutcome { indexed, truncated })
     }
 
+    /// Whether the lexical index is missing postings for a non-evicted
+    /// generation that has rows — the exact condition
+    /// [`Self::reindex_lexical`]'s doc names as "a store written before S5
+    /// W2". Cheap: an anti-join over generation ids, not a rebuild, so it is
+    /// safe to call every startup rather than only once at a version
+    /// boundary this crate has no other way to detect (F-SF-01).
+    pub fn lexical_index_needs_rebuild(&self) -> Result<bool, AtlasError> {
+        let mut statement = self.conn.prepare(
+            "SELECT COUNT(*) FROM source.generations g \
+             WHERE g.state != ? \
+               AND NOT EXISTS ( \
+                 SELECT 1 FROM context.lexical_units l \
+                 WHERE l.generation_id = g.generation_id \
+               )",
+        )?;
+        let mut rows = statement.query(duckdb::params![STATE_EVICTED])?;
+        let count: i64 = match rows.next()? {
+            Some(row) => row.get(0)?,
+            None => 0,
+        };
+        Ok(count > 0)
+    }
+
     /// Every generation's state, keyed by id — a diagnostic read, and what a
     /// crash-window test inspects.
     pub fn generation_states(&self) -> Result<BTreeMap<String, String>, AtlasError> {
@@ -6788,6 +6811,77 @@ mod tests {
         let debug = format!("{atlas:?}");
         assert!(debug.contains(":memory:"), "{debug}");
         assert!(!debug.contains("Connection"), "{debug}");
+    }
+
+    /// F-SF-01: `reindex_lexical`'s own doc names its upgrade condition as
+    /// "a store written before S5 W2, whose generations have rows but no
+    /// postings" — but nothing detected that condition. Reproduce it
+    /// directly (strip a confirmed generation's own postings, the same rows
+    /// `reindex_lexical` itself deletes before rebuilding) rather than via a
+    /// second `Connection::open` on the file, which `tests/x1_atlas_substrate.rs`'s
+    /// one-owner assertion forbids: `db.conn` here is the *same* connection
+    /// `record` staged and confirmed through, just used to remove rows the
+    /// same way an old on-disk store would already be missing them.
+    #[test]
+    fn a_confirmed_generation_missing_postings_is_detected_and_backfilled() {
+        let mut db = AtlasDb::open_in_memory().expect("atlas");
+        let generation_id = record(
+            &mut db,
+            &scan_of("notes", "PaymentRetryPolicy lives here"),
+            "evt-1",
+        );
+
+        // A generation confirmed through the normal path already has
+        // postings (index_generation runs at staging) — strip them to
+        // reproduce the exact shape a pre-W2 store would have.
+        db.conn
+            .execute(
+                "DELETE FROM context.lexical_postings WHERE generation_id = ?",
+                duckdb::params![generation_id],
+            )
+            .expect("strip postings");
+        db.conn
+            .execute(
+                "DELETE FROM context.lexical_units WHERE generation_id = ?",
+                duckdb::params![generation_id],
+            )
+            .expect("strip units");
+
+        assert!(
+            db.lexical_index_needs_rebuild().expect("check"),
+            "a confirmed generation with rows but no lexical_units must be flagged stale"
+        );
+        let before = db
+            .lexical_search(&LexicalQuery {
+                text: "PaymentRetryPolicy",
+                filter: &Admissibility::default(),
+                family: None,
+                limit: 10,
+            })
+            .expect("search");
+        assert!(
+            before.hits.is_empty(),
+            "with postings stripped, the unit must be silently unreachable — F-SF-01's gap"
+        );
+
+        let outcome = db.reindex_lexical().expect("reindex");
+        assert!(outcome.indexed > 0, "the rebuild must actually index units");
+        assert!(
+            !db.lexical_index_needs_rebuild().expect("recheck"),
+            "after reindex_lexical the store must no longer look stale"
+        );
+        let after = db
+            .lexical_search(&LexicalQuery {
+                text: "PaymentRetryPolicy",
+                filter: &Admissibility::default(),
+                family: None,
+                limit: 10,
+            })
+            .expect("search");
+        assert!(
+            !after.hits.is_empty(),
+            "reindex_lexical must backfill the generation's postings"
+        );
     }
 }
 

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -2844,8 +2844,7 @@ impl AtlasDb {
             "SELECT generation_id FROM source.generations WHERE state != ? \
              ORDER BY observed_at, generation_id LIMIT ?",
         )?;
-        let mut rows =
-            statement.query(duckdb::params![STATE_EVICTED, MAX_ROWS as i64 + 1])?;
+        let mut rows = statement.query(duckdb::params![STATE_EVICTED, MAX_ROWS as i64 + 1])?;
         let mut targets: Vec<String> = Vec::new();
         while let Some(row) = rows.next()? {
             targets.push(row.get(0)?);

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -2835,20 +2835,25 @@ impl AtlasDb {
     ///
     /// Every non-evicted generation is re-derived through the same
     /// [`index_generation`] the staging transaction uses, in one transaction,
-    /// after its existing rows are cleared. Returns how many units were
-    /// indexed.
-    pub fn reindex_lexical(&mut self) -> Result<u64, AtlasError> {
+    /// after its existing rows are cleared — up to [`MAX_ROWS`] generations;
+    /// beyond that the generation list is capped and
+    /// [`ReindexOutcome::truncated`] says so, the same bound and the same
+    /// disclosure `lexical_search` uses for its posting scan.
+    pub fn reindex_lexical(&mut self) -> Result<ReindexOutcome, AtlasError> {
         let mut statement = self.conn.prepare(
             "SELECT generation_id FROM source.generations WHERE state != ? \
              ORDER BY observed_at, generation_id LIMIT ?",
         )?;
-        let mut rows = statement.query(duckdb::params![STATE_EVICTED, MAX_ROWS as i64])?;
+        let mut rows =
+            statement.query(duckdb::params![STATE_EVICTED, MAX_ROWS as i64 + 1])?;
         let mut targets: Vec<String> = Vec::new();
         while let Some(row) = rows.next()? {
             targets.push(row.get(0)?);
         }
         drop(rows);
         drop(statement);
+        let truncated = targets.len() > MAX_ROWS;
+        targets.truncate(MAX_ROWS);
         let tx = self.conn.transaction()?;
         let mut indexed = 0u64;
         for generation_id in &targets {
@@ -2863,7 +2868,7 @@ impl AtlasDb {
             indexed += index_generation(&tx, generation_id)?;
         }
         tx.commit()?;
-        Ok(indexed)
+        Ok(ReindexOutcome { indexed, truncated })
     }
 
     /// Every generation's state, keyed by id — a diagnostic read, and what a
@@ -4499,6 +4504,22 @@ pub struct LexicalAnswer {
     /// What this answer covers — see [`WorkScope`].
     pub scope: WorkScope,
     /// Whether the posting scan reached [`MAX_ROWS`] and stopped.
+    pub truncated: bool,
+}
+
+/// Outcome of [`AtlasDb::reindex_lexical`]: how many units were indexed,
+/// and whether the *generation list itself* was capped at [`MAX_ROWS`]
+/// (F-IN-01) — mirroring [`LexicalAnswer::truncated`] for the same reason
+/// that field exists: a cap that silently changes what a rebuild covers is
+/// not merely a shorter list, and a caller must be able to state what its
+/// rebuild covers rather than assume the completeness the doc promises but
+/// the cap quietly withdraws.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReindexOutcome {
+    /// How many units were (re)indexed across the rebuilt generations.
+    pub indexed: u64,
+    /// Whether the generation list itself hit [`MAX_ROWS`] and was capped —
+    /// not every non-evicted generation may have been rebuilt.
     pub truncated: bool,
 }
 

--- a/src/runtime/atlas/lexical.rs
+++ b/src/runtime/atlas/lexical.rs
@@ -1,0 +1,609 @@
+//! S5 W2 — A2 §5's lexical retrieval: tokenization and BM25 scoring.
+//!
+//! A2 §5, verbatim: *"Start with a small local BM25 implementation tuned for
+//! identifier/document tokens rather than adding a full search server."*
+//! Decision **A2-05 (R7)** already checked the lower rungs and this module
+//! does not re-derive them: *"R1 yes; R2 no current lexical index exists;
+//! R3–R5 stdlib/platform/installed deps do not provide BM25; R6 cannot
+//! express an index; one small local implementation is less machinery than a
+//! search service."*
+//!
+//! This module is **pure Rust over strings and numbers**. It holds no
+//! database connection and names no database driver — Atlas's one-owner
+//! invariant ([`super::db`], pinned by
+//! `tests/x1_atlas_substrate.rs::atlas_database_has_exactly_one_owner`) means
+//! the SQL that stores postings and applies A2 §2's admissibility filter
+//! lives in [`super::db`], and only the tokenizer, the scoring expression and
+//! the result vocabulary live here.
+//!
+//! # What A2 §5 asks tokenization to preserve
+//!
+//! *"Tokenization should preserve useful forms such as"* — six literal forms,
+//! and each one is a test case in `tests/w2_lexical_retrieval.rs`:
+//!
+//! ```text
+//! PaymentRetryPolicy
+//! payment_retry_policy
+//! payment-retry-policy
+//! Foo::bar
+//! POST /payments
+//! INC0012345
+//! ```
+//!
+//! [`tokenize`] emits, for every compound it finds, **the whole compound as
+//! written** *and* its parts. Both halves matter and the first is the one
+//! easy to lose: a tokenizer that only splits `PaymentRetryPolicy` into
+//! `payment`/`retry`/`policy` has destroyed the exact-identifier advantage
+//! that is BM25's entire reason for being in this design (A2 §5's own
+//! "tuned for identifier/document tokens", and [EXT-SEMBLE]'s "particularly
+//! for identifiers/API names"). So `PaymentRetryPolicy` and `payment` both
+//! find the unit, and `tests/w2_lexical_retrieval.rs::
+//! splitting_a_camel_identifier_never_costs_the_whole_identifier` fails if
+//! either half stops being true.
+//!
+//! # *"Document/mail retrieval additionally retains ordinary
+//! natural-language tokens"*
+//!
+//! That sentence is true of this design through **what each family indexes**,
+//! not through a second tokenizer (R1: a second token rule does not need to
+//! exist). [`LexicalFamily::Code`]'s indexed text is the symbol name a
+//! grammar claimed — identifiers, and nothing else. The document, mail and
+//! selected-row-text families index the unit's own title and body, so their
+//! postings additionally carry every ordinary word of the prose. One
+//! tokenizer, applied to different text, which is the minimum that makes the
+//! contract sentence true;
+//! `tests/w2_lexical_retrieval.rs::code_units_index_identifiers_while_
+//! document_units_additionally_index_prose` is what pins it.
+//!
+//! # Scoring
+//!
+//! [`bm25_contribution`] is the textbook Okapi BM25 term contribution, one
+//! expression, summed over the query's distinct terms by [`Bm25Corpus`].
+//! Nothing is trained and nothing self-tunes (A2 §16 forbids both).
+
+use std::collections::BTreeMap;
+
+/// Which of A2 §17 item 2's four unit families a lexical hit belongs to —
+/// *"lexical search returns code/document/mail/selected-row-text units with
+/// exact A1 provenance"*.
+///
+/// The family is a property of the A1 rows the posting was derived from, not
+/// a guess about content: [`Self::Code`] is a `source.occurrences` row,
+/// [`Self::Document`] and [`Self::Mail`] are `source.units` rows split by the
+/// owning file's extractor identity, and [`Self::RowText`] is a
+/// `context.row_units` row (A1's F10a-gated selected-row text).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LexicalFamily {
+    /// A grammar-claimed symbol site (`source.occurrences`).
+    Code,
+    /// A document structure unit (`source.units`, a document extractor).
+    Document,
+    /// A mail structure unit (`source.units`, the mail extractor).
+    Mail,
+    /// One selected-row-text unit (`context.row_units`).
+    RowText,
+}
+
+impl LexicalFamily {
+    /// The stable DB spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Code => "code",
+            Self::Document => "document",
+            Self::Mail => "mail",
+            Self::RowText => "row-text",
+        }
+    }
+
+    /// The inverse of [`Self::as_str`].
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "code" => Some(Self::Code),
+            "document" => Some(Self::Document),
+            "mail" => Some(Self::Mail),
+            "row-text" => Some(Self::RowText),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for LexicalFamily {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The characters a compound is made of: every alphanumeric character, plus
+/// the three separators the six contract forms are spelled with (`_`, `-`,
+/// `:`). `char::is_alphanumeric` rather than `is_ascii_alphanumeric` so a
+/// non-ASCII word (`café`) is one compound rather than a truncated `caf`.
+fn is_compound(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-' || c == ':'
+}
+
+/// The separators a compound is split on into words.
+fn is_separator(c: char) -> bool {
+    c == '_' || c == '-' || c == ':'
+}
+
+/// A2 §5's tokenizer: every token `text` contributes, **in order, with
+/// repeats** (the caller counts term frequencies).
+///
+/// For each maximal run of [`is_compound`] characters holding at least one
+/// alphanumeric:
+///
+/// 1. the whole compound, lowercased — `payment_retry_policy`, `foo::bar`,
+///    `inc0012345`, `paymentretrypolicy`;
+/// 2. its separator-split words, when there is more than one — `payment`,
+///    `retry`, `policy` from `payment-retry-policy`; `foo`, `bar` from
+///    `Foo::bar`;
+/// 3. each word's camel/digit-split parts, when there is more than one —
+///    `payment`, `retry`, `policy` from `PaymentRetryPolicy`; `inc`,
+///    `0012345` from `INC0012345`; `http`, `server` from `HTTPServer`.
+///
+/// Plus one joint form, because `POST /payments` is the one contract form
+/// that spans a space: an all-uppercase compound of 2–8 letters followed by
+/// exactly `" /"` and a path run emits `post /payments` in addition to
+/// `post` and `payments`. The bound is a shape, not a method allowlist —
+/// this tokenizer has no business knowing HTTP's verb set, and an allowlist
+/// would silently drop tomorrow's verb.
+///
+/// Everything is lowercased, so retrieval is case-insensitive in both
+/// directions; the exact-case spelling survives in the A1 unit the hit cites,
+/// which is where an answer's exactness actually lives.
+pub fn tokenize(text: &str) -> Vec<String> {
+    let compounds = compounds_of(text);
+    let mut out = Vec::new();
+    for (index, (start, end)) in compounds.iter().enumerate() {
+        let compound = &text[*start..*end];
+        if !compound.chars().any(char::is_alphanumeric) {
+            continue;
+        }
+        out.push(compound.to_lowercase());
+        let words: Vec<&str> = compound
+            .split(is_separator)
+            .filter(|w| !w.is_empty())
+            .collect();
+        for word in &words {
+            if words.len() > 1 {
+                out.push(word.to_lowercase());
+            }
+            let parts = case_split(word);
+            if parts.len() > 1 {
+                for part in parts {
+                    out.push(part.to_lowercase());
+                }
+            }
+        }
+        if let Some(joint) = method_path_token(text, &compounds, index) {
+            out.push(joint);
+        }
+    }
+    out
+}
+
+/// The byte spans of every maximal [`is_compound`] run in `text`.
+fn compounds_of(text: &str) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut open: Option<usize> = None;
+    for (offset, c) in text.char_indices() {
+        match (is_compound(c), open) {
+            (true, None) => open = Some(offset),
+            (false, Some(start)) => {
+                spans.push((start, offset));
+                open = None;
+            }
+            _ => {}
+        }
+    }
+    if let Some(start) = open {
+        spans.push((start, text.len()));
+    }
+    spans
+}
+
+/// `POST /payments`'s joint token, when the compound at `index` is an
+/// uppercase method-shaped run immediately followed by `" /"` and a path.
+fn method_path_token(text: &str, compounds: &[(usize, usize)], index: usize) -> Option<String> {
+    let (start, end) = compounds[index];
+    let method = &text[start..end];
+    if method.len() < 2 || method.len() > 8 || !method.chars().all(|c| c.is_ascii_uppercase()) {
+        return None;
+    }
+    let rest = text.get(end..)?;
+    let path = rest.strip_prefix(" /")?;
+    let taken: String = path
+        .chars()
+        .take_while(|c| is_compound(*c) || *c == '/')
+        .collect();
+    if taken.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{} /{}",
+        method.to_lowercase(),
+        taken.to_lowercase()
+    ))
+}
+
+/// Split one separator-free word at camel-case and letter/digit boundaries.
+fn case_split(word: &str) -> Vec<&str> {
+    let chars: Vec<(usize, char)> = word.char_indices().collect();
+    let mut parts = Vec::new();
+    let mut start = 0usize;
+    for position in 1..chars.len() {
+        let (offset, current) = chars[position];
+        let (_, previous) = chars[position - 1];
+        let next = chars.get(position + 1).map(|(_, c)| *c);
+        let boundary =
+            // lower/digit -> upper: `paymentRetry`
+            (!previous.is_uppercase() && current.is_uppercase())
+            // acronym end: `HTTPServer` breaks before `Server`
+            || (previous.is_uppercase()
+                && current.is_uppercase()
+                && next.is_some_and(|c| c.is_lowercase()))
+            // letter <-> digit: `INC0012345`, `v1Alpha`
+            || (previous.is_alphabetic() && current.is_numeric())
+            || (previous.is_numeric() && current.is_alphabetic());
+        if boundary {
+            parts.push(&word[start..offset]);
+            start = offset;
+        }
+    }
+    parts.push(&word[start..]);
+    parts.retain(|p| !p.is_empty());
+    parts
+}
+
+/// Distinct query terms, in a deterministic order — [`tokenize`] with
+/// repeats folded away, because a term repeated in the *query* multiplies a
+/// document's score without saying anything more about the document.
+pub fn query_terms(text: &str) -> Vec<String> {
+    let mut terms: Vec<String> = tokenize(text);
+    terms.sort();
+    terms.dedup();
+    terms
+}
+
+/// [`tokenize`]'s output as `(term, frequency)` pairs, plus the document
+/// length the scorer needs — one pass, deterministic order (`BTreeMap`).
+pub fn term_frequencies(text: &str) -> (BTreeMap<String, u64>, u64) {
+    let tokens = tokenize(text);
+    let length = tokens.len() as u64;
+    let mut counts: BTreeMap<String, u64> = BTreeMap::new();
+    for token in tokens {
+        *counts.entry(token).or_insert(0) += 1;
+    }
+    (counts, length)
+}
+
+/// Okapi BM25's `k1` — the term-frequency saturation constant.
+///
+/// **Provenance: this is the textbook default, not a measurement of this
+/// corpus.** `k1 = 1.2` and `b = 0.75` are the values Robertson et al.'s
+/// Okapi BM25 has carried since the TREC-3 experiments, and they are used
+/// here because no corpus of Sergeant evidence units has been measured. When
+/// one is, this constant is the thing a measurement replaces; until then it
+/// is honest to say it was inherited rather than derived.
+pub const BM25_K1: f64 = 1.2;
+
+/// Okapi BM25's `b` — the document-length normalization constant. See
+/// [`BM25_K1`] for its provenance, which is the same.
+pub const BM25_B: f64 = 0.75;
+
+/// The corpus-level facts BM25 needs, measured over the **admissible** set
+/// and nothing wider (A2 §2: the filter decides the world; ranking happens
+/// inside it). A term's IDF and a unit's length normalization are therefore
+/// both relative to what the caller was allowed to see — an inadmissible
+/// generation does not merely fail to appear in the results, it does not
+/// influence them either.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Bm25Corpus {
+    /// How many admissible units are in the corpus.
+    pub units: u64,
+    /// Their mean token count.
+    pub average_length: f64,
+}
+
+/// One term's BM25 contribution to one unit's score.
+///
+/// ```text
+/// idf(t)  = ln(1 + (N - df + 0.5) / (df + 0.5))
+/// score  += idf(t) * tf * (k1 + 1) / (tf + k1 * (1 - b + b * dl / avgdl))
+/// ```
+///
+/// The `ln(1 + ...)` form is the standard non-negative variant: the raw
+/// Robertson/Sparck-Jones IDF goes negative for a term appearing in more than
+/// half the corpus, and a negative contribution would let a *matching* term
+/// push a unit down the list, which is not a ranking anyone can explain.
+pub fn bm25_contribution(
+    corpus: Bm25Corpus,
+    document_frequency: u64,
+    term_frequency: u64,
+    unit_length: u64,
+) -> f64 {
+    if corpus.units == 0 || document_frequency == 0 || term_frequency == 0 {
+        return 0.0;
+    }
+    let n = corpus.units as f64;
+    let df = document_frequency as f64;
+    let tf = term_frequency as f64;
+    let idf = (1.0 + (n - df + 0.5) / (df + 0.5)).ln();
+    let average = if corpus.average_length > 0.0 {
+        corpus.average_length
+    } else {
+        1.0
+    };
+    let normalized = BM25_K1 * (1.0 - BM25_B + BM25_B * (unit_length as f64) / average);
+    idf * (tf * (BM25_K1 + 1.0)) / (tf + normalized)
+}
+
+/// Where one lexical hit came from, in A1's own coordinates — A2 §3: *"A
+/// retrievable unit resolves back to an A1 SourceGeneration/Resource/native
+/// coordinate"*, and *"the result's evidence coordinate remains A1-owned"*.
+///
+/// **The coordinate is family-shaped, because A2 §3 says it is.** §3 lists a
+/// different coordinate per family, and only three of the four are spans:
+/// code is `source/revision/path/symbol/span`, document is
+/// `source/generation/path/heading-or-slide/section`, email is
+/// `source/generation/path/message-id/body-or-attachment coordinate`, and
+/// **structured text is `source/generation/dataset/row-id/field-set` — no
+/// byte range at all**, because a selected-row-text unit is assembled from
+/// allowlisted columns of a row that is read in place and never copied into
+/// Atlas. The W2 brief's summary line ("every hit cites source + generation +
+/// unit + byte range") is the common case, not the contract; where the two
+/// disagree the contract wins (J5), so [`Self::RowText`] carries the row
+/// identity and the exposed field set instead of a span it could only invent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnitCoordinate {
+    /// A2 §3's code coordinate: path, symbol, and the span of the definition
+    /// site in the original file bytes.
+    Code {
+        /// Path relative to the source root.
+        relative_path: String,
+        /// The grammar's language name.
+        language: String,
+        /// The grammar's own label for the site (`function`, `struct`, ...).
+        label: String,
+        /// The symbol name as written.
+        symbol: String,
+        /// Position of the site within its file, in extraction order.
+        ordinal: u64,
+        /// Start offset into the original file bytes.
+        byte_start: u64,
+        /// End offset into the original file bytes, exclusive.
+        byte_end: u64,
+    },
+    /// A2 §3's document coordinate: path, the heading/section this unit is,
+    /// and its span of the original file bytes.
+    Document {
+        /// Path relative to the source root.
+        relative_path: String,
+        /// Position of the unit within its file.
+        ordinal: u64,
+        /// The heading text, when the unit is a section.
+        title: Option<String>,
+        /// Start offset into the original file bytes.
+        byte_start: u64,
+        /// End offset into the original file bytes, exclusive.
+        byte_end: u64,
+    },
+    /// A2 §3's email coordinate, as far as A1's stored rows carry it: the
+    /// `.eml` resource's path, the unit within it, and its byte span.
+    Mail {
+        /// Path relative to the source root.
+        relative_path: String,
+        /// Position of the unit within the message.
+        ordinal: u64,
+        /// The unit's title — the subject, for a message's own body unit.
+        title: Option<String>,
+        /// Start offset into the original file bytes.
+        byte_start: u64,
+        /// End offset into the original file bytes, exclusive.
+        byte_end: u64,
+    },
+    /// A2 §3's structured-text coordinate:
+    /// `source/generation/dataset/row-id/field-set`.
+    RowText {
+        /// Path relative to the source root.
+        relative_path: String,
+        /// F7's key for the dataset the row came from.
+        dataset_key: String,
+        /// Position in the dataset, in reader order.
+        ordinal: u64,
+        /// The row's name.
+        row_key: String,
+        /// The allowlisted columns that produced this unit (F10a's audit
+        /// trail of what was exposed).
+        fields: Vec<String>,
+    },
+}
+
+impl UnitCoordinate {
+    /// The family this coordinate belongs to.
+    pub fn family(&self) -> LexicalFamily {
+        match self {
+            Self::Code { .. } => LexicalFamily::Code,
+            Self::Document { .. } => LexicalFamily::Document,
+            Self::Mail { .. } => LexicalFamily::Mail,
+            Self::RowText { .. } => LexicalFamily::RowText,
+        }
+    }
+
+    /// Path relative to the source root — the one field every coordinate
+    /// shape has, and half of the deterministic tie-break key.
+    pub fn relative_path(&self) -> &str {
+        match self {
+            Self::Code { relative_path, .. }
+            | Self::Document { relative_path, .. }
+            | Self::Mail { relative_path, .. }
+            | Self::RowText { relative_path, .. } => relative_path,
+        }
+    }
+
+    /// Position within the resource — the other half of the tie-break key.
+    pub fn ordinal(&self) -> u64 {
+        match self {
+            Self::Code { ordinal, .. }
+            | Self::Document { ordinal, .. }
+            | Self::Mail { ordinal, .. }
+            | Self::RowText { ordinal, .. } => *ordinal,
+        }
+    }
+}
+
+/// One ranked lexical hit: a BM25 score and the A1 coordinate that makes it
+/// traceable to exact evidence.
+///
+/// *"A hit that cannot be traced back to exact bytes is not a hit, it is a
+/// claim"* (the W2 brief) — so `source_name`, `generation_id`, `content_key`
+/// and `coordinate` are not decoration and are not optional. A caller holding
+/// one of these can name the source, the exact generation of it, the resource
+/// inside that generation, and — for every family whose evidence is a
+/// resource's bytes — the byte range within it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexicalHit {
+    /// The summed BM25 score over the query's distinct terms.
+    pub score: f64,
+    /// The declared source.
+    pub source_name: String,
+    /// The exact SourceGeneration this unit belongs to.
+    pub generation_id: String,
+    /// That generation's content identity.
+    pub content_key: String,
+    /// The index's own per-generation unit identity — `<family>:<path>#<ordinal>`.
+    pub unit_key: String,
+    /// A1's coordinate for the unit itself.
+    pub coordinate: UnitCoordinate,
+}
+
+impl LexicalHit {
+    /// The stated tie-break key: `(source_name, relative_path, ordinal,
+    /// unit_key)`, applied in that order to hits whose scores are equal.
+    ///
+    /// Every component is a stored value, so the order is a function of the
+    /// evidence and nothing else — never `HashMap` iteration order, never the
+    /// order rows happened to arrive in. `tests/w2_lexical_retrieval.rs::
+    /// equal_scores_are_broken_by_the_stated_key_not_by_row_arrival_order`
+    /// seeds the tying units in the reverse of this order and fails if the
+    /// answer follows arrival instead.
+    pub fn tie_break_key(&self) -> (&str, &str, u64, &str) {
+        (
+            &self.source_name,
+            self.coordinate.relative_path(),
+            self.coordinate.ordinal(),
+            &self.unit_key,
+        )
+    }
+}
+
+/// Order two hits by A2 §8's deterministic rule: **score descending, then
+/// [`LexicalHit::tie_break_key`] ascending.**
+///
+/// `f64::total_cmp` rather than `partial_cmp`: a total order over the score
+/// leaves no pair of hits whose relative order is undefined, which is what
+/// "same query + same generations ⇒ same ordered result" actually requires.
+pub fn rank_order(left: &LexicalHit, right: &LexicalHit) -> std::cmp::Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| left.tie_break_key().cmp(&right.tie_break_key()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokens(text: &str) -> Vec<String> {
+        tokenize(text)
+    }
+
+    #[test]
+    fn a_camel_identifier_keeps_the_whole_form_and_its_parts() {
+        let out = tokens("PaymentRetryPolicy");
+        assert!(
+            out.contains(&"paymentretrypolicy".to_string()),
+            "the whole identifier must survive splitting: {out:?}"
+        );
+        for part in ["payment", "retry", "policy"] {
+            assert!(out.contains(&part.to_string()), "missing {part}: {out:?}");
+        }
+    }
+
+    #[test]
+    fn snake_and_kebab_identifiers_keep_the_whole_form_and_its_words() {
+        for whole in ["payment_retry_policy", "payment-retry-policy"] {
+            let out = tokens(whole);
+            assert!(out.contains(&whole.to_string()), "{whole}: {out:?}");
+            for part in ["payment", "retry", "policy"] {
+                assert!(
+                    out.contains(&part.to_string()),
+                    "{whole} missing {part}: {out:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_path_scoped_identifier_keeps_its_whole_form() {
+        let out = tokens("Foo::bar");
+        assert!(out.contains(&"foo::bar".to_string()), "{out:?}");
+        assert!(out.contains(&"foo".to_string()), "{out:?}");
+        assert!(out.contains(&"bar".to_string()), "{out:?}");
+    }
+
+    #[test]
+    fn a_method_and_path_keeps_the_joint_form() {
+        let out = tokens("POST /payments");
+        assert!(out.contains(&"post /payments".to_string()), "{out:?}");
+        assert!(out.contains(&"post".to_string()), "{out:?}");
+        assert!(out.contains(&"payments".to_string()), "{out:?}");
+    }
+
+    #[test]
+    fn a_ticket_identifier_keeps_the_whole_form_and_its_halves() {
+        let out = tokens("INC0012345");
+        assert!(out.contains(&"inc0012345".to_string()), "{out:?}");
+        assert!(out.contains(&"inc".to_string()), "{out:?}");
+        assert!(out.contains(&"0012345".to_string()), "{out:?}");
+    }
+
+    #[test]
+    fn an_acronym_prefix_breaks_before_the_word_that_follows_it() {
+        let out = tokens("HTTPServer");
+        assert!(out.contains(&"http".to_string()), "{out:?}");
+        assert!(out.contains(&"server".to_string()), "{out:?}");
+    }
+
+    #[test]
+    fn a_non_ascii_word_is_one_token_not_a_truncated_one() {
+        let out = tokens("café");
+        assert_eq!(out, vec!["café".to_string()], "{out:?}");
+    }
+
+    #[test]
+    fn query_terms_are_distinct_and_ordered() {
+        assert_eq!(
+            query_terms("retry retry policy"),
+            vec!["policy".to_string(), "retry".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_term_in_every_unit_never_scores_below_zero() {
+        let corpus = Bm25Corpus {
+            units: 10,
+            average_length: 5.0,
+        };
+        assert!(bm25_contribution(corpus, 10, 3, 5) >= 0.0);
+    }
+
+    #[test]
+    fn a_rarer_term_outscores_a_common_one_at_equal_frequency() {
+        let corpus = Bm25Corpus {
+            units: 100,
+            average_length: 10.0,
+        };
+        assert!(bm25_contribution(corpus, 1, 2, 10) > bm25_contribution(corpus, 50, 2, 10));
+    }
+}

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -181,6 +181,7 @@ pub mod deny;
 pub mod external_git;
 pub mod git;
 pub mod lane;
+pub mod lexical;
 pub mod locator;
 pub mod mail;
 pub mod office;

--- a/tests/w2_lexical_retrieval.rs
+++ b/tests/w2_lexical_retrieval.rs
@@ -40,7 +40,7 @@ use tempfile::TempDir;
 use sergeant_rs::domain::event::rfc3339_utc_now;
 use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
 use sergeant_rs::runtime::atlas::db::{
-    Admissibility, AtlasDb, LexicalAnswer, LexicalQuery, SourceSelector,
+    Admissibility, AtlasDb, LexicalAnswer, LexicalQuery, MAX_ROWS, SourceSelector,
 };
 use sergeant_rs::runtime::atlas::lexical::{LexicalFamily, LexicalHit, UnitCoordinate};
 use sergeant_rs::runtime::atlas::mail::MAIL_EXTRACTOR;
@@ -956,5 +956,51 @@ fn a_bounded_answer_states_whether_the_posting_scan_was_capped() {
     assert!(
         !answer.truncated,
         "this corpus is far under the cap; a true flag here means the cap logic is wrong"
+    );
+}
+
+/// F-TH-01: the sibling of the test above, exercising the branch that one
+/// never reaches — `MAX_ROWS + 1` postings for a single term, all admissible,
+/// so the posting scan (`db.rs`'s `'terms` loop) must hit the cap and report
+/// it. Without this test, `truncated = true;` could be deleted or made a
+/// permanent no-op and nothing in the suite would notice.
+#[test]
+fn a_bounded_answer_reports_true_when_the_posting_scan_is_actually_capped() {
+    let mut db = AtlasDb::open_in_memory().expect("atlas");
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+
+    let unit_count = MAX_ROWS + 1;
+    let units: Vec<ScannedUnit> = (0..unit_count as u64)
+        .map(|ordinal| ScannedUnit {
+            ordinal,
+            kind: UnitKind::Document,
+            heading_level: None,
+            title: None,
+            byte_start: 0,
+            byte_end: 8,
+            text: "needleterm".to_string(),
+        })
+        .collect();
+    let bulk = hand_built_scan(
+        "bulk",
+        SourceKind::LocalKnowledge,
+        AuthorityClass::EstateReadonly,
+        "bulk@key-1",
+        vec![scanned_file("bulk.md", MARKDOWN_EXTRACTOR, units)],
+    );
+    record_scan(&mut db, &mut journal, &bulk, None).expect("record bulk");
+
+    let answer = db
+        .lexical_search(&LexicalQuery {
+            text: "needleterm",
+            filter: &Admissibility::default(),
+            family: None,
+            limit: MAX_ROWS,
+        })
+        .expect("lexical search");
+    assert!(
+        answer.truncated,
+        "{unit_count} admissible postings for one term must trip the {MAX_ROWS}-row cap"
     );
 }

--- a/tests/w2_lexical_retrieval.rs
+++ b/tests/w2_lexical_retrieval.rs
@@ -933,8 +933,12 @@ fn the_lexical_index_rebuilds_from_the_a1_rows_it_derives_from() {
     let mut estate = estate();
     let filter = Admissibility::default();
     let before = estate.search("PaymentRetryPolicy INC0012345", &filter, None);
-    let indexed = estate.db.reindex_lexical().expect("reindex");
-    assert!(indexed > 0, "the rebuild must actually index units");
+    let outcome = estate.db.reindex_lexical().expect("reindex");
+    assert!(outcome.indexed > 0, "the rebuild must actually index units");
+    assert!(
+        !outcome.truncated,
+        "this fixture is far under MAX_ROWS generations; a true flag here means the cap logic is wrong"
+    );
     let after = estate.search("PaymentRetryPolicy INC0012345", &filter, None);
     assert_eq!(
         before, after,

--- a/tests/w2_lexical_retrieval.rs
+++ b/tests/w2_lexical_retrieval.rs
@@ -1,0 +1,956 @@
+//! S5 W2 — A2 §5's lexical retrieval (BM25), and A2 §17 item 2.
+//!
+//! A2 §5, verbatim: *"Start with a small local BM25 implementation tuned for
+//! identifier/document tokens rather than adding a full search server."*
+//! A2 §17 item 2, verbatim: *"lexical search returns code/document/mail/
+//! selected-row-text units with exact A1 provenance."* All four families are
+//! enumerated below, each with a test that finds a unit of that kind and
+//! resolves its provenance — a family present in the machinery and absent
+//! from the tests is the defect this program has recorded three times.
+//!
+//! **The most important test in this file is a negative.** A2 §8: *"The
+//! reranker must never silently cross an authority/source filter merely
+//! because a candidate scores well."* So
+//! [`an_inadmissible_unit_with_a_perfect_lexical_match_is_never_returned`]
+//! plants a unit that is a *better* lexical match than anything admissible
+//! and proves it does not come back — after first proving it is reachable at
+//! all, because a decoy that was never in the index proves nothing.
+//!
+//! # What is real here and what is a fixture
+//!
+//! The code, document and selected-row-text families come from a **real**
+//! `scan_local_knowledge` walk over a real directory, recorded through the
+//! real three-step `record_scan` path — so their byte ranges are the real
+//! offsets into real files, and the tests slice the files with them.
+//!
+//! The mail family is a hand-built [`SourceScan`] carrying
+//! [`MAIL_EXTRACTOR`] units. That is deliberate and is not a gap in what is
+//! proved: `.eml` extraction routes through a supervised **worker
+//! subprocess** (`scan.rs`'s `worker_extractor_for`), which this suite
+//! deliberately does not spawn — spawning is `tests/y4_mail_adapter.rs`'s
+//! job, and it already proves the parse. What W2 owns is what happens to a
+//! stored mail unit once it exists, and a hand-built `source.units` row under
+//! the mail extractor identity is byte-for-byte the row that adapter writes.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use sergeant_rs::domain::event::rfc3339_utc_now;
+use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
+use sergeant_rs::runtime::atlas::db::{
+    Admissibility, AtlasDb, LexicalAnswer, LexicalQuery, SourceSelector,
+};
+use sergeant_rs::runtime::atlas::lexical::{LexicalFamily, LexicalHit, UnitCoordinate};
+use sergeant_rs::runtime::atlas::mail::MAIL_EXTRACTOR;
+use sergeant_rs::runtime::atlas::record::{ScanRecord, record_scan, scan_and_record};
+use sergeant_rs::runtime::atlas::scan::{
+    KnowledgeSource, ScannedFile, ScannedSymbol, ScannedSyntax, ScannedUnit, SourceScan,
+};
+use sergeant_rs::runtime::atlas::tabular::ContextFields;
+use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+use sergeant_rs::runtime::journal::Journal;
+
+// ---------------------------------------------------------------- fixtures
+
+/// A2 §5's six literal token forms, in the contract's own order.
+const FORMS: [&str; 6] = [
+    "PaymentRetryPolicy",
+    "payment_retry_policy",
+    "payment-retry-policy",
+    "Foo::bar",
+    "POST /payments",
+    "INC0012345",
+];
+
+/// The Markdown document every one of the six forms is written into.
+const FORMS_MD: &str = "\
+# Retry forms
+
+The PaymentRetryPolicy is spelled payment_retry_policy in Rust and
+payment-retry-policy in configuration. The helper is Foo::bar. The
+endpoint is POST /payments. The originating ticket is INC0012345.
+";
+
+/// A Rust file: one grammar-claimed symbol, and prose that only its
+/// plain-text fallback unit can carry.
+const LIB_RS: &str = "\
+// Ordinary narrative prose about reconciliation of settlement batches.
+pub fn payment_retry_policy() {}
+";
+
+/// A CSV whose allowlisted columns become `context.row_units`.
+const TICKETS_CSV: &str = "\
+number,short_description
+INC0012345,PaymentRetryPolicy timed out during settlement
+INC0099999,unrelated printer jam
+";
+
+fn write(root: &Path, relative: &str, body: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create fixture directory");
+    }
+    std::fs::write(&path, body).expect("write fixture");
+}
+
+/// A whole-resource [`ScannedUnit`], the shape every document extractor's
+/// first unit takes.
+fn document_unit(title: Option<&str>, text: &str) -> ScannedUnit {
+    ScannedUnit {
+        ordinal: 0,
+        kind: UnitKind::Document,
+        heading_level: None,
+        title: title.map(str::to_string),
+        byte_start: 0,
+        byte_end: text.len() as u64,
+        text: text.to_string(),
+    }
+}
+
+fn scanned_file(relative_path: &str, extractor: &str, units: Vec<ScannedUnit>) -> ScannedFile {
+    ScannedFile {
+        relative_path: relative_path.to_string(),
+        content_hash: format!("hash/{relative_path}"),
+        extractor: extractor.to_string(),
+        local_key: format!("key/{relative_path}"),
+        byte_len: 64,
+        mtime_millis: None,
+        units,
+        syntax: None,
+    }
+}
+
+fn hand_built_scan(
+    source_name: &str,
+    kind: SourceKind,
+    authority: AuthorityClass,
+    content_key: &str,
+    files: Vec<ScannedFile>,
+) -> SourceScan {
+    let mut extractors = BTreeSet::new();
+    for f in &files {
+        extractors.insert(f.extractor.clone());
+        if let Some(s) = &f.syntax {
+            extractors.insert(s.extractor.clone());
+        }
+    }
+    SourceScan {
+        source_name: source_name.to_string(),
+        kind,
+        authority,
+        content_key: content_key.to_string(),
+        revision: None,
+        observed_at: rfc3339_utc_now(),
+        files,
+        coverage: Vec::new(),
+        extractors,
+        datasets: Vec::new(),
+        root: None,
+        context_fields: ContextFields::none(),
+    }
+}
+
+/// A one-symbol Rust syntax extraction, for the overlay fixtures.
+fn rust_symbol(name: &str) -> ScannedSyntax {
+    ScannedSyntax {
+        language: "rust",
+        extractor: "syntax-rust/v1".to_string(),
+        syntax_key: format!("syntax-key/rust/{name}"),
+        symbols: vec![ScannedSymbol {
+            ordinal: 0,
+            label: "function",
+            name: name.to_string(),
+            byte_start: 0,
+            byte_end: name.len() as u64,
+        }],
+        edges: Vec::new(),
+    }
+}
+
+/// The estate every test below queries.
+///
+/// * `knowledge` (local-knowledge, estate-readonly) — a REAL walk over a real
+///   directory: `docs/forms.md`, `src/lib.rs`, `tickets.csv` with
+///   `number`/`short_description` allowlisted (F10a).
+/// * `mailbox` (local-knowledge, estate-readonly) — one hand-built
+///   [`MAIL_EXTRACTOR`] unit (see the module doc for why it is hand-built).
+/// * `vendor-lib` (external-git, external) — the decoy: a document whose body
+///   is a *better* lexical match for the queries below than anything
+///   admissible, planted so the negative-admission test has something real to
+///   fail on.
+struct Estate {
+    _data: TempDir,
+    root: TempDir,
+    journal: Journal,
+    db: AtlasDb,
+}
+
+impl Estate {
+    /// Bytes of one file in the real knowledge root — what a byte range from
+    /// a hit is sliced out of.
+    fn bytes(&self, relative: &str) -> Vec<u8> {
+        std::fs::read(self.root.path().join(relative)).expect("read fixture bytes")
+    }
+
+    fn search(
+        &self,
+        text: &str,
+        filter: &Admissibility,
+        family: Option<LexicalFamily>,
+    ) -> LexicalAnswer {
+        self.db
+            .lexical_search(&LexicalQuery {
+                text,
+                filter,
+                family,
+                limit: 50,
+            })
+            .expect("lexical search")
+    }
+}
+
+/// The decoy body: every one of the six forms, repeated, so BM25 cannot
+/// prefer anything else on any of the queries this suite runs.
+fn decoy_body() -> String {
+    let once = FORMS.join(" ");
+    format!("{once} {once} {once} {once}")
+}
+
+fn estate() -> Estate {
+    let data = tempfile::tempdir().expect("data dir");
+    let root = tempfile::tempdir().expect("knowledge root");
+    write(root.path(), "docs/forms.md", FORMS_MD);
+    write(root.path(), "src/lib.rs", LIB_RS);
+    write(root.path(), "tickets.csv", TICKETS_CSV);
+
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    let knowledge = KnowledgeSource {
+        name: "knowledge".to_string(),
+        root: root.path().to_path_buf(),
+        ignore: Vec::new(),
+        context_fields: ContextFields::declared(&[
+            "number".to_string(),
+            "short_description".to_string(),
+        ]),
+    };
+    scan_and_record(&mut db, &mut journal, &knowledge, None).expect("record knowledge");
+
+    let mailbox = hand_built_scan(
+        "mailbox",
+        SourceKind::LocalKnowledge,
+        AuthorityClass::EstateReadonly,
+        "mailbox@key-1",
+        vec![scanned_file(
+            "inbox/message.eml",
+            MAIL_EXTRACTOR,
+            vec![document_unit(
+                Some("Payment retry policy failure"),
+                "The PaymentRetryPolicy raised INC0012345 during settlement.",
+            )],
+        )],
+    );
+    record_scan(&mut db, &mut journal, &mailbox, None).expect("record mailbox");
+
+    let decoy = decoy_body();
+    let vendor = hand_built_scan(
+        "vendor-lib",
+        SourceKind::ExternalGit,
+        AuthorityClass::External,
+        "vendor-lib@key-1",
+        vec![scanned_file(
+            "docs/leak.md",
+            MARKDOWN_EXTRACTOR,
+            vec![document_unit(None, &decoy)],
+        )],
+    );
+    record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
+
+    Estate {
+        _data: data,
+        root,
+        journal,
+        db,
+    }
+}
+
+/// Only the `knowledge` source: the world the six-form tests run in.
+fn only_knowledge() -> Admissibility {
+    Admissibility {
+        source: SourceSelector::Named("knowledge".to_string()),
+        kind: None,
+        authority: None,
+    }
+}
+
+fn paths(answer: &LexicalAnswer) -> Vec<String> {
+    answer
+        .hits
+        .iter()
+        .map(|hit| format!("{}:{}", hit.source_name, hit.coordinate.relative_path()))
+        .collect()
+}
+
+fn finds(answer: &LexicalAnswer, relative_path: &str) -> bool {
+    answer
+        .hits
+        .iter()
+        .any(|hit| hit.coordinate.relative_path() == relative_path)
+}
+
+fn hit_at<'a>(answer: &'a LexicalAnswer, relative_path: &str) -> &'a LexicalHit {
+    answer
+        .hits
+        .iter()
+        .find(|hit| hit.coordinate.relative_path() == relative_path)
+        .unwrap_or_else(|| panic!("no hit at {relative_path}; got {:?}", paths(answer)))
+}
+
+// ------------------------------------------- A2 §5's six literal forms
+
+/// A2 §5 names six forms tokenization *"should preserve"*. Each is a query
+/// here, and each must find the document that spells it — the contract naming
+/// its own minimum, tested as six cases rather than one.
+#[test]
+fn each_of_the_six_contract_token_forms_finds_the_document_that_spells_it() {
+    let estate = estate();
+    let filter = only_knowledge();
+    for form in FORMS {
+        let answer = estate.search(form, &filter, None);
+        assert!(
+            finds(&answer, "docs/forms.md"),
+            "A2 §5's form {form:?} must find the document that spells it; got {:?}",
+            paths(&answer)
+        );
+    }
+}
+
+/// **The trap A2 §5 sets.** Camel-case splitting must not cost the whole
+/// identifier: searching `PaymentRetryPolicy` and searching `payment` must
+/// BOTH find the unit. A tokenizer that only splits passes the second half
+/// and fails the first, and has destroyed the exact-identifier advantage that
+/// is BM25's entire reason for being in this design.
+#[test]
+fn splitting_a_camel_identifier_never_costs_the_whole_identifier() {
+    let estate = estate();
+    let filter = only_knowledge();
+    for query in ["PaymentRetryPolicy", "payment"] {
+        let answer = estate.search(query, &filter, None);
+        assert!(
+            finds(&answer, "docs/forms.md"),
+            "{query:?} must find the unit spelling PaymentRetryPolicy; got {:?}",
+            paths(&answer)
+        );
+    }
+}
+
+/// A2 §5's second sentence: *"Document/mail retrieval additionally retains
+/// ordinary natural-language tokens."* The code family's indexed text is the
+/// symbol name a grammar claimed and nothing else, so a prose word from the
+/// same file's comments is unreachable through it — and reachable through the
+/// document family, which indexes the file's own body.
+#[test]
+fn code_units_index_identifiers_while_document_units_additionally_index_prose() {
+    let estate = estate();
+    let filter = only_knowledge();
+
+    let code = estate.search("reconciliation", &filter, Some(LexicalFamily::Code));
+    assert!(
+        code.hits.is_empty(),
+        "the code family indexes identifiers, not prose; got {:?}",
+        paths(&code)
+    );
+
+    let document = estate.search("reconciliation", &filter, Some(LexicalFamily::Document));
+    assert!(
+        finds(&document, "src/lib.rs"),
+        "the document family must retain the ordinary prose word; got {:?}",
+        paths(&document)
+    );
+
+    let identifier = estate.search("payment_retry_policy", &filter, Some(LexicalFamily::Code));
+    assert!(
+        finds(&identifier, "src/lib.rs"),
+        "the code family must still find the identifier; got {:?}",
+        paths(&identifier)
+    );
+}
+
+// ------------------------------------ A2 §17 item 2: all four families
+
+/// Family 1 of 4 — **code**, with A2 §3's code coordinate
+/// (`source/revision/path/symbol/span`) resolving to the exact bytes of the
+/// real file the real walk read.
+#[test]
+fn lexical_search_returns_a_code_unit_with_exact_a1_provenance() {
+    let estate = estate();
+    let answer = estate.search(
+        "payment_retry_policy",
+        &only_knowledge(),
+        Some(LexicalFamily::Code),
+    );
+    let hit = hit_at(&answer, "src/lib.rs");
+    assert_eq!(hit.source_name, "knowledge");
+    assert!(!hit.generation_id.is_empty(), "a hit names its generation");
+    assert!(
+        !hit.content_key.is_empty(),
+        "a hit names the generation's content identity"
+    );
+    let UnitCoordinate::Code {
+        symbol,
+        language,
+        byte_start,
+        byte_end,
+        ..
+    } = &hit.coordinate
+    else {
+        panic!("expected a code coordinate, got {:?}", hit.coordinate);
+    };
+    assert_eq!(symbol, "payment_retry_policy");
+    assert_eq!(language, "rust");
+    let bytes = estate.bytes("src/lib.rs");
+    let span = String::from_utf8(bytes[*byte_start as usize..*byte_end as usize].to_vec())
+        .expect("the span is utf-8");
+    assert!(
+        span.contains("payment_retry_policy"),
+        "the byte range must resolve to the bytes the hit claims: {span:?}"
+    );
+}
+
+/// Family 2 of 4 — **document**, with A2 §3's document coordinate resolving
+/// to the exact bytes of the real Markdown file.
+#[test]
+fn lexical_search_returns_a_document_unit_with_exact_a1_provenance() {
+    let estate = estate();
+    let answer = estate.search(
+        "payment-retry-policy",
+        &only_knowledge(),
+        Some(LexicalFamily::Document),
+    );
+    let hit = hit_at(&answer, "docs/forms.md");
+    assert_eq!(hit.source_name, "knowledge");
+    let UnitCoordinate::Document {
+        byte_start,
+        byte_end,
+        ..
+    } = &hit.coordinate
+    else {
+        panic!("expected a document coordinate, got {:?}", hit.coordinate);
+    };
+    let bytes = estate.bytes("docs/forms.md");
+    let span = String::from_utf8(bytes[*byte_start as usize..*byte_end as usize].to_vec())
+        .expect("the span is utf-8");
+    assert!(
+        span.contains("payment-retry-policy"),
+        "the byte range must resolve to the bytes the hit claims: {span:?}"
+    );
+}
+
+/// Family 3 of 4 — **mail**. A2 §3's email coordinate, as far as A1's stored
+/// rows carry it: the `.eml` resource's path, the unit inside it, and the
+/// span of the message bytes.
+#[test]
+fn lexical_search_returns_a_mail_unit_with_exact_a1_provenance() {
+    let estate = estate();
+    let filter = Admissibility {
+        source: SourceSelector::Named("mailbox".to_string()),
+        kind: None,
+        authority: None,
+    };
+    let answer = estate.search("INC0012345", &filter, Some(LexicalFamily::Mail));
+    let hit = hit_at(&answer, "inbox/message.eml");
+    assert_eq!(hit.source_name, "mailbox");
+    let UnitCoordinate::Mail {
+        title,
+        byte_start,
+        byte_end,
+        ..
+    } = &hit.coordinate
+    else {
+        panic!("expected a mail coordinate, got {:?}", hit.coordinate);
+    };
+    assert_eq!(title.as_deref(), Some("Payment retry policy failure"));
+    assert!(
+        byte_end > byte_start,
+        "a mail unit's span must be a real range: {byte_start}..{byte_end}"
+    );
+}
+
+/// Family 4 of 4 — **selected-row-text**, with A2 §3's structured-text
+/// coordinate `source/generation/dataset/row-id/field-set`.
+///
+/// **This coordinate carries no byte range, and that is the contract, not an
+/// omission.** A2 §3 gives structured text `source/generation/dataset/row-id/
+/// field-set`; the row is read in place and never copied into Atlas, so there
+/// are no Atlas-owned bytes to point at. The W2 brief's summary line ("every
+/// hit cites ... byte range") is the common case; where it and A2 §3 disagree
+/// the contract wins (J5).
+#[test]
+fn lexical_search_returns_a_selected_row_text_unit_with_exact_a1_provenance() {
+    let estate = estate();
+    let answer = estate.search(
+        "INC0012345",
+        &only_knowledge(),
+        Some(LexicalFamily::RowText),
+    );
+    let hit = hit_at(&answer, "tickets.csv");
+    assert_eq!(hit.source_name, "knowledge");
+    let UnitCoordinate::RowText {
+        dataset_key,
+        row_key,
+        fields,
+        ..
+    } = &hit.coordinate
+    else {
+        panic!("expected a row-text coordinate, got {:?}", hit.coordinate);
+    };
+    assert!(!dataset_key.is_empty(), "a row hit names its dataset");
+    assert!(!row_key.is_empty(), "a row hit names its row");
+    assert!(
+        fields.contains(&"short_description".to_string()),
+        "F10a's exposed field set rides with the hit: {fields:?}"
+    );
+    // The index is per ROW, not per file: the sibling ticket shares the `inc`
+    // part-token, so it is a legitimate weaker match — and the row that
+    // spells the whole identifier outranks it, which is the exact-identifier
+    // advantage A2 §5 buys.
+    assert_eq!(
+        hit.coordinate.ordinal(),
+        0,
+        "the matching row is the first one"
+    );
+    let sibling = answer
+        .hits
+        .iter()
+        .find(|other| other.coordinate.ordinal() != 0)
+        .expect("the sibling row matches on the shared `inc` part-token");
+    assert!(
+        hit.score > sibling.score,
+        "the row spelling the whole identifier must outrank the one sharing only a part:          {} vs {}",
+        hit.score,
+        sibling.score
+    );
+    let UnitCoordinate::RowText {
+        row_key: sibling_key,
+        ..
+    } = &sibling.coordinate
+    else {
+        panic!(
+            "expected a row-text coordinate, got {:?}",
+            sibling.coordinate
+        );
+    };
+    assert_ne!(
+        row_key, sibling_key,
+        "two rows of one dataset are two units with two row identities"
+    );
+}
+
+// ------------------------------------------- A2 §8: the filter is never crossed
+
+/// **The wave's most important test.** A2 §8: *"The reranker must never
+/// silently cross an authority/source filter merely because a candidate
+/// scores well."*
+///
+/// `vendor-lib`'s planted document is the best lexical match in the store for
+/// every one of A2 §5's six forms — the first half of this test proves that,
+/// because a decoy that never ranked first would make the second half
+/// vacuous. The second half applies the authority filter and the decoy is
+/// gone: not demoted, not present-but-last — absent, because BM25 ranks
+/// inside the admissible set and cannot widen it.
+#[test]
+fn an_inadmissible_unit_with_a_perfect_lexical_match_is_never_returned() {
+    let estate = estate();
+    let unfiltered = Admissibility::default();
+    let wide = estate.search("PaymentRetryPolicy", &unfiltered, None);
+    assert_eq!(
+        wide.hits.first().map(|hit| hit.source_name.as_str()),
+        Some("vendor-lib"),
+        "the decoy must actually be the best-scoring candidate, or this test proves nothing: \
+         {:?}",
+        paths(&wide)
+    );
+
+    for filter in [
+        Admissibility {
+            source: SourceSelector::Any,
+            kind: None,
+            authority: Some(AuthorityClass::EstateReadonly),
+        },
+        only_knowledge(),
+        Admissibility {
+            source: SourceSelector::Any,
+            kind: Some(SourceKind::LocalKnowledge),
+            authority: None,
+        },
+    ] {
+        let answer = estate.search("PaymentRetryPolicy", &filter, None);
+        assert!(
+            !answer.hits.is_empty(),
+            "the filter must still admit the legitimate matches: {filter:?}"
+        );
+        assert!(
+            answer
+                .hits
+                .iter()
+                .all(|hit| hit.source_name != "vendor-lib"),
+            "a perfect lexical match outside the admissible set must never be returned \
+             ({filter:?}); got {:?}",
+            paths(&answer)
+        );
+    }
+}
+
+/// The same prohibition on the Work-overlay axis (S5 W1b): a lexical query
+/// scoped to one Work sees that Work's own overlay and never another's, and a
+/// plain `--source` query sees no overlay at all — even when the other Work's
+/// overlay is the better lexical match.
+#[test]
+fn another_works_overlay_unit_never_surfaces_through_a_lexical_query() {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    const MINE: &str = "01MINE0000000000000000000A";
+    const OTHER: &str = "01OTHER000000000000000000B";
+
+    let base = hand_built_scan(
+        "repo-a",
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        "repo-a@key-1",
+        vec![ScannedFile {
+            syntax: Some(rust_symbol("widget_base")),
+            ..scanned_file(
+                "src/main.rs",
+                sergeant_rs::runtime::atlas::text::TEXT_EXTRACTOR,
+                vec![document_unit(None, "fn widget_base() {}\n")],
+            )
+        }],
+    );
+    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+
+    for (work_id, symbol) in [(MINE, "widget_mine"), (OTHER, "widget_theirs")] {
+        let overlay = hand_built_scan(
+            &sergeant_rs::runtime::atlas::overlay::overlay_source_name(work_id, "repo-a"),
+            SourceKind::EstateGit,
+            AuthorityClass::EstateMutable,
+            &format!("repo-a@base+{work_id}"),
+            vec![ScannedFile {
+                syntax: Some(rust_symbol(symbol)),
+                ..scanned_file(
+                    "src/main.rs",
+                    sergeant_rs::runtime::atlas::text::TEXT_EXTRACTOR,
+                    vec![document_unit(None, &format!("fn {symbol}() {{}}\n"))],
+                )
+            }],
+        );
+        let recorded = record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+        assert!(
+            matches!(recorded, ScanRecord::Recorded { .. }),
+            "the overlay fixture must be journaled and confirmed: {recorded:?}"
+        );
+    }
+
+    let mine = Admissibility {
+        source: SourceSelector::WorkBase {
+            work_id: MINE.to_string(),
+            repository: "repo-a".to_string(),
+        },
+        kind: None,
+        authority: None,
+    };
+    let answer = db
+        .lexical_search(&LexicalQuery {
+            text: "widget_theirs widget_mine widget_base",
+            filter: &mine,
+            family: None,
+            limit: 50,
+        })
+        .expect("lexical search");
+    let sources: BTreeSet<String> = answer
+        .hits
+        .iter()
+        .map(|hit| hit.source_name.clone())
+        .collect();
+    assert!(
+        sources.contains(&sergeant_rs::runtime::atlas::overlay::overlay_source_name(
+            MINE, "repo-a"
+        )),
+        "--work must see its own overlay: {sources:?}"
+    );
+    assert!(
+        !sources.contains(&sergeant_rs::runtime::atlas::overlay::overlay_source_name(
+            OTHER, "repo-a"
+        )),
+        "--work must never see another Work's overlay, however well it scores: {sources:?}"
+    );
+
+    let named = Admissibility {
+        source: SourceSelector::Named("repo-a".to_string()),
+        kind: None,
+        authority: None,
+    };
+    let plain = db
+        .lexical_search(&LexicalQuery {
+            text: "widget_theirs widget_mine widget_base",
+            filter: &named,
+            family: None,
+            limit: 50,
+        })
+        .expect("lexical search");
+    assert!(
+        plain.hits.iter().all(|hit| hit.source_name == "repo-a"),
+        "a plain --source query reaches no overlay at all: {:?}",
+        paths(&plain)
+    );
+
+    // And retiring the Work takes its overlay's postings with it (H2).
+    db.evict_work_overlays(MINE).expect("evict overlays");
+    let after = db
+        .lexical_search(&LexicalQuery {
+            text: "widget_mine",
+            filter: &mine,
+            family: None,
+            limit: 50,
+        })
+        .expect("lexical search");
+    assert!(
+        after
+            .hits
+            .iter()
+            .all(|hit| !hit.source_name.starts_with("work:")),
+        "a retired Work's overlay postings are evicted with it: {:?}",
+        paths(&after)
+    );
+}
+
+/// The cross-check that keeps W2's own composed predicate honest: every
+/// generation a lexical hit cites is one [`AtlasDb::admissible_generations`]
+/// admits under the same filter. Compared as answers, not as SQL strings —
+/// two identically wrong queries would agree on the string.
+#[test]
+fn every_generation_a_lexical_hit_cites_is_one_the_admissibility_filter_admits() {
+    let estate = estate();
+    for filter in [
+        Admissibility::default(),
+        only_knowledge(),
+        Admissibility {
+            source: SourceSelector::Any,
+            kind: None,
+            authority: Some(AuthorityClass::EstateReadonly),
+        },
+    ] {
+        let admitted: BTreeSet<String> = estate
+            .db
+            .admissible_generations(&filter, 1_000)
+            .expect("admissible generations")
+            .hits
+            .into_iter()
+            .map(|generation| generation.id)
+            .collect();
+        let answer = estate.search("PaymentRetryPolicy INC0012345", &filter, None);
+        assert!(!answer.hits.is_empty(), "no hits to check for {filter:?}");
+        for hit in &answer.hits {
+            assert!(
+                admitted.contains(&hit.generation_id),
+                "a hit cited generation {} which the filter {filter:?} does not admit",
+                hit.generation_id
+            );
+        }
+    }
+}
+
+/// An empty query returns nothing rather than everything — the degenerate
+/// case where "rank the admissible set" could quietly become "dump it".
+#[test]
+fn a_query_with_no_terms_returns_no_hits_rather_than_the_whole_corpus() {
+    let estate = estate();
+    for text in ["", "   ", "!!! ---"] {
+        let answer = estate.search(text, &only_knowledge(), None);
+        assert!(
+            answer.hits.is_empty(),
+            "{text:?} must not return the corpus; got {:?}",
+            paths(&answer)
+        );
+    }
+}
+
+// ---------------------------------------------------------- determinism
+
+/// Same query + same generations ⇒ same ordered result, scores included.
+#[test]
+fn the_same_query_over_the_same_generations_returns_the_same_ordered_result() {
+    let estate = estate();
+    let filter = Admissibility::default();
+    let first = estate.search("PaymentRetryPolicy INC0012345 payments", &filter, None);
+    for _ in 0..5 {
+        let again = estate.search("PaymentRetryPolicy INC0012345 payments", &filter, None);
+        assert_eq!(
+            first, again,
+            "the same query over the same generations must return the same ordered result"
+        );
+    }
+}
+
+/// **The stated tie-break rule, pinned.** Two units with byte-identical text
+/// score identically, so their order is decided entirely by
+/// `LexicalHit::tie_break_key` — `(source_name, relative_path, ordinal,
+/// unit_key)` ascending.
+///
+/// The fixture records the sources in the REVERSE of that order (`zeta`
+/// first, `alpha` second), so an implementation accumulating into a hash map
+/// would put them in whatever order that map iterated and fail here.
+///
+/// That score outranks arrival order at all is proved next door rather than
+/// here: in
+/// [`an_inadmissible_unit_with_a_perfect_lexical_match_is_never_returned`],
+/// `vendor-lib` is last in every arrival ordering the store produces
+/// (`knowledge` < `mailbox` < `vendor-lib`) and is asserted to come back
+/// first, which only the score-descending sort can do.
+#[test]
+fn equal_scores_are_broken_by_the_stated_key_not_by_row_arrival_order() {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    for name in ["zeta", "alpha"] {
+        let scan = hand_built_scan(
+            name,
+            SourceKind::LocalKnowledge,
+            AuthorityClass::EstateReadonly,
+            &format!("{name}@key-1"),
+            vec![scanned_file(
+                "note.md",
+                MARKDOWN_EXTRACTOR,
+                vec![document_unit(None, "PaymentRetryPolicy")],
+            )],
+        );
+        record_scan(&mut db, &mut journal, &scan, None).expect("record tie fixture");
+    }
+
+    let filter = Admissibility::default();
+    let answer = db
+        .lexical_search(&LexicalQuery {
+            text: "PaymentRetryPolicy",
+            filter: &filter,
+            family: None,
+            limit: 50,
+        })
+        .expect("lexical search");
+    let order: Vec<&str> = answer
+        .hits
+        .iter()
+        .map(|hit| hit.source_name.as_str())
+        .collect();
+    assert_eq!(
+        order,
+        vec!["alpha", "zeta"],
+        "tied hits order by the stated key, not by the order the rows were written"
+    );
+    assert_eq!(
+        answer.hits[0].score, answer.hits[1].score,
+        "the fixture must actually tie, or the tie-break is untested"
+    );
+}
+
+// ------------------------------------------------------ index lifecycle
+
+/// H2: the index is keyed by SourceGeneration, so a superseded generation's
+/// postings are evicted with it — no stale hit survives a re-scan, and every
+/// surviving hit cites the new generation.
+#[test]
+fn a_superseded_generations_postings_are_evicted_with_it() {
+    let mut estate = estate();
+    let before = estate.search(
+        "INC0012345",
+        &only_knowledge(),
+        Some(LexicalFamily::Document),
+    );
+    let stale_generation = hit_at(&before, "docs/forms.md").generation_id.clone();
+
+    // Re-scan the same source with different bytes: the ticket is gone.
+    write(
+        estate.root.path(),
+        "docs/forms.md",
+        "# Retry forms\n\nThe ticket reference was withdrawn.\n",
+    );
+    let knowledge = KnowledgeSource {
+        name: "knowledge".to_string(),
+        root: estate.root.path().to_path_buf(),
+        ignore: Vec::new(),
+        context_fields: ContextFields::declared(&[
+            "number".to_string(),
+            "short_description".to_string(),
+        ]),
+    };
+    let recorded = scan_and_record(&mut estate.db, &mut estate.journal, &knowledge, None)
+        .expect("re-record knowledge");
+    assert!(
+        matches!(recorded, ScanRecord::Recorded { .. }),
+        "the re-scan must actually supersede: {recorded:?}"
+    );
+
+    let after = estate.search(
+        "INC0012345",
+        &only_knowledge(),
+        Some(LexicalFamily::Document),
+    );
+    assert!(
+        !finds(&after, "docs/forms.md"),
+        "the superseded generation's postings must be gone: {:?}",
+        paths(&after)
+    );
+    for hit in &after.hits {
+        assert_ne!(
+            hit.generation_id, stale_generation,
+            "no surviving hit may cite the evicted generation"
+        );
+    }
+    // The CSV row unit is unchanged bytes in the new generation, so it is
+    // still findable — proving the eviction took the superseded generation
+    // and not the index.
+    let rows = estate.search(
+        "INC0012345",
+        &only_knowledge(),
+        Some(LexicalFamily::RowText),
+    );
+    assert!(
+        finds(&rows, "tickets.csv"),
+        "the new generation's own postings must be there: {:?}",
+        paths(&rows)
+    );
+}
+
+/// The index is derived evidence (A1-01: the journal, Git and the original
+/// bytes remain authority), so it must be rebuildable from the A1 rows alone
+/// — and the rebuild must produce the same answer as the build.
+#[test]
+fn the_lexical_index_rebuilds_from_the_a1_rows_it_derives_from() {
+    let mut estate = estate();
+    let filter = Admissibility::default();
+    let before = estate.search("PaymentRetryPolicy INC0012345", &filter, None);
+    let indexed = estate.db.reindex_lexical().expect("reindex");
+    assert!(indexed > 0, "the rebuild must actually index units");
+    let after = estate.search("PaymentRetryPolicy INC0012345", &filter, None);
+    assert_eq!(
+        before, after,
+        "a rebuilt index must answer identically to the one built at staging time"
+    );
+}
+
+/// A bounded answer says it is bounded. Nothing in this fixture reaches
+/// `MAX_ROWS`, so the flag is false — which is the assertion that keeps it
+/// from being a field nobody ever reads.
+#[test]
+fn a_bounded_answer_states_whether_the_posting_scan_was_capped() {
+    let estate = estate();
+    let answer = estate.search("PaymentRetryPolicy", &Admissibility::default(), None);
+    assert!(
+        !answer.truncated,
+        "this corpus is far under the cap; a true flag here means the cap logic is wrong"
+    );
+}


### PR DESCRIPTION
## What

A small local BM25 over the evidence units A1 already writes — **no new chunker** (A2-02 forbids a second chunk universe), no search service, no new store. `src/runtime/atlas/lexical.rs` (tokenizer + scoring, names no database driver) plus two tables in the one Atlas database: `context.lexical_units`, `context.lexical_postings`.

Postings are built **inside `stage_scan_impl`'s staging transaction, from the rows just written** — not from the in-memory scan — so the index cites exactly the evidence it indexed. `evict` takes them with every other derived row.

A2 §6 makes this the prerequisite for semantic retrieval: *"only after lexical retrieval exists."*

## A2 §5's six token forms are literal, and each is a test

`PaymentRetryPolicy`, `payment_retry_policy`, `payment-retry-policy`, `Foo::bar`, `POST /payments`, `INC0012345` — driven from a `FORMS` const holding the contract's own six strings.

And the trap: **camel splitting must not cost the whole identifier.** `splitting_a_camel_identifier_never_costs_the_whole_identifier` proves `PaymentRetryPolicy` *and* `payment` both find it. A tokenizer that only splits destroys the exact-identifier advantage that is BM25's reason for being here.

§5's *"document/mail retrieval additionally retains ordinary natural-language tokens"* is pinned too: a prose word from a comment is unreachable in the code family and reachable in the document family, while the identifier stays reachable in both.

## Acceptance item 2 — all four families, with provenance that resolves

`code` / `document` / `mail` / `selected-row-text`, each with its own test asserting source, generation, content key and coordinate. The code and document tests **slice the real file bytes with the hit's byte range**.

**J5 deviation, stated:** the brief's summary said every hit cites "source + generation + unit + byte range". A2 §3 gives each family its own coordinate, and structured text has none — it is `source/generation/dataset/row-id/field-set`, read in place, never copied into Atlas. The contract wins: `UnitCoordinate` is family-shaped and `RowText` carries dataset key, row key and F10a's exposed field set rather than a span it could only invent.

## The wave's most important test is a negative

A2 §8 forbids crossing an authority/source filter *"merely because a candidate scores well."* `an_inadmissible_unit_with_a_perfect_lexical_match_is_never_returned` first proves the planted unit ranks **first** unfiltered — so the negative is not vacuous — then proves it **absent** under authority, source and kind filters. The overlay axis gets the same treatment: `--work` sees its own overlay and never another Work's.

And `every_generation_a_lexical_hit_cites_is_one_the_admissibility_filter_admits` compares **answers** against `admissible_generations`, not SQL strings.

## Two existing boundaries pushed back, and were obeyed rather than widened

1. **The item-13 no-client-SQL tripwire rejected the first draft.** It pins an exhaustive list of interpolations in `db.rs`'s SQL literals, and a `format!`-built predicate added five holes. Rather than extend the allowlist, all runtime SQL building was removed — the predicate and joins are `macro_rules!` literals spliced by `concat!`, and the IN-list became one statement per query term. **The pinned list is unchanged.**
2. **`y6a_estate_scoped_scan` caught a real performance regression**: row-at-a-time posting `INSERT`s turned an 11.6s real estate scan into one that blew the test's 100s client timeout. Fixed with the DuckDB appender `db.rs` already owns and has already measured (~4µs/row vs ~1–2ms). Scan now 15.3s; baseline verified by stashing and re-running.

## Panel — 3 raised, 3 confirmed, one commit each

- **`reindex_lexical` had no production caller** — the wave's own stated upgrade path for a store written before W2. That is this program's signature defect for the fourth time (estate-git trigger, Office dispatch, overlay trigger, now this), caught before shipping. Wired into daemon startup.
- `reindex_lexical` silently capped its generation set at `MAX_ROWS` while its doc said *"every non-evicted generation"*. Now returns `ReindexOutcome { indexed, truncated }`, mirroring `LexicalAnswer::truncated`'s existing disclosure pattern.
- The `truncated = true` branch had **zero coverage**; the existing test only exercised the untruncated path.

Re-verify then found `cargo fmt --check` red on one of the fix commits and **escalated rather than round-tripping it** — fixed separately.

## Determinism

Same query + same generations ⇒ same ordered result, with ties broken by a stated key: `equal_scores_are_broken_by_the_stated_key_not_by_row_arrival_order` records sources `zeta` then `alpha`, expects `alpha, zeta`, and asserts the scores actually tie.

## Validation

Full suite once: **2311 passed, 0 failed, 39 skipped.** clippy `-D warnings` clean, fmt clean. New suite wired into `scripts/coverage/c2-suites.sh` in the same commit (#231).

R2 throughout (A1's units, W1's admissibility predicate, `evict`'s delete list, the appender already owned and measured). A2-05's R7 not re-derived — the contract already checked its lower rungs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4