### PR TITLE
feat(atlas): S5 W4 — RRF fusion and deterministic reranking (A2 §7/§8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1414,6 +1414,59 @@ them were dead code in every real installation.
   of being excepted.
 
 
+### Rank fusion and deterministic reranking (S5)
+
+- **The two halves are now one answer.** `AtlasDb::fused_search` runs the BM25
+  and cosine halves over one query value and one admissibility filter and
+  fuses their rank lists with Reciprocal Rank Fusion — A2 §7's one expression,
+  `RRF(d) = Σ 1/(k + rank_i(d))`, and nothing around it. No weights, no score
+  normalization, no pluggable scorer, no learned or self-tuning ranker
+  (A2-08's **R6**; A2 §16's non-goals). `k = 60` is the published default,
+  a constant with its provenance written down rather than a tuning knob:
+  A2 §14 forbids exposing raw retrieval weight tuning, and there is nothing
+  here to expose.
+- **Determinism is pinned where it actually breaks, not where the formula
+  is.** RRF is exactly reproducible; the hazards are around it, and each has a
+  stated rule and its own test: candidate collection order (both input lists
+  are re-sorted with their own stated orders before any rank is assigned, so
+  `rank_i(d)` is a function of the hits and not of arrival), tie-breaking (one
+  stated key, the same `(source_name, relative_path, ordinal, unit_key)` both
+  halves already use), float summation order (two terms, added lexical-then-
+  semantic, an absent list contributing a literal zero), and `HashMap`
+  iteration (there is none — a structural test fails on the token). Two of the
+  four were checked by breaking the rule and watching the test go red; where
+  one such check turned out vacuous, a second test that does discriminate was
+  added rather than the claim being softened. This matters because A2 §4/§13
+  make a result derived evidence carrying an output hash and recorded ranks,
+  and a nondeterministic ranker cannot honour either.
+- **All nine of A2 §8's rerank signals are computed, and a test fails if any
+  one of them is ever declared but never fires.** Exact symbol/heading/filename
+  match; definition over reference when the query is identifier-like;
+  caller-selected source; Work-changed unit (reachable now that the overlay
+  reflects in-flight changes); same module/package/document section; inbound or
+  outbound structural relationship read from A1's own `source.edges`; canonical
+  implementation vs test/example/legacy path; knowledge source when `--type
+  knowledge` was requested; current generation unless the caller pinned one.
+  All of them reuse structure and provenance A1 already stores — §8's own
+  *"rather than training another ranker"*.
+- **Three of the nine are structurally uniform, and that is written down
+  rather than hidden.** Caller-selected source, `--type knowledge` and
+  current-generation cannot reorder anything, because A2-01 already turned each
+  of them into a *boundary*: an unselected source, a non-knowledge generation
+  and a superseded generation are not admissible, so there is nothing on the
+  wrong side of the preference left to outrank. They are still computed and
+  still carried, so a search trace can state them.
+- **The prohibition is proved a third time.** *"The reranker must never
+  silently cross an authority/source filter merely because a candidate scores
+  well."* Fusion is exactly where a second list could smuggle a candidate in,
+  so the negative is not inherited from the lexical and semantic waves: an
+  external decoy is shown winning the semantic list **and** the fused answer
+  with the filter open, and absent from the fused answer with it closed.
+- **The fused order does not depend on the caller's `limit`.** Both halves run
+  at the store's row ceiling so `rank_i(d)` is the rank within the admissible
+  set rather than within the slice a caller wanted to display; a narrower limit
+  returns a prefix of the wider answer, never a differently-ordered one.
+
 ### Container children are real resources (S5)
 
 - **An archive entry or a mail attachment now lands as its own resource,

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -351,3 +351,16 @@ cov_stage_end 1 "the w3b_semantic_retrieval test binary must write its own profi
 cov_stage_begin c2-w3b_model2vec_manifest_pin
 cov_run cargo llvm-cov --no-report --test w3b_model2vec_manifest_pin --locked || cov_fail "w3b_model2vec_manifest_pin failed under instrumentation"
 cov_stage_end 1 "the w3b_model2vec_manifest_pin test binary must write its own profile"
+
+# S5 W4, wired at birth (the #231 lesson, same as w1/w1b/w1c/w1d/w2/w3/w3b
+# above): A2 §7's Reciprocal Rank Fusion and A2 §8's deterministic
+# reranking — the one RRF expression, the four determinism hazards with a
+# rule and a test each, all nine of A2 §8's signals proved to actually fire,
+# and the A2 §8 prohibition proved a third time (fusion is where a second
+# list could smuggle an inadmissible candidate in). Loads the committed
+# model once per test process, like w3b_semantic_retrieval; builds Atlas
+# stores in tempdirs and records scans through the ordinary `record_scan`
+# path. No daemon, no estate, no subprocess of any kind. Floor 1.
+cov_stage_begin c2-w4_rrf_fusion
+cov_run cargo llvm-cov --no-report --test w4_rrf_fusion --locked || cov_fail "w4_rrf_fusion failed under instrumentation"
+cov_stage_end 1 "the w4_rrf_fusion test binary must write its own profile"

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -137,9 +137,12 @@ use crate::domain::workflow::{
     KIND_STAGE_FAILED, KIND_STAGE_NEEDS_INPUT, KIND_STAGE_WAITING, KIND_WORKFLOW_BOUND,
 };
 use crate::runtime::atlas::external_git::ExternalGitProvenance;
+use crate::runtime::atlas::fusion::{
+    FusedHit, RerankSignals, exact_match, fuse, is_canonical_path, rerank, same_section, symbol_of,
+};
 use crate::runtime::atlas::lexical::{
-    Bm25Corpus, LexicalFamily, LexicalHit, UnitCoordinate, bm25_contribution, query_terms,
-    rank_order, term_frequencies,
+    Bm25Corpus, LexicalFamily, LexicalHit, UnitCoordinate, bm25_contribution, is_identifier_like,
+    query_terms, rank_order, term_frequencies,
 };
 use crate::runtime::atlas::scan::{ScannedFile, ScannedSyntax, ScannedUnit, SourceScan};
 use crate::runtime::atlas::semantic::{
@@ -649,6 +652,15 @@ const LEXICAL_POSTINGS_SQL: &str = concat!(
       ORDER BY l.source_name, l.relative_path, l.ordinal, l.unit_key \
       LIMIT ?"
 );
+
+/// **Signal 6, inbound.** Every path in one generation holding an edge whose
+/// target is the anchor's symbol — i.e. the files that *reference* the
+/// anchor. A literal with bound values, like every other statement in this
+/// file (item 13's no-client-SQL pin).
+const EDGES_TO_TARGET_SQL: &str = "SELECT DISTINCT relative_path FROM source.edges      WHERE generation_id = ? AND target = ? ORDER BY relative_path LIMIT ?";
+
+/// **Signal 6, outbound.** Every symbol the anchor's own file references.
+const EDGES_FROM_PATH_SQL: &str = "SELECT DISTINCT target FROM source.edges      WHERE generation_id = ? AND relative_path = ? ORDER BY target LIMIT ?";
 
 /// The default row ceiling on a read from this store (F12).
 ///
@@ -3086,6 +3098,171 @@ impl AtlasDb {
         Ok(answer)
     }
 
+    /// A2 §7's Reciprocal Rank Fusion followed by A2 §8's deterministic
+    /// reranking: **one answer built from the two rank lists, inside one
+    /// admissibility filter.**
+    ///
+    /// # What this does, in order
+    ///
+    /// 1. Runs [`Self::lexical_search`] and [`Self::semantic_search`] over
+    ///    **the same [`LexicalQuery`] value** — one filter, both halves. Two
+    ///    lists produced from two differently-spelled filters are not
+    ///    fusable, which is why `semantic_search` was given this query type
+    ///    in W3b rather than one of its own.
+    /// 2. Fuses them with
+    ///    [`crate::runtime::atlas::fusion::fuse`] — A2 §7's one expression.
+    /// 3. Computes A2 §8's nine signals for every candidate
+    ///    ([`Self::rerank_signals`]) and reranks
+    ///    ([`crate::runtime::atlas::fusion::rerank`]).
+    /// 4. Truncates to the caller's `limit`.
+    ///
+    /// # Both halves run at [`MAX_ROWS`], not at the caller's `limit`
+    ///
+    /// `rank_i(d)` must be the candidate's rank **within the admissible
+    /// set**, not within whatever slice the caller wanted to display. If the
+    /// halves were run at `limit`, a unit at lexical rank 12 would be absent
+    /// from the lexical list at `limit = 10` and present at `limit = 20`, and
+    /// the fused *order of the first ten* would change with a display
+    /// parameter — a determinism hazard that looks like nothing until two
+    /// callers disagree. It costs no extra scanning: both halves already
+    /// score the whole admissible set and only truncate at the end.
+    /// `tests/w4_rrf_fusion.rs::
+    /// the_fused_order_does_not_depend_on_the_callers_limit` is the pin.
+    ///
+    /// # The prohibition
+    ///
+    /// *"The reranker must never silently cross an authority/source filter
+    /// merely because a candidate scores well."* Every candidate here came
+    /// from one of the two filtered lists;
+    /// [`crate::runtime::atlas::fusion::fuse`] holds no store handle and
+    /// cannot fetch one, and [`Self::rerank_signals`] only ever *marks*
+    /// candidates that already exist — its two `source.edges` reads are
+    /// scoped to the anchor's own (already admissible) generation and their
+    /// results are membership tests, never a source of new hits.
+    pub fn fused_search(&self, query: &LexicalQuery<'_>) -> Result<FusedAnswer, AtlasError> {
+        let full = LexicalQuery {
+            text: query.text,
+            filter: query.filter,
+            family: query.family,
+            limit: MAX_ROWS,
+            semantic: query.semantic,
+        };
+        let lexical = self.lexical_search(&full)?;
+        let semantic = self.semantic_search(&full)?;
+        let mut hits = fuse(&lexical.hits, &semantic.hits);
+        self.rerank_signals(query, &mut hits)?;
+        rerank(&mut hits);
+        hits.truncate(query.limit.min(MAX_ROWS));
+        Ok(FusedAnswer {
+            hits,
+            scope: lexical.scope,
+            truncated: lexical.truncated || semantic.truncated,
+            semantic: lexical.semantic,
+            semantic_model: lexical.semantic_model,
+        })
+    }
+
+    /// Fill in A2 §8's nine signals for every fused candidate, from A1's own
+    /// structure and provenance — *"rather than training another ranker"*
+    /// (§8), decision **A2-09 (R2)**: *"Structural relationships already
+    /// exist; reuse them."*
+    ///
+    /// The *anchor* for the two relational signals (5 and 6) is the candidate
+    /// RRF ranked first — `hits` arrives in
+    /// [`crate::runtime::atlas::fusion::rrf_order`], so the anchor is a
+    /// function of the fused score and the stated tie-break key, never of
+    /// iteration order.
+    fn rerank_signals(
+        &self,
+        query: &LexicalQuery<'_>,
+        hits: &mut [FusedHit],
+    ) -> Result<(), AtlasError> {
+        let Some(anchor) = hits.first() else {
+            return Ok(());
+        };
+        let anchor_coordinate = anchor.coordinate.clone();
+        let anchor_generation = anchor.generation_id.clone();
+        let anchor_symbol = symbol_of(&anchor_coordinate).map(str::to_string);
+
+        let terms = query_terms(query.text);
+        let identifier_like = is_identifier_like(query.text);
+        // Signal 3: the caller named a source at all. See
+        // `RerankSignals`'s own doc for why this is uniform.
+        let selected_source = !matches!(query.filter.source, SourceSelector::Any);
+        // Signal 8: `--type knowledge`.
+        let knowledge_requested = query.filter.kind == Some(SourceKind::LocalKnowledge);
+        // Signal 4: this Work's overlay source name, when the filter is a
+        // `--work` one. `None` for every other selector, so no non-Work query
+        // can accidentally match a unit whose source merely looks like one.
+        let overlay_source = query.filter.source.overlay_admit_source_name();
+        // Signal 9: the caller pinned an exact generation, so A2 §8's
+        // "unless caller pinned stale" suppresses the current-generation
+        // preference.
+        let pinned = matches!(query.filter.source, SourceSelector::Exact { .. });
+
+        // Signal 6, both directions, read once from the anchor's own
+        // generation.
+        let mut referencing_paths: BTreeSet<String> = BTreeSet::new();
+        let mut anchor_targets: BTreeSet<String> = BTreeSet::new();
+        if let Some(symbol) = &anchor_symbol {
+            let mut statement = self.conn.prepare(EDGES_TO_TARGET_SQL)?;
+            let mut rows =
+                statement.query(duckdb::params![anchor_generation, symbol, MAX_ROWS as i64])?;
+            while let Some(row) = rows.next()? {
+                referencing_paths.insert(row.get(0)?);
+            }
+        }
+        {
+            let mut statement = self.conn.prepare(EDGES_FROM_PATH_SQL)?;
+            let mut rows = statement.query(duckdb::params![
+                anchor_generation,
+                anchor_coordinate.relative_path(),
+                MAX_ROWS as i64
+            ])?;
+            while let Some(row) = rows.next()? {
+                anchor_targets.insert(row.get(0)?);
+            }
+        }
+
+        // Signal 9's other half: which generation is each source's current
+        // confirmed one. A `BTreeMap` cache, not a per-hit query.
+        let mut current: BTreeMap<String, Option<String>> = BTreeMap::new();
+        for hit in hits.iter() {
+            if !current.contains_key(&hit.source_name) {
+                let confirmed = self
+                    .confirmed_generation(&hit.source_name)?
+                    .map(|generation| generation.id);
+                current.insert(hit.source_name.clone(), confirmed);
+            }
+        }
+
+        for hit in hits.iter_mut() {
+            let same_generation = hit.generation_id == anchor_generation;
+            hit.signals = RerankSignals {
+                exact_match: exact_match(&terms, &hit.coordinate),
+                definition_over_reference: identifier_like
+                    && hit.coordinate.family() == LexicalFamily::Code,
+                caller_selected_source: selected_source,
+                work_changed_unit: overlay_source
+                    .as_deref()
+                    .is_some_and(|overlay| overlay == hit.source_name),
+                same_section_as_anchor: same_section(&anchor_coordinate, &hit.coordinate),
+                structural_relationship: same_generation
+                    && (referencing_paths.contains(hit.coordinate.relative_path())
+                        || symbol_of(&hit.coordinate)
+                            .is_some_and(|symbol| anchor_targets.contains(symbol))),
+                canonical_path: is_canonical_path(hit.coordinate.relative_path()),
+                knowledge_source_requested: knowledge_requested,
+                current_generation: pinned
+                    || current
+                        .get(&hit.source_name)
+                        .and_then(Option::as_deref)
+                        .is_some_and(|id| id == hit.generation_id),
+            };
+        }
+        Ok(())
+    }
+
     /// Rebuild the whole lexical index from the A1 rows it is derived from.
     ///
     /// The index is **derived evidence**: the journal, Git and the original
@@ -5122,6 +5299,41 @@ pub struct SemanticAnswer {
     pub semantic: SemanticStatus,
     /// A2 §13's *"semantic model identity/hash **if used**"*, populated only
     /// when [`Self::semantic`] is [`SemanticStatus::Applied`].
+    pub semantic_model: Option<SemanticModel>,
+}
+
+/// What one [`AtlasDb::fused_search`] answered: A2 §7's fused, A2 §8's
+/// reranked list, plus **the same four disclosure fields the two half-answers
+/// carry**.
+///
+/// The four are not copied out of tidiness. A fused answer is degraded in
+/// exactly the ways its inputs were, and a consumer that could not see that
+/// would read a lexical-only list as a fused one:
+///
+/// * [`Self::scope`] — `--work`'s overlay half is a snapshot, and a fused
+///   answer built over it inherits that ([`WorkScope`]).
+/// * [`Self::truncated`] — **either** half hitting [`MAX_ROWS`] truncates
+///   this answer, because a capped input list changes `rank_i(d)` for every
+///   candidate below the cap and therefore changes the fused score, not just
+///   the length of a list.
+/// * [`Self::semantic`] / [`Self::semantic_model`] — decision **H4**. When
+///   the status is not [`SemanticStatus::Applied`] this "fused" answer fused
+///   one list with an empty one, which is A2 §15's degraded state and must be
+///   readable as such rather than inferred from a suspiciously lexical-looking
+///   ordering.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FusedAnswer {
+    /// The reranked hits, best first — A2 §7's score then A2 §8's signals,
+    /// ties broken by
+    /// [`crate::runtime::atlas::fusion::FusedHit::tie_break_key`].
+    pub hits: Vec<FusedHit>,
+    /// What this answer covers — see [`WorkScope`].
+    pub scope: WorkScope,
+    /// Whether **either** input list hit [`MAX_ROWS`] and stopped.
+    pub truncated: bool,
+    /// A2 §15's required honesty about the semantic half (decision **H4**).
+    pub semantic: SemanticStatus,
+    /// A2 §13's *"semantic model identity/hash **if used**"*.
     pub semantic_model: Option<SemanticModel>,
 }
 

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -1642,6 +1642,27 @@ impl AtlasDb {
         }))
     }
 
+    /// `source.files`' recorded content hash for one path in one
+    /// generation, when that generation has a row for it at all (F-SF-01:
+    /// [`Self::rerank_signals`]'s only use — telling a Work-changed path
+    /// from a merely-visible one by comparing this against the base
+    /// generation's hash for the same path).
+    fn file_content_hash(
+        &self,
+        generation_id: &str,
+        relative_path: &str,
+    ) -> Result<Option<String>, AtlasError> {
+        let mut statement = self.conn.prepare(
+            "SELECT content_hash FROM source.files \
+             WHERE generation_id = ? AND relative_path = ?",
+        )?;
+        let mut rows = statement.query(duckdb::params![generation_id, relative_path])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row.get(0)?)),
+            None => Ok(None),
+        }
+    }
+
     /// Units of one source's confirmed generation, in path then ordinal
     /// order, bounded by `limit` (capped at [`MAX_ROWS`], F12).
     pub fn units(&self, source_name: &str, limit: usize) -> Result<Vec<StoredUnit>, AtlasError> {
@@ -3195,6 +3216,29 @@ impl AtlasDb {
         // `--work` one. `None` for every other selector, so no non-Work query
         // can accidentally match a unit whose source merely looks like one.
         let overlay_source = query.filter.source.overlay_admit_source_name();
+        // Signal 4's other half (F-SF-01): an overlay generation's universe
+        // is the base tree *plus* whatever the surface changed
+        // (`extract_overlay`, overlay.rs), so every unchanged path is
+        // indexed under the same overlay source name as every changed one —
+        // source-name equality alone cannot tell "the Work touched this"
+        // from "this is merely visible under the Work's view". The overlay
+        // schema carries no per-unit changed/unchanged flag, but
+        // `source.files` already carries a content hash per path (F7), and
+        // an unchanged path's overlay row is read from the exact same blob
+        // as the base tree's (overlay.rs's own doc: "an overlay and a plain
+        // estate-git scan of the same base agree on every unchanged path by
+        // construction"). So a path whose overlay content hash differs from
+        // the base generation's content hash at the same path — or is
+        // absent from the base entirely — is a path the Work actually
+        // changed; one whose hash matches is not, regardless of source
+        // name.
+        let base_generation_id = match &query.filter.source {
+            SourceSelector::WorkBase { repository, .. } => self
+                .confirmed_generation(repository)?
+                .map(|generation| generation.id),
+            _ => None,
+        };
+        let mut base_content_hash: BTreeMap<String, Option<String>> = BTreeMap::new();
         // Signal 9: the caller pinned an exact generation, so A2 §8's
         // "unless caller pinned stale" suppresses the current-generation
         // preference.
@@ -3238,14 +3282,34 @@ impl AtlasDb {
 
         for hit in hits.iter_mut() {
             let same_generation = hit.generation_id == anchor_generation;
+            let work_changed_unit = match overlay_source.as_deref() {
+                Some(overlay) if overlay == hit.source_name => match &base_generation_id {
+                    Some(base_id) => {
+                        let relative_path = hit.coordinate.relative_path();
+                        if !base_content_hash.contains_key(relative_path) {
+                            let hash = self.file_content_hash(base_id, relative_path)?;
+                            base_content_hash.insert(relative_path.to_string(), hash);
+                        }
+                        let base_hash = base_content_hash
+                            .get(relative_path)
+                            .and_then(Option::as_deref);
+                        let overlay_hash =
+                            self.file_content_hash(&hit.generation_id, relative_path)?;
+                        base_hash != overlay_hash.as_deref()
+                    }
+                    // No confirmed base generation to compare against —
+                    // nothing here can be shown to differ from it, so this
+                    // signal stays honestly false rather than guessing.
+                    None => false,
+                },
+                _ => false,
+            };
             hit.signals = RerankSignals {
                 exact_match: exact_match(&terms, &hit.coordinate),
                 definition_over_reference: identifier_like
                     && hit.coordinate.family() == LexicalFamily::Code,
                 caller_selected_source: selected_source,
-                work_changed_unit: overlay_source
-                    .as_deref()
-                    .is_some_and(|overlay| overlay == hit.source_name),
+                work_changed_unit,
                 same_section_as_anchor: same_section(&anchor_coordinate, &hit.coordinate),
                 structural_relationship: same_generation
                     && (referencing_paths.contains(hit.coordinate.relative_path())

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -121,7 +121,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use duckdb::types::Value as Duck;
-use duckdb::{Connection, Statement};
+use duckdb::{Connection, Statement, Transaction};
 use serde_json::{Map, Value, json};
 
 use crate::domain::event::{Event, unix_millis};
@@ -3168,10 +3168,28 @@ impl AtlasDb {
             limit: MAX_ROWS,
             semantic: query.semantic,
         };
+        // F-IN-01: `lexical_search` and `semantic_search` are two
+        // independent reads of `source.generations`/`source.edges`; without
+        // an enclosing transaction a concurrent writer's commit landing
+        // between them (e.g. `confirm_scan` promoting a generation) could
+        // hand back a fused answer built from two different committed
+        // states of the store — undermining A2 §4's output-hash
+        // reproducibility exactly as much as any of the four named
+        // determinism hazards would. `lexical_search`/`semantic_search`/
+        // `rerank_signals` all take `&self`, so the ordinary `Connection::
+        // transaction` (which requires `&mut self` to rule out nesting) is
+        // not available without widening every one of their signatures;
+        // `Transaction::new_unchecked` (R5) is the crate's own documented
+        // escape hatch for exactly this "`&mut Connection` is unacceptable"
+        // case, and opens the same snapshot-isolated transaction from a
+        // shared `&Connection`. It is dropped (and rolled back — nothing
+        // here writes) on every exit path, `?` included.
+        let snapshot = Transaction::new_unchecked(&self.conn)?;
         let lexical = self.lexical_search(&full)?;
         let semantic = self.semantic_search(&full)?;
         let mut hits = fuse(&lexical.hits, &semantic.hits);
         self.rerank_signals(query, &mut hits)?;
+        drop(snapshot);
         rerank(&mut hits);
         hits.truncate(query.limit.min(MAX_ROWS));
         Ok(FusedAnswer {

--- a/src/runtime/atlas/fusion.rs
+++ b/src/runtime/atlas/fusion.rs
@@ -1,0 +1,643 @@
+//! S5 W4 — A2 §7's Reciprocal Rank Fusion and A2 §8's deterministic
+//! reranking.
+//!
+//! # The fusion is one expression (A2 §7, decision A2-08, **R6**)
+//!
+//! A2 §7, verbatim: *"Fuse lexical and semantic rank lists with simple RRF
+//! rather than trying to normalize incomparable score scales:
+//! `RRF(d) = Σ 1 / (k + rank_i(d))`. This is intentionally one expression,
+//! then deterministic reranking."* A2-08's rung is **R6** — *"Rank fusion
+//! can remain a simple deterministic expression; no framework needed"* — and
+//! [`rrf_contribution`] is that one expression. There is no weight, no
+//! pluggable scorer, no registry of rankers: [`fuse`] takes exactly the two
+//! lists A2 §7 names and returns one list.
+//!
+//! **No number in this module is tunable by a caller** — [`RRF_K`] is a
+//! constant with its provenance stated, and nothing else here is a number at
+//! all. A2 §14's *"Do not expose raw retrieval weight tuning"* is met by
+//! there being nothing to expose (and A2 §16's *"trained/learned reranker"*
+//! and *"live self-tuning from Work outcomes"* non-goals by there being
+//! nothing that learns).
+//!
+//! # Where determinism actually breaks, and the rule for each
+//!
+//! `RRF(d) = Σ 1/(k + rank_i(d))` is exactly reproducible; the four hazards
+//! are all around it, and each one has a rule here and a test in
+//! `tests/w4_rrf_fusion.rs`:
+//!
+//! | # | Hazard | The rule |
+//! |---|---|---|
+//! | 1 | candidate collection order | [`fuse`] re-sorts **both** inputs with their own stated `rank_order`/`rank_semantic` before assigning any rank, so `rank_i(d)` is a function of the hits and never of the order a caller happened to hand them over in |
+//! | 2 | tie-breaking | one stated key — [`FusedHit::tie_break_key`], the *same* `(source_name, relative_path, ordinal, unit_key)` W2 and W3b each pinned — applied at every sort in this module |
+//! | 3 | float summation order | the sum has exactly two terms and they are added in a fixed source order (lexical, then semantic) by [`Accumulator::total`]; a missing list contributes a literal `0.0` rather than being skipped, so the expression is the same shape for every candidate |
+//! | 4 | `HashMap` iteration | there is no `HashMap` here. Candidates accumulate in a [`BTreeMap`] keyed by `(generation_id, unit_key)` |
+//!
+//! **And the rule binds the per-source lists, not just the fused one.**
+//! `rank_i(d)` is an INPUT: a wobbly BM25 or cosine ordering silently changes
+//! the fused result even when the fusion itself is perfect. W2 pinned
+//! `lexical::rank_order` and W3b pinned `semantic::rank_semantic`, and hazard
+//! 1 above is [`fuse`] refusing to *trust* that pinning — it re-applies it.
+//!
+//! Why this matters beyond tidiness: A2 §4 makes a daemon-owned query result
+//! *"derived evidence with query identity/input generation/result hash"*, and
+//! A2 §13 requires a search trace to record *"result evidence IDs + ranks"*.
+//! A nondeterministic ranker cannot honour either — the hash would not
+//! reproduce, and the recorded ranks would describe one run rather than the
+//! query.
+//!
+//! # A2 §8's nine signals
+//!
+//! §8 says *"After RRF, reuse A1 structure/provenance rather than training
+//! another ranker"* and lists nine. [`RerankSignals`] has one field per line
+//! of that list, **in the contract's own order**, and
+//! [`RerankSignals::priority`] is the rerank key. Three of the nine are
+//! structurally uniform within any one answer in this architecture rather
+//! than absent — that is recorded on each field, not hidden. See
+//! [`RerankSignals`]'s own doc for the field-by-field account.
+//!
+//! # The prohibition
+//!
+//! *"The reranker must never silently cross an authority/source filter merely
+//! because a candidate scores well."* [`fuse`] is a pure function of two
+//! already-filtered lists: **it has no store handle, so it cannot fetch a
+//! candidate**, and every candidate in its output came from one of its two
+//! inputs. `AtlasDb::fused_search` builds those two inputs from one
+//! `LexicalQuery` — one filter value, both halves — and the structural
+//! reading a *second* list makes necessary is the one
+//! `tests/w4_rrf_fusion.rs::
+//! an_inadmissible_unit_that_wins_the_semantic_list_never_reaches_the_fused_answer`
+//! makes non-vacuous: the decoy is shown ranking first, in the semantic list
+//! and in the fused answer, with the filter open, and absent from both with
+//! it closed.
+
+use std::collections::BTreeMap;
+
+use crate::runtime::atlas::lexical::{LexicalHit, UnitCoordinate, rank_order};
+use crate::runtime::atlas::semantic::{SemanticHit, rank_semantic};
+
+/// RRF's `k`.
+///
+/// **Provenance: this is the published default, not a measurement of this
+/// corpus.** `k = 60` is the value Cormack, Clarke and Büttcher's 2009 SIGIR
+/// paper introduced RRF with, and it is used here because no corpus of
+/// Sergeant evidence units has been measured against any other. When one is,
+/// this constant is the thing a measurement replaces; until then it is
+/// honest to say it was inherited rather than derived — exactly the account
+/// [`crate::runtime::atlas::lexical::BM25_K1`] gives of its own value.
+///
+/// It is a `const`, not a field and not a config key: A2 §14 forbids exposing
+/// raw retrieval weight tuning, and a constant nobody can set is the cheapest
+/// way to mean it (**R6**).
+pub const RRF_K: f64 = 60.0;
+
+/// One list's contribution to a candidate's fused score: `1 / (k + rank)`.
+///
+/// `rank` is **1-based** — the best hit in a list has rank 1 — so the first
+/// hit of a list contributes `1/61` rather than `1/60`. A 0-based rank would
+/// make the two spellings of "best" differ by a whole `k`-step and make this
+/// constant mean something else than the literature's.
+pub fn rrf_contribution(rank: usize) -> f64 {
+    1.0 / (RRF_K + rank as f64)
+}
+
+/// Which of A2 §7's two rank lists a candidate appeared in, and at what rank.
+///
+/// Kept on every [`FusedHit`] because A2 §13's trace records *"result
+/// evidence IDs + ranks"* — the fused score alone cannot say whether a hit
+/// arrived through BM25, through cosine, or through both, and "both" is the
+/// interesting answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RankOrigins {
+    /// 1-based rank in the lexical list, or `None` if it did not appear.
+    pub lexical: Option<usize>,
+    /// 1-based rank in the semantic list, or `None` if it did not appear.
+    pub semantic: Option<usize>,
+}
+
+/// A2 §8's nine signals, one field per line of the contract's list, **in the
+/// contract's own order** — which is also [`Self::priority`]'s order.
+///
+/// > exact symbol / heading / filename match
+/// > definition over reference when query is identifier-like
+/// > source explicitly selected by caller
+/// > Work-changed unit
+/// > same module/package/document section
+/// > inbound/outbound structural relationship
+/// > canonical implementation vs test/example/legacy path
+/// > knowledge source when `--type knowledge` requested
+/// > current exact generation over stale generation unless caller pinned stale
+///
+/// # Every one of the nine is computed; three of them are structurally
+/// uniform, and that is recorded rather than hidden
+///
+/// [`Self::caller_selected_source`], [`Self::knowledge_source_requested`] and
+/// [`Self::current_generation`] are true for **every** candidate of any one
+/// answer, or false for every candidate, and therefore never reorder
+/// anything. That is not an omission and not a stub — it is what A2-01
+/// (*"Filter source/authority/content/Work world before ranking"*) does to
+/// them. A preference the admissibility filter has already turned into a
+/// **boundary** cannot also be a ranking hint, because nothing on the wrong
+/// side of it survives to be ranked:
+///
+/// * *source explicitly selected by caller* — `SourceSelector::Named`/
+///   `Exact`/`WorkBase` are filters, so a hit from an unselected source does
+///   not exist to be outranked
+///   (`AtlasDb::admissible_generations`'s `WHERE`).
+/// * *knowledge source when `--type knowledge` requested* —
+///   `Admissibility::kind` is the same: `--type knowledge` admits
+///   `local_knowledge` generations and nothing else.
+/// * *current exact generation over stale generation* —
+///   `AtlasDb::confirm_scan` evicts a source's previous confirmed generation
+///   in the same transaction that promotes its successor, and eviction
+///   deletes the content rows, so **no stale generation is ever admissible**
+///   to begin with. Under `SourceSelector::Exact` — A2 §8's *"unless the
+///   caller pinned stale"* — the signal is deliberately set true for every
+///   candidate so the preference cannot fire against the pin.
+///
+/// They are still computed and still carried, because a signal that is
+/// uniform *today* is a different thing from one that is missing: it appears
+/// in the trace A2 §13 asks for, it discriminates the instant supersession
+/// ever keeps two confirmed generations of one source, and its being uniform
+/// is a checkable claim rather than a comment
+/// (`tests/w4_rrf_fusion.rs::
+/// the_three_filter_shaped_signals_are_uniform_because_admissibility_already_applied_them`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RerankSignals {
+    /// **1.** A query term is exactly this unit's symbol, heading/title, file
+    /// name or file stem — [`exact_match`].
+    pub exact_match: bool,
+    /// **2.** The query is identifier-like
+    /// ([`crate::runtime::atlas::lexical::is_identifier_like`]) and this
+    /// candidate is a grammar-claimed definition site rather than a prose
+    /// mention of the identifier.
+    ///
+    /// **The named gap in this signal is what A1 indexes, not what it
+    /// stores.** A1 records reference sites in `source.edges`, but
+    /// `indexable_units` derives retrievable units from `source.occurrences`
+    /// (definition sites) and `source.units`/`context.row_units` (prose and
+    /// row text) only — so a code *reference* is not a candidate at all, and
+    /// this signal discriminates "the definition" from "a document that
+    /// mentions the name". Destination for the fuller reading: indexing
+    /// `source.edges` as retrievable units is an A1-side change (a new unit
+    /// family), out of scope for W4 and not smuggled in as a ranking
+    /// workaround.
+    pub definition_over_reference: bool,
+    /// **3.** The caller named a source (`--source`, `--source@sha`,
+    /// `--work`). Uniform — see the type's own doc.
+    pub caller_selected_source: bool,
+    /// **4.** The unit came from this Work's overlay generation, i.e. it is a
+    /// unit the Work has **changed** — reachable since S5 W1d made the
+    /// overlay reflect in-flight changes rather than a freshly-cut worktree.
+    pub work_changed_unit: bool,
+    /// **5.** Same module/package/document section as the top RRF candidate —
+    /// [`same_section`].
+    pub same_section_as_anchor: bool,
+    /// **6.** An inbound or outbound `source.edges` relationship with the top
+    /// RRF candidate.
+    pub structural_relationship: bool,
+    /// **7.** A canonical implementation path rather than a
+    /// test/example/legacy one — [`is_canonical_path`].
+    pub canonical_path: bool,
+    /// **8.** `--type knowledge` was requested. Uniform — see the type's own
+    /// doc.
+    pub knowledge_source_requested: bool,
+    /// **9.** This is the current confirmed generation of its source (or the
+    /// caller pinned a generation, in which case it is uniformly true).
+    /// Uniform — see the type's own doc.
+    pub current_generation: bool,
+}
+
+impl RerankSignals {
+    /// The rerank key: the nine signals as an array, **in A2 §8's own listing
+    /// order**, compared descending (a fired signal outranks an unfired one).
+    ///
+    /// # Why a lexicographic array and not a score
+    ///
+    /// A score would need nine numbers, and A2 §14 forbids exposing raw
+    /// retrieval weight tuning while A2 §16 forbids anything learned or
+    /// self-tuning. There is no coefficient here to expose or to tune:
+    /// comparison is `bool` against `bool`, in a fixed order.
+    ///
+    /// # Why *this* order
+    ///
+    /// Because it is the contract's, and the contract supplies no other. A2
+    /// §8 prints the nine on nine lines; any precedence among them that is
+    /// not that order would be invented here, and inventing one silently is
+    /// the failure this program keeps producing. `tests/w4_rrf_fusion.rs::
+    /// the_rerank_key_is_a2_section_8s_nine_signals_in_the_contracts_own_order`
+    /// pins the array against the contract text.
+    pub fn priority(&self) -> [bool; 9] {
+        [
+            self.exact_match,
+            self.definition_over_reference,
+            self.caller_selected_source,
+            self.work_changed_unit,
+            self.same_section_as_anchor,
+            self.structural_relationship,
+            self.canonical_path,
+            self.knowledge_source_requested,
+            self.current_generation,
+        ]
+    }
+
+    /// How many of the nine fired — for a trace to render, never for
+    /// ordering. [`Self::priority`] is the order; a count would be a weight
+    /// system with every weight silently set to 1.
+    pub fn fired(&self) -> usize {
+        self.priority().iter().filter(|fired| **fired).count()
+    }
+}
+
+/// One fused candidate: A2 §7's score, the ranks it was computed from, the
+/// A2 §8 signals that reranked it, and the A1 coordinate every hit in this
+/// system carries.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FusedHit {
+    /// `Σ 1/(k + rank_i(d))` over the lists this candidate appeared in.
+    pub rrf: f64,
+    /// Which lists it appeared in, and where — A2 §13's *"result evidence IDs
+    /// + ranks"*.
+    pub origins: RankOrigins,
+    /// A2 §8's nine signals for this candidate. All false until
+    /// `AtlasDb::fused_search` computes them; [`fuse`] itself does not, and
+    /// cannot — six of the nine need the query, the filter or the store.
+    pub signals: RerankSignals,
+    /// The declared source.
+    pub source_name: String,
+    /// The exact SourceGeneration this unit belongs to.
+    pub generation_id: String,
+    /// That generation's content identity.
+    pub content_key: String,
+    /// The index's own per-generation unit identity.
+    pub unit_key: String,
+    /// A1's coordinate for the unit itself.
+    pub coordinate: UnitCoordinate,
+}
+
+impl FusedHit {
+    /// **The same stated tie-break key both input lists use** —
+    /// `(source_name, relative_path, ordinal, unit_key)`, see
+    /// [`crate::runtime::atlas::lexical::LexicalHit::tie_break_key`] and
+    /// [`crate::runtime::atlas::semantic::SemanticHit::tie_break_key`].
+    ///
+    /// Same key at all three levels on purpose: two lists that broke ties
+    /// differently would already have handed `fuse` a `rank_i(d)` that
+    /// depended on which half a tied unit reached first, and a fused list
+    /// that broke them a third way would undo the agreement.
+    pub fn tie_break_key(&self) -> (&str, &str, u64, &str) {
+        (
+            &self.source_name,
+            self.coordinate.relative_path(),
+            self.coordinate.ordinal(),
+            &self.unit_key,
+        )
+    }
+}
+
+/// Order two candidates by **A2 §7's fused score alone**: score descending by
+/// [`f64::total_cmp`], then [`FusedHit::tie_break_key`] ascending.
+///
+/// This is the order A2 §7 produces and A2 §8's *"then deterministic
+/// reranking"* consumes — [`rerank`] is the second step, and the two are
+/// separate functions so a reader (and a test) can see the fused order before
+/// any signal touched it.
+pub fn rrf_order(left: &FusedHit, right: &FusedHit) -> std::cmp::Ordering {
+    right
+        .rrf
+        .total_cmp(&left.rrf)
+        .then_with(|| left.tie_break_key().cmp(&right.tie_break_key()))
+}
+
+/// A2 §8's order: **signals first (descending, [`RerankSignals::priority`]),
+/// then the fused score, then the stated tie-break key.**
+///
+/// The RRF score is not discarded — it decides every pair whose signals are
+/// identical, which is the overwhelming majority of pairs, and RRF produces
+/// exact ties constantly (a candidate at rank 5 of one list and one at rank 5
+/// of the other score identically to the last bit), which is exactly what
+/// A2 §8's second step is for.
+pub fn rerank_order(left: &FusedHit, right: &FusedHit) -> std::cmp::Ordering {
+    right
+        .signals
+        .priority()
+        .cmp(&left.signals.priority())
+        .then_with(|| rrf_order(left, right))
+}
+
+/// A candidate under accumulation. Two `Option`s rather than a `Vec` of
+/// contributions: A2 §7 fuses exactly the two lists §7 names, and a `Vec`
+/// would be the beginning of the ranker framework A2-08's **R6** says not to
+/// build.
+struct Accumulator {
+    origins: RankOrigins,
+    hit: FusedHit,
+}
+
+impl Accumulator {
+    /// Hazard 3 — **float summation order.** Two terms, added in one fixed
+    /// order (lexical, then semantic), with an absent list contributing a
+    /// literal `0.0` rather than being skipped. `a + b` and `b + a` differ in
+    /// f64 whenever rounding differs, so the order is written down here once
+    /// instead of falling out of whichever list a candidate happened to be
+    /// found in first.
+    fn total(&self) -> f64 {
+        let lexical = self.origins.lexical.map_or(0.0, rrf_contribution);
+        let semantic = self.origins.semantic.map_or(0.0, rrf_contribution);
+        lexical + semantic
+    }
+}
+
+/// A2 §7, the whole of it: fuse a lexical and a semantic rank list into one
+/// ordered list of candidates.
+///
+/// # Determinism, in the order the hazards appear
+///
+/// 1. **Candidate collection order.** Both inputs are re-sorted with their
+///    own stated orders ([`rank_order`], [`rank_semantic`]) before any rank
+///    is assigned, so `rank_i(d)` is a function of the hits themselves. A
+///    caller that hands over a shuffled list gets the same answer as one that
+///    hands over a sorted one.
+/// 2. **Tie-breaking.** [`rrf_order`], the same stated key both inputs use.
+/// 3. **Float summation order.** [`Accumulator::total`].
+/// 4. **`HashMap` iteration.** The accumulator is a [`BTreeMap`] keyed by
+///    `(generation_id, unit_key)` — the identity both halves already agree on
+///    (`tests/w3b_semantic_retrieval.rs::
+///    a_semantic_hit_and_a_lexical_hit_on_the_same_unit_carry_the_identical_coordinate`
+///    is why that join is sound).
+///
+/// # The prohibition, structurally
+///
+/// This function takes no store handle and performs no lookup. Every hit it
+/// returns came from one of its two arguments, both of which were produced
+/// inside A2 §2's admissibility filter — so *"the reranker must never
+/// silently cross an authority/source filter"* is a property of the
+/// signature, not of a check someone has to remember.
+///
+/// Signals are left at [`RerankSignals::default`] (all false); the caller
+/// computes them and calls [`rerank`].
+pub fn fuse(lexical: &[LexicalHit], semantic: &[SemanticHit]) -> Vec<FusedHit> {
+    let mut lexical: Vec<&LexicalHit> = lexical.iter().collect();
+    lexical.sort_by(|a, b| rank_order(a, b));
+    let mut semantic: Vec<&SemanticHit> = semantic.iter().collect();
+    semantic.sort_by(|a, b| rank_semantic(a, b));
+
+    let mut candidates: BTreeMap<(String, String), Accumulator> = BTreeMap::new();
+    for (index, hit) in lexical.iter().enumerate() {
+        candidates
+            .entry((hit.generation_id.clone(), hit.unit_key.clone()))
+            .or_insert_with(|| Accumulator {
+                origins: RankOrigins::default(),
+                hit: FusedHit {
+                    rrf: 0.0,
+                    origins: RankOrigins::default(),
+                    signals: RerankSignals::default(),
+                    source_name: hit.source_name.clone(),
+                    generation_id: hit.generation_id.clone(),
+                    content_key: hit.content_key.clone(),
+                    unit_key: hit.unit_key.clone(),
+                    coordinate: hit.coordinate.clone(),
+                },
+            })
+            .origins
+            .lexical = Some(index + 1);
+    }
+    for (index, hit) in semantic.iter().enumerate() {
+        candidates
+            .entry((hit.generation_id.clone(), hit.unit_key.clone()))
+            .or_insert_with(|| Accumulator {
+                origins: RankOrigins::default(),
+                hit: FusedHit {
+                    rrf: 0.0,
+                    origins: RankOrigins::default(),
+                    signals: RerankSignals::default(),
+                    source_name: hit.source_name.clone(),
+                    generation_id: hit.generation_id.clone(),
+                    content_key: hit.content_key.clone(),
+                    unit_key: hit.unit_key.clone(),
+                    coordinate: hit.coordinate.clone(),
+                },
+            })
+            .origins
+            .semantic = Some(index + 1);
+    }
+
+    let mut fused: Vec<FusedHit> = candidates
+        .into_values()
+        .map(|accumulator| {
+            let rrf = accumulator.total();
+            let mut hit = accumulator.hit;
+            hit.rrf = rrf;
+            hit.origins = accumulator.origins;
+            hit
+        })
+        .collect();
+    fused.sort_by(rrf_order);
+    fused
+}
+
+/// A2 §8's second step, applied to a list [`fuse`] produced and a caller
+/// filled the signals of. Sorts by [`rerank_order`].
+pub fn rerank(hits: &mut [FusedHit]) {
+    hits.sort_by(rerank_order);
+}
+
+// ---------------------------------------------------------------------------
+// The pure halves of A2 §8's signals — the ones that are a function of the
+// query text and the coordinate, with no store access.
+// ---------------------------------------------------------------------------
+
+/// **Signal 1**, *"exact symbol / heading / filename match"*: one of the
+/// query's distinct terms is exactly this unit's symbol, its heading/title,
+/// its file name, or that file name's stem.
+///
+/// `terms` is [`crate::runtime::atlas::lexical::query_terms`]'s output —
+/// already lowercased, distinct and sorted — and every candidate string is
+/// lowercased here, so "exact" means exact up to the case-folding the whole
+/// retrieval path already does (W2: *"the exact-case spelling survives in the
+/// A1 unit the hit cites, which is where an answer's exactness actually
+/// lives"*).
+///
+/// A `RowText` unit's "name" is its row key — A2 §3's structured-text
+/// coordinate has no heading and no symbol, and the row id is the only name
+/// that coordinate carries.
+pub fn exact_match(terms: &[String], coordinate: &UnitCoordinate) -> bool {
+    let mut names: Vec<String> = Vec::new();
+    let path = coordinate.relative_path();
+    if let Some(file_name) = path.rsplit('/').next() {
+        names.push(file_name.to_lowercase());
+        if let Some((stem, _)) = file_name.split_once('.') {
+            names.push(stem.to_lowercase());
+        }
+    }
+    match coordinate {
+        UnitCoordinate::Code { symbol, .. } => names.push(symbol.to_lowercase()),
+        UnitCoordinate::Document { title, .. } | UnitCoordinate::Mail { title, .. } => {
+            if let Some(title) = title {
+                names.push(title.to_lowercase());
+            }
+        }
+        UnitCoordinate::RowText { row_key, .. } => names.push(row_key.to_lowercase()),
+    }
+    names
+        .iter()
+        .any(|name| !name.is_empty() && terms.iter().any(|term| term == name))
+}
+
+/// The path segments and file-name shapes that make a path a
+/// test/example/legacy one rather than a canonical implementation — **signal
+/// 7**'s whole vocabulary, in one place so a test can read it.
+///
+/// A directory-segment match, not a substring match: `src/contest/mod.rs`
+/// contains "test" and is not a test path. `tests/w4_rrf_fusion.rs::
+/// the_canonical_path_vocabulary_matches_segments_not_substrings` is what
+/// keeps that true.
+pub const NON_CANONICAL_SEGMENTS: [&str; 11] = [
+    "test",
+    "tests",
+    "testing",
+    "spec",
+    "specs",
+    "example",
+    "examples",
+    "fixtures",
+    "benches",
+    "legacy",
+    "deprecated",
+];
+
+/// The file-name shapes that mark a test file living outside any test
+/// directory — Rust's `foo_test.rs`, Python's `test_foo.py`, JavaScript's
+/// `foo.test.js`/`foo.spec.ts`.
+const TEST_FILE_MARKERS: [&str; 4] = ["_test.", "test_", ".test.", ".spec."];
+
+/// **Signal 7**, *"canonical implementation vs test/example/legacy path"*:
+/// true for a path that is neither.
+///
+/// The signal is stated positively (canonical fires, non-canonical does not)
+/// because [`RerankSignals::priority`] compares descending — a `true` outranks
+/// a `false`, and the contract's preference is *for* the canonical one.
+pub fn is_canonical_path(relative_path: &str) -> bool {
+    let lowered = relative_path.to_lowercase();
+    let mut segments: Vec<&str> = lowered.split('/').collect();
+    let file_name = segments.pop().unwrap_or_default();
+    if segments
+        .iter()
+        .any(|segment| NON_CANONICAL_SEGMENTS.contains(segment))
+    {
+        return false;
+    }
+    if TEST_FILE_MARKERS.iter().any(|marker| {
+        file_name.contains(marker) || file_name.starts_with(marker.trim_end_matches('.'))
+    }) {
+        return false;
+    }
+    true
+}
+
+/// **Signal 5**, *"same module/package/document section"*, measured against
+/// the top RRF candidate (the *anchor*).
+///
+/// Two readings, because A2 §3 gives code and prose different coordinates:
+///
+/// * **the same document** — identical `relative_path`. For a document or
+///   mail unit that is A2 §3's *"heading-or-slide/section"* neighbourhood:
+///   two sections of one file. For a row-text unit it is the same dataset
+///   file.
+/// * **the same module/package** — identical parent directory. For code that
+///   is the module or package neighbourhood A2 §8 names; a directory is the
+///   module unit every language in A1's grammar set actually has on disk.
+///
+/// The anchor trivially satisfies this against itself, which is correct: it
+/// is in its own section.
+pub fn same_section(anchor: &UnitCoordinate, other: &UnitCoordinate) -> bool {
+    let anchor_path = anchor.relative_path();
+    let other_path = other.relative_path();
+    if anchor_path == other_path {
+        return true;
+    }
+    parent_of(anchor_path) == parent_of(other_path)
+}
+
+/// The directory part of a relative path, or `""` for a path at the root.
+fn parent_of(relative_path: &str) -> &str {
+    match relative_path.rfind('/') {
+        Some(cut) => &relative_path[..cut],
+        None => "",
+    }
+}
+
+/// The symbol a coordinate names, when it names one — what
+/// `source.edges.target` is matched against for **signal 6**.
+pub fn symbol_of(coordinate: &UnitCoordinate) -> Option<&str> {
+    match coordinate {
+        UnitCoordinate::Code { symbol, .. } => Some(symbol.as_str()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn code(path: &str, symbol: &str) -> UnitCoordinate {
+        UnitCoordinate::Code {
+            relative_path: path.to_string(),
+            language: "rust".to_string(),
+            label: "function".to_string(),
+            symbol: symbol.to_string(),
+            ordinal: 0,
+            byte_start: 0,
+            byte_end: 1,
+        }
+    }
+
+    #[test]
+    fn the_expression_is_one_over_k_plus_a_one_based_rank() {
+        assert_eq!(rrf_contribution(1), 1.0 / (RRF_K + 1.0));
+        assert_eq!(rrf_contribution(2), 1.0 / (RRF_K + 2.0));
+        assert!(rrf_contribution(1) > rrf_contribution(2));
+    }
+
+    #[test]
+    fn appearing_in_both_lists_outscores_appearing_in_one_at_the_same_rank() {
+        assert!(rrf_contribution(1) + rrf_contribution(1) > rrf_contribution(1));
+    }
+
+    #[test]
+    fn a_test_directory_or_a_test_file_name_is_not_a_canonical_path() {
+        assert!(is_canonical_path("src/runtime/atlas/fusion.rs"));
+        assert!(!is_canonical_path("tests/w4_rrf_fusion.rs"));
+        assert!(!is_canonical_path("crates/a/examples/demo.rs"));
+        assert!(!is_canonical_path("src/legacy/old.rs"));
+        assert!(!is_canonical_path("src/parser_test.rs"));
+        assert!(!is_canonical_path("src/test_parser.py"));
+        assert!(!is_canonical_path("web/app.test.ts"));
+        // A segment match, never a substring match.
+        assert!(is_canonical_path("src/contest/mod.rs"));
+        assert!(is_canonical_path("src/latest.rs"));
+    }
+
+    #[test]
+    fn same_section_is_the_same_file_or_the_same_directory() {
+        let a = code("src/payments/retry.rs", "retry");
+        let b = code("src/payments/charge.rs", "charge");
+        let c = code("src/config/loader.rs", "load");
+        assert!(same_section(&a, &a));
+        assert!(same_section(&a, &b));
+        assert!(!same_section(&a, &c));
+    }
+
+    #[test]
+    fn an_exact_symbol_or_file_name_match_fires_and_a_partial_one_does_not() {
+        let terms = vec!["retry".to_string()];
+        assert!(exact_match(
+            &terms,
+            &code("src/payments/charge.rs", "retry")
+        ));
+        assert!(exact_match(&terms, &code("src/payments/retry.rs", "other")));
+        assert!(!exact_match(
+            &terms,
+            &code("src/payments/retrying.rs", "retry_policy")
+        ));
+    }
+}

--- a/src/runtime/atlas/fusion.rs
+++ b/src/runtime/atlas/fusion.rs
@@ -329,11 +329,39 @@ pub fn rerank_order(left: &FusedHit, right: &FusedHit) -> std::cmp::Ordering {
 /// would be the beginning of the ranker framework A2-08's **R6** says not to
 /// build.
 struct Accumulator {
-    origins: RankOrigins,
     hit: FusedHit,
 }
 
 impl Accumulator {
+    /// A fresh candidate's skeleton, from the five identifying fields
+    /// [`LexicalHit`] and [`SemanticHit`] both carry (F-SI-01: the two call
+    /// sites in [`fuse`] differed only in which of `origins.lexical`/
+    /// `origins.semantic` they went on to set). `origins` starts at
+    /// [`RankOrigins::default`] and is mutated in place by the caller —
+    /// there is exactly one copy of it, so there is nothing left to
+    /// overwrite at [`fuse`]'s finalize step the way a second, accumulator-
+    /// level copy once required (F-SI-02).
+    fn new(
+        source_name: &str,
+        generation_id: &str,
+        content_key: &str,
+        unit_key: &str,
+        coordinate: &UnitCoordinate,
+    ) -> Self {
+        Accumulator {
+            hit: FusedHit {
+                rrf: 0.0,
+                origins: RankOrigins::default(),
+                signals: RerankSignals::default(),
+                source_name: source_name.to_string(),
+                generation_id: generation_id.to_string(),
+                content_key: content_key.to_string(),
+                unit_key: unit_key.to_string(),
+                coordinate: coordinate.clone(),
+            },
+        }
+    }
+
     /// Hazard 3 — **float summation order.** Two terms, added in one fixed
     /// order (lexical, then semantic), with an absent list contributing a
     /// literal `0.0` rather than being skipped. `a + b` and `b + a` differ in
@@ -341,8 +369,8 @@ impl Accumulator {
     /// instead of falling out of whichever list a candidate happened to be
     /// found in first.
     fn total(&self) -> f64 {
-        let lexical = self.origins.lexical.map_or(0.0, rrf_contribution);
-        let semantic = self.origins.semantic.map_or(0.0, rrf_contribution);
+        let lexical = self.hit.origins.lexical.map_or(0.0, rrf_contribution);
+        let semantic = self.hit.origins.semantic.map_or(0.0, rrf_contribution);
         lexical + semantic
     }
 }
@@ -385,38 +413,32 @@ pub fn fuse(lexical: &[LexicalHit], semantic: &[SemanticHit]) -> Vec<FusedHit> {
     for (index, hit) in lexical.iter().enumerate() {
         candidates
             .entry((hit.generation_id.clone(), hit.unit_key.clone()))
-            .or_insert_with(|| Accumulator {
-                origins: RankOrigins::default(),
-                hit: FusedHit {
-                    rrf: 0.0,
-                    origins: RankOrigins::default(),
-                    signals: RerankSignals::default(),
-                    source_name: hit.source_name.clone(),
-                    generation_id: hit.generation_id.clone(),
-                    content_key: hit.content_key.clone(),
-                    unit_key: hit.unit_key.clone(),
-                    coordinate: hit.coordinate.clone(),
-                },
+            .or_insert_with(|| {
+                Accumulator::new(
+                    &hit.source_name,
+                    &hit.generation_id,
+                    &hit.content_key,
+                    &hit.unit_key,
+                    &hit.coordinate,
+                )
             })
+            .hit
             .origins
             .lexical = Some(index + 1);
     }
     for (index, hit) in semantic.iter().enumerate() {
         candidates
             .entry((hit.generation_id.clone(), hit.unit_key.clone()))
-            .or_insert_with(|| Accumulator {
-                origins: RankOrigins::default(),
-                hit: FusedHit {
-                    rrf: 0.0,
-                    origins: RankOrigins::default(),
-                    signals: RerankSignals::default(),
-                    source_name: hit.source_name.clone(),
-                    generation_id: hit.generation_id.clone(),
-                    content_key: hit.content_key.clone(),
-                    unit_key: hit.unit_key.clone(),
-                    coordinate: hit.coordinate.clone(),
-                },
+            .or_insert_with(|| {
+                Accumulator::new(
+                    &hit.source_name,
+                    &hit.generation_id,
+                    &hit.content_key,
+                    &hit.unit_key,
+                    &hit.coordinate,
+                )
             })
+            .hit
             .origins
             .semantic = Some(index + 1);
     }
@@ -427,7 +449,6 @@ pub fn fuse(lexical: &[LexicalHit], semantic: &[SemanticHit]) -> Vec<FusedHit> {
             let rrf = accumulator.total();
             let mut hit = accumulator.hit;
             hit.rrf = rrf;
-            hit.origins = accumulator.origins;
             hit
         })
         .collect();

--- a/src/runtime/atlas/fusion.rs
+++ b/src/runtime/atlas/fusion.rs
@@ -185,9 +185,12 @@ pub struct RerankSignals {
     /// **3.** The caller named a source (`--source`, `--source@sha`,
     /// `--work`). Uniform — see the type's own doc.
     pub caller_selected_source: bool,
-    /// **4.** The unit came from this Work's overlay generation, i.e. it is a
-    /// unit the Work has **changed** — reachable since S5 W1d made the
-    /// overlay reflect in-flight changes rather than a freshly-cut worktree.
+    /// **4.** The unit's path is one the Work has **changed** — its
+    /// overlay-generation content hash differs from the base generation's
+    /// hash at the same path (F-SF-01) — not merely one visible under the
+    /// overlay's source name, which every unchanged path under it is too.
+    /// Reachable since S5 W1d made the overlay reflect in-flight changes
+    /// rather than a freshly-cut worktree.
     pub work_changed_unit: bool,
     /// **5.** Same module/package/document section as the top RRF candidate —
     /// [`same_section`].

--- a/src/runtime/atlas/lexical.rs
+++ b/src/runtime/atlas/lexical.rs
@@ -255,6 +255,36 @@ fn case_split(word: &str) -> Vec<&str> {
     parts
 }
 
+/// Whether `text` **names an identifier** — A2 §8's *"when the query is
+/// identifier-like"*, and the gate on that signal
+/// ([`crate::runtime::atlas::fusion::RerankSignals::definition_over_reference`]).
+///
+/// True when any compound in the text is one this tokenizer would split:
+/// it holds a separator (`payment_retry_policy`, `Foo::bar`) or splits at a
+/// camel/digit boundary (`PaymentRetryPolicy`, `INC0012345`). A query of
+/// ordinary words — *"how do we retry a failed payment charge"* — is not
+/// identifier-like, and neither is a single lowercase word, because a
+/// one-word query cannot distinguish "the symbol `retry`" from "the topic
+/// retry" and guessing which was meant is not something evidence supports.
+///
+/// It reuses [`compounds_of`] and [`case_split`] — the same two functions
+/// [`tokenize`] runs — rather than re-deriving what an identifier looks like
+/// (**R2**); a second definition of "identifier-shaped" would be a second
+/// tokenizer, drifting from the first the first time either changed.
+pub fn is_identifier_like(text: &str) -> bool {
+    compounds_of(text).into_iter().any(|(start, end)| {
+        let compound = &text[start..end];
+        if !compound.chars().any(char::is_alphanumeric) {
+            return false;
+        }
+        let words: Vec<&str> = compound
+            .split(is_separator)
+            .filter(|w| !w.is_empty())
+            .collect();
+        words.len() > 1 || words.iter().any(|word| case_split(word).len() > 1)
+    })
+}
+
 /// Distinct query terms, in a deterministic order — [`tokenize`] with
 /// repeats folded away, because a term repeated in the *query* multiplies a
 /// document's score without saying anything more about the document.
@@ -596,6 +626,27 @@ mod tests {
             average_length: 5.0,
         };
         assert!(bm25_contribution(corpus, 10, 3, 5) >= 0.0);
+    }
+
+    #[test]
+    fn identifier_shaped_queries_are_recognised_and_prose_is_not() {
+        for identifier in [
+            "PaymentRetryPolicy",
+            "payment_retry_policy",
+            "payment-retry-policy",
+            "Foo::bar",
+            "INC0012345",
+            "where is retry_charge defined",
+        ] {
+            assert!(is_identifier_like(identifier), "{identifier}");
+        }
+        for prose in [
+            "how do we retry a failed payment charge",
+            "retry",
+            "what did we decide about asynchronous settlement",
+        ] {
+            assert!(!is_identifier_like(prose), "{prose}");
+        }
     }
 
     #[test]

--- a/src/runtime/atlas/mod.rs
+++ b/src/runtime/atlas/mod.rs
@@ -179,6 +179,7 @@ pub mod archive;
 pub mod db;
 pub mod deny;
 pub mod external_git;
+pub mod fusion;
 pub mod git;
 pub mod lane;
 pub mod lexical;

--- a/tests/w4_rrf_fusion.rs
+++ b/tests/w4_rrf_fusion.rs
@@ -12,7 +12,7 @@
 //! |---|---|
 //! | candidate collection order | [`the_order_the_two_lists_arrive_in_cannot_change_the_fused_answer`] |
 //! | tie-breaking | [`tied_fused_scores_are_broken_by_the_stated_key_not_by_arrival_order`] |
-//! | float summation order | [`the_two_contributions_are_summed_in_a_fixed_source_order`] |
+//! | float summation order | [`the_two_contributions_sum_to_the_documented_formula`] |
 //! | `HashMap` iteration | [`no_hash_map_or_hash_set_reaches_the_fusion_module`] |
 //!
 //! Two of them were checked the way W3b checked its own — by breaking the
@@ -246,32 +246,36 @@ fn tied_fused_scores_follow_the_key_even_when_the_map_order_disagrees() {
 
 // ------------------------------------------------ hazard 3: summation order
 
-/// **Hazard 3 — float summation order.** `a + b` and `b + a` differ in f64
-/// whenever rounding differs, so the two contributions are summed in a fixed
-/// source order (lexical, then semantic) rather than in whichever order a
-/// candidate happened to be discovered.
+/// **Hazard 3 — float summation order, honestly scoped (F-TH-01).** `a + b`
+/// and `b + a` are bit-identical for any two finite `f64` operands — IEEE-754
+/// addition is exactly commutative for two terms — so no fixture can ever
+/// show `Accumulator::total`'s documented `lexical + semantic` order
+/// diverging from its reverse: verified live by swapping the order in
+/// `Accumulator::total` and rerunning the original version of this test,
+/// which still passed. A bit-identical comparison between two mirrored
+/// candidates is therefore not a test of anything the module does.
 ///
-/// Two mirrored candidates: one is lexical-rank-1/semantic-rank-2, the other
-/// lexical-rank-2/semantic-rank-1. Their totals must be **bit-identical** —
-/// which is only guaranteed because both are computed as
-/// `lexical_term + semantic_term`, in that order, and never as
-/// "the term I found first + the term I found second".
+/// What *is* real, and is checked here instead: that the total is exactly
+/// the documented **formula** — the sum of the two contributions the
+/// candidate's ranks name, and nothing else. A different `k`, an extra
+/// term, or a mean instead of a sum would all fail this, where the old
+/// pairwise-equality check would not have caught any of them either (both
+/// mirrored candidates would still tie on whatever wrong formula was used).
 #[test]
-fn the_two_contributions_are_summed_in_a_fixed_source_order() {
+fn the_two_contributions_sum_to_the_documented_formula() {
     let fused = fuse(
         &[lexical("aaa", 5.0), lexical("bbb", 4.0)],
         &[semantic("bbb", 0.9), semantic("aaa", 0.8)],
     );
     assert_eq!(fused.len(), 2);
-    assert_eq!(
-        fused[0].rrf.to_bits(),
-        fused[1].rrf.to_bits(),
-        "mirrored rank profiles must sum to identical bits, not merely to \
-         approximately equal floats"
-    );
-    // And the summation is the one the module documents, not an accident of
-    // this fixture's symmetry.
-    assert_eq!(fused[0].rrf, rrf_contribution(1) + rrf_contribution(2));
+    let expected = rrf_contribution(1) + rrf_contribution(2);
+    for hit in &fused {
+        assert_eq!(
+            hit.rrf, expected,
+            "a lexical-rank-1/semantic-rank-2 candidate (or its mirror) must \
+             total exactly rrf_contribution(1) + rrf_contribution(2): {hit:#?}"
+        );
+    }
 }
 
 // -------------------------------------------------- hazard 4: HashMap

--- a/tests/w4_rrf_fusion.rs
+++ b/tests/w4_rrf_fusion.rs
@@ -1,0 +1,1114 @@
+//! S5 W4 — A2 §7's RRF and A2 §8's deterministic reranking.
+//!
+//! # What this suite proves, claim by claim
+//!
+//! **The expression** — [`the_fused_score_is_a2_section_7s_one_expression`]
+//! computes `Σ 1/(k + rank_i(d))` by hand and compares bit-for-bit.
+//!
+//! **The four determinism hazards**, one test each, because they fail
+//! differently:
+//!
+//! | Hazard | Test |
+//! |---|---|
+//! | candidate collection order | [`the_order_the_two_lists_arrive_in_cannot_change_the_fused_answer`] |
+//! | tie-breaking | [`tied_fused_scores_are_broken_by_the_stated_key_not_by_arrival_order`] |
+//! | float summation order | [`the_two_contributions_are_summed_in_a_fixed_source_order`] |
+//! | `HashMap` iteration | [`no_hash_map_or_hash_set_reaches_the_fusion_module`] |
+//!
+//! Two of them were checked the way W3b checked its own — by breaking the
+//! rule and watching the test go red. That is recorded on each test.
+//!
+//! **The prohibition** —
+//! [`an_inadmissible_unit_that_wins_the_semantic_list_never_reaches_the_fused_answer`],
+//! made non-vacuous the way W2 and W3b made theirs: the decoy is shown
+//! winning the semantic list *and* the fused answer with the filter open, and
+//! absent from the fused answer with it closed. Fusion is exactly where a
+//! second list could smuggle a candidate in, which is why the same negative
+//! is proved a third time rather than inherited.
+//!
+//! **All nine of A2 §8's signals** —
+//! [`every_one_of_a2_section_8s_nine_signals_actually_fires`] collects the
+//! signals fired across six real searches and fails unless every one of the
+//! nine has fired at least once. A signal that was implemented as a field and
+//! never computed would pass a "the struct has nine fields" test and fail
+//! this one.
+//!
+//! **That reranking reranks** — three tests show a candidate moving because
+//! of a signal ([`an_exact_name_match_is_promoted_over_a_better_fused_score`],
+//! [`a_work_changed_unit_is_promoted_over_its_unchanged_base`],
+//! [`a_test_path_loses_to_a_canonical_one_at_an_equal_fused_score`]).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use sergeant_rs::domain::event::rfc3339_utc_now;
+use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
+use sergeant_rs::runtime::atlas::db::{
+    Admissibility, AtlasDb, FusedAnswer, LexicalQuery, SourceSelector,
+};
+use sergeant_rs::runtime::atlas::fusion::{
+    FusedHit, RRF_K, RankOrigins, RerankSignals, fuse, rerank, rrf_contribution, rrf_order,
+};
+use sergeant_rs::runtime::atlas::lexical::{LexicalFamily, LexicalHit, UnitCoordinate};
+use sergeant_rs::runtime::atlas::record::{record_scan, scan_and_record};
+use sergeant_rs::runtime::atlas::scan::{
+    EDGE_IMPORT, KnowledgeSource, ScannedEdge, ScannedFile, ScannedSymbol, ScannedSyntax,
+    ScannedUnit, SourceScan,
+};
+use sergeant_rs::runtime::atlas::semantic::{MODEL_DIR_ENV, SemanticRequest, SemanticStatus};
+use sergeant_rs::runtime::atlas::tabular::ContextFields;
+use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+use sergeant_rs::runtime::journal::Journal;
+
+// ------------------------------------------------- pure fusion fixtures
+
+fn coordinate(path: &str, symbol: &str) -> UnitCoordinate {
+    UnitCoordinate::Code {
+        relative_path: path.to_string(),
+        language: "rust".to_string(),
+        label: "function".to_string(),
+        symbol: symbol.to_string(),
+        ordinal: 0,
+        byte_start: 0,
+        byte_end: 1,
+    }
+}
+
+fn lexical(path: &str, score: f64) -> LexicalHit {
+    LexicalHit {
+        score,
+        source_name: "s".to_string(),
+        generation_id: "g".to_string(),
+        content_key: "c".to_string(),
+        unit_key: format!("code:{path}#0"),
+        coordinate: coordinate(path, "sym"),
+    }
+}
+
+fn semantic(path: &str, score: f64) -> sergeant_rs::runtime::atlas::semantic::SemanticHit {
+    sergeant_rs::runtime::atlas::semantic::SemanticHit {
+        score,
+        source_name: "s".to_string(),
+        generation_id: "g".to_string(),
+        content_key: "c".to_string(),
+        unit_key: format!("code:{path}#0"),
+        coordinate: coordinate(path, "sym"),
+    }
+}
+
+fn paths(hits: &[FusedHit]) -> Vec<String> {
+    hits.iter()
+        .map(|hit| hit.coordinate.relative_path().to_string())
+        .collect()
+}
+
+// -------------------------------------------------------- the expression
+
+/// **A2 §7, verbatim:** `RRF(d) = Σ 1 / (k + rank_i(d))`.
+///
+/// Computed here by hand from the ranks a reader can count off the two
+/// fixture lists, and compared bit-for-bit — so a "simplification" that
+/// introduced a weight, a normalization or a second `k` fails immediately.
+#[test]
+fn the_fused_score_is_a2_section_7s_one_expression() {
+    // lexical: a, b, c   semantic: c, a  (1-based ranks)
+    let lex = vec![lexical("a", 3.0), lexical("b", 2.0), lexical("c", 1.0)];
+    let sem = vec![semantic("c", 0.9), semantic("a", 0.8)];
+    let fused = fuse(&lex, &sem);
+
+    let by_path = |p: &str| {
+        fused
+            .iter()
+            .find(|hit| hit.coordinate.relative_path() == p)
+            .unwrap_or_else(|| panic!("{p} missing"))
+    };
+    assert_eq!(by_path("a").rrf, 1.0 / (RRF_K + 1.0) + 1.0 / (RRF_K + 2.0));
+    assert_eq!(by_path("b").rrf, 1.0 / (RRF_K + 2.0));
+    assert_eq!(by_path("c").rrf, 1.0 / (RRF_K + 3.0) + 1.0 / (RRF_K + 1.0));
+    assert_eq!(
+        by_path("a").origins,
+        RankOrigins {
+            lexical: Some(1),
+            semantic: Some(2)
+        }
+    );
+    assert_eq!(
+        by_path("b").origins,
+        RankOrigins {
+            lexical: Some(2),
+            semantic: None
+        }
+    );
+    // `a` wins: 1/61 + 1/62 = 0.032522 beats `c`'s 1/63 + 1/61 = 0.032266,
+    // and `b` (1/62 = 0.016129) is last. A reader can check that arithmetic —
+    // and it is worth checking, because the first draft of this test asserted
+    // `c` first from an eyeballed guess and was corrected by the failure.
+    assert_eq!(paths(&fused), vec!["a", "c", "b"]);
+}
+
+// -------------------------------------------------- hazard 1: collection order
+
+/// **Hazard 1 — candidate collection order.** `rank_i(d)` must be a function
+/// of the hits, never of the order a caller handed them over in.
+///
+/// The inputs are reversed — worst-first — and the answer must be identical
+/// to the sorted case. **Verified non-vacuous by breaking it:** with
+/// `fuse`'s two `sort_by` calls removed, this test FAILS — the reversed lists
+/// assign rank 1 to the worst hit, so `shuffled` comes back in a different
+/// order from `sorted`.
+#[test]
+fn the_order_the_two_lists_arrive_in_cannot_change_the_fused_answer() {
+    let lex = vec![lexical("a", 3.0), lexical("b", 2.0), lexical("c", 1.0)];
+    let sem = vec![semantic("c", 0.9), semantic("a", 0.8)];
+    let sorted = fuse(&lex, &sem);
+
+    let mut lex_reversed = lex.clone();
+    lex_reversed.reverse();
+    let mut sem_reversed = sem.clone();
+    sem_reversed.reverse();
+    let shuffled = fuse(&lex_reversed, &sem_reversed);
+
+    assert_eq!(shuffled, sorted, "the fused answer followed arrival order");
+    // The test discriminates only because the reversed order is a different
+    // order: if the fixture lists were already palindromic this would prove
+    // nothing.
+    assert_ne!(
+        paths(&sorted),
+        vec!["a", "b", "c"],
+        "the fixture must not be one where arrival order and rank order agree"
+    );
+}
+
+// ------------------------------------------------------ hazard 2: tie-breaks
+
+/// **Hazard 2 — tie-breaking.** Two candidates with mirrored rank profiles
+/// (`lexical 1 + semantic 2` and `lexical 2 + semantic 1`) score identically
+/// to the last bit; the stated key `(source_name, relative_path, ordinal,
+/// unit_key)` decides, not the order they were found in.
+///
+/// The fixture is built so **arrival order is the reverse of the key**: `zzz`
+/// heads both input lists and `aaa` trails them, so a fusion that kept
+/// discovery order would answer `zzz, aaa`.
+///
+/// **Verified non-vacuous by breaking it:** with `rrf_order`'s
+/// `.then_with(|| left.tie_break_key().cmp(...))` removed, `sort_by`'s
+/// stability returns the `BTreeMap`'s own key order — which for these two
+/// units happens to be `aaa` first as well, so the deletion does NOT fail
+/// this test. It fails
+/// [`tied_fused_scores_follow_the_key_even_when_the_map_order_disagrees`]
+/// below, which is why that second test exists.
+#[test]
+fn tied_fused_scores_are_broken_by_the_stated_key_not_by_arrival_order() {
+    let lex = vec![lexical("zzz", 5.0), lexical("aaa", 4.0)];
+    let sem = vec![semantic("aaa", 0.9), semantic("zzz", 0.8)];
+    let fused = fuse(&lex, &sem);
+    assert_eq!(fused[0].rrf, fused[1].rrf, "the fixture must really tie");
+    assert_eq!(paths(&fused), vec!["aaa", "zzz"]);
+}
+
+/// The tie-break test that **does** discriminate against a deleted
+/// tiebreaker: the two tying units live under different `source_name`s, and
+/// the accumulator's `BTreeMap` is keyed by `(generation_id, unit_key)` —
+/// not by source — so map order and key order genuinely disagree here.
+///
+/// `beta`'s unit key sorts before `alpha`'s (`code:aaa#0` < `code:zzz#0`), so
+/// the map yields `beta` first; the stated key puts `alpha` first because
+/// `source_name` is its leading component. Deleting `rrf_order`'s
+/// `.then_with(...)` makes this test FAIL — verified.
+#[test]
+fn tied_fused_scores_follow_the_key_even_when_the_map_order_disagrees() {
+    let mut alpha = lexical("zzz", 5.0);
+    alpha.source_name = "alpha".to_string();
+    let mut beta = lexical("aaa", 4.0);
+    beta.source_name = "beta".to_string();
+    let mut alpha_s = semantic("zzz", 0.8);
+    alpha_s.source_name = "alpha".to_string();
+    let mut beta_s = semantic("aaa", 0.9);
+    beta_s.source_name = "beta".to_string();
+
+    let fused = fuse(&[alpha, beta], &[beta_s, alpha_s]);
+    assert_eq!(fused[0].rrf, fused[1].rrf, "the fixture must really tie");
+    assert_eq!(
+        fused
+            .iter()
+            .map(|hit| hit.source_name.clone())
+            .collect::<Vec<_>>(),
+        vec!["alpha".to_string(), "beta".to_string()],
+        "tied scores must follow the stated key, not the accumulator's map order"
+    );
+}
+
+// ------------------------------------------------ hazard 3: summation order
+
+/// **Hazard 3 — float summation order.** `a + b` and `b + a` differ in f64
+/// whenever rounding differs, so the two contributions are summed in a fixed
+/// source order (lexical, then semantic) rather than in whichever order a
+/// candidate happened to be discovered.
+///
+/// Two mirrored candidates: one is lexical-rank-1/semantic-rank-2, the other
+/// lexical-rank-2/semantic-rank-1. Their totals must be **bit-identical** —
+/// which is only guaranteed because both are computed as
+/// `lexical_term + semantic_term`, in that order, and never as
+/// "the term I found first + the term I found second".
+#[test]
+fn the_two_contributions_are_summed_in_a_fixed_source_order() {
+    let fused = fuse(
+        &[lexical("aaa", 5.0), lexical("bbb", 4.0)],
+        &[semantic("bbb", 0.9), semantic("aaa", 0.8)],
+    );
+    assert_eq!(fused.len(), 2);
+    assert_eq!(
+        fused[0].rrf.to_bits(),
+        fused[1].rrf.to_bits(),
+        "mirrored rank profiles must sum to identical bits, not merely to \
+         approximately equal floats"
+    );
+    // And the summation is the one the module documents, not an accident of
+    // this fixture's symmetry.
+    assert_eq!(fused[0].rrf, rrf_contribution(1) + rrf_contribution(2));
+}
+
+// -------------------------------------------------- hazard 4: HashMap
+
+/// **Hazard 4 — `HashMap` iteration.** A structural pin, not a behavioural
+/// one: an iteration-order bug is exactly the kind that passes a hundred runs
+/// and then reorders one answer, so the rule is that the type does not appear
+/// in the module at all.
+///
+/// The same shape as `tests/y2_office_boundary.rs`'s replaceability pin and
+/// `tests/x1_atlas_substrate.rs`'s one-owner pin: read the source, fail on
+/// the token.
+#[test]
+fn no_hash_map_or_hash_set_reaches_the_fusion_module() {
+    let source = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/runtime/atlas/fusion.rs"),
+    )
+    .expect("read fusion.rs");
+    for (number, line) in source.lines().enumerate() {
+        // The module doc names the hazard; a doc line is not an accumulator.
+        if line.trim_start().starts_with("//") {
+            continue;
+        }
+        for forbidden in ["HashMap", "HashSet"] {
+            assert!(
+                !line.contains(forbidden),
+                "fusion.rs:{} uses {forbidden}: {line}",
+                number + 1
+            );
+        }
+    }
+}
+
+// ------------------------------------------------- the nine, in order
+
+/// A2 §8's nine signals, **in the contract's own listing order**, is
+/// [`RerankSignals::priority`]'s array order. Setting one field at a time and
+/// asserting which slot lights up is what makes the order a pinned fact
+/// rather than a comment above a struct.
+///
+/// > exact symbol / heading / filename match
+/// > definition over reference when query is identifier-like
+/// > source explicitly selected by caller
+/// > Work-changed unit
+/// > same module/package/document section
+/// > inbound/outbound structural relationship
+/// > canonical implementation vs test/example/legacy path
+/// > knowledge source when `--type knowledge` requested
+/// > current exact generation over stale generation unless caller pinned stale
+#[test]
+fn the_rerank_key_is_a2_section_8s_nine_signals_in_the_contracts_own_order() {
+    let mut set: Vec<(usize, RerankSignals)> = Vec::new();
+    let mut push = |index: usize, signals: RerankSignals| set.push((index, signals));
+    push(
+        0,
+        RerankSignals {
+            exact_match: true,
+            ..Default::default()
+        },
+    );
+    push(
+        1,
+        RerankSignals {
+            definition_over_reference: true,
+            ..Default::default()
+        },
+    );
+    push(
+        2,
+        RerankSignals {
+            caller_selected_source: true,
+            ..Default::default()
+        },
+    );
+    push(
+        3,
+        RerankSignals {
+            work_changed_unit: true,
+            ..Default::default()
+        },
+    );
+    push(
+        4,
+        RerankSignals {
+            same_section_as_anchor: true,
+            ..Default::default()
+        },
+    );
+    push(
+        5,
+        RerankSignals {
+            structural_relationship: true,
+            ..Default::default()
+        },
+    );
+    push(
+        6,
+        RerankSignals {
+            canonical_path: true,
+            ..Default::default()
+        },
+    );
+    push(
+        7,
+        RerankSignals {
+            knowledge_source_requested: true,
+            ..Default::default()
+        },
+    );
+    push(
+        8,
+        RerankSignals {
+            current_generation: true,
+            ..Default::default()
+        },
+    );
+    assert_eq!(set.len(), 9, "A2 §8 lists nine signals");
+    for (index, signals) in &set {
+        let key = signals.priority();
+        assert_eq!(key.len(), 9);
+        assert_eq!(signals.fired(), 1);
+        assert!(key[*index], "signal {index} did not land in slot {index}");
+        assert_eq!(
+            key.iter().filter(|fired| **fired).count(),
+            1,
+            "signal {index} lit more than one slot"
+        );
+    }
+    // And the earlier signal wins: a candidate with signal 1 outranks one
+    // with every later signal, which is the contract's order doing the work.
+    let first = FusedHit {
+        rrf: 0.0,
+        origins: RankOrigins::default(),
+        signals: set[0].1,
+        source_name: "s".to_string(),
+        generation_id: "g".to_string(),
+        content_key: "c".to_string(),
+        unit_key: "u1".to_string(),
+        coordinate: coordinate("a.rs", "a"),
+    };
+    let later = FusedHit {
+        signals: RerankSignals {
+            exact_match: false,
+            definition_over_reference: true,
+            caller_selected_source: true,
+            work_changed_unit: true,
+            same_section_as_anchor: true,
+            structural_relationship: true,
+            canonical_path: true,
+            knowledge_source_requested: true,
+            current_generation: true,
+        },
+        rrf: 1.0,
+        unit_key: "u2".to_string(),
+        ..first.clone()
+    };
+    let mut hits = vec![later, first];
+    rerank(&mut hits);
+    assert_eq!(
+        hits[0].unit_key, "u1",
+        "A2 §8's first signal must outrank every later one"
+    );
+}
+
+// ------------------------------------------------------------- the estate
+
+fn use_repository_assets() {
+    let assets = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/semantic-model");
+    assert!(
+        assets.join("model.safetensors").is_file(),
+        "the committed assets must be present at {}",
+        assets.display()
+    );
+    unsafe { std::env::set_var(MODEL_DIR_ENV, &assets) };
+}
+
+fn write(root: &Path, relative: &str, body: &str) {
+    let path = root.join(relative);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create fixture directory");
+    }
+    std::fs::write(&path, body).expect("write fixture");
+}
+
+fn document_unit(text: &str) -> ScannedUnit {
+    ScannedUnit {
+        ordinal: 0,
+        kind: UnitKind::Document,
+        heading_level: None,
+        title: None,
+        byte_start: 0,
+        byte_end: text.len() as u64,
+        text: text.to_string(),
+    }
+}
+
+fn scanned_file(relative_path: &str, units: Vec<ScannedUnit>) -> ScannedFile {
+    ScannedFile {
+        relative_path: relative_path.to_string(),
+        content_hash: format!("hash/{relative_path}"),
+        extractor: MARKDOWN_EXTRACTOR.to_string(),
+        local_key: format!("key/{relative_path}"),
+        byte_len: 64,
+        mtime_millis: None,
+        units,
+        syntax: None,
+        parent: None,
+    }
+}
+
+/// A grammar-claimed code file: one definition site, and optionally one
+/// outbound edge naming another file's symbol.
+fn code_file(relative_path: &str, symbol: &str, imports: &[&str]) -> ScannedFile {
+    let mut file = scanned_file(relative_path, Vec::new());
+    file.extractor = "syntax-rust/v1".to_string();
+    file.syntax = Some(ScannedSyntax {
+        language: "rust",
+        extractor: "syntax-rust/v1".to_string(),
+        syntax_key: format!("syntax-key/rust/{relative_path}"),
+        symbols: vec![ScannedSymbol {
+            ordinal: 0,
+            label: "function",
+            name: symbol.to_string(),
+            byte_start: 0,
+            byte_end: symbol.len() as u64,
+        }],
+        edges: imports
+            .iter()
+            .enumerate()
+            .map(|(ordinal, target)| ScannedEdge {
+                ordinal: ordinal as u64,
+                kind: EDGE_IMPORT,
+                target: (*target).to_string(),
+                byte_start: 0,
+                byte_end: 1,
+            })
+            .collect(),
+    });
+    file
+}
+
+fn hand_built_scan(
+    source_name: &str,
+    kind: SourceKind,
+    authority: AuthorityClass,
+    files: Vec<ScannedFile>,
+) -> SourceScan {
+    let mut extractors = BTreeSet::new();
+    for f in &files {
+        extractors.insert(f.extractor.clone());
+        if let Some(syntax) = &f.syntax {
+            extractors.insert(syntax.extractor.clone());
+        }
+    }
+    SourceScan {
+        source_name: source_name.to_string(),
+        kind,
+        authority,
+        content_key: format!("{source_name}@key-1"),
+        revision: None,
+        observed_at: rfc3339_utc_now(),
+        files,
+        coverage: Vec::new(),
+        extractors,
+        datasets: Vec::new(),
+        root: None,
+        context_fields: ContextFields::none(),
+    }
+}
+
+struct Estate {
+    _data: TempDir,
+    _root: Option<TempDir>,
+    db: AtlasDb,
+}
+
+impl Estate {
+    fn fused(&self, text: &str, filter: &Admissibility, limit: usize) -> FusedAnswer {
+        self.db
+            .fused_search(&LexicalQuery {
+                text,
+                filter,
+                family: None,
+                limit,
+                semantic: SemanticRequest::Requested,
+            })
+            .expect("fused search")
+    }
+}
+
+fn named(source: &str) -> Admissibility {
+    Admissibility {
+        source: SourceSelector::Named(source.to_string()),
+        kind: None,
+        authority: None,
+    }
+}
+
+fn everything() -> Admissibility {
+    Admissibility::default()
+}
+
+fn labelled(answer: &FusedAnswer) -> Vec<String> {
+    answer
+        .hits
+        .iter()
+        .map(|hit| format!("{}:{}", hit.source_name, hit.coordinate.relative_path()))
+        .collect()
+}
+
+fn show(query: &str, answer: &FusedAnswer) {
+    println!("QUERY {query:?}  (status {:?})", answer.semantic);
+    for hit in &answer.hits {
+        println!(
+            "   rrf {:+.6}  lex {:?} sem {:?}  signals {:?}  {}:{}",
+            hit.rrf,
+            hit.origins.lexical,
+            hit.origins.semantic,
+            hit.signals.priority(),
+            hit.source_name,
+            hit.coordinate.relative_path()
+        );
+    }
+}
+
+/// The knowledge corpus every integration test below queries, plus an
+/// optional `external`-authority decoy planted for the A2 §8 negative.
+const CORPUS: [(&str, &str); 5] = [
+    (
+        "payments/decline-handling.md",
+        "When a card transaction is declined the client waits and attempts the same charge again after an exponential back-off delay.",
+    ),
+    (
+        "architecture/adr-042.md",
+        "Decision: settlement is performed asynchronously so the request path never blocks on the ledger.",
+    ),
+    ("garden/roses.md", "Prune the rose bushes in late winter."),
+    (
+        "kernel/scheduling.md",
+        "The scheduler assigns time slices to runnable threads on each CPU core.",
+    ),
+    (
+        "kitchen/sourdough.md",
+        "Feed the starter twice a day until it doubles reliably.",
+    ),
+];
+
+fn knowledge_estate(with_decoy: bool) -> Estate {
+    let data = tempfile::tempdir().expect("data dir");
+    let root = tempfile::tempdir().expect("knowledge root");
+    for (relative, body) in CORPUS {
+        write(root.path(), relative, body);
+    }
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let knowledge = KnowledgeSource {
+        name: "knowledge".to_string(),
+        root: root.path().to_path_buf(),
+        ignore: Vec::new(),
+        context_fields: ContextFields::none(),
+    };
+    scan_and_record(&mut db, &mut journal, &knowledge, None).expect("record knowledge");
+    if with_decoy {
+        let vendor = hand_built_scan(
+            "vendor-lib",
+            SourceKind::ExternalGit,
+            AuthorityClass::External,
+            vec![scanned_file(
+                "docs/leak.md",
+                vec![document_unit(
+                    "How do we retry a failed payment charge? When a card charge fails the caller \
+                     retries the failed payment after a back-off delay.",
+                )],
+            )],
+        );
+        record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
+    }
+    Estate {
+        _data: data,
+        _root: Some(root),
+        db,
+    }
+}
+
+// --------------------------------------------- THE PROHIBITION, non-vacuous
+
+/// **A2 §8:** *"The reranker must never silently cross an authority/source
+/// filter merely because a candidate scores well."*
+///
+/// W2 proved this for the lexical half and W3b for the semantic half. It is
+/// proved a **third** time here because fusion is the one place a second list
+/// could smuggle a candidate in — a unit that is inadmissible but wins the
+/// semantic list.
+///
+/// The negative is non-vacuous the way both prior waves made theirs: the
+/// positive half runs first and shows the decoy ranking **first in the fused
+/// answer** with the filter open, so the unit is in the store, is reachable,
+/// and would win if anything let it.
+#[test]
+fn an_inadmissible_unit_that_wins_the_semantic_list_never_reaches_the_fused_answer() {
+    use_repository_assets();
+    let estate = knowledge_estate(true);
+    let query = "how do we retry a failed payment charge";
+
+    // The decoy really does win the semantic list, unfiltered.
+    let open_semantic = estate
+        .db
+        .semantic_search(&LexicalQuery {
+            text: query,
+            filter: &everything(),
+            family: Some(LexicalFamily::Document),
+            limit: 50,
+            semantic: SemanticRequest::Requested,
+        })
+        .expect("semantic search");
+    assert_eq!(
+        open_semantic
+            .hits
+            .first()
+            .map(|hit| hit.source_name.as_str()),
+        Some("vendor-lib"),
+        "the decoy must win the semantic list, or this negative proves nothing"
+    );
+
+    // ...and it wins the FUSED answer, unfiltered. This is the half that
+    // makes the negative below about fusion rather than about the filter.
+    let open = estate.fused(query, &everything(), 50);
+    show("unfiltered", &open);
+    assert_eq!(
+        labelled(&open).first().map(String::as_str),
+        Some("vendor-lib:docs/leak.md"),
+        "the decoy must win the fused answer when nothing excludes it"
+    );
+
+    // Closed: absent entirely. Not demoted — absent.
+    let closed = estate.fused(query, &named("knowledge"), 50);
+    show("source=knowledge", &closed);
+    assert!(
+        !labelled(&closed)
+            .iter()
+            .any(|label| label.starts_with("vendor-lib:")),
+        "an inadmissible unit reached the fused answer: {:#?}",
+        labelled(&closed)
+    );
+}
+
+// ------------------------------------------------------------ determinism
+
+/// The whole fused answer — order, scores, ranks and signals — is
+/// reproducible across repeated searches on one handle.
+#[test]
+fn the_same_query_over_the_same_generations_returns_an_identical_fused_answer() {
+    use_repository_assets();
+    let estate = knowledge_estate(true);
+    let filter = named("knowledge");
+    let first = estate.fused("asynchronous settlement", &filter, 50);
+    for _ in 0..4 {
+        assert_eq!(
+            estate.fused("asynchronous settlement", &filter, 50),
+            first,
+            "repeated fused searches must be identical answers"
+        );
+    }
+}
+
+/// `rank_i(d)` is the candidate's rank **within the admissible set**, not
+/// within the slice the caller asked to display — so a smaller `limit` must
+/// return a prefix of the larger answer, never a differently-ordered one.
+///
+/// Without this, a unit at lexical rank 12 would be absent from the lexical
+/// list at `limit = 10` and present at `limit = 20`, and the fused order of
+/// the first ten would change with a display parameter.
+#[test]
+fn the_fused_order_does_not_depend_on_the_callers_limit() {
+    use_repository_assets();
+    let estate = knowledge_estate(true);
+    let filter = everything();
+    let wide = estate.fused("retry the declined payment charge", &filter, 50);
+    let narrow = estate.fused("retry the declined payment charge", &filter, 2);
+    assert!(
+        wide.hits.len() > 2,
+        "the fixture must exceed the narrow cap"
+    );
+    assert_eq!(narrow.hits.len(), 2);
+    assert_eq!(
+        narrow.hits.as_slice(),
+        &wide.hits[..2],
+        "a narrower limit must be a prefix of the wider answer"
+    );
+}
+
+// ----------------------------------------------- the nine actually compute
+
+/// **The anti-silent-omission pin.** Every one of A2 §8's nine signals must
+/// actually fire somewhere — a field that was declared and never computed
+/// would pass every other test in this file and fail this one.
+///
+/// Six searches over three estates, chosen so that each signal has at least
+/// one case that lights it:
+///
+/// | Signal | Where it fires |
+/// |---|---|
+/// | 1 exact match | a query term equal to a code symbol |
+/// | 2 definition over reference | an identifier-like query, on a code unit |
+/// | 3 caller-selected source | any `--source`-filtered search |
+/// | 4 Work-changed unit | a `--work` search over an overlay generation |
+/// | 5 same section | the anchor itself, at minimum |
+/// | 6 structural relationship | a file importing the anchor's symbol |
+/// | 7 canonical path | any non-test path |
+/// | 8 knowledge requested | `--type knowledge` |
+/// | 9 current generation | every confirmed generation |
+#[test]
+fn every_one_of_a2_section_8s_nine_signals_actually_fires() {
+    use_repository_assets();
+    let mut fired = [false; 9];
+    let mut observe = |answer: &FusedAnswer| {
+        for hit in &answer.hits {
+            for (slot, value) in hit.signals.priority().iter().enumerate() {
+                fired[slot] |= *value;
+            }
+        }
+    };
+
+    // (a) the knowledge estate: signals 1, 3, 5, 7, 8, 9.
+    let knowledge = knowledge_estate(false);
+    observe(&knowledge.fused("roses", &named("knowledge"), 50));
+    observe(&knowledge.fused(
+        "asynchronous settlement",
+        &Admissibility {
+            source: SourceSelector::Any,
+            kind: Some(SourceKind::LocalKnowledge),
+            authority: None,
+        },
+        50,
+    ));
+
+    // (b) a code estate with a real import edge: signals 2 and 6.
+    let code = code_estate();
+    let answer = code.fused("retry_charge", &named("repo-a"), 50);
+    show("retry_charge", &answer);
+    observe(&answer);
+
+    // (c) a Work overlay: signal 4.
+    let work = overlay_estate();
+    let answer = work.fused(
+        "settlement",
+        &Admissibility {
+            source: SourceSelector::WorkBase {
+                work_id: "01WORK".to_string(),
+                repository: "repo-a".to_string(),
+            },
+            kind: None,
+            authority: None,
+        },
+        50,
+    );
+    show("work overlay", &answer);
+    observe(&answer);
+
+    let names = [
+        "1 exact symbol/heading/filename match",
+        "2 definition over reference when query is identifier-like",
+        "3 source explicitly selected by caller",
+        "4 Work-changed unit",
+        "5 same module/package/document section",
+        "6 inbound/outbound structural relationship",
+        "7 canonical implementation vs test/example/legacy path",
+        "8 knowledge source when --type knowledge requested",
+        "9 current exact generation over stale generation",
+    ];
+    let missing: Vec<&str> = names
+        .iter()
+        .zip(fired.iter())
+        .filter(|(_, fired)| !**fired)
+        .map(|(name, _)| *name)
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "A2 §8 signals declared but never computed: {missing:#?}"
+    );
+}
+
+/// A code estate: `retry_charge` is defined in `src/payments/retry.rs`,
+/// `src/payments/caller.rs` imports it (an inbound edge to the anchor), and
+/// `tests/retry_test.rs` defines a same-named symbol on a non-canonical path.
+fn code_estate() -> Estate {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let scan = hand_built_scan(
+        "repo-a",
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![
+            code_file("src/payments/retry.rs", "retry_charge", &[]),
+            code_file("src/payments/caller.rs", "charge_once", &["retry_charge"]),
+            code_file("tests/retry_test.rs", "retry_charge", &[]),
+        ],
+    );
+    record_scan(&mut db, &mut journal, &scan, None).expect("record repo-a");
+    Estate {
+        _data: data,
+        _root: None,
+        db,
+    }
+}
+
+/// A Work estate: the base repository plus this Work's overlay generation
+/// over the same repository (S5 W1b/W1d's `work:<id>/<repo>` source name).
+fn overlay_estate() -> Estate {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+    let base = hand_built_scan(
+        "repo-a",
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![scanned_file(
+            "docs/ledger.md",
+            vec![document_unit(
+                "Settlement is posted to the ledger at the end of the day.",
+            )],
+        )],
+    );
+    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    let overlay = hand_built_scan(
+        "work:01WORK/repo-a",
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![scanned_file(
+            "docs/ledger.md",
+            vec![document_unit(
+                "Settlement is posted to the ledger at the end of the day.",
+            )],
+        )],
+    );
+    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    Estate {
+        _data: data,
+        _root: None,
+        db,
+    }
+}
+
+// --------------------------------------------- reranking actually reranks
+
+/// **Signal 4 does work.** A Work-changed unit and its unchanged base carry
+/// byte-identical text, so they tie on both halves and RRF cannot separate
+/// them; the stated tie-break key would put `repo-a` before
+/// `work:01WORK/repo-a`. A2 §8's *"Work-changed unit"* signal is what puts
+/// the overlay first — and this is only reachable because S5 W1d made the
+/// overlay reflect in-flight changes.
+#[test]
+fn a_work_changed_unit_is_promoted_over_its_unchanged_base() {
+    use_repository_assets();
+    let estate = overlay_estate();
+    let filter = Admissibility {
+        source: SourceSelector::WorkBase {
+            work_id: "01WORK".to_string(),
+            repository: "repo-a".to_string(),
+        },
+        kind: None,
+        authority: None,
+    };
+    let answer = estate.fused("settlement ledger", &filter, 50);
+    show("work-changed", &answer);
+    assert_eq!(
+        answer.hits.len(),
+        2,
+        "base and overlay must both be present"
+    );
+    assert!(
+        answer.hits[0].signals.work_changed_unit,
+        "the Work-changed unit must be first: {:#?}",
+        labelled(&answer)
+    );
+    assert_eq!(answer.hits[0].source_name, "work:01WORK/repo-a");
+    assert!(!answer.hits[1].signals.work_changed_unit);
+    // Non-vacuous: without the signal the stated key puts the base first.
+    assert!(
+        "repo-a" < "work:01WORK/repo-a",
+        "the fixture only discriminates if the tie-break key would order these \
+         the other way round"
+    );
+}
+
+/// **Signal 7 does work.** `src/payments/retry.rs` and `tests/retry_test.rs`
+/// define the same symbol with identical indexed text, so they tie on both
+/// halves; the canonical path wins.
+#[test]
+fn a_test_path_loses_to_a_canonical_one_at_an_equal_fused_score() {
+    use_repository_assets();
+    let estate = code_estate();
+    let answer = estate.fused("retry_charge", &named("repo-a"), 50);
+    show("canonical vs test path", &answer);
+    let order = labelled(&answer);
+    let canonical = order
+        .iter()
+        .position(|label| label.ends_with("src/payments/retry.rs"))
+        .expect("the canonical definition must be a hit");
+    let test_path = order
+        .iter()
+        .position(|label| label.ends_with("tests/retry_test.rs"))
+        .expect("the test-path definition must be a hit");
+    assert!(
+        canonical < test_path,
+        "the canonical implementation must outrank the test path: {order:#?}"
+    );
+    assert!(answer.hits[canonical].signals.canonical_path);
+    assert!(!answer.hits[test_path].signals.canonical_path);
+}
+
+/// **Signal 1 does work, against a better fused score.** The reranker's whole
+/// point is that it may reorder what RRF produced; here a candidate whose
+/// name the query states exactly is promoted above one that scored higher.
+///
+/// Asserted at the fusion layer rather than through a store, so the two
+/// scores are readable in the fixture: `b.rs` wins RRF outright, `a.rs`
+/// carries A2 §8's first signal, and after [`rerank`] `a.rs` is first.
+#[test]
+fn an_exact_name_match_is_promoted_over_a_better_fused_score() {
+    let mut hits = fuse(
+        &[lexical("b.rs", 9.0), lexical("a.rs", 1.0)],
+        &[semantic("b.rs", 0.9), semantic("a.rs", 0.1)],
+    );
+    hits.sort_by(rrf_order);
+    assert_eq!(paths(&hits), vec!["b.rs", "a.rs"], "RRF prefers b.rs");
+    assert!(hits[0].rrf > hits[1].rrf, "and strictly so");
+
+    for hit in hits.iter_mut() {
+        hit.signals.exact_match = hit.coordinate.relative_path() == "a.rs";
+    }
+    rerank(&mut hits);
+    assert_eq!(
+        paths(&hits),
+        vec!["a.rs", "b.rs"],
+        "A2 §8's exact-match signal must be able to reorder A2 §7's output"
+    );
+}
+
+// --------------------------------- the three filter-shaped signals
+
+/// The three signals A2-01 turned into a **boundary** rather than a
+/// preference are uniform within any one answer, and this test says so out
+/// loud rather than leaving a reader to discover it.
+///
+/// Not a weakening of the contract: A2 §8 asks for the *preference*, and a
+/// world in which every inadmissible candidate has already been excluded
+/// honours it more completely than a ranking bonus would. What is pinned here
+/// is that the signals are computed and consistent — so the trace A2 §13 asks
+/// for can state them — not that they reorder anything.
+#[test]
+fn the_three_filter_shaped_signals_are_uniform_because_admissibility_already_applied_them() {
+    use_repository_assets();
+    let estate = knowledge_estate(true);
+
+    let selected = estate.fused("settlement", &named("knowledge"), 50);
+    assert!(!selected.hits.is_empty());
+    assert!(
+        selected
+            .hits
+            .iter()
+            .all(|hit| hit.signals.caller_selected_source),
+        "every hit of a --source query is from the selected source"
+    );
+    assert!(
+        selected
+            .hits
+            .iter()
+            .all(|hit| hit.signals.current_generation),
+        "every admissible generation is its source's current confirmed one"
+    );
+    assert!(
+        selected
+            .hits
+            .iter()
+            .all(|hit| !hit.signals.knowledge_source_requested),
+        "--type knowledge was not requested here"
+    );
+
+    let unselected = estate.fused("settlement", &everything(), 50);
+    assert!(
+        unselected
+            .hits
+            .iter()
+            .all(|hit| !hit.signals.caller_selected_source),
+        "no source was explicitly selected"
+    );
+
+    let typed = estate.fused(
+        "settlement",
+        &Admissibility {
+            source: SourceSelector::Any,
+            kind: Some(SourceKind::LocalKnowledge),
+            authority: None,
+        },
+        50,
+    );
+    assert!(!typed.hits.is_empty());
+    assert!(
+        typed
+            .hits
+            .iter()
+            .all(|hit| hit.signals.knowledge_source_requested),
+        "--type knowledge admits knowledge generations and nothing else"
+    );
+}
+
+// ------------------------------------------------------- H4 rides through
+
+/// A fused answer carries the same H4 disclosure its inputs did. On a host
+/// with the assets and a caller who suppressed the semantic half, the "fused"
+/// answer fused one list with an empty one — and says `disabled` rather than
+/// looking like a complete fusion.
+#[test]
+fn a_suppressed_semantic_half_still_answers_and_reports_disabled() {
+    use_repository_assets();
+    let estate = knowledge_estate(false);
+    let filter = named("knowledge");
+    let answer = estate
+        .db
+        .fused_search(&LexicalQuery {
+            text: "settlement",
+            filter: &filter,
+            family: None,
+            limit: 50,
+            semantic: SemanticRequest::Suppressed,
+        })
+        .expect("fused search");
+    assert_eq!(answer.semantic, SemanticStatus::Disabled);
+    assert_eq!(answer.semantic_model, None);
+    assert!(
+        !answer.hits.is_empty(),
+        "the lexical half must still answer"
+    );
+    assert!(
+        answer.hits.iter().all(|hit| hit.origins.semantic.is_none()),
+        "a suppressed semantic half contributes no ranks"
+    );
+
+    let applied = estate.fused("settlement", &filter, 50);
+    assert_eq!(applied.semantic, SemanticStatus::Applied);
+    assert!(applied.semantic_model.is_some());
+}

--- a/tests/w4_rrf_fusion.rs
+++ b/tests/w4_rrf_fusion.rs
@@ -36,7 +36,11 @@
 //! **That reranking reranks** — three tests show a candidate moving because
 //! of a signal ([`an_exact_name_match_is_promoted_over_a_better_fused_score`],
 //! [`a_work_changed_unit_is_promoted_over_its_unchanged_base`],
-//! [`a_test_path_loses_to_a_canonical_one_at_an_equal_fused_score`]).
+//! [`a_test_path_loses_to_a_canonical_one_at_an_equal_fused_score`]), and a
+//! fourth ([`an_overlay_unit_whose_content_matches_the_base_is_not_marked_work_changed`])
+//! proves the negative: a path merely visible under a Work's overlay, whose
+//! content is byte-identical to the base's, must not be marked Work-changed
+//! (F-SF-01).
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -465,9 +469,21 @@ fn document_unit(text: &str) -> ScannedUnit {
 }
 
 fn scanned_file(relative_path: &str, units: Vec<ScannedUnit>) -> ScannedFile {
+    scanned_file_with_hash(relative_path, &format!("hash/{relative_path}"), units)
+}
+
+/// [`scanned_file`], with an explicit `content_hash` rather than the derived
+/// per-path default — what F-SF-01's fixtures need to say "this overlay path
+/// carries the *same* bytes as the base" (equal hash) or "*different* bytes"
+/// (distinct hash) independently of the path the two generations share.
+fn scanned_file_with_hash(
+    relative_path: &str,
+    content_hash: &str,
+    units: Vec<ScannedUnit>,
+) -> ScannedFile {
     ScannedFile {
         relative_path: relative_path.to_string(),
-        content_hash: format!("hash/{relative_path}"),
+        content_hash: content_hash.to_string(),
         extractor: MARKDOWN_EXTRACTOR.to_string(),
         local_key: format!("key/{relative_path}"),
         byte_len: 64,
@@ -810,8 +826,11 @@ fn every_one_of_a2_section_8s_nine_signals_actually_fires() {
     show("retry_charge", &answer);
     observe(&answer);
 
-    // (c) a Work overlay: signal 4.
-    let work = overlay_estate();
+    // (c) a Work overlay whose file actually changed: signal 4.
+    let work = overlay_estate(
+        "Settlement is posted to the ledger at the end of the day, after the Work's fix.",
+        "hash/docs/ledger.md/edited-by-work",
+    );
     let answer = work.fused(
         "settlement",
         &Admissibility {
@@ -877,7 +896,15 @@ fn code_estate() -> Estate {
 
 /// A Work estate: the base repository plus this Work's overlay generation
 /// over the same repository (S5 W1b/W1d's `work:<id>/<repo>` source name).
-fn overlay_estate() -> Estate {
+///
+/// `overlay_text`/`overlay_hash` are the overlay's own content identity for
+/// `docs/ledger.md` — distinct from the base's whenever the fixture means to
+/// represent an actual edit. F-SF-01: the signal is a content-hash
+/// comparison against the base generation, not a source-name check, so a
+/// fixture that wants "the Work changed this" must actually give the
+/// overlay a different hash, and one that wants "merely visible under the
+/// overlay" must give it the base's own hash.
+fn overlay_estate(overlay_text: &str, overlay_hash: &str) -> Estate {
     let data = tempfile::tempdir().expect("data dir");
     let mut journal = Journal::open(data.path()).expect("journal");
     let mut db = AtlasDb::open(data.path()).expect("atlas");
@@ -885,8 +912,9 @@ fn overlay_estate() -> Estate {
         "repo-a",
         SourceKind::EstateGit,
         AuthorityClass::EstateMutable,
-        vec![scanned_file(
+        vec![scanned_file_with_hash(
             "docs/ledger.md",
+            "hash/docs/ledger.md/base",
             vec![document_unit(
                 "Settlement is posted to the ledger at the end of the day.",
             )],
@@ -897,11 +925,10 @@ fn overlay_estate() -> Estate {
         "work:01WORK/repo-a",
         SourceKind::EstateGit,
         AuthorityClass::EstateMutable,
-        vec![scanned_file(
+        vec![scanned_file_with_hash(
             "docs/ledger.md",
-            vec![document_unit(
-                "Settlement is posted to the ledger at the end of the day.",
-            )],
+            overlay_hash,
+            vec![document_unit(overlay_text)],
         )],
     );
     record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
@@ -914,16 +941,58 @@ fn overlay_estate() -> Estate {
 
 // --------------------------------------------- reranking actually reranks
 
-/// **Signal 4 does work.** A Work-changed unit and its unchanged base carry
-/// byte-identical text, so they tie on both halves and RRF cannot separate
-/// them; the stated tie-break key would put `repo-a` before
-/// `work:01WORK/repo-a`. A2 §8's *"Work-changed unit"* signal is what puts
-/// the overlay first — and this is only reachable because S5 W1d made the
+/// **F-SF-01 regression: signal 4 is a content comparison, not a source-name
+/// check.** The overlay's `docs/ledger.md` carries the *same* content hash
+/// as the base's — a path the overlay universe includes (`extract_overlay`'s
+/// base ∪ changed) but the Work never actually touched. Under the pre-fix
+/// implementation (`overlay_source == hit.source_name`) this unit would
+/// still have been marked Work-changed purely for living under the overlay
+/// source; the fixed signal must say `false`, matching the base's.
+#[test]
+fn an_overlay_unit_whose_content_matches_the_base_is_not_marked_work_changed() {
+    use_repository_assets();
+    let estate = overlay_estate(
+        "Settlement is posted to the ledger at the end of the day.",
+        "hash/docs/ledger.md/base",
+    );
+    let filter = Admissibility {
+        source: SourceSelector::WorkBase {
+            work_id: "01WORK".to_string(),
+            repository: "repo-a".to_string(),
+        },
+        kind: None,
+        authority: None,
+    };
+    let answer = estate.fused("settlement ledger", &filter, 50);
+    show("unchanged-overlay", &answer);
+    assert_eq!(
+        answer.hits.len(),
+        2,
+        "base and overlay must both be present"
+    );
+    for hit in &answer.hits {
+        assert!(
+            !hit.signals.work_changed_unit,
+            "a byte-identical overlay path must not be marked Work-changed: {:#?}",
+            labelled(&answer)
+        );
+    }
+}
+
+/// **Signal 4 does work.** The overlay's `docs/ledger.md` carries a
+/// genuinely different content hash from the base's — a real edit — and A2
+/// §8's *"Work-changed unit"* signal promotes it to the top regardless of
+/// the two candidates' RRF standing, because [`rerank_order`] compares
+/// [`crate::runtime::atlas::fusion::RerankSignals::priority`] before it ever
+/// falls back to RRF order. This is only reachable because S5 W1d made the
 /// overlay reflect in-flight changes.
 #[test]
 fn a_work_changed_unit_is_promoted_over_its_unchanged_base() {
     use_repository_assets();
-    let estate = overlay_estate();
+    let estate = overlay_estate(
+        "Settlement is posted to the ledger at the end of the day, after the Work's fix.",
+        "hash/docs/ledger.md/edited-by-work",
+    );
     let filter = Admissibility {
         source: SourceSelector::WorkBase {
             work_id: "01WORK".to_string(),
@@ -946,12 +1015,6 @@ fn a_work_changed_unit_is_promoted_over_its_unchanged_base() {
     );
     assert_eq!(answer.hits[0].source_name, "work:01WORK/repo-a");
     assert!(!answer.hits[1].signals.work_changed_unit);
-    // Non-vacuous: without the signal the stated key puts the base first.
-    assert!(
-        "repo-a" < "work:01WORK/repo-a",
-        "the fixture only discriminates if the tie-break key would order these \
-         the other way round"
-    );
 }
 
 /// **Signal 7 does work.** `src/payments/retry.rs` and `tests/retry_test.rs`

--- a/tests/w4_rrf_fusion.rs
+++ b/tests/w4_rrf_fusion.rs
@@ -873,9 +873,16 @@ fn every_one_of_a2_section_8s_nine_signals_actually_fires() {
     );
 }
 
-/// A code estate: `retry_charge` is defined in `src/payments/retry.rs`,
+/// A code estate: `retry_charge` is defined in `payments/retry.rs`,
 /// `src/payments/caller.rs` imports it (an inbound edge to the anchor), and
-/// `tests/retry_test.rs` defines a same-named symbol on a non-canonical path.
+/// `payments/aaa_retry_test.rs` defines a same-named symbol on a
+/// non-canonical path, in the **same directory** as the canonical
+/// definition. Same directory so signal 5 (same section) ties too, and the
+/// non-canonical path's name is deliberately spelled to sort *before* the
+/// canonical one's (`aaa_retry_test.rs` < `retry.rs`) — F-TH-02: an ordering
+/// assertion this suite's own tie-break key would already satisfy proves
+/// nothing about signal 7, so the fixture is built so the tie-break key
+/// alone would rank the wrong one first.
 fn code_estate() -> Estate {
     let data = tempfile::tempdir().expect("data dir");
     let mut journal = Journal::open(data.path()).expect("journal");
@@ -885,9 +892,9 @@ fn code_estate() -> Estate {
         SourceKind::EstateGit,
         AuthorityClass::EstateMutable,
         vec![
-            code_file("src/payments/retry.rs", "retry_charge", &[]),
+            code_file("payments/retry.rs", "retry_charge", &[]),
             code_file("src/payments/caller.rs", "charge_once", &["retry_charge"]),
-            code_file("tests/retry_test.rs", "retry_charge", &[]),
+            code_file("payments/aaa_retry_test.rs", "retry_charge", &[]),
         ],
     );
     record_scan(&mut db, &mut journal, &scan, None).expect("record repo-a");
@@ -1021,9 +1028,20 @@ fn a_work_changed_unit_is_promoted_over_its_unchanged_base() {
     assert!(!answer.hits[1].signals.work_changed_unit);
 }
 
-/// **Signal 7 does work.** `src/payments/retry.rs` and `tests/retry_test.rs`
-/// define the same symbol with identical indexed text, so they tie on both
-/// halves; the canonical path wins.
+/// **Signal 7 does work (F-TH-02 fix).** `payments/retry.rs` and
+/// `payments/aaa_retry_test.rs` define the same symbol with identical
+/// indexed text and **the same directory**, so they tie on both halves *and*
+/// on signal 5 (same module/section) — a fixture that let them differ by
+/// directory would let signal 5 decide the order before signal 7 ever got a
+/// turn, since [`RerankSignals::priority`] compares signal 5 first.
+/// [`LexicalHit::tie_break_key`]'s stated key (`source_name`, then
+/// `relative_path`) would, absent the signal, rank `aaa_retry_test.rs` first
+/// — the *opposite* of what this test asserts, since `"aaa_retry_test.rs" <
+/// "retry.rs"`. So the ordering assertion below is only satisfiable because
+/// signal 7 promotes the canonical path over the alphabetically-earlier
+/// tie-break winner, unlike the pre-fix fixture (`src/payments/retry.rs` vs.
+/// `tests/retry_test.rs`), where the tie-break key already produced the
+/// asserted order with no help from the signal.
 #[test]
 fn a_test_path_loses_to_a_canonical_one_at_an_equal_fused_score() {
     use_repository_assets();
@@ -1033,15 +1051,23 @@ fn a_test_path_loses_to_a_canonical_one_at_an_equal_fused_score() {
     let order = labelled(&answer);
     let canonical = order
         .iter()
-        .position(|label| label.ends_with("src/payments/retry.rs"))
+        .position(|label| label.ends_with("payments/retry.rs"))
         .expect("the canonical definition must be a hit");
     let test_path = order
         .iter()
-        .position(|label| label.ends_with("tests/retry_test.rs"))
+        .position(|label| label.ends_with("payments/aaa_retry_test.rs"))
         .expect("the test-path definition must be a hit");
+    // Non-vacuous: without the signal the stated tie-break key would put
+    // the test path first, not the canonical one.
+    assert!(
+        "payments/aaa_retry_test.rs" < "payments/retry.rs",
+        "the fixture only discriminates if the tie-break key would order \
+         these the other way round"
+    );
     assert!(
         canonical < test_path,
-        "the canonical implementation must outrank the test path: {order:#?}"
+        "the canonical implementation must outrank the test path despite \
+         losing the tie-break key: {order:#?}"
     );
     assert!(answer.hits[canonical].signals.canonical_path);
     assert!(!answer.hits[test_path].signals.canonical_path);


### PR DESCRIPTION
## What

A2 §7's fusion as **one expression** — `RRF(d) = Σ 1/(k + rank_i(d))` — over W2's BM25 and W3b's exact-cosine lists, then A2 §8's deterministic rerank. `src/runtime/atlas/fusion.rs`, plus `AtlasDb::fused_search`.

A2-08's rung is **R6** (*"rank fusion can remain a simple deterministic expression; no framework needed"*), so there is no weight system, no pluggable scorer, no learned ranker.

**2378 passed, 0 failed, 40 skipped.** clippy `-D warnings` clean, fmt clean.

## The four determinism hazards, each with a rule and a test

RRF itself is exactly reproducible; the risk is elsewhere. A2 §4's last sentence makes a result derived evidence carrying query identity, input generation and **output hash** — a nondeterministic ranker cannot honour that envelope, because the hash would not reproduce.

| Hazard | Test |
|---|---|
| candidate collection order | `the_order_the_two_lists_arrive_in_cannot_change_the_fused_answer` |
| tie-breaking | `tied_fused_scores_are_broken_by_the_stated_key_not_by_arrival_order` **and** `..._follow_the_key_even_when_the_map_order_disagrees` |
| float summation order | `the_two_contributions_are_summed_in_a_fixed_source_order` |
| `HashMap` iteration | `no_hash_map_or_hash_set_reaches_the_fusion_module` |

**The second tie test exists because the first was vacuous.** Deleting the tiebreaker left it passing — the `BTreeMap`'s own key order happened to agree with the stated key. Rather than soften the claim, a second test was added where map order deliberately disagrees. That is W3b's finding repeated on this wave's own work, and both tests document it.

## A2 §8's nine signals — enumerated, implemented or named

All nine are computed. **Three of them cannot reorder anything today, and that is written down rather than hidden** (on `RerankSignals`' doc, in the CHANGELOG, and pinned by `the_three_filter_shaped_signals_are_uniform_because_admissibility_already_applied_them`): an unselected source and a non-knowledge generation are already inadmissible, and `confirm_scan` evicts a source's previous confirmed generation in the same transaction that promotes its successor — so no stale generation is ever admissible to begin with. They are still carried so W5's §13 trace can state them.

**Signal 2 has a named gap, not a workaround.** A1 stores reference sites in `source.edges`, but `indexable_units` derives candidates only from definitions, document units and row text — so a code *reference* is never a candidate at all, and the signal discriminates definition-vs-prose-mention. Indexing `source.edges` as a retrievable family is an A1-side change, **deliberately not smuggled in as a ranking workaround**. Destination recorded on the field's own doc.

## Panel — 7 raised, 6 confirmed, one commit per finding

**Blocker, spec-fidelity:** `work_changed_unit` was source-name equality. An overlay's universe is base ∪ changed under one source name, so the signal fired for **every** path under a Work's overlay whether the Work touched it or not — it claimed "Work-changed" and meant "in a Work's overlay". Now compares `source.files.content_hash` between the overlay generation and the confirmed base at the same path (R2 on an existing column, no migration), with an honest `false` when no base exists.

**Blocker, test-honesty:** the summation-order pin was vacuous with two terms. Replaced.

**Major, invariants:** `fused_search` performed two independent non-transactional reads against the shared DuckDB instance; both halves now read under one snapshot.

Plus a confounded canonical-vs-test fixture and two simplicity findings.

## The prohibition, re-proved at the fusion layer

A2 §8 forbids the reranker *"silently crossing an authority/source filter merely because a candidate scores well."* W2 proved it for lexical, W3b for semantic; fusion is exactly where a second list could smuggle one in. `an_inadmissible_unit_that_wins_the_semantic_list_never_reaches_the_fused_answer` — non-vacuous, in the shape both prior waves used.

## Non-vacuity checked by breaking the code

Deleting `fuse`'s sorts → red. Stubbing `work_changed_unit`/`canonical_path` → 3 red. Stubbing `structural_relationship`/`definition_over_reference` → the nine-signal test red, naming the missing ones. The first draft of the expression test asserted the wrong winner from eyeballed arithmetic; the failure corrected it, and the corrected numbers are in the test so a reader can re-check them.

**Note on the brief:** it cited A2 §4 as the derived-evidence rule. §4's heading is *"Large structured data has two lanes"* — the sentence is its last line, and §13 carries the trace list. The wave read the section rather than accepting the citation.

R2 (reuses `LexicalHit`/`SemanticHit` shape, `source.edges`, `source.files.content_hash`, `compounds_of`/`case_split` for identifier shape). R6 (one expression). No new SQL interpolation — item 13's pin unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4