### PR TITLE
test(harness): schedule the one heavy m7 test alone via threads-required (#258)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,43 @@
+# Repository-wide nextest configuration (`.config/nextest.toml` at the Cargo
+# workspace root — nextest's own documented location for checked-in,
+# shared-with-every-user config). CI runs a bare `cargo nextest run --locked`
+# (`.github/workflows/ci.yml`) with `cargo-nextest@0.9.99` pinned in the same
+# job, so everything here must be valid for that version and must apply to the
+# `default` profile: CI names no profile, and neither does a developer typing
+# `cargo nextest run`.
+
+# --- The one heavy test in the suite, scheduled alone (#258) -----------------
+#
+# `m7_docker_executor::large_captured_output_does_not_grow_this_process_
+# proportionally` streams ~256 MiB of combined stdout/stderr out of a real
+# container through the capture path. Measured on this repo's own CI on
+# 2026-08-29, three unrelated suites failed in the same job *while that test
+# was running long beside them*:
+#
+#   estate_routes::get_doctor_matches_the_shape_sgt_doctor_json_already_prints
+#       -> Transport("error sending request") after >60 s
+#   m9_watch::w7_stream_closure_is_honest_and_never_restarts_the_daemon
+#       -> daemon_pids().len() == 2, expected 1
+#   y6a_estate_scoped_scan::a_registered_repository_is_scanned_through_the_
+#       git_path_and_map_symbol_resolves_a_real_function
+#       -> reqwest .../v1/intelligence/scan TimedOut
+#
+# All three pass in isolation. The heavy test itself took 283.3 s in that job
+# against 88.6 s solo, so it was being starved *and* starving everything
+# beside it.
+#
+# `threads-required = "num-test-threads"` reserves the entire thread budget
+# nextest is running with, so this test is scheduled with no siblings at all.
+#
+# DELIBERATELY NOT A TEST GROUP. A `[test-groups]` entry's `max-threads` caps
+# concurrency *within* the group; this test's problem is contention with
+# everything *outside* any group it could belong to, which a group cannot
+# express. Do not "simplify" this into a group — it would not do the same
+# thing.
+#
+# The filter is the narrowest one that works: this single test, in this single
+# binary. The rest of `m7_docker_executor` (the next-slowest test in it is
+# ~22 s) keeps running in parallel with the suite.
+[[profile.default.overrides]]
+filter = 'binary_id(=sergeant-rs::m7_docker_executor) and test(=large_captured_output_does_not_grow_this_process_proportionally)'
+threads-required = "num-test-threads"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1196,8 +1196,8 @@ them were dead code in every real installation.
   heavy test's own runtime fell from 142.7–147.6 s to 97.9–102.8 s (−31 %),
   confirming it was being starved as well as starving. The cost is stated
   rather than buried: **total suite wall time gets slightly worse** — ~+5 %
-  on the mean of three full runs per arm at 20 cores, and 1020.7 s → 1098.8 s
-  (+7.6 %, one sample per arm) in a 4-CPU CI-shaped run — because isolation
+  on the mean of three full runs per arm at 20 cores, and 1025.4 s → 1095.5 s
+  (+6.9 %, two runs per arm) in a 4-CPU CI-shaped run — because isolation
   gives up parallelism during that ~100 s. Deliberately **not** a
   `[test-groups]` entry: a group's `max-threads` caps concurrency *within*
   the group, and this test's problem is contention with everything *outside*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1177,6 +1177,36 @@ them were dead code in every real installation.
   0.48×–3.78× vs 1.29× regressed — and rejected as indistinguishable from the
   regression on two cores.)
 
+- **The one heavy test in the suite is now scheduled alone (#258).** This
+  repository gains its first `.config/nextest.toml`. Its single override gives
+  `m7_docker_executor::large_captured_output_does_not_grow_this_process_proportionally`
+  — the 256 MiB-capture test, one test accounting for essentially all of
+  `m7_docker_executor`'s runtime — `threads-required = "num-test-threads"`, so
+  nextest reserves the whole thread budget for it and runs it with no
+  siblings. This is a **test-harness contract change**: it is the first
+  checked-in nextest configuration, it applies to the `default` profile
+  (which is what CI's bare `cargo nextest run --locked` and a developer's
+  bare `cargo nextest run` both use), and it changes how every test in the
+  suite is scheduled around that one test. Measured on 2026-08-29, 20-core
+  container, `cargo-nextest 0.9.99` (the version CI pins): under deliberate
+  load the CI victim
+  `y6a_estate_scoped_scan::a_registered_repository_is_scanned_through_the_git_path_and_map_symbol_resolves_a_real_function`
+  failed **3/3** attempts before and passed **3/3** after, with the same
+  `reqwest … /v1/intelligence/scan … TimedOut` signature CI reported; the
+  heavy test's own runtime fell from 142.7–147.6 s to 97.9–102.8 s (−31 %),
+  confirming it was being starved as well as starving. The cost is stated
+  rather than buried: **total suite wall time gets slightly worse** — ~+5 %
+  on the mean of three full runs per arm at 20 cores, and 1020.7 s → 1098.8 s
+  (+7.6 %, one sample per arm) in a 4-CPU CI-shaped run — because isolation
+  gives up parallelism during that ~100 s. Deliberately **not** a
+  `[test-groups]` entry: a group's `max-threads` caps concurrency *within*
+  the group, and this test's problem is contention with everything *outside*
+  any group it could join. Every number and the full method are in
+  sergeant-rs-workspace's `knowledge/evidence/perf/m7-thread-budget-2026-08-29.md`.
+  (R3/R7: the test runner's own documented feature, no new script or wrapper;
+  J4: the wave brief scopes exactly this one test, and the wall-time cost is
+  reported for Captain's ship decision rather than absorbed silently.)
+
 ### One Atlas database (S5)
 
 - **`sergeant.duckdb` is gone.** A1 §5 declares one physical file,

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -284,3 +284,14 @@ cov_stage_end 1 "the w1c_one_atlas_database test binary must write its own profi
 cov_stage_begin c2-w1d_overlay_freshness
 cov_run cargo llvm-cov --no-report --test w1d_overlay_freshness --locked || cov_fail "w1d_overlay_freshness failed under instrumentation"
 cov_stage_end 1 "the w1d_overlay_freshness test binary must write its own profile"
+
+# #258 thread-budget contract, wired at birth (the #231 lesson, same as the
+# suites above): the structural pin for `.config/nextest.toml`'s
+# `threads-required` override on m7's heavy test. It reads the config file and
+# the test tree and asserts the override still exists in the form the config's
+# own comment describes — no daemon, no subprocess, so its profile is the test
+# binary's own. NOT allowlisted: the allowlist is for `#[ignore]`d measurement
+# suites that need a developer's own corpus, and this one runs normally. Floor 1.
+cov_stage_begin c2-f258_nextest_thread_budget
+cov_run cargo llvm-cov --no-report --test f258_nextest_thread_budget --locked || cov_fail "f258_nextest_thread_budget failed under instrumentation"
+cov_stage_end 1 "the f258_nextest_thread_budget test binary must write its own profile"

--- a/tests/f258_nextest_thread_budget.rs
+++ b/tests/f258_nextest_thread_budget.rs
@@ -45,8 +45,12 @@ const EXPECTED_FILTER: &str = "binary_id(=sergeant-rs::m7_docker_executor) and t
 fn m7_heavy_test_is_still_scheduled_alone_via_threads_required() {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let config_path = repo_root.join(".config/nextest.toml");
-    let raw = std::fs::read_to_string(&config_path)
-        .unwrap_or_else(|e| panic!("expected {} to exist and be readable: {e}", config_path.display()));
+    let raw = std::fs::read_to_string(&config_path).unwrap_or_else(|e| {
+        panic!(
+            "expected {} to exist and be readable: {e}",
+            config_path.display()
+        )
+    });
 
     let config: NextestConfig =
         toml::from_str(&raw).expect(".config/nextest.toml must parse as valid nextest config");
@@ -66,7 +70,10 @@ fn m7_heavy_test_is_still_scheduled_alone_via_threads_required() {
         });
 
     assert_eq!(
-        heavy.threads_required.as_ref().and_then(toml::Value::as_str),
+        heavy
+            .threads_required
+            .as_ref()
+            .and_then(toml::Value::as_str),
         Some("num-test-threads"),
         "the #258 override must keep `threads-required = \"num-test-threads\"` \
          (reserving the whole thread budget so the heavy test runs with no \
@@ -79,7 +86,8 @@ fn m7_heavy_test_is_still_scheduled_alone_via_threads_required() {
     // Deliberately not a test-groups conversion: assert no [test-groups]
     // table exists in the raw document at all, since that would be exactly
     // the "simplification" the checked-in comment forbids.
-    let doc: toml::Value = toml::from_str(&raw).expect("re-parsing as a generic Value must also succeed");
+    let doc: toml::Value =
+        toml::from_str(&raw).expect("re-parsing as a generic Value must also succeed");
     assert!(
         doc.get("test-groups").is_none(),
         "found a [test-groups] table in .config/nextest.toml — the #258 \

--- a/tests/f258_nextest_thread_budget.rs
+++ b/tests/f258_nextest_thread_budget.rs
@@ -1,0 +1,90 @@
+//! #258 / F-IN-01 — the m7 thread-budget isolation contract is structural,
+//! not prose.
+//!
+//! `.config/nextest.toml` schedules
+//! `m7_docker_executor::large_captured_output_does_not_grow_this_process_
+//! proportionally` alone via `threads-required = "num-test-threads"`,
+//! deliberately instead of a `[test-groups]` entry (see that file's own
+//! comment for why). Before this test, that contract was asserted only in a
+//! TOML comment: nothing failed if the override were weakened, retargeted by
+//! a typo, dropped, or converted to the `test-groups` form the comment warns
+//! against — CI's bare `cargo nextest run --locked` only validates that the
+//! file parses, not what it says. This test parses the checked-in config and
+//! pins the override's filter and its `threads-required` value, so a drift
+//! in either fails here instead of silently reintroducing the starvation
+//! class #258 fixed.
+
+use std::path::Path;
+
+#[derive(serde::Deserialize)]
+struct NextestConfig {
+    profile: Profiles,
+}
+
+#[derive(serde::Deserialize)]
+struct Profiles {
+    default: DefaultProfile,
+}
+
+#[derive(serde::Deserialize)]
+struct DefaultProfile {
+    #[serde(default)]
+    overrides: Vec<Override>,
+}
+
+#[derive(serde::Deserialize)]
+struct Override {
+    filter: String,
+    #[serde(rename = "threads-required")]
+    threads_required: Option<toml::Value>,
+}
+
+const EXPECTED_FILTER: &str = "binary_id(=sergeant-rs::m7_docker_executor) and test(=large_captured_output_does_not_grow_this_process_proportionally)";
+
+#[test]
+fn m7_heavy_test_is_still_scheduled_alone_via_threads_required() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let config_path = repo_root.join(".config/nextest.toml");
+    let raw = std::fs::read_to_string(&config_path)
+        .unwrap_or_else(|e| panic!("expected {} to exist and be readable: {e}", config_path.display()));
+
+    let config: NextestConfig =
+        toml::from_str(&raw).expect(".config/nextest.toml must parse as valid nextest config");
+
+    let overrides = &config.profile.default.overrides;
+    let heavy = overrides
+        .iter()
+        .find(|o| o.filter == EXPECTED_FILTER)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a [[profile.default.overrides]] entry with filter = {EXPECTED_FILTER:?}; \
+                 found filters: {:?}. This is the #258 isolation contract for \
+                 m7_docker_executor::large_captured_output_does_not_grow_this_process_proportionally \
+                 — it must keep targeting exactly this binary and test.",
+                overrides.iter().map(|o| &o.filter).collect::<Vec<_>>()
+            )
+        });
+
+    assert_eq!(
+        heavy.threads_required.as_ref().and_then(toml::Value::as_str),
+        Some("num-test-threads"),
+        "the #258 override must keep `threads-required = \"num-test-threads\"` \
+         (reserving the whole thread budget so the heavy test runs with no \
+         siblings) — not a numeric value, not absent, and deliberately not a \
+         `[test-groups]` entry (a group's max-threads only caps concurrency \
+         *within* the group, which does not address contention with \
+         everything outside it)."
+    );
+
+    // Deliberately not a test-groups conversion: assert no [test-groups]
+    // table exists in the raw document at all, since that would be exactly
+    // the "simplification" the checked-in comment forbids.
+    let doc: toml::Value = toml::from_str(&raw).expect("re-parsing as a generic Value must also succeed");
+    assert!(
+        doc.get("test-groups").is_none(),
+        "found a [test-groups] table in .config/nextest.toml — the #258 \
+         override must stay a profile override (threads-required), not be \
+         converted into a test group, which cannot express contention with \
+         tests outside the group."
+    );
+}


### PR DESCRIPTION
## What

The repo's **first** `.config/nextest.toml`, with one override:

```toml
[[profile.default.overrides]]
filter = 'binary_id(=sergeant-rs::m7_docker_executor) and test(=large_captured_output_does_not_grow_this_process_proportionally)'
threads-required = "num-test-threads"
```

## Why — four CI failures today, one common factor

Three distinct suites failed on CI on 2026-08-29, each while `m7_docker_executor::large_captured_output_does_not_grow_this_process_proportionally` ran long **in the same job**:

| test | failure | m7 concurrent |
|---|---|---|
| `estate_routes::get_doctor_matches_the_shape…` | `Transport("error sending request")` after >60s | SLOW >60s |
| `m9_watch::w7_stream_closure_is_honest…` | `daemon_pids().len()` = 2, expected 1 | SLOW >60s |
| `y6a_estate_scoped_scan::a_registered_repository…` (×2) | `reqwest … /v1/intelligence/scan … TimedOut` | **283.3s**, then **305.6s** |

All pass in isolation. 305s against an 88.6s solo runtime — m7 was starved **and** starving everything beside it. #258 already suspected this; these are the numbers.

## Proved, not assumed

**A victim actually failed here first.** `y6a`, run beside the heavy test under 32 CPU hogs at `-j 4`: **3/3 attempts FAILED before** (49.9 / 52.6 / 57.7s) with CI's exact signature, **3/3 passed after**. Script and logs in the evidence doc.

**The heavy test was starved too:** 142.7 / 147.6 / 144.6s → 97.9 / 102.8 / 100.7s (**−31%**) at 20 cores; 179.1 / 173.5s → 107.1 / 106.3s (**−39%**) at 4 CPUs.

**The schema was verified against the pinned binary, not against docs.** Corrupting the value makes `cargo nextest list` exit 96 with `profile.default.overrides[0].threads-required: invalid value: string "not-a-real-value", expected an integer, the string "num-cpus" or the string "num-test-threads"`. That single message proves the file is found, the `default` profile override is parsed (CI's `cargo nextest run --locked` names no profile), and the value is accepted by `cargo-nextest@0.9.99`.

**Narrowest filter that works:** `nextest list -E '<the filter>'` prints that one test and nothing else. The rest of `m7_docker_executor` (next-slowest 22.0s) still runs in parallel. Developer path with no flags still works.

## The cost, reported rather than absorbed

Total suite wall time gets **worse**:

| arm | 20 cores (3 runs) | 4 CPUs `-j 4` (2 runs) |
|---|---|---|
| before | mean **365.5s** | mean **1025.4s** |
| after | mean **386.6s** | mean **1095.5s** |

**+5% and +6.9%** — roughly **70s on a ~17-minute job**. A test that runs alone cannot share the box.

**Captain's call, taken: ship.** A flake class that broke four CI runs today, going 3/3 red → 3/3 green, plus 31–39% off the slowest test, is worth 7% of one job. **J2** (the brief delegated exactly this tradeoff and required it be reported, not decided in the lane). **R1** on the change itself.

## Panel — 2 raised, 2 confirmed

- The isolation contract was asserted only in a **comment**. Now pinned structurally: a test fails if the override is weakened, removed, or converted to the `test-groups` form the comment warns against.
- The CHANGELOG quoted a single-sample figure (+7.6%) where the evidence doc reports the two-run mean (+6.9%). Corrected to match its own cited source.

## Caveats, stated

- **Only one of three victims reproduced locally.** `estate_routes` and `m9_watch` never failed in any before-arm attempt on this host — said plainly rather than generalised.
- **A measurement-order mistake, self-reported:** the config was written while baseline run 2 was in flight, so run 3 began with it present; it is counted as an *after* sample and a genuine fourth baseline was taken later with the file moved aside. Evidence doc §3.
- Samples: 3/arm at 20 cores, 2/arm at 4 CPUs, one host, a container not a GitHub runner. Direction and rough magnitude, not a precise percentage.
- One unrelated flake in eight full runs (`m9_watch::r_watch_10a…`, a journal race). A `threads-required` override can only *reduce* concurrency, so it cannot have caused it — recorded so it is not attributed here.

`scripts/coverage/README.md` deliberately **not** edited: its sections cover wall-clock deadlines and asserted performance bounds, and this change asserts no figure in a test (R1, with the contract read in full).

Evidence: `knowledge/evidence/perf/m7-thread-budget-2026-08-29.md`.

Advances #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4