### PR TITLE
fix(atlas): S5 closeout — nine findings, and the SQL boundary that took three rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1340,11 +1340,14 @@ them were dead code in every real installation.
 - **All four unit families answer, with A1's own coordinates.** Code,
   document, mail and selected-row-text (A2 §17 item 2), each with a test that
   finds a unit of that kind and resolves its provenance — source, generation,
-  unit, and the byte range for the three families whose evidence is a
-  resource's bytes. Selected-row text carries A2 §3's structured-text
+  unit, and the byte range for the families whose evidence really is a span of
+  a resource's bytes. Selected-row text carries A2 §3's structured-text
   coordinate instead (`dataset/row-id/field-set`): a row is read in place and
   never copied into Atlas, so there is no byte range to cite and none is
-  invented.
+  invented. A mail body and an Office section have no byte span either, and
+  carry the native coordinate described under "Worker-landed units keep their
+  provenance" below; the S5 closeout corrected this bullet, which had claimed
+  a byte range for all three non-row families.
 - **Tokenization keeps the whole identifier as well as its parts.** A2 §5's
   six named forms — `PaymentRetryPolicy`, `payment_retry_policy`,
   `payment-retry-policy`, `Foo::bar`, `POST /payments`, `INC0012345` — are
@@ -1518,6 +1521,37 @@ them were dead code in every real installation.
   coverage row still has no field on the worker batch to travel in, so an
   entry-level refusal is proven in the adapter's own tests and does not
   reach the daemon.
+
+### Worker-landed units keep their provenance (S5 closeout)
+
+- **A mail or Office unit now lands with everything its adapter knew about
+  it.** The daemon-side landing path for every worker-routed adapter built
+  each unit with `heading_level: None, title: None` and dropped the
+  normalizer's native coordinate entirely, so Markdown and text kept their
+  provenance and mail, Office and container children lost theirs: a real
+  `.eml` hit carried no title, no span and no way to tell a message's text
+  body from its html body — the one field that distinguishes them. All three
+  values travel the worker wire and land now
+  (`y8_adapter_dispatch::a_real_scan_dispatches_docx_zip_and_eml_through_the_worker_and_the_recorded_generation_carries_the_proof`).
+- **A message's subject is the unit's title** (A1 §6.5's `subject`), on both
+  of its bodies.
+- **A2 §9's native coordinate is stored and cited.** It lives in a new
+  `source.unit_coordinates` table rather than a column added to the landed
+  `source.units` — this store's own rule is that a landed table is only ever
+  added to — and is joined onto both the lexical postings read and the shared
+  `indexable_units` derivation, so a lexical hit and a semantic hit on one
+  unit still carry the identical coordinate. `GET /v1/search` renders it as
+  `unit.native`, and `sgt search` prints `<title> at <native>` for a unit that
+  has one instead of the `bytes 0..0` it used to print, which printed the
+  absence rather than the evidence.
+- **The mail family's item-2 test now lands a real `.eml` through the real
+  worker subprocess.** It was a hand-built row that never touched the worker
+  and asserted a title and a byte span production could not produce — it would
+  have passed with the whole mail adapter deleted. It now asserts what a
+  production mail hit actually carries: the subject as title, `0`/`0` as the
+  honest not-applicable span, and `text-body`/`html-body` as the coordinate
+  that distinguishes the two bodies
+  (`w2_lexical_retrieval::lexical_search_returns_mail_units_with_exact_a1_provenance`).
 
 
 ## [0.2.4] - 2026-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1553,6 +1553,35 @@ them were dead code in every real installation.
   that distinguishes the two bodies
   (`w2_lexical_retrieval::lexical_search_returns_mail_units_with_exact_a1_provenance`).
 
+### The relational half of a search has a surface (S5 closeout)
+
+- **`sgt map facts <source>` / `GET /v1/map/facts?source=<name>`** — one
+  source's stored relational evidence: every canned dataset query's answer
+  with the query identity and output hash that make it checkable (A1 §6.4).
+  A2 §17 item 3 asks for a relational answer available *independently of
+  text retrieval* that *joins to retrieved row evidence*; the join was
+  performed, but only between two library calls with no caller anywhere in
+  `src/`, so no consumer outside this process could reach the aggregate
+  half. `dataset_key` — the key `sgt search --content row-text` already
+  prints on every row hit — is the join, and both sides are now readable
+  from outside
+  (`w5_search_surface::item_3s_relational_read_is_reachable_from_outside_the_process`).
+- `AtlasDb::dataset_probe` is deliberately **not** on that surface and the
+  new test asserts it stays off: it opens a file path the caller names,
+  which is a different property from its query being canned, and its own doc
+  already said it must never become HTTP-reachable. The scan-time producer
+  that computes these facts is unchanged.
+- Two reads remain test-only and are named here rather than left implied.
+  `AtlasDb::datasets` is the per-dataset inventory — `sgt map stats` reports
+  each source's dataset *count*, not those rows. The three content-kind
+  observers `admissible_units`/`admissible_occurrences`/`admissible_datasets`
+  return one family's admissible set; §2's filter itself is production-
+  reachable, because every search runs the same `WHERE` through
+  `admissible_generations`, so what has no surface is reading a family's
+  admitted set back, not the filtering. Both are cited as test evidence
+  today; if either earns a surface it is S6's intelligence read, and no §17
+  item is claimed met by their existence.
+
 
 ## [0.2.4] - 2026-08-25
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -593,6 +593,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/map/stats", get(map_stats))
         .route("/map/outline", get(map_outline))
         .route("/map/children", get(map_children))
+        .route("/map/facts", get(map_facts))
         .route("/map/symbol", get(map_symbol))
         .route("/map/references", get(map_references))
         // S5 W5, A2 §14's minimum useful surface — BOTH verbs. Canned and
@@ -5902,6 +5903,51 @@ async fn map_children(State(state): State<ApiState>, Query(query): Query<MapQuer
     }
 }
 
+/// `GET /v1/map/facts?source=<name>` — the derived relational evidence one
+/// source's confirmed generation holds: every canned dataset query's stored
+/// answer, with the identity and output hash that make it checkable
+/// (A1 §6.4).
+///
+/// This is A2 §17 item 3's **relational** read, and it exists because that
+/// item asks for two things that must both be reachable from outside the
+/// process: a relational answer available *independently of text retrieval*,
+/// and one that *joins to retrieved row evidence*. The join key is
+/// `dataset_key`, which `sgt search --content row-text` already prints on
+/// every row hit; without this route the aggregate half of that join had no
+/// caller outside the test suite (S5 closeout F-AC-03).
+///
+/// It reads rows the store already holds — never a path a client named. The
+/// producer that opens a dataset file, `AtlasDb::dataset_probe`, is
+/// deliberately NOT routed here and its own doc says why.
+async fn map_facts(State(state): State<ApiState>, Query(query): Query<MapQuery>) -> Response {
+    let source = match query.source() {
+        Ok(source) => source.to_string(),
+        Err(response) => return *response,
+    };
+    let limit = query.limit();
+    match with_atlas(&state, |atlas| atlas.dataset_facts(&source, limit)).await {
+        Ok(None) => atlas_absent(),
+        Ok(Some(facts)) => Json(json!({
+            "atlas": {"present": true},
+            "source": source,
+            "limit": limit,
+            "facts": facts.iter().map(|f| json!({
+                "path": f.relative_path,
+                "dataset_key": f.dataset_key,
+                "query": f.query,
+                "query_identity": f.query_identity,
+                "row_limit": f.row_limit,
+                "truncated": f.truncated,
+                "columns": f.columns,
+                "rows": f.rows,
+                "output_hash": f.output_hash,
+            })).collect::<Vec<_>>(),
+        }))
+        .into_response(),
+        Err(response) => *response,
+    }
+}
+
 /// `GET /v1/map/symbol?name=<symbol>` — the symbol index, by exact name.
 async fn map_symbol(State(state): State<ApiState>, Query(query): Query<MapQuery>) -> Response {
     let name = match query.name() {
@@ -8153,6 +8199,35 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert!(body["children"].is_array(), "{body}");
 
+        // `map facts` is the READ side of `source.dataset_facts` — A2 §17
+        // item 3's relational half, which had no production caller at all
+        // before the S5 closeout (F-AC-03). The scanned source holds one
+        // dataset, so this is a real answer, not an empty envelope.
+        let (status, body) = body_json(
+            map_facts(
+                State(state.clone()),
+                Query(MapQuery {
+                    source: Some("notes".to_string()),
+                    ..MapQuery::default()
+                }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let facts = body["facts"].as_array().expect("facts");
+        assert!(
+            !facts.is_empty(),
+            "the scanned dataset's stored answers: {body}"
+        );
+        assert!(
+            facts.iter().all(
+                |f| !f["dataset_key"].as_str().unwrap_or_default().is_empty()
+                    && !f["output_hash"].as_str().unwrap_or_default().is_empty()
+            ),
+            "every fact carries the join key and the hash that makes it checkable: {body}"
+        );
+
         // `map repos` is repository sources; a knowledge source is not one.
         let (status, body) = body_json(map_repos(State(state.clone())).await).await;
         assert_eq!(status, StatusCode::OK);
@@ -8174,6 +8249,11 @@ mod tests {
 
         let (status, body) =
             body_json(map_outline(State(state.clone()), Query(MapQuery::default())).await).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "source_required");
+
+        let (status, body) =
+            body_json(map_facts(State(state.clone()), Query(MapQuery::default())).await).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(body["error"]["code"], "source_required");
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -6180,6 +6180,19 @@ impl SearchQuery {
             atlas_db::Admissibility {
                 source,
                 kind,
+                // A2 §2's stage 2. `None` narrows nothing, and no selector
+                // sets it, because in this build `authority_class` is a
+                // total function of `source_kind` — every producer pairs
+                // LocalKnowledge/EstateReadonly, EstateGit/EstateMutable and
+                // ExternalGit/External — so `--type` above already names
+                // every world an authority selector could name, and A2 §14's
+                // selector list carries no authority flag. That is a
+                // property of today's producers, not of the design, so it is
+                // pinned rather than assumed:
+                // `w1_deterministic_filter::the_authority_axis_earns_no_\
+                // selector_only_while_it_is_a_function_of_source_kind` fails
+                // the moment a producer breaks the pairing, which is when
+                // this field needs a caller.
                 authority: None,
             },
             attribution,

--- a/src/api.rs
+++ b/src/api.rs
@@ -6274,7 +6274,7 @@ fn answer_disclosure(answer: &atlas_db::FusedAnswer) -> Value {
 /// A **pure read**. Nothing here indexes, scans, warms or writes: H13.2
 /// rejected query-time scanning precisely so this verb could be one, and
 /// `tests/w1b_overlay_lifecycle_trigger.rs::
-/// the_admissibility_filter_cannot_write_because_every_method_takes_an_immutable_self`
+/// the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls`
 /// is the structural pin. It reaches Atlas through the read-only
 /// [`with_atlas`], which hands `&AtlasDb`, never `&mut`.
 async fn search_query(State(state): State<ApiState>, Query(query): Query<SearchQuery>) -> Response {

--- a/src/bin/atlas_worker.rs
+++ b/src/bin/atlas_worker.rs
@@ -328,6 +328,8 @@ fn normal_batch(args: &Args, input: &[u8]) -> Result<WorkerBatch, String> {
                     byte_start,
                     byte_end,
                     coordinate: unit.coordinate,
+                    heading_level: unit.heading_level,
+                    title: unit.title,
                     text: unit.text,
                 }
             })
@@ -379,6 +381,12 @@ fn normal_batch(args: &Args, input: &[u8]) -> Result<WorkerBatch, String> {
                 byte_start: 0,
                 byte_end: 0,
                 coordinate: Some("text-body".to_string()),
+                heading_level: None,
+                // A1 §6.5 lists `subject` among the fields a mail message
+                // must preserve rather than flatten into anonymous prose.
+                // A unit's title is where this store keeps that, so both of
+                // a message's bodies carry it.
+                title: message.subject.clone(),
                 text,
             });
         }
@@ -388,6 +396,8 @@ fn normal_batch(args: &Args, input: &[u8]) -> Result<WorkerBatch, String> {
                 byte_start: 0,
                 byte_end: 0,
                 coordinate: Some("html-body".to_string()),
+                heading_level: None,
+                title: message.subject.clone(),
                 text: html,
             });
         }
@@ -407,6 +417,8 @@ fn normal_batch(args: &Args, input: &[u8]) -> Result<WorkerBatch, String> {
                 byte_start: 0,
                 byte_end: input.len() as u64,
                 coordinate: None,
+                heading_level: None,
+                title: None,
                 text: text.to_string(),
             }],
             Err(_) => Vec::new(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -689,6 +689,21 @@ pub enum MapCommand {
         #[arg(long)]
         limit: Option<usize>,
     },
+    /// One source's stored relational evidence: every canned dataset
+    /// query's answer, with the query identity and output hash that make it
+    /// checkable (A1 §6.4).
+    ///
+    /// A2 §17 item 3's relational read. `dataset_key` is the join key
+    /// `sgt search --content row-text` prints on every row hit, so an
+    /// aggregate and the example rows behind it cite one identity instead of
+    /// becoming two unrelated representations (A2 §4).
+    Facts {
+        /// Declared source name.
+        source: String,
+        /// Row ceiling; the store caps it regardless (F12).
+        #[arg(long)]
+        limit: Option<usize>,
+    },
     /// The symbol index, by exact name.
     Symbol {
         /// Symbol name, matched exactly — never as a pattern.
@@ -1895,6 +1910,14 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
                         limit_query(*limit)
                     ),
                     "children",
+                ),
+                MapCommand::Facts { source, limit } => (
+                    format!(
+                        "/v1/map/facts?source={}{}",
+                        crate::api::urlencode(source),
+                        limit_query(*limit)
+                    ),
+                    "facts",
                 ),
                 MapCommand::Symbol { name, limit } => (
                     format!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3185,12 +3185,24 @@ fn print_hit(rank: usize, hit: &Value) {
             cell_text(&unit["row_key"]),
             cell_text(&unit["fields"]),
         ),
-        _ => format!(
-            "{} bytes {}..{}",
-            unit["title"].as_str().unwrap_or("(untitled)"),
-            cell_text(&unit["byte_start"]),
-            cell_text(&unit["byte_end"]),
-        ),
+        // A2 §9: a result cites the original source path *and native
+        // coordinate*. A document or mail unit the adapter had to decode a
+        // container to reach has no byte span (`0`/`0` is its honest
+        // not-applicable), and its native coordinate — which body of the
+        // message, which block of the document — is the only thing that
+        // addresses it. Printing `bytes 0..0` there prints the absence
+        // instead of the evidence (S5 closeout, F-AC-02).
+        _ => {
+            let title = unit["title"].as_str().unwrap_or("(untitled)");
+            match unit["native"].as_str() {
+                Some(native) => format!("{title} at {native}"),
+                None => format!(
+                    "{title} bytes {}..{}",
+                    cell_text(&unit["byte_start"]),
+                    cell_text(&unit["byte_end"]),
+                ),
+            }
+        }
     };
     println!(
         "{rank}. {}  [{}/{}]",

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -452,6 +452,14 @@ CREATE TABLE IF NOT EXISTS source.units (\n\
   byte_end      BIGINT NOT NULL,\n\
   body          TEXT NOT NULL\n\
 );\n\
+CREATE TABLE IF NOT EXISTS source.unit_coordinates (\n\
+  generation_id TEXT NOT NULL,\n\
+  source_name   TEXT NOT NULL,\n\
+  relative_path TEXT NOT NULL,\n\
+  local_key     TEXT NOT NULL,\n\
+  ordinal       BIGINT NOT NULL,\n\
+  coordinate    TEXT NOT NULL\n\
+);\n\
 CREATE TABLE IF NOT EXISTS source.symbols (\n\
   generation_id TEXT NOT NULL,\n\
   source_name   TEXT NOT NULL,\n\
@@ -617,11 +625,20 @@ macro_rules! admissible_generations_where {
 /// procedural.
 macro_rules! lexical_posting_join {
     () => {
-        "FROM context.lexical_postings p \
-         JOIN context.lexical_units l ON l.generation_id = p.generation_id \
-                                      AND l.unit_key = p.unit_key \
-         JOIN source.generations g ON g.generation_id = l.generation_id \
-         WHERE "
+        lexical_posting_join!("")
+    };
+    // `$extra` is spliced between the joins and the `WHERE`, and must be a
+    // literal for the same reason every statement in this file is one
+    // (item 13's no-client-SQL pin): `concat!` takes literals only.
+    ($extra:expr) => {
+        concat!(
+            "FROM context.lexical_postings p \
+             JOIN context.lexical_units l ON l.generation_id = p.generation_id \
+                                          AND l.unit_key = p.unit_key \
+             JOIN source.generations g ON g.generation_id = l.generation_id ",
+            $extra,
+            " WHERE "
+        )
     };
 }
 
@@ -649,8 +666,20 @@ const LEXICAL_POSTINGS_SQL: &str = concat!(
     "SELECT l.generation_id, l.source_name, g.content_key, l.family, l.unit_key, \
             l.relative_path, l.ordinal, l.title, l.symbol, l.language, l.label, \
             l.dataset_key, l.row_key, l.fields, l.byte_start, l.byte_end, \
-            l.token_count, p.term_frequency, g.source_kind, g.authority_class ",
-    lexical_posting_join!(),
+            l.token_count, p.term_frequency, g.source_kind, g.authority_class, \
+            c.coordinate ",
+    // A2 §9's native coordinate, joined rather than stored a second time:
+    // `context.lexical_units` is a landed table this module may not alter,
+    // and a derived index re-deriving a stored fact is how two copies drift.
+    // The family guard is not decoration — a code unit and a document unit
+    // can share one path and ordinal (`unit_key`'s own doc), and only the
+    // document/mail families read `source.units` rows at all.
+    lexical_posting_join!(
+        "LEFT JOIN source.unit_coordinates c ON c.generation_id = l.generation_id \
+                                            AND c.relative_path = l.relative_path \
+                                            AND c.ordinal = l.ordinal \
+                                            AND l.family IN ('document', 'mail') "
+    ),
     admissible_generations_where!(),
     " AND (? IS NULL OR l.family = ?) AND p.term = ? \
       ORDER BY l.source_name, l.relative_path, l.ordinal, l.unit_key \
@@ -3840,6 +3869,29 @@ fn insert_unit(
         unit.byte_end as i64,
         &unit.text,
     ])?;
+    // A2 §9's *native coordinate*, in its own table rather than a column on
+    // `source.units` — this module's own rule (see the module doc): a landed
+    // table is only ever added to, never altered, so a new fact arrives as a
+    // new table carrying its own copy of the coordinates that address it.
+    //
+    // A row only when there is one. `None` is every in-process text/Markdown
+    // unit, whose byte span is already its address; a row of `NULL` here
+    // would be a declared-but-empty promise for those.
+    if let Some(coordinate) = unit.coordinate.as_deref() {
+        conn.prepare_cached(
+            "INSERT INTO source.unit_coordinates \
+             (generation_id, source_name, relative_path, local_key, ordinal, coordinate) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )?
+        .execute(duckdb::params![
+            generation_id,
+            source_name,
+            &file.relative_path,
+            &file.local_key,
+            unit.ordinal as i64,
+            coordinate,
+        ])?;
+    }
     Ok(())
 }
 
@@ -4484,10 +4536,13 @@ fn indexable_units(
     let [doc_a, doc_b, doc_c, doc_d] = DOCUMENT_EXTRACTOR_IDENTITIES;
     let mut statement = conn.prepare(
         "SELECT u.source_name, u.relative_path, u.ordinal, u.title, u.byte_start, u.byte_end, \
-                u.body, f.extractor \
+                u.body, f.extractor, c.coordinate \
          FROM source.units u \
          JOIN source.files f ON f.generation_id = u.generation_id \
                              AND f.relative_path = u.relative_path \
+         LEFT JOIN source.unit_coordinates c ON c.generation_id = u.generation_id \
+                                             AND c.relative_path = u.relative_path \
+                                             AND c.ordinal = u.ordinal \
          WHERE u.generation_id = ? AND f.extractor IN (?, ?, ?, ?) \
          ORDER BY u.relative_path, u.ordinal",
     )?;
@@ -4522,6 +4577,7 @@ fn indexable_units(
             fields: None,
             byte_start: Some(row.get::<usize, i64>(4)? as u64),
             byte_end: Some(row.get::<usize, i64>(5)? as u64),
+            native: row.get(8)?,
             text,
         });
     }
@@ -4554,6 +4610,7 @@ fn indexable_units(
             fields: None,
             byte_start: Some(row.get::<usize, i64>(6)? as u64),
             byte_end: Some(row.get::<usize, i64>(7)? as u64),
+            native: None,
             text: name,
         });
     }
@@ -4583,6 +4640,7 @@ fn indexable_units(
             fields: Some(row.get(5)?),
             byte_start: None,
             byte_end: None,
+            native: None,
             text: row.get(6)?,
         });
     }
@@ -4687,6 +4745,10 @@ fn coordinate_of(row: &duckdb::Row<'_>) -> Result<UnitCoordinate, AtlasError> {
     let title: Option<String> = row.get(7)?;
     let byte_start = row.get::<usize, Option<i64>>(14)?.unwrap_or(0) as u64;
     let byte_end = row.get::<usize, Option<i64>>(15)?.unwrap_or(0) as u64;
+    // A2 §9's native coordinate, `LEFT JOIN`ed on the posting row: `None`
+    // for a unit whose byte span is its address, and for every family that
+    // does not come from `source.units` at all.
+    let native: Option<String> = row.get(20)?;
     Ok(match family {
         LexicalFamily::Code => UnitCoordinate::Code {
             relative_path,
@@ -4703,6 +4765,7 @@ fn coordinate_of(row: &duckdb::Row<'_>) -> Result<UnitCoordinate, AtlasError> {
             title,
             byte_start,
             byte_end,
+            native,
         },
         LexicalFamily::Mail => UnitCoordinate::Mail {
             relative_path,
@@ -4710,6 +4773,7 @@ fn coordinate_of(row: &duckdb::Row<'_>) -> Result<UnitCoordinate, AtlasError> {
             title,
             byte_start,
             byte_end,
+            native,
         },
         LexicalFamily::RowText => UnitCoordinate::RowText {
             relative_path,
@@ -4753,6 +4817,9 @@ struct IndexableUnit {
     fields: Option<String>,
     byte_start: Option<u64>,
     byte_end: Option<u64>,
+    /// A2 §9's native coordinate for this unit, when the adapter produced
+    /// one — `source.unit_coordinates`, joined in by [`indexable_units`].
+    native: Option<String>,
     text: String,
 }
 
@@ -4783,6 +4850,7 @@ impl IndexableUnit {
                 title: self.title.clone(),
                 byte_start: self.byte_start.unwrap_or(0),
                 byte_end: self.byte_end.unwrap_or(0),
+                native: self.native.clone(),
             },
             LexicalFamily::Mail => UnitCoordinate::Mail {
                 relative_path: self.relative_path.clone(),
@@ -4790,6 +4858,7 @@ impl IndexableUnit {
                 title: self.title.clone(),
                 byte_start: self.byte_start.unwrap_or(0),
                 byte_end: self.byte_end.unwrap_or(0),
+                native: self.native.clone(),
             },
             LexicalFamily::RowText => UnitCoordinate::RowText {
                 relative_path: self.relative_path.clone(),
@@ -4866,6 +4935,10 @@ fn evict(
 ) -> Result<(), AtlasError> {
     conn.execute(
         "DELETE FROM source.units WHERE generation_id = ?",
+        duckdb::params![generation_id],
+    )?;
+    conn.execute(
+        "DELETE FROM source.unit_coordinates WHERE generation_id = ?",
         duckdb::params![generation_id],
     )?;
     conn.execute(
@@ -7655,6 +7728,7 @@ mod tests {
                     title: None,
                     byte_start: 0,
                     byte_end: body.len() as u64,
+                    coordinate: None,
                     text: body.to_string(),
                 }],
                 syntax: None,

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -121,8 +121,10 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use duckdb::types::Value as Duck;
-use duckdb::{Connection, Statement, Transaction};
+use duckdb::{Connection, Statement};
+
 use serde_json::{Map, Value, json};
+use store::{ReadOnly, Sql, Statements, Store};
 
 use crate::domain::event::{Event, unix_millis};
 use crate::domain::execution::{
@@ -784,11 +786,12 @@ fn reader_call(format: DatasetFormat) -> &'static str {
 /// [`output_hash`] hashes exactly what is stored — so an answer's digest
 /// covers the answer a reader will actually see, with no formatting step in
 /// between where two builds could disagree about how a `DOUBLE` renders.
-fn rows_sql(format: DatasetFormat) -> String {
-    format!(
-        "SELECT COLUMNS(*)::VARCHAR FROM {} LIMIT ?",
-        reader_call(format)
-    )
+fn rows_sql(format: DatasetFormat) -> Sql {
+    Sql::from_parts(&[
+        "SELECT COLUMNS(*)::VARCHAR FROM ",
+        reader_call(format),
+        " LIMIT ?",
+    ])
 }
 
 /// [`DATASET_ROW_COUNT`]'s SQL for one format.
@@ -796,24 +799,26 @@ fn rows_sql(format: DatasetFormat) -> String {
 /// The count is taken over a *bounded* subquery, so a dataset far larger than
 /// the cap costs one capped scan rather than a full one (F12). The caller asks
 /// for `cap + 1` and learns from the answer whether the cap bit.
-fn row_count_sql(format: DatasetFormat) -> String {
-    format!(
-        "SELECT count(*)::VARCHAR AS rows FROM (SELECT 1 FROM {} LIMIT ?)",
-        reader_call(format)
-    )
+fn row_count_sql(format: DatasetFormat) -> Sql {
+    Sql::from_parts(&[
+        "SELECT count(*)::VARCHAR AS rows FROM (SELECT 1 FROM ",
+        reader_call(format),
+        " LIMIT ?)",
+    ])
 }
 
 /// [`DATASET_COLUMN_PROFILE`]'s SQL for one format.
-fn column_profile_sql(format: DatasetFormat) -> String {
-    format!(
+fn column_profile_sql(format: DatasetFormat) -> Sql {
+    Sql::from_parts(&[
         "SELECT column_name, count(*)::VARCHAR AS rows, \
          count(value)::VARCHAR AS non_null_rows, \
          count(DISTINCT value)::VARCHAR AS distinct_values \
-         FROM (SELECT COLUMNS(*)::VARCHAR FROM {} LIMIT ?) \
+         FROM (SELECT COLUMNS(*)::VARCHAR FROM ",
+        reader_call(format),
+        " LIMIT ?) \
          UNPIVOT (value FOR column_name IN (COLUMNS(*))) \
          GROUP BY column_name ORDER BY column_name",
-        reader_call(format)
-    )
+    ])
 }
 
 /// The SQL for one canned query over one format.
@@ -821,7 +826,7 @@ fn column_profile_sql(format: DatasetFormat) -> String {
 /// A `match` over the catalogue rather than a function pointer on
 /// [`DatasetQuery`]: the catalogue is a `const`, and a `const` holding
 /// function pointers is harder to read than the two arms it would replace.
-fn sql_for(query: &DatasetQuery, format: DatasetFormat) -> String {
+fn sql_for(query: &DatasetQuery, format: DatasetFormat) -> Sql {
     if query.name == DATASET_ROW_COUNT.name {
         row_count_sql(format)
     } else {
@@ -836,12 +841,12 @@ fn sql_for(query: &DatasetQuery, format: DatasetFormat) -> String {
 /// a human keeps; the digest is a fact about the statement. If someone edits
 /// the SQL and forgets the version bump, stored evidence still says the
 /// question changed.
-pub fn query_identity(query: &DatasetQuery, sql: &str) -> String {
+pub fn query_identity(query: &DatasetQuery, sql: &Sql) -> String {
     format!(
         "{}/{}#{}",
         query.name,
         query.version,
-        blake3::hash(sql.as_bytes()).to_hex()
+        blake3::hash(sql.text().as_bytes()).to_hex()
     )
 }
 
@@ -901,6 +906,384 @@ pub struct DatasetFact {
     pub output_hash: String,
 }
 
+/// **Where the compiler, not a scan of this file's text, enforces two of
+/// Atlas's boundaries.**
+///
+/// Both boundaries below were guarded until the S5 closeout by structural
+/// tests that read `db.rs` as text and looked for forbidden spellings. Both
+/// guards were then defeated by a single hop — a `format!`-assembled verb the
+/// scan's case handling could never match, and a caller's string laundered
+/// through one local rebinding. Widening the spellings would only move the
+/// hop. So the spellings stopped being the load-bearing mechanism and these
+/// types took over; the scans remain as a cheap second net over the shapes a
+/// type cannot see (see `tests/w1b_overlay_lifecycle_trigger.rs` and
+/// `tests/x5_a1a_acceptance.rs`, whose docs name their own blind spots).
+///
+/// This is a **child module on purpose (R4 — the language's own privacy is
+/// the mechanism)**, not a sibling file. A private field is private to its
+/// defining module and its descendants, never to its parent, so nothing in
+/// the rest of `db.rs` can reach [`Store::conn`] or construct a [`Sql`] out
+/// of a runtime string — while `db.rs` remains the single file naming the
+/// database driver, which `tests/x1_atlas_substrate.rs`'s
+/// `atlas_database_has_exactly_one_owner` requires and which a second file
+/// would break.
+///
+/// # What each type buys
+///
+/// * [`Sql`] — a statement this crate wrote. Its only constructors take
+///   `&'static str`, so a value that arrived from a caller cannot become one:
+///   `store.execute_batch(user_text)` where `user_text: &str` is a **compile
+///   error**, and so is every `String`. A1a §17 item 13 ("no client SQL
+///   reaches the store") is therefore a property of the type system here.
+/// * [`Store`] / [`StoreTx`] — the only statement-running surfaces `db.rs`
+///   has. They take `impl Into<Sql>`, and they wrap the driver's
+///   `Connection`/`Transaction` rather than deref to them, so no code outside
+///   this module can hand the driver a `&str` at all.
+/// * [`ReadOnly`] — a handle that **cannot write**, because it exposes no
+///   write call and hands out no `Statement`, no `Appender`, no
+///   `Transaction`, and no `Connection`. `impl Admissible` holds one of these
+///   and nothing else, so H13.2's "the admissibility filter cannot write" is
+///   a type error to violate rather than a string absent from a scan.
+///
+/// # What these types do NOT stop
+///
+/// Stated because an unstated limit is how a guard becomes a false claim:
+///
+/// * `String::leak`/`Box::leak` manufacture a `&'static str` from a runtime
+///   string. Nothing here sees that; the second-net scan names it too.
+/// * Opening a *new* `Connection` inside this file bypasses every handle
+///   above. Atlas's one-owner rule and DuckDB's own file locking are what
+///   stand against that, plus the second-net scan, which forbids
+///   `Connection::` anywhere the admissibility filter can reach.
+/// * `unsafe` or a `#[cfg(test)]` shim inside this module. The module is
+///   small enough to read in one sitting, which is the point of keeping it
+///   small.
+pub(crate) mod store {
+    use duckdb::{Appender, CachedStatement, Connection, Statement, ToSql, Transaction};
+
+    /// A statement **this crate** wrote.
+    ///
+    /// Constructible only from `&'static str` — a literal, a `const`, or a
+    /// concatenation of them. There is deliberately no constructor taking
+    /// `&str` or `String`: that absence is the whole guarantee, so adding one
+    /// (or making the field `pub`) is not a refactor, it is the removal of
+    /// A1a item 13's enforcement.
+    #[derive(Clone)]
+    pub struct Sql(String);
+
+    impl Sql {
+        /// Assemble a statement from compile-time pieces.
+        ///
+        /// The one interpolation shape Atlas needs: a canned template plus a
+        /// fragment chosen by an enum or read out of a `&'static` table
+        /// (`reader_call`, `TABLES`). Every piece is `'static`, so no
+        /// caller's value can be among them.
+        pub fn from_parts(parts: &[&'static str]) -> Self {
+            Self(parts.concat())
+        }
+
+        /// Append another vetted statement — two `Sql`s concatenate, a `&str`
+        /// still cannot join one.
+        pub fn extend(&mut self, more: &Sql) {
+            self.0.push_str(&more.0);
+        }
+
+        /// The statement text, for hashing and for handing to the driver.
+        pub fn text(&self) -> &str {
+            &self.0
+        }
+    }
+
+    impl From<&'static str> for Sql {
+        fn from(sql: &'static str) -> Self {
+            Self(sql.to_string())
+        }
+    }
+
+    impl From<&Sql> for Sql {
+        fn from(sql: &Sql) -> Self {
+            sql.clone()
+        }
+    }
+
+    /// The narrowed statement surface, shared by [`Store`] and [`StoreTx`]
+    /// so a helper that runs inside a transaction is written once.
+    ///
+    /// Every method takes `impl Into<Sql>` — the whole point. A helper
+    /// generic over this trait therefore cannot be handed a caller's `&str`
+    /// either, wherever it is called from.
+    pub trait Statements {
+        fn prepare<S: Into<Sql>>(&self, sql: S) -> Result<Statement<'_>, duckdb::Error>;
+        fn prepare_cached<S: Into<Sql>>(
+            &self,
+            sql: S,
+        ) -> Result<CachedStatement<'_>, duckdb::Error>;
+        fn execute<S: Into<Sql>>(
+            &self,
+            sql: S,
+            params: &[&dyn ToSql],
+        ) -> Result<usize, duckdb::Error>;
+        fn execute_batch<S: Into<Sql>>(&self, sql: S) -> Result<(), duckdb::Error>;
+        fn appender_to_db(
+            &self,
+            table: &'static str,
+            schema: &'static str,
+        ) -> Result<Appender<'_>, duckdb::Error>;
+    }
+
+    /// Atlas's connection, with every statement surface narrowed to [`Sql`].
+    pub struct Store {
+        conn: Connection,
+    }
+
+    impl Store {
+        pub fn new(conn: Connection) -> Self {
+            Self { conn }
+        }
+
+        /// A handle onto this same connection that cannot write.
+        pub fn reader(&self) -> ReadOnly<'_> {
+            ReadOnly { conn: &self.conn }
+        }
+
+        pub fn set_statement_cache_capacity(&self, capacity: usize) {
+            self.conn.set_prepared_statement_cache_capacity(capacity);
+        }
+
+        /// A second handle onto the **same database instance**, never a
+        /// second instance (`Connection::try_clone`'s own contract).
+        pub fn try_clone(&self) -> Result<Self, duckdb::Error> {
+            Ok(Self {
+                conn: self.conn.try_clone()?,
+            })
+        }
+
+        pub fn transaction(&mut self) -> Result<StoreTx<'_>, duckdb::Error> {
+            Ok(StoreTx {
+                tx: self.conn.transaction()?,
+            })
+        }
+
+        /// A snapshot-isolated read transaction from a shared borrow —
+        /// `Transaction::new_unchecked`, kept behind this wrapper so the one
+        /// caller that needs it (`fused_search`) still cannot reach a raw
+        /// `Connection` through the value it gets back.
+        pub fn snapshot(&self) -> Result<StoreTx<'_>, duckdb::Error> {
+            Ok(StoreTx {
+                tx: Transaction::new_unchecked(&self.conn)?,
+            })
+        }
+    }
+
+    /// A transaction with the same narrowing [`Store`] applies.
+    ///
+    /// It **wraps** rather than derefs: `duckdb::Transaction` derefs to
+    /// `Connection`, and a deref here would hand every caller the raw `&str`
+    /// surface back through one extra dot.
+    pub struct StoreTx<'conn> {
+        tx: Transaction<'conn>,
+    }
+
+    impl Statements for Store {
+        fn prepare<S: Into<Sql>>(&self, sql: S) -> Result<Statement<'_>, duckdb::Error> {
+            self.conn.prepare(sql.into().text())
+        }
+
+        fn prepare_cached<S: Into<Sql>>(
+            &self,
+            sql: S,
+        ) -> Result<CachedStatement<'_>, duckdb::Error> {
+            self.conn.prepare_cached(sql.into().text())
+        }
+
+        fn execute<S: Into<Sql>>(
+            &self,
+            sql: S,
+            params: &[&dyn ToSql],
+        ) -> Result<usize, duckdb::Error> {
+            self.conn.execute(sql.into().text(), params)
+        }
+
+        fn execute_batch<S: Into<Sql>>(&self, sql: S) -> Result<(), duckdb::Error> {
+            self.conn.execute_batch(sql.into().text())
+        }
+
+        /// A table name is not a statement, but it is still interpolated into
+        /// one by the driver, so it is `&'static str` for the same reason.
+        fn appender_to_db(
+            &self,
+            table: &'static str,
+            schema: &'static str,
+        ) -> Result<Appender<'_>, duckdb::Error> {
+            self.conn.appender_to_db(table, schema)
+        }
+    }
+
+    impl Statements for StoreTx<'_> {
+        fn prepare<S: Into<Sql>>(&self, sql: S) -> Result<Statement<'_>, duckdb::Error> {
+            self.tx.prepare(sql.into().text())
+        }
+
+        fn prepare_cached<S: Into<Sql>>(
+            &self,
+            sql: S,
+        ) -> Result<CachedStatement<'_>, duckdb::Error> {
+            self.tx.prepare_cached(sql.into().text())
+        }
+
+        fn execute<S: Into<Sql>>(
+            &self,
+            sql: S,
+            params: &[&dyn ToSql],
+        ) -> Result<usize, duckdb::Error> {
+            self.tx.execute(sql.into().text(), params)
+        }
+
+        fn execute_batch<S: Into<Sql>>(&self, sql: S) -> Result<(), duckdb::Error> {
+            self.tx.execute_batch(sql.into().text())
+        }
+
+        fn appender_to_db(
+            &self,
+            table: &'static str,
+            schema: &'static str,
+        ) -> Result<Appender<'_>, duckdb::Error> {
+            self.tx.appender_to_db(table, schema)
+        }
+    }
+
+    impl StoreTx<'_> {
+        pub fn commit(self) -> Result<(), duckdb::Error> {
+            self.tx.commit()
+        }
+
+        pub fn rollback(self) -> Result<(), duckdb::Error> {
+            self.tx.rollback()
+        }
+    }
+
+    /// A statement that **reads**: a `&'static str` beginning `SELECT `.
+    ///
+    /// [`ReadOnly`] takes one of these rather than a [`Sql`], and the
+    /// difference is a hop that used to be open. `ReadOnly` exposes no write
+    /// *call* — but DuckDB runs whatever statement it is handed, so
+    /// `prepare("DELETE …")` followed by `query()` writes, and a `Sql`
+    /// assembled from a `&'static str` `DELETE` would have been accepted.
+    /// Checked live in the S5 closeout: that exact hop compiled, before this
+    /// type existed.
+    ///
+    /// The check is deliberately narrow — the statement's first seven bytes —
+    /// because a narrow check that holds is worth more than a verb blacklist
+    /// that a spelling walks past. A `WITH`-prefixed CTE is refused too, and
+    /// widening this to admit one means widening it deliberately, in the one
+    /// place the rule lives.
+    ///
+    /// Build one with [`read_sql!`](crate::read_sql), which evaluates the
+    /// check in a `const` block so a non-`SELECT` is a **compile error**.
+    /// [`ReadSql::new`] called outside a `const` context panics instead;
+    /// that is a loud failure rather than a silent write, but it is not the
+    /// guarantee — the macro is.
+    pub struct ReadSql(&'static str);
+
+    impl ReadSql {
+        pub const fn new(sql: &'static str) -> Self {
+            assert!(
+                begins_with_select(sql),
+                "a read-only handle may only run a statement beginning `SELECT `"
+            );
+            Self(sql)
+        }
+    }
+
+    const fn begins_with_select(sql: &str) -> bool {
+        let bytes = sql.as_bytes();
+        let want = b"SELECT ";
+        if bytes.len() < want.len() {
+            return false;
+        }
+        let mut i = 0;
+        while i < want.len() {
+            if bytes[i] != want[i] {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// A read-only handle onto an Atlas connection.
+    ///
+    /// The type H13.2's "`sgt search` is a pure reader" is enforced by. It
+    /// exposes exactly two operations, both of which run a statement and
+    /// return owned rows; it hands out no `Statement` (whose `execute` takes
+    /// `&mut self` and could run anything prepared), no `Appender`, no
+    /// `Transaction`, and no `Connection`. A caller holding one of these has
+    /// **no expressible way** to write, whatever it does with it.
+    ///
+    /// The `&Row` a mapping closure receives can reach `&Statement` through
+    /// the driver's `AsRef`, and that is checked, not overlooked: every
+    /// writing method on `Statement` takes `&mut self`, so a shared reference
+    /// to one runs nothing.
+    pub struct ReadOnly<'conn> {
+        conn: &'conn Connection,
+    }
+
+    impl ReadOnly<'_> {
+        /// Run one statement and map every row.
+        pub fn rows<T, E, F>(
+            &self,
+            sql: ReadSql,
+            params: &[&dyn ToSql],
+            mut map: F,
+        ) -> Result<Vec<T>, E>
+        where
+            E: From<duckdb::Error>,
+            F: FnMut(&duckdb::Row<'_>) -> Result<T, E>,
+        {
+            let mut statement = self.conn.prepare(sql.0)?;
+            let mut rows = statement.query(params)?;
+            let mut out = Vec::new();
+            while let Some(row) = rows.next()? {
+                out.push(map(row)?);
+            }
+            Ok(out)
+        }
+
+        /// Run one statement and map its first row, if any.
+        pub fn first<T, E, F>(
+            &self,
+            sql: ReadSql,
+            params: &[&dyn ToSql],
+            map: F,
+        ) -> Result<Option<T>, E>
+        where
+            E: From<duckdb::Error>,
+            F: FnMut(&duckdb::Row<'_>) -> Result<T, E>,
+        {
+            Ok(self.rows(sql, params, map)?.into_iter().next())
+        }
+    }
+}
+
+/// A [`ReadSql`] whose `SELECT `-prefix check runs at **compile time**.
+///
+/// `const { .. }` forces the evaluation, so a statement that is not a read is
+/// a build failure rather than a panic — which is the whole reason
+/// [`Admissible`] can claim it cannot write.
+macro_rules! read_sql {
+    ($sql:expr) => {{
+        // A named `const` **item**, not a `const { .. }` block. Both refuse a
+        // non-`SELECT` statement, but a `const` block inside a
+        // lifetime-generic `impl` is a post-monomorphization error that
+        // `cargo check` does not reach — verified, by watching exactly that
+        // happen during the S5 closeout. The item is evaluated eagerly, so
+        // `cargo check` fails too.
+        const CHECKED: $crate::runtime::atlas::db::store::ReadSql =
+            $crate::runtime::atlas::db::store::ReadSql::new($sql);
+        CHECKED
+    }};
+}
+
 /// The bootstrap DDL every fresh read-write connection onto `atlas.duckdb`
 /// needs before its first query: F4's hardening settings, then A1 §5's five
 /// schema namespaces, then Atlas's own tables — in that order, and always
@@ -911,7 +1294,7 @@ pub struct DatasetFact {
 /// sequence; this is the one place it is spelled out, so a future DDL
 /// addition to one caller cannot silently miss the other and leave the
 /// file's shape depend on which struct opened it first.
-fn bootstrap_atlas_ddl(conn: &Connection) -> Result<(), duckdb::Error> {
+fn bootstrap_atlas_ddl(conn: &impl Statements) -> Result<(), duckdb::Error> {
     conn.execute_batch(HARDENING_DDL)?;
     conn.execute_batch(SCHEMA_DDL)?;
     conn.execute_batch(TABLE_DDL)?;
@@ -924,7 +1307,7 @@ fn bootstrap_atlas_ddl(conn: &Connection) -> Result<(), duckdb::Error> {
 /// cross this boundary as plain Rust, the same rule the operations
 /// projection holds for its own file.
 pub struct AtlasDb {
-    conn: Connection,
+    conn: Store,
     path: PathBuf,
     /// A2 §6's model, loaded **at most once per handle** and only when a
     /// query first needs it.
@@ -966,14 +1349,14 @@ impl AtlasDb {
     pub fn open(data_dir: &Path) -> Result<Self, AtlasError> {
         create_dir_all_durable(&atlas_dir(data_dir))?;
         let path = atlas_db_path(data_dir);
-        let conn = Connection::open(&path)?;
+        let conn = Store::new(Connection::open(&path)?);
         Self::over(conn, path)
     }
 
     /// An in-memory Atlas database, for callers that want the namespaces
     /// without a file (tests, and any read-only rendering).
     pub fn open_in_memory() -> Result<Self, AtlasError> {
-        let conn = Connection::open_in_memory()?;
+        let conn = Store::new(Connection::open_in_memory()?);
         Self::over(conn, PathBuf::from(":memory:"))
     }
 
@@ -1009,8 +1392,8 @@ impl AtlasDb {
     pub fn open_read_only(data_dir: &Path) -> Result<Self, AtlasError> {
         let path = atlas_db_path(data_dir);
         let config = duckdb::Config::default().access_mode(duckdb::AccessMode::ReadOnly)?;
-        let conn = Connection::open_with_flags(&path, config)?;
-        conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
+        let conn = Store::new(Connection::open_with_flags(&path, config)?);
+        conn.set_statement_cache_capacity(STATEMENT_CACHE);
         // F4's network-hardening settings only — no `SCHEMA_DDL`, no
         // `TABLE_DDL`. Both are genuine DDL and a read-only connection
         // cannot run them even under `IF NOT EXISTS`; skipping them here
@@ -1024,8 +1407,8 @@ impl AtlasDb {
         })
     }
 
-    fn over(conn: Connection, path: PathBuf) -> Result<Self, AtlasError> {
-        conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
+    fn over(conn: Store, path: PathBuf) -> Result<Self, AtlasError> {
+        conn.set_statement_cache_capacity(STATEMENT_CACHE);
         // First, before any other statement: extension autoloading and
         // autoinstalling are off, and locked off (F4). A connection that ran
         // one query before this ran is a connection that could have reached
@@ -1492,104 +1875,6 @@ impl AtlasDb {
         }
         tx.commit()?;
         Ok(targets.into_iter().map(|(id, _)| id).collect())
-    }
-
-    /// What a `--work` answer actually covers, read from the store rather
-    /// than derived from the selector alone (S5 W1b).
-    ///
-    /// [`WorkScope`]'s whole job is to be TRUE about the answer beside it,
-    /// and whether an overlay stands for a Work is a fact about the store,
-    /// not about the filter a caller typed: the Work may not have bound a
-    /// surface yet, its overlay scan may have failed, or the Work may have
-    /// retired and had its overlay evicted with it
-    /// ([`Self::evict_work_overlays`]). So this asks. One extra bounded
-    /// read per admissibility call, on the same connection.
-    ///
-    /// **Also true about the store, and just as load-bearing: whether the
-    /// TABLE this particular call reads can carry an overlay-authored row at
-    /// all.** An overlay generation stands for exactly one repository
-    /// (S5 W1b's own fix — see [`SourceSelector::overlay_admit_source_name`]),
-    /// is always stamped `SourceKind::EstateGit` / `AuthorityClass::
-    /// EstateMutable` ([`crate::runtime::atlas::overlay::scan_work_overlay`]),
-    /// and never writes a `source.datasets` row at all — an overlay's
-    /// unchanged bytes come from the base tree's objects, so its own scan
-    /// records `datasets: Vec::new()` unconditionally. So an overlay
-    /// standing is not, by itself, enough to say an answer includes it:
-    ///
-    /// - `carries_overlay_rows: false` — this table (`source.datasets`) is
-    ///   one an overlay scan structurally never populates. `BaseOnly`
-    ///   always, regardless of whether an overlay stands.
-    /// - `filter.kind` narrowed to anything but [`SourceKind::EstateGit`],
-    ///   or `filter.authority` narrowed to anything but
-    ///   [`AuthorityClass::EstateMutable`] — the caller's own stage-2/4
-    ///   filter structurally excludes every row an overlay could ever have
-    ///   written. `BaseOnly` for the same reason.
-    ///
-    /// Asserting `BaseAndOverlaySnapshot` in either case would claim the
-    /// answer reflects overlay evidence as of a given instant when no row it
-    /// could contain was ever capable of coming from the overlay — the same
-    /// class of false claim [`WorkScope`]'s own doc names for "current"
-    /// dressed up as a snapshot.
-    fn work_scope(
-        &self,
-        filter: &Admissibility,
-        carries_overlay_rows: bool,
-    ) -> Result<WorkScope, AtlasError> {
-        let SourceSelector::WorkBase {
-            work_id,
-            repository,
-        } = &filter.source
-        else {
-            return Ok(WorkScope::NotWorkScoped);
-        };
-        if !carries_overlay_rows
-            || filter
-                .kind
-                .is_some_and(|kind| kind != SourceKind::EstateGit)
-            || filter
-                .authority
-                .is_some_and(|authority| authority != AuthorityClass::EstateMutable)
-        {
-            return Ok(WorkScope::BaseOnly);
-        }
-        Ok(
-            match self.newest_overlay_observed_at(work_id, repository)? {
-                Some(overlay_observed_at) => WorkScope::BaseAndOverlaySnapshot {
-                    overlay_observed_at,
-                },
-                None => WorkScope::BaseOnly,
-            },
-        )
-    }
-
-    /// When this Work's overlay half — over the one `repository` a
-    /// [`SourceSelector::WorkBase`] names — was last read off its surface:
-    /// the matching CONFIRMED `work:<id>/<repo>` generation's `observed_at`,
-    /// or `None` when no such generation stands.
-    ///
-    /// An exact lookup on the one source name
-    /// [`overlay_source_name`](crate::runtime::atlas::overlay::overlay_source_name)
-    /// can ever produce for this `(work_id, repository)` pair, not a
-    /// `work_id`-only prefix scan — the earlier prefix form answered about
-    /// *any* repository under this Work id, over-claiming past the
-    /// repository the caller actually asked about, the sibling of the
-    /// admission bug [`SourceSelector::overlay_admit_source_name`] fixes.
-    fn newest_overlay_observed_at(
-        &self,
-        work_id: &str,
-        repository: &str,
-    ) -> Result<Option<String>, AtlasError> {
-        let source_name = crate::runtime::atlas::overlay::overlay_source_name(work_id, repository);
-        let mut statement = self.conn.prepare(
-            "SELECT observed_at FROM source.generations \
-             WHERE state = ? AND source_name = ? \
-             ORDER BY observed_at DESC, generation_id DESC LIMIT 1",
-        )?;
-        let mut rows = statement.query(duckdb::params![STATE_CONFIRMED, source_name])?;
-        match rows.next()? {
-            Some(row) => Ok(Some(row.get(0)?)),
-            None => Ok(None),
-        }
     }
 
     /// Record that a Work overlay could **not** be read off its surface at
@@ -2383,412 +2668,59 @@ impl AtlasDb {
     // (H1), never a new table or a new column (H13.1).
     // ------------------------------------------------------------------
 
-    /// The fixed, code-owned `NOT LIKE` bound every admissibility query
-    /// below applies to `source_name`, excluding the whole Work-overlay
-    /// family ([`crate::runtime::atlas::overlay::OVERLAY_PREFIX`],
-    /// `work:<id>/<repo>`) — see [`Self::admissible_generations`]'s own doc
-    /// for what re-admits exactly one Work's own overlay on top of it
-    /// ([`SourceSelector::overlay_admit_source_name`], S5 W1b) and why the
-    /// default-deny stays the default. Derived from the overlay module's
-    /// own prefix constant rather than a second hardcoded literal, so the
-    /// two can never drift apart; still never a client-supplied pattern
-    /// (F12), the same precedent as [`CODE_EXTRACTOR_LIKE`].
-    fn overlay_exclude_like() -> String {
-        format!("{}%", crate::runtime::atlas::overlay::OVERLAY_PREFIX)
+    /// A handle onto this connection that **cannot write**, carrying the
+    /// whole A2 §2 admissibility filter ([`Admissible`]).
+    fn admissible(&self) -> Admissible<'_> {
+        Admissible {
+            reader: self.conn.reader(),
+        }
     }
 
-    /// A2 §2 stages 1(+4) and 2 in one canned query: the source/estate/
-    /// Work-generation filter, the optional repo/knowledge/external
-    /// selector ([`Admissibility::kind`], composable with any
-    /// [`SourceSelector`]), and the authority filter — composed once here
-    /// and reused, in identical shape, by every content-kind method below,
-    /// so a generation excluded at this stage can never resurface through
-    /// a different table.
-    ///
-    /// Every clause is `(? IS NULL OR column = ?)`: an unset filter field
-    /// admits every value of that column rather than narrowing it, so
-    /// `Admissibility::default()` (bare [`SourceSelector::Any`], no
-    /// authority) is "every confirmed generation this store holds" — never
-    /// approximate, never partial. Bounded by `limit` (capped at
-    /// [`MAX_ROWS`], F12).
-    ///
-    /// **The Work-overlay family is denied by default, and exactly one
-    /// Work's own overlay is re-admitted on top of that — never by name.**
-    /// A generation whose `source_name` carries
-    /// [`crate::runtime::atlas::overlay::OVERLAY_PREFIX`]
-    /// (`work:<id>/<repo>`) describes a world only one Work's surface can
-    /// see (H13.2). The composed predicate is
-    ///
-    /// ```text
-    /// (source_name NOT LIKE 'work:%' AND (?src IS NULL OR source_name = ?src))
-    ///   OR (?admit IS NOT NULL AND source_name = ?admit)
-    /// ```
-    ///
-    /// where `?admit` is `Some("work:<id>/<repository>")` — the *exact*
-    /// overlay source name, never a pattern — **only** for
-    /// [`SourceSelector::WorkBase`], built from that variant's own
-    /// `work_id` **and** `repository`
-    /// (`SourceSelector::overlay_admit_source_name`). So:
-    ///
-    /// - [`SourceSelector::Named`]/[`SourceSelector::Exact`] can never
-    ///   reach an overlay, not even naming the exact coordinate — a caller
-    ///   who merely learns another Work's id (e.g. from `sgt work list`)
-    ///   must not be able to type it into `--source` and read that Work's
-    ///   surface. `?admit` is `None` for those variants, so the left
-    ///   branch is the only one available and it denies the whole family.
-    /// - `--work <mine>` admits `mine`'s base generation and `mine`'s
-    ///   overlay over exactly the repository `WorkBase` names. It does
-    ///   **not** admit another Work's overlay over the same repository
-    ///   (`work:<other>/repo-a` fails both branches), and — because `?admit`
-    ///   is an exact name rather than a `work:<id>/%` prefix — it does
-    ///   **not** admit `mine`'s own overlay over a *different* repository
-    ///   either: `WorkBase { work_id: "mine", repository: "repo-a" }`
-    ///   admits only `work:mine/repo-a`, never `work:mine/repo-b`, matching
-    ///   the base half's own restriction to one named repository
-    ///   ([`SourceSelector::bindings`]).
-    ///
-    /// S5 W1b is what made the right branch worth having: until its
-    /// daemon-side lifecycle hook landed, no overlay generation was ever
-    /// written outside a test. `sgt search` remains a pure reader either
-    /// way — this is a `SELECT` predicate, and nothing on any query path
-    /// writes (H13.2).
+    /// A2 §2 stages 1(+4) and 2 — see [`Admissible::generations`], which is
+    /// where this is implemented and where the doc lives.
     pub fn admissible_generations(
         &self,
         filter: &Admissibility,
         limit: usize,
     ) -> Result<Admitted<SourceGeneration>, AtlasError> {
-        let limit = limit.min(MAX_ROWS) as i64;
-        let (source_name, content_key) = filter.source.bindings();
-        let source_kind = filter.kind.map(SourceKind::as_str);
-        let authority = filter.authority.map(AuthorityClass::as_str);
-        let overlay_exclude = Self::overlay_exclude_like();
-        let overlay_admit = filter.source.overlay_admit_source_name();
-        let mut statement = self.conn.prepare(
-            "SELECT generation_id, source_name, source_kind, authority_class, content_key, \
-                    observed_at \
-             FROM source.generations \
-             WHERE state = ? \
-               AND ( (source_name NOT LIKE ? \
-                      AND (? IS NULL OR source_name = ?)) \
-                     OR (? IS NOT NULL AND source_name = ?) ) \
-               AND (? IS NULL OR content_key = ?) \
-               AND (? IS NULL OR source_kind = ?) \
-               AND (? IS NULL OR authority_class = ?) \
-             ORDER BY source_name, observed_at DESC, generation_id DESC LIMIT ?",
-        )?;
-        let mut rows = statement.query(duckdb::params![
-            STATE_CONFIRMED,
-            overlay_exclude,
-            source_name,
-            source_name,
-            &overlay_admit,
-            &overlay_admit,
-            content_key,
-            content_key,
-            source_kind,
-            source_kind,
-            authority,
-            authority,
-            limit
-        ])?;
-        let mut out = Vec::new();
-        while let Some(row) = rows.next()? {
-            let kind: String = row.get(2)?;
-            let auth: String = row.get(3)?;
-            out.push(SourceGeneration {
-                id: row.get(0)?,
-                source_name: row.get(1)?,
-                kind: SourceKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
-                    column: "source_kind".to_string(),
-                    value: kind.clone(),
-                })?,
-                authority: AuthorityClass::parse(&auth).ok_or_else(|| {
-                    AtlasError::UnknownValue {
-                        column: "authority_class".to_string(),
-                        value: auth.clone(),
-                    }
-                })?,
-                content_key: row.get(4)?,
-                observed_at: row.get(5)?,
-            });
-        }
-        Ok(Admitted {
-            hits: out,
-            scope: self.work_scope(filter, true)?,
-        })
+        self.admissible().generations(filter, limit)
     }
 
-    /// A2 §2's content-kind filter, **document family** — H13.1's decided
-    /// mechanism: table-routing (`source.units` is physically separate from
-    /// the code and tabular families, so the coarse split needs no new
-    /// column) plus an extractor-identity allowlist joined off
-    /// `source.files`, pinned by [`DOCUMENT_EXTRACTOR_IDENTITIES`] and its
-    /// own structural test (`tests/w1_deterministic_filter.rs`).
-    ///
-    /// **The allowlist is a safety net, not a clean split — verified live,
-    /// correcting a premise H13.1's own text carried.** `claims_for`
-    /// (`src/runtime/atlas/scan.rs`) gives every grammar-claimed-but-
-    /// document-unclaimed file (`main.rs`, `Cargo.toml`) a plain-text
-    /// fallback unit under [`crate::runtime::atlas::text::TEXT_EXTRACTOR`]
-    /// so "every acquired resource still has units" — checked directly in
-    /// this worktree: a `Cargo.toml` fixture produces exactly one
-    /// `Document` unit (extractor `"text/v1"`, body = the whole file) in
-    /// *addition* to its `source.occurrences` rows under `"syntax-toml/v1"`.
-    /// That is the *same* extractor identity a genuine `.txt` document
-    /// carries, so this filter cannot separate "real prose" from a
-    /// code/config file's catch-all body — no `extractor` value
-    /// distinguishes them — and it does not try to. H13.1's "no new
-    /// column" holds regardless: the gap is named here, not engineered
-    /// around with state this wave was told not to add.
-    ///
-    /// Stages 1/2/4 come from `filter`, identically to
-    /// [`Self::admissible_generations`]. Bounded by `limit` (capped at
-    /// [`MAX_ROWS`], F12).
+    /// A2 §2's **document family** — see [`Admissible::units`].
     pub fn admissible_units(
         &self,
         filter: &Admissibility,
         limit: usize,
     ) -> Result<Admitted<StoredUnitHit>, AtlasError> {
-        let limit = limit.min(MAX_ROWS) as i64;
-        let (source_name, content_key) = filter.source.bindings();
-        let source_kind = filter.kind.map(SourceKind::as_str);
-        let authority = filter.authority.map(AuthorityClass::as_str);
-        let [doc_a, doc_b, doc_c, doc_d] = DOCUMENT_EXTRACTOR_IDENTITIES;
-        let overlay_exclude = Self::overlay_exclude_like();
-        let overlay_admit = filter.source.overlay_admit_source_name();
-        let mut statement = self.conn.prepare(
-            "SELECT g.source_name, u.relative_path, u.local_key, u.ordinal, u.unit_kind, \
-                    u.heading_level, u.title, u.byte_start, u.byte_end, u.body \
-             FROM source.units u \
-             JOIN source.generations g USING (generation_id) \
-             JOIN source.files f ON f.generation_id = u.generation_id \
-                                 AND f.relative_path = u.relative_path \
-             WHERE g.state = ? \
-               AND f.extractor IN (?, ?, ?, ?) \
-               AND ( (g.source_name NOT LIKE ? \
-                      AND (? IS NULL OR g.source_name = ?)) \
-                     OR (? IS NOT NULL AND g.source_name = ?) ) \
-               AND (? IS NULL OR g.content_key = ?) \
-               AND (? IS NULL OR g.source_kind = ?) \
-               AND (? IS NULL OR g.authority_class = ?) \
-             ORDER BY g.source_name, u.relative_path, u.ordinal LIMIT ?",
-        )?;
-        let mut rows = statement.query(duckdb::params![
-            STATE_CONFIRMED,
-            doc_a,
-            doc_b,
-            doc_c,
-            doc_d,
-            overlay_exclude,
-            source_name,
-            source_name,
-            &overlay_admit,
-            &overlay_admit,
-            content_key,
-            content_key,
-            source_kind,
-            source_kind,
-            authority,
-            authority,
-            limit
-        ])?;
-        let mut out = Vec::new();
-        while let Some(row) = rows.next()? {
-            let kind: String = row.get(4)?;
-            out.push(StoredUnitHit {
-                source_name: row.get(0)?,
-                unit: StoredUnit {
-                    relative_path: row.get(1)?,
-                    local_key: row.get(2)?,
-                    ordinal: row.get::<usize, i64>(3)? as u64,
-                    kind: UnitKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
-                        column: "unit_kind".to_string(),
-                        value: kind.clone(),
-                    })?,
-                    heading_level: row.get::<usize, Option<i64>>(5)?.map(|v| v as u8),
-                    title: row.get(6)?,
-                    byte_start: row.get::<usize, i64>(7)? as u64,
-                    byte_end: row.get::<usize, i64>(8)? as u64,
-                    body: row.get(9)?,
-                },
-            });
-        }
-        Ok(Admitted {
-            hits: out,
-            scope: self.work_scope(filter, true)?,
-        })
+        self.admissible().units(filter, limit)
     }
 
-    /// A2 §2's content-kind filter, **code family** — `source.symbols` +
-    /// `source.occurrences` + `source.edges`, physically separate from the
-    /// document and tabular families (H13.1, no new column). This method
-    /// reads `source.occurrences`; `symbols`/`edges` follow the identical
-    /// shape and are not duplicated here (R1 — nothing in this wave's
-    /// negative-admission proof needs them; each is a mechanical variant of
-    /// this one for a later wave to add on demand).
-    ///
-    /// The extractor match is `extractor LIKE ?` bound to
-    /// [`CODE_EXTRACTOR_LIKE`] (`"syntax-%"`) — a fixed, code-owned pattern
-    /// (F12: never a client-supplied pattern), pinned by a structural test
-    /// against every
-    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::ALL`] identity.
-    /// **This is also where a `.toml` config file's occurrences live**
-    /// (H13.1's decided exception): a config file's key/table structure is
-    /// claimed by
-    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::Toml`] the same way
-    /// Rust is claimed by
-    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::Rust`], under
-    /// extractor identity `"syntax-toml/v1"` — matched by this same `LIKE`
-    /// pattern. `--content config` has no document-side backing (see
-    /// [`Self::admissible_units`]'s own doc) and is not offered as a
-    /// distinct value; a caller wanting config content calls this method,
-    /// exactly as for code.
-    ///
-    /// Stages 1/2/4 come from `filter`, identically to
-    /// [`Self::admissible_generations`]. Bounded by `limit` (capped at
-    /// [`MAX_ROWS`], F12).
+    /// A2 §2's **code family** — see [`Admissible::occurrences`].
     pub fn admissible_occurrences(
         &self,
         filter: &Admissibility,
         limit: usize,
     ) -> Result<Admitted<StoredOccurrenceHit>, AtlasError> {
-        let limit = limit.min(MAX_ROWS) as i64;
-        let (source_name, content_key) = filter.source.bindings();
-        let source_kind = filter.kind.map(SourceKind::as_str);
-        let authority = filter.authority.map(AuthorityClass::as_str);
-        let overlay_exclude = Self::overlay_exclude_like();
-        let overlay_admit = filter.source.overlay_admit_source_name();
-        let mut statement = self.conn.prepare(
-            "SELECT g.source_name, o.relative_path, o.syntax_key, o.extractor, o.language, \
-                    o.ordinal, o.label, o.name, o.byte_start, o.byte_end \
-             FROM source.occurrences o JOIN source.generations g USING (generation_id) \
-             WHERE g.state = ? \
-               AND o.extractor LIKE ? \
-               AND ( (g.source_name NOT LIKE ? \
-                      AND (? IS NULL OR g.source_name = ?)) \
-                     OR (? IS NOT NULL AND g.source_name = ?) ) \
-               AND (? IS NULL OR g.content_key = ?) \
-               AND (? IS NULL OR g.source_kind = ?) \
-               AND (? IS NULL OR g.authority_class = ?) \
-             ORDER BY g.source_name, o.relative_path, o.ordinal LIMIT ?",
-        )?;
-        let mut rows = statement.query(duckdb::params![
-            STATE_CONFIRMED,
-            CODE_EXTRACTOR_LIKE,
-            overlay_exclude,
-            source_name,
-            source_name,
-            &overlay_admit,
-            &overlay_admit,
-            content_key,
-            content_key,
-            source_kind,
-            source_kind,
-            authority,
-            authority,
-            limit
-        ])?;
-        let mut out = Vec::new();
-        while let Some(row) = rows.next()? {
-            out.push(StoredOccurrenceHit {
-                source_name: row.get(0)?,
-                occurrence: StoredOccurrence {
-                    relative_path: row.get(1)?,
-                    syntax_key: row.get(2)?,
-                    extractor: row.get(3)?,
-                    language: row.get(4)?,
-                    ordinal: row.get::<usize, i64>(5)? as u64,
-                    label: row.get(6)?,
-                    name: row.get(7)?,
-                    byte_start: row.get::<usize, i64>(8)? as u64,
-                    byte_end: row.get::<usize, i64>(9)? as u64,
-                },
-            });
-        }
-        Ok(Admitted {
-            hits: out,
-            scope: self.work_scope(filter, true)?,
-        })
+        self.admissible().occurrences(filter, limit)
     }
 
-    /// A2 §2's content-kind filter, **tabular family** — `source.datasets`
-    /// (+ `context.row_units`, not read here — see
-    /// [`Self::admissible_occurrences`]'s note on why the whole family is
-    /// not duplicated). No extractor ambiguity here: `source.datasets`
-    /// carries no `extractor` column at all (`format`/`reader` are a
-    /// different axis), so table-routing alone is exact for this family
-    /// (H13.1).
-    ///
-    /// Stages 1/2/4 come from `filter`, identically to
-    /// [`Self::admissible_generations`]. Bounded by `limit` (capped at
-    /// [`MAX_ROWS`], F12).
+    /// A2 §2's **tabular family** — see [`Admissible::datasets`].
     pub fn admissible_datasets(
         &self,
         filter: &Admissibility,
         limit: usize,
     ) -> Result<Admitted<StoredDatasetHit>, AtlasError> {
-        let limit = limit.min(MAX_ROWS) as i64;
-        let (source_name, content_key) = filter.source.bindings();
-        let source_kind = filter.kind.map(SourceKind::as_str);
-        let authority = filter.authority.map(AuthorityClass::as_str);
-        let overlay_exclude = Self::overlay_exclude_like();
-        let overlay_admit = filter.source.overlay_admit_source_name();
-        let mut statement = self.conn.prepare(
-            "SELECT g.source_name, d.relative_path, d.format, d.content_hash, d.reader, \
-                    d.dataset_key, d.byte_len, d.columns, d.row_count, d.truncated, d.row_units \
-             FROM source.datasets d JOIN source.generations g USING (generation_id) \
-             WHERE g.state = ? \
-               AND ( (g.source_name NOT LIKE ? \
-                      AND (? IS NULL OR g.source_name = ?)) \
-                     OR (? IS NOT NULL AND g.source_name = ?) ) \
-               AND (? IS NULL OR g.content_key = ?) \
-               AND (? IS NULL OR g.source_kind = ?) \
-               AND (? IS NULL OR g.authority_class = ?) \
-             ORDER BY g.source_name, d.relative_path LIMIT ?",
-        )?;
-        let mut rows = statement.query(duckdb::params![
-            STATE_CONFIRMED,
-            overlay_exclude,
-            source_name,
-            source_name,
-            &overlay_admit,
-            &overlay_admit,
-            content_key,
-            content_key,
-            source_kind,
-            source_kind,
-            authority,
-            authority,
-            limit
-        ])?;
-        let mut out = Vec::new();
-        while let Some(row) = rows.next()? {
-            let format: String = row.get(2)?;
-            out.push(StoredDatasetHit {
-                source_name: row.get(0)?,
-                dataset: StoredDataset {
-                    relative_path: row.get(1)?,
-                    format: DatasetFormat::parse(&format).ok_or_else(|| {
-                        AtlasError::UnknownValue {
-                            column: "format".to_string(),
-                            value: format.clone(),
-                        }
-                    })?,
-                    content_hash: row.get(3)?,
-                    reader: row.get(4)?,
-                    dataset_key: row.get(5)?,
-                    byte_len: row.get::<usize, i64>(6)? as u64,
-                    columns: split_names(&row.get::<usize, String>(7)?),
-                    row_count: row.get::<usize, i64>(8)? as u64,
-                    truncated: row.get(9)?,
-                    row_units: row.get::<usize, i64>(10)? as u64,
-                },
-            });
-        }
-        Ok(Admitted {
-            hits: out,
-            scope: self.work_scope(filter, false)?,
-        })
+        self.admissible().datasets(filter, limit)
+    }
+
+    /// What `--work` can honestly claim about this answer — see
+    /// [`Admissible::work_scope`].
+    fn work_scope(
+        &self,
+        filter: &Admissibility,
+        carries_overlay_rows: bool,
+    ) -> Result<WorkScope, AtlasError> {
+        self.admissible().work_scope(filter, carries_overlay_rows)
     }
 
     // ------------------------------------------------------------------
@@ -2831,7 +2763,7 @@ impl AtlasDb {
         let overlay_admit = filter.source.overlay_admit_source_name();
         vec![
             Duck::Text(STATE_CONFIRMED.to_string()),
-            Duck::Text(Self::overlay_exclude_like()),
+            Duck::Text(overlay_exclude_like()),
             optional_text(source_name),
             optional_text(source_name),
             overlay_admit.clone().map_or(Duck::Null, Duck::Text),
@@ -3228,7 +3160,7 @@ impl AtlasDb {
         // case, and opens the same snapshot-isolated transaction from a
         // shared `&Connection`. It is dropped (and rolled back — nothing
         // here writes) on every exit path, `?` included.
-        let snapshot = Transaction::new_unchecked(&self.conn)?;
+        let snapshot = self.conn.snapshot()?;
         let lexical = self.lexical_search(&full)?;
         let semantic = self.semantic_search(&full)?;
         let mut hits = fuse(&lexical.hits, &semantic.hits);
@@ -3729,7 +3661,7 @@ fn split_extractors(stored: &str) -> BTreeSet<String> {
 
 /// Insert one acquired file and its units.
 fn insert_file(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     source_name: &str,
     file: &ScannedFile,
@@ -3791,7 +3723,7 @@ fn insert_file(
 /// generation and belongs to the transaction that knows all of it
 /// ([`AtlasDb::stage_scan`]).
 fn insert_syntax(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     source_name: &str,
     file: &ScannedFile,
@@ -3844,7 +3776,7 @@ fn insert_syntax(
 
 /// Insert one structure unit.
 fn insert_unit(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     source_name: &str,
     file: &ScannedFile,
@@ -3910,8 +3842,8 @@ type TextAnswer = (Vec<String>, Vec<Vec<Option<String>>>);
 /// casts to `VARCHAR` — see [`rows_sql`] for why that is a contract and not a
 /// shortcut.
 fn fetch_text(
-    conn: &Connection,
-    sql: &str,
+    conn: &impl Statements,
+    sql: &Sql,
     path: &str,
     limit: i64,
 ) -> Result<TextAnswer, AtlasError> {
@@ -3958,9 +3890,9 @@ fn fetch_text(
 /// about the *input*, established once by [`read_dataset`]'s probe and
 /// propagated to every answer derived under the same bound.
 fn dataset_fact(
-    conn: &Connection,
+    conn: &impl Statements,
     query: &DatasetQuery,
-    sql: &str,
+    sql: &Sql,
     dataset: &ScannedDataset,
     absolute: &str,
     limit: i64,
@@ -3998,7 +3930,7 @@ fn dataset_fact(
 /// [`counted_fact`] turns its answer into evidence under the bound that is
 /// stored.
 fn dataset_bound(
-    conn: &Connection,
+    conn: &impl Statements,
     format: DatasetFormat,
     absolute: &str,
 ) -> Result<(Vec<String>, u64, bool), AtlasError> {
@@ -4027,7 +3959,7 @@ fn dataset_bound(
 /// and the stored evidence still describes the bound it claims.
 fn counted_fact(
     query: &DatasetQuery,
-    sql: &str,
+    sql: &Sql,
     dataset: &ScannedDataset,
     columns: &[String],
     row_count: u64,
@@ -4136,7 +4068,7 @@ fn materialise_child_dataset(
 }
 
 fn read_dataset(
-    conn: &Connection,
+    conn: &impl Statements,
     scan: &SourceScan,
     dataset: &ScannedDataset,
     scratch_root: &Path,
@@ -4317,7 +4249,7 @@ struct IngestedDataset {
 /// [`AtlasDb::stage_scan`]), so F8's one-row-per-path rule still holds and the
 /// row says what happened rather than what was attempted.
 fn write_dataset(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     scan: &SourceScan,
     dataset: &ScannedDataset,
@@ -4394,7 +4326,7 @@ fn write_dataset(
 /// keeps arbitrary client SQL off the surface, so the coordinate was
 /// reachable only by opening the database file directly.
 fn insert_child_resource(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     source_name: &str,
     relative_path: &str,
@@ -4421,7 +4353,7 @@ fn insert_child_resource(
 
 /// Insert one derived-evidence row (A1 §6.4).
 fn insert_dataset_fact(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     source_name: &str,
     fact: &DatasetFact,
@@ -4451,7 +4383,7 @@ fn insert_dataset_fact(
 
 /// Insert one F10a-gated context unit.
 fn insert_row_unit(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     source_name: &str,
     dataset: &ScannedDataset,
@@ -4528,7 +4460,7 @@ fn insert_row_unit(
 /// is satisfied the same way — what this returns IS A1's evidence units, and
 /// the semantic half has no other way to reach text.
 fn indexable_units(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
 ) -> Result<Vec<IndexableUnit>, AtlasError> {
     let mut units: Vec<IndexableUnit> = Vec::new();
@@ -4650,7 +4582,7 @@ fn indexable_units(
     Ok(units)
 }
 
-fn index_generation(conn: &Connection, generation_id: &str) -> Result<u64, AtlasError> {
+fn index_generation(conn: &impl Statements, generation_id: &str) -> Result<u64, AtlasError> {
     let units = indexable_units(conn, generation_id)?;
 
     // The two batches, appended rather than inserted row by row. This file
@@ -4897,7 +4829,7 @@ fn parse_rows(stored: &str) -> Vec<Vec<Option<String>>> {
 
 /// Insert one coverage observation.
 fn insert_coverage(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     source_name: &str,
     row: &CoverageRow,
@@ -4927,7 +4859,7 @@ fn insert_coverage(
 /// its derived evidence is gone" is a fact worth keeping — a deleted row
 /// would be exactly the silent gap ruling §4 forbids.
 fn evict(
-    conn: &Connection,
+    conn: &impl Statements,
     generation_id: &str,
     source_name: &str,
     reason: &str,
@@ -5771,6 +5703,538 @@ pub struct RelatedAnswer {
     /// there instead would make the trace unreproducible.
     pub trace: SearchTrace,
 }
+/// **The admissibility filter, over a handle that cannot write** — H13.2's
+/// "`sgt search` is a pure reader", enforced by the type system rather than
+/// by a scan of this file's text.
+///
+/// Every A2 §2 content-family query lives here, and the only thing this
+/// struct holds is a [`ReadOnly`]: no `Connection`, no `Store`, no
+/// `Transaction`, no `&self` route back to one. A write inside any method
+/// below is therefore not a forbidden spelling — it is a **compile error**,
+/// because there is no value in scope with a write on it. That is the
+/// difference the S5 closeout bought: the previous guarantee was a
+/// source-text scan of `admissible_*` bodies, and a `format!`-assembled
+/// `DELETE` walked straight past it (`tests/w1b_overlay_lifecycle_trigger.rs`
+/// tells that story, and now stands as the *second* net, not the first).
+///
+/// [`AtlasDb`]'s `admissible_*` methods are one-line delegates onto this
+/// type. They keep `&self` — a caller cannot write through them either — but
+/// `&self` was never the guarantee: DuckDB's `Connection::execute`,
+/// `execute_batch` and `prepare` all take `&self`.
+struct Admissible<'conn> {
+    reader: ReadOnly<'conn>,
+}
+
+impl Admissible<'_> {
+    /// A2 §2 stages 1(+4) and 2 in one canned query: the source/estate/
+    /// Work-generation filter, the optional repo/knowledge/external
+    /// selector ([`Admissibility::kind`], composable with any
+    /// [`SourceSelector`]), and the authority filter — composed once here
+    /// and reused, in identical shape, by every content-kind method below,
+    /// so a generation excluded at this stage can never resurface through
+    /// a different table.
+    ///
+    /// Every clause is `(? IS NULL OR column = ?)`: an unset filter field
+    /// admits every value of that column rather than narrowing it, so
+    /// `Admissibility::default()` (bare [`SourceSelector::Any`], no
+    /// authority) is "every confirmed generation this store holds" — never
+    /// approximate, never partial. Bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    ///
+    /// **The Work-overlay family is denied by default, and exactly one
+    /// Work's own overlay is re-admitted on top of that — never by name.**
+    /// A generation whose `source_name` carries
+    /// [`crate::runtime::atlas::overlay::OVERLAY_PREFIX`]
+    /// (`work:<id>/<repo>`) describes a world only one Work's surface can
+    /// see (H13.2). The composed predicate is
+    ///
+    /// ```text
+    /// (source_name NOT LIKE 'work:%' AND (?src IS NULL OR source_name = ?src))
+    ///   OR (?admit IS NOT NULL AND source_name = ?admit)
+    /// ```
+    ///
+    /// where `?admit` is `Some("work:<id>/<repository>")` — the *exact*
+    /// overlay source name, never a pattern — **only** for
+    /// [`SourceSelector::WorkBase`], built from that variant's own
+    /// `work_id` **and** `repository`
+    /// (`SourceSelector::overlay_admit_source_name`). So:
+    ///
+    /// - [`SourceSelector::Named`]/[`SourceSelector::Exact`] can never
+    ///   reach an overlay, not even naming the exact coordinate — a caller
+    ///   who merely learns another Work's id (e.g. from `sgt work list`)
+    ///   must not be able to type it into `--source` and read that Work's
+    ///   surface. `?admit` is `None` for those variants, so the left
+    ///   branch is the only one available and it denies the whole family.
+    /// - `--work <mine>` admits `mine`'s base generation and `mine`'s
+    ///   overlay over exactly the repository `WorkBase` names. It does
+    ///   **not** admit another Work's overlay over the same repository
+    ///   (`work:<other>/repo-a` fails both branches), and — because `?admit`
+    ///   is an exact name rather than a `work:<id>/%` prefix — it does
+    ///   **not** admit `mine`'s own overlay over a *different* repository
+    ///   either: `WorkBase { work_id: "mine", repository: "repo-a" }`
+    ///   admits only `work:mine/repo-a`, never `work:mine/repo-b`, matching
+    ///   the base half's own restriction to one named repository
+    ///   ([`SourceSelector::bindings`]).
+    ///
+    /// S5 W1b is what made the right branch worth having: until its
+    /// daemon-side lifecycle hook landed, no overlay generation was ever
+    /// written outside a test. `sgt search` remains a pure reader either
+    /// way — this is a `SELECT` predicate, and nothing on any query path
+    /// writes (H13.2).
+    fn generations(
+        &self,
+        filter: &Admissibility,
+        limit: usize,
+    ) -> Result<Admitted<SourceGeneration>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let overlay_exclude = overlay_exclude_like();
+        let overlay_admit = filter.source.overlay_admit_source_name();
+        let out = self.reader.rows(
+            read_sql!(
+                "SELECT generation_id, source_name, source_kind, authority_class, content_key, \
+                        observed_at \
+                 FROM source.generations \
+                 WHERE state = ? \
+                   AND ( (source_name NOT LIKE ? \
+                          AND (? IS NULL OR source_name = ?)) \
+                         OR (? IS NOT NULL AND source_name = ?) ) \
+                   AND (? IS NULL OR content_key = ?) \
+                   AND (? IS NULL OR source_kind = ?) \
+                   AND (? IS NULL OR authority_class = ?) \
+                 ORDER BY source_name, observed_at DESC, generation_id DESC LIMIT ?"
+            ),
+            duckdb::params![
+                STATE_CONFIRMED,
+                overlay_exclude,
+                source_name,
+                source_name,
+                &overlay_admit,
+                &overlay_admit,
+                content_key,
+                content_key,
+                source_kind,
+                source_kind,
+                authority,
+                authority,
+                limit
+            ],
+            |row| -> Result<SourceGeneration, AtlasError> {
+                let kind: String = row.get(2)?;
+                let auth: String = row.get(3)?;
+                Ok(SourceGeneration {
+                    id: row.get(0)?,
+                    source_name: row.get(1)?,
+                    kind: SourceKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
+                        column: "source_kind".to_string(),
+                        value: kind.clone(),
+                    })?,
+                    authority: AuthorityClass::parse(&auth).ok_or_else(|| {
+                        AtlasError::UnknownValue {
+                            column: "authority_class".to_string(),
+                            value: auth.clone(),
+                        }
+                    })?,
+                    content_key: row.get(4)?,
+                    observed_at: row.get(5)?,
+                })
+            },
+        )?;
+        Ok(Admitted {
+            hits: out,
+            scope: self.work_scope(filter, true)?,
+        })
+    }
+
+    /// A2 §2's content-kind filter, **document family** — H13.1's decided
+    /// mechanism: table-routing (`source.units` is physically separate from
+    /// the code and tabular families, so the coarse split needs no new
+    /// column) plus an extractor-identity allowlist joined off
+    /// `source.files`, pinned by [`DOCUMENT_EXTRACTOR_IDENTITIES`] and its
+    /// own structural test (`tests/w1_deterministic_filter.rs`).
+    ///
+    /// **The allowlist is a safety net, not a clean split — verified live,
+    /// correcting a premise H13.1's own text carried.** `claims_for`
+    /// (`src/runtime/atlas/scan.rs`) gives every grammar-claimed-but-
+    /// document-unclaimed file (`main.rs`, `Cargo.toml`) a plain-text
+    /// fallback unit under [`crate::runtime::atlas::text::TEXT_EXTRACTOR`]
+    /// so "every acquired resource still has units" — checked directly in
+    /// this worktree: a `Cargo.toml` fixture produces exactly one
+    /// `Document` unit (extractor `"text/v1"`, body = the whole file) in
+    /// *addition* to its `source.occurrences` rows under `"syntax-toml/v1"`.
+    /// That is the *same* extractor identity a genuine `.txt` document
+    /// carries, so this filter cannot separate "real prose" from a
+    /// code/config file's catch-all body — no `extractor` value
+    /// distinguishes them — and it does not try to. H13.1's "no new
+    /// column" holds regardless: the gap is named here, not engineered
+    /// around with state this wave was told not to add.
+    ///
+    /// Stages 1/2/4 come from `filter`, identically to
+    /// [`Self::generations`]. Bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    fn units(
+        &self,
+        filter: &Admissibility,
+        limit: usize,
+    ) -> Result<Admitted<StoredUnitHit>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let [doc_a, doc_b, doc_c, doc_d] = DOCUMENT_EXTRACTOR_IDENTITIES;
+        let overlay_exclude = overlay_exclude_like();
+        let overlay_admit = filter.source.overlay_admit_source_name();
+        let out = self.reader.rows(
+            read_sql!(
+                "SELECT g.source_name, u.relative_path, u.local_key, u.ordinal, u.unit_kind, \
+                        u.heading_level, u.title, u.byte_start, u.byte_end, u.body \
+                 FROM source.units u \
+                 JOIN source.generations g USING (generation_id) \
+                 JOIN source.files f ON f.generation_id = u.generation_id \
+                                     AND f.relative_path = u.relative_path \
+                 WHERE g.state = ? \
+                   AND f.extractor IN (?, ?, ?, ?) \
+                   AND ( (g.source_name NOT LIKE ? \
+                          AND (? IS NULL OR g.source_name = ?)) \
+                         OR (? IS NOT NULL AND g.source_name = ?) ) \
+                   AND (? IS NULL OR g.content_key = ?) \
+                   AND (? IS NULL OR g.source_kind = ?) \
+                   AND (? IS NULL OR g.authority_class = ?) \
+                 ORDER BY g.source_name, u.relative_path, u.ordinal LIMIT ?"
+            ),
+            duckdb::params![
+                STATE_CONFIRMED,
+                doc_a,
+                doc_b,
+                doc_c,
+                doc_d,
+                overlay_exclude,
+                source_name,
+                source_name,
+                &overlay_admit,
+                &overlay_admit,
+                content_key,
+                content_key,
+                source_kind,
+                source_kind,
+                authority,
+                authority,
+                limit
+            ],
+            |row| -> Result<StoredUnitHit, AtlasError> {
+                let kind: String = row.get(4)?;
+                Ok(StoredUnitHit {
+                    source_name: row.get(0)?,
+                    unit: StoredUnit {
+                        relative_path: row.get(1)?,
+                        local_key: row.get(2)?,
+                        ordinal: row.get::<usize, i64>(3)? as u64,
+                        kind: UnitKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
+                            column: "unit_kind".to_string(),
+                            value: kind.clone(),
+                        })?,
+                        heading_level: row.get::<usize, Option<i64>>(5)?.map(|v| v as u8),
+                        title: row.get(6)?,
+                        byte_start: row.get::<usize, i64>(7)? as u64,
+                        byte_end: row.get::<usize, i64>(8)? as u64,
+                        body: row.get(9)?,
+                    },
+                })
+            },
+        )?;
+        Ok(Admitted {
+            hits: out,
+            scope: self.work_scope(filter, true)?,
+        })
+    }
+
+    /// A2 §2's content-kind filter, **code family** — `source.symbols` +
+    /// `source.occurrences` + `source.edges`, physically separate from the
+    /// document and tabular families (H13.1, no new column). This method
+    /// reads `source.occurrences`; `symbols`/`edges` follow the identical
+    /// shape and are not duplicated here (R1 — nothing in this wave's
+    /// negative-admission proof needs them; each is a mechanical variant of
+    /// this one for a later wave to add on demand).
+    ///
+    /// The extractor match is `extractor LIKE ?` bound to
+    /// [`CODE_EXTRACTOR_LIKE`] (`"syntax-%"`) — a fixed, code-owned pattern
+    /// (F12: never a client-supplied pattern), pinned by a structural test
+    /// against every
+    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::ALL`] identity.
+    /// **This is also where a `.toml` config file's occurrences live**
+    /// (H13.1's decided exception): a config file's key/table structure is
+    /// claimed by
+    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::Toml`] the same way
+    /// Rust is claimed by
+    /// [`crate::runtime::atlas::syntax::SyntaxLanguage::Rust`], under
+    /// extractor identity `"syntax-toml/v1"` — matched by this same `LIKE`
+    /// pattern. `--content config` has no document-side backing (see
+    /// [`Self::admissible_units`]'s own doc) and is not offered as a
+    /// distinct value; a caller wanting config content calls this method,
+    /// exactly as for code.
+    ///
+    /// Stages 1/2/4 come from `filter`, identically to
+    /// [`Self::generations`]. Bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    fn occurrences(
+        &self,
+        filter: &Admissibility,
+        limit: usize,
+    ) -> Result<Admitted<StoredOccurrenceHit>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let overlay_exclude = overlay_exclude_like();
+        let overlay_admit = filter.source.overlay_admit_source_name();
+        let out = self.reader.rows(
+            read_sql!(
+                "SELECT g.source_name, o.relative_path, o.syntax_key, o.extractor, o.language, \
+                        o.ordinal, o.label, o.name, o.byte_start, o.byte_end \
+                 FROM source.occurrences o JOIN source.generations g USING (generation_id) \
+                 WHERE g.state = ? \
+                   AND o.extractor LIKE ? \
+                   AND ( (g.source_name NOT LIKE ? \
+                          AND (? IS NULL OR g.source_name = ?)) \
+                         OR (? IS NOT NULL AND g.source_name = ?) ) \
+                   AND (? IS NULL OR g.content_key = ?) \
+                   AND (? IS NULL OR g.source_kind = ?) \
+                   AND (? IS NULL OR g.authority_class = ?) \
+                 ORDER BY g.source_name, o.relative_path, o.ordinal LIMIT ?"
+            ),
+            duckdb::params![
+                STATE_CONFIRMED,
+                CODE_EXTRACTOR_LIKE,
+                overlay_exclude,
+                source_name,
+                source_name,
+                &overlay_admit,
+                &overlay_admit,
+                content_key,
+                content_key,
+                source_kind,
+                source_kind,
+                authority,
+                authority,
+                limit
+            ],
+            |row| -> Result<StoredOccurrenceHit, AtlasError> {
+                Ok(StoredOccurrenceHit {
+                    source_name: row.get(0)?,
+                    occurrence: StoredOccurrence {
+                        relative_path: row.get(1)?,
+                        syntax_key: row.get(2)?,
+                        extractor: row.get(3)?,
+                        language: row.get(4)?,
+                        ordinal: row.get::<usize, i64>(5)? as u64,
+                        label: row.get(6)?,
+                        name: row.get(7)?,
+                        byte_start: row.get::<usize, i64>(8)? as u64,
+                        byte_end: row.get::<usize, i64>(9)? as u64,
+                    },
+                })
+            },
+        )?;
+        Ok(Admitted {
+            hits: out,
+            scope: self.work_scope(filter, true)?,
+        })
+    }
+
+    /// A2 §2's content-kind filter, **tabular family** — `source.datasets`
+    /// (+ `context.row_units`, not read here — see
+    /// [`Self::occurrences`]'s note on why the whole family is
+    /// not duplicated). No extractor ambiguity here: `source.datasets`
+    /// carries no `extractor` column at all (`format`/`reader` are a
+    /// different axis), so table-routing alone is exact for this family
+    /// (H13.1).
+    ///
+    /// Stages 1/2/4 come from `filter`, identically to
+    /// [`Self::generations`]. Bounded by `limit` (capped at
+    /// [`MAX_ROWS`], F12).
+    fn datasets(
+        &self,
+        filter: &Admissibility,
+        limit: usize,
+    ) -> Result<Admitted<StoredDatasetHit>, AtlasError> {
+        let limit = limit.min(MAX_ROWS) as i64;
+        let (source_name, content_key) = filter.source.bindings();
+        let source_kind = filter.kind.map(SourceKind::as_str);
+        let authority = filter.authority.map(AuthorityClass::as_str);
+        let overlay_exclude = overlay_exclude_like();
+        let overlay_admit = filter.source.overlay_admit_source_name();
+        let out = self.reader.rows(
+            read_sql!(
+                    "SELECT g.source_name, d.relative_path, d.format, d.content_hash, d.reader, \
+                        d.dataset_key, d.byte_len, d.columns, d.row_count, d.truncated, d.row_units \
+                 FROM source.datasets d JOIN source.generations g USING (generation_id) \
+                 WHERE g.state = ? \
+                   AND ( (g.source_name NOT LIKE ? \
+                          AND (? IS NULL OR g.source_name = ?)) \
+                         OR (? IS NOT NULL AND g.source_name = ?) ) \
+                   AND (? IS NULL OR g.content_key = ?) \
+                   AND (? IS NULL OR g.source_kind = ?) \
+                   AND (? IS NULL OR g.authority_class = ?) \
+                 ORDER BY g.source_name, d.relative_path LIMIT ?"
+            ),
+            duckdb::params![
+                STATE_CONFIRMED,
+                overlay_exclude,
+                source_name,
+                source_name,
+                &overlay_admit,
+                &overlay_admit,
+                content_key,
+                content_key,
+                source_kind,
+                source_kind,
+                authority,
+                authority,
+                limit
+            ],
+            |row| -> Result<StoredDatasetHit, AtlasError> {
+                let format: String = row.get(2)?;
+                Ok(StoredDatasetHit {
+                    source_name: row.get(0)?,
+                    dataset: StoredDataset {
+                        relative_path: row.get(1)?,
+                        format: DatasetFormat::parse(&format).ok_or_else(|| {
+                            AtlasError::UnknownValue {
+                                column: "format".to_string(),
+                                value: format.clone(),
+                            }
+                        })?,
+                        content_hash: row.get(3)?,
+                        reader: row.get(4)?,
+                        dataset_key: row.get(5)?,
+                        byte_len: row.get::<usize, i64>(6)? as u64,
+                        columns: split_names(&row.get::<usize, String>(7)?),
+                        row_count: row.get::<usize, i64>(8)? as u64,
+                        truncated: row.get(9)?,
+                        row_units: row.get::<usize, i64>(10)? as u64,
+                    },
+                })
+            },
+        )?;
+        Ok(Admitted {
+            hits: out,
+            scope: self.work_scope(filter, false)?,
+        })
+    }
+
+    /// What a `--work` answer actually covers, read from the store rather
+    /// than derived from the selector alone (S5 W1b).
+    ///
+    /// [`WorkScope`]'s whole job is to be TRUE about the answer beside it,
+    /// and whether an overlay stands for a Work is a fact about the store,
+    /// not about the filter a caller typed: the Work may not have bound a
+    /// surface yet, its overlay scan may have failed, or the Work may have
+    /// retired and had its overlay evicted with it
+    /// ([`Self::evict_work_overlays`]). So this asks. One extra bounded
+    /// read per admissibility call, on the same connection.
+    ///
+    /// **Also true about the store, and just as load-bearing: whether the
+    /// TABLE this particular call reads can carry an overlay-authored row at
+    /// all.** An overlay generation stands for exactly one repository
+    /// (S5 W1b's own fix — see [`SourceSelector::overlay_admit_source_name`]),
+    /// is always stamped `SourceKind::EstateGit` / `AuthorityClass::
+    /// EstateMutable` ([`crate::runtime::atlas::overlay::scan_work_overlay`]),
+    /// and never writes a `source.datasets` row at all — an overlay's
+    /// unchanged bytes come from the base tree's objects, so its own scan
+    /// records `datasets: Vec::new()` unconditionally. So an overlay
+    /// standing is not, by itself, enough to say an answer includes it:
+    ///
+    /// - `carries_overlay_rows: false` — this table (`source.datasets`) is
+    ///   one an overlay scan structurally never populates. `BaseOnly`
+    ///   always, regardless of whether an overlay stands.
+    /// - `filter.kind` narrowed to anything but [`SourceKind::EstateGit`],
+    ///   or `filter.authority` narrowed to anything but
+    ///   [`AuthorityClass::EstateMutable`] — the caller's own stage-2/4
+    ///   filter structurally excludes every row an overlay could ever have
+    ///   written. `BaseOnly` for the same reason.
+    ///
+    /// Asserting `BaseAndOverlaySnapshot` in either case would claim the
+    /// answer reflects overlay evidence as of a given instant when no row it
+    /// could contain was ever capable of coming from the overlay — the same
+    /// class of false claim [`WorkScope`]'s own doc names for "current"
+    /// dressed up as a snapshot.
+    fn work_scope(
+        &self,
+        filter: &Admissibility,
+        carries_overlay_rows: bool,
+    ) -> Result<WorkScope, AtlasError> {
+        let SourceSelector::WorkBase {
+            work_id,
+            repository,
+        } = &filter.source
+        else {
+            return Ok(WorkScope::NotWorkScoped);
+        };
+        if !carries_overlay_rows
+            || filter
+                .kind
+                .is_some_and(|kind| kind != SourceKind::EstateGit)
+            || filter
+                .authority
+                .is_some_and(|authority| authority != AuthorityClass::EstateMutable)
+        {
+            return Ok(WorkScope::BaseOnly);
+        }
+        Ok(
+            match self.newest_overlay_observed_at(work_id, repository)? {
+                Some(overlay_observed_at) => WorkScope::BaseAndOverlaySnapshot {
+                    overlay_observed_at,
+                },
+                None => WorkScope::BaseOnly,
+            },
+        )
+    }
+
+    /// When this Work's overlay half — over the one `repository` a
+    /// [`SourceSelector::WorkBase`] names — was last read off its surface:
+    /// the matching CONFIRMED `work:<id>/<repo>` generation's `observed_at`,
+    /// or `None` when no such generation stands.
+    ///
+    /// An exact lookup on the one source name
+    /// [`overlay_source_name`](crate::runtime::atlas::overlay::overlay_source_name)
+    /// can ever produce for this `(work_id, repository)` pair, not a
+    /// `work_id`-only prefix scan — the earlier prefix form answered about
+    /// *any* repository under this Work id, over-claiming past the
+    /// repository the caller actually asked about, the sibling of the
+    /// admission bug [`SourceSelector::overlay_admit_source_name`] fixes.
+    fn newest_overlay_observed_at(
+        &self,
+        work_id: &str,
+        repository: &str,
+    ) -> Result<Option<String>, AtlasError> {
+        let source_name = crate::runtime::atlas::overlay::overlay_source_name(work_id, repository);
+        self.reader.first(
+            read_sql!(
+                "SELECT observed_at FROM source.generations \
+                 WHERE state = ? AND source_name = ? \
+                 ORDER BY observed_at DESC, generation_id DESC LIMIT 1"
+            ),
+            duckdb::params![STATE_CONFIRMED, source_name],
+            |row| -> Result<String, AtlasError> { Ok(row.get(0)?) },
+        )
+    }
+}
+
+/// The fixed, code-owned `NOT LIKE` bound every admissibility query
+/// below applies to `source_name`, excluding the whole Work-overlay
+/// family ([`crate::runtime::atlas::overlay::OVERLAY_PREFIX`],
+/// `work:<id>/<repo>`) — see [`Admissible::generations`]'s own doc
+/// for what re-admits exactly one Work's own overlay on top of it
+/// ([`SourceSelector::overlay_admit_source_name`], S5 W1b) and why the
+/// default-deny stays the default. Derived from the overlay module's
+/// own prefix constant rather than a second hardcoded literal, so the
+/// two can never drift apart; still never a client-supplied pattern
+/// (F12), the same precedent as [`CODE_EXTRACTOR_LIKE`].
+fn overlay_exclude_like() -> String {
+    format!("{}%", crate::runtime::atlas::overlay::OVERLAY_PREFIX)
+}
 
 /// [`WorkScope`] as one stable word for A2 §13's field 3.
 ///
@@ -5959,8 +6423,23 @@ const CONTEXT_SCHEMA: &str = "context";
 /// The quoting is what keeps `usage` (a reserved word) addressable; the
 /// qualification is what stops a bare name from resolving against DuckDB's
 /// default `main` schema, which this database deliberately leaves empty.
-fn ops(table: &str) -> String {
-    format!("{OPS_SCHEMA}.\"{table}\"")
+fn ops(table: &'static str) -> Sql {
+    Sql::from_parts(&[OPS_SCHEMA, ".\"", table, "\""])
+}
+
+/// `DELETE FROM <ops table>` — [`ops`] behind a `DELETE`, assembled from
+/// compile-time pieces because [`Sql`] admits no other kind.
+fn delete_from(table: &'static str) -> Sql {
+    let mut sql = Sql::from("DELETE FROM ");
+    sql.extend(&ops(table));
+    sql
+}
+
+/// `SELECT COUNT(*) FROM <ops table>` — see [`delete_from`].
+fn count_of(table: &'static str) -> Sql {
+    let mut sql = Sql::from("SELECT COUNT(*) FROM ");
+    sql.extend(&ops(table));
+    sql
 }
 
 /// The §22 schema, in the [`OPS_SCHEMA`] namespace. Written on every rebuild;
@@ -6263,7 +6742,7 @@ pub struct GraphView {
 /// journal, and the incremental path and the rebuild path are the *same*
 /// fold rather than two implementations that have to be kept in agreement.
 pub struct Analytics {
-    conn: Connection,
+    conn: Store,
     path: PathBuf,
     /// The mutable §22 tables, folded in memory.
     rows: Rows,
@@ -6631,7 +7110,7 @@ impl Analytics {
     pub fn begin_rebuild(data_dir: &Path) -> Result<Self, AnalyticsError> {
         create_dir_all_durable(&atlas_dir(data_dir))?;
         let path = atlas_db_path(data_dir);
-        let conn = Connection::open(&path)?;
+        let conn = Store::new(Connection::open(&path)?);
         bootstrap_atlas_ddl(&conn)?;
         Self::over(conn, path)
     }
@@ -6642,14 +7121,14 @@ impl Analytics {
     where
         I: IntoIterator<Item = Result<Event, JournalError>>,
     {
-        let conn = Connection::open_in_memory()?;
+        let conn = Store::new(Connection::open_in_memory()?);
         let mut analytics = Self::over(conn, PathBuf::from(":memory:"))?;
         analytics.catch_up(events)?;
         Ok(analytics)
     }
 
-    fn over(conn: Connection, path: PathBuf) -> Result<Self, AnalyticsError> {
-        conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
+    fn over(conn: Store, path: PathBuf) -> Result<Self, AnalyticsError> {
+        conn.set_statement_cache_capacity(STATEMENT_CACHE);
         conn.execute_batch(OPS_DDL)?;
         Ok(Self {
             conn,
@@ -6729,8 +7208,7 @@ impl Analytics {
     /// marked and is simply retried by the next call.
     fn reset(&mut self) -> Result<(), AnalyticsError> {
         for table in TABLES {
-            self.conn
-                .execute_batch(&format!("DELETE FROM {}", ops(table)))?;
+            self.conn.execute_batch(delete_from(table))?;
         }
         self.rows = Rows::default();
         self.graph = GraphContext::default();
@@ -6769,8 +7247,7 @@ impl Analytics {
             return Ok(());
         }
         for table in MUTABLE_TABLES {
-            self.conn
-                .execute_batch(&format!("DELETE FROM {}", ops(table)))?;
+            self.conn.execute_batch(delete_from(table))?;
         }
         append_all(
             &self.conn,
@@ -7210,9 +7687,7 @@ impl Analytics {
         self.materialize()?;
         let mut counts = Vec::new();
         for table in TABLES {
-            let mut statement = self
-                .conn
-                .prepare(&format!("SELECT COUNT(*) FROM {}", ops(table)))?;
+            let mut statement = self.conn.prepare(count_of(table))?;
             let count: i64 = statement.query_row(duckdb::params![], |row| row.get(0))?;
             counts.push(((*table).to_string(), count));
         }
@@ -7243,12 +7718,13 @@ impl Analytics {
                 name: table.to_string(),
             })?;
         self.materialize()?;
-        let sql = format!("SELECT * FROM {}", ops(table));
+        let mut sql = Sql::from("SELECT * FROM ");
+        sql.extend(&ops(table));
         let (columns, rows) = self.select(&sql, duckdb::params![])?;
         Ok(QueryResult {
             name: (*table).to_string(),
             question: format!("every row of the {table} table"),
-            sql,
+            sql: sql.text().to_string(),
             columns,
             rows,
         })
@@ -7284,7 +7760,7 @@ impl Analytics {
     /// Run one SELECT, returning column names and JSON rows.
     fn select<P: duckdb::Params>(
         &self,
-        sql: &str,
+        sql: impl Into<Sql>,
         params: P,
     ) -> Result<(Vec<String>, Vec<Vec<Value>>), AnalyticsError> {
         let mut statement = self.conn.prepare(sql)?;
@@ -7385,7 +7861,11 @@ const TABLES: &[&str] = &[
 /// The appender is the reason this projection is usable at all: measured on
 /// this container, a single-row `INSERT` costs ~1 ms and an appended row
 /// ~4 µs. An empty batch is a no-op rather than an open-and-close.
-fn append_all(conn: &Connection, table: &str, rows: Vec<Vec<Duck>>) -> Result<(), AnalyticsError> {
+fn append_all(
+    conn: &impl Statements,
+    table: &'static str,
+    rows: Vec<Vec<Duck>>,
+) -> Result<(), AnalyticsError> {
     append_rows(conn, OPS_SCHEMA, table, rows)?;
     Ok(())
 }
@@ -7395,9 +7875,9 @@ fn append_all(conn: &Connection, table: &str, rows: Vec<Vec<Duck>>) -> Result<()
 /// because the measurement that justifies the appender is a property of
 /// DuckDB, not of the `ops` schema.
 fn append_rows(
-    conn: &Connection,
-    schema: &str,
-    table: &str,
+    conn: &impl Statements,
+    schema: &'static str,
+    table: &'static str,
     rows: Vec<Vec<Duck>>,
 ) -> Result<(), duckdb::Error> {
     if rows.is_empty() {
@@ -7516,7 +7996,7 @@ impl Analytics {
     /// halves of that module's public surface are still plain data.
     pub fn atlas(&self) -> Result<AtlasDb, AtlasError> {
         let conn = self.conn.try_clone()?;
-        conn.set_prepared_statement_cache_capacity(STATEMENT_CACHE);
+        conn.set_statement_cache_capacity(STATEMENT_CACHE);
         // No [`HARDENING_DDL`] here, and its absence is stronger than its
         // presence would be. Those four settings are database-wide and
         // `lock_configuration = true` makes them permanent, so re-issuing
@@ -7872,12 +8352,14 @@ mod tests {
         // `indexed_sources` (which only ever shows the confirmed row).
         let orphaned: i64 = db
             .conn
-            .query_row(
-                "SELECT count(*) FROM git.provenance WHERE generation_id = ?",
+            .reader()
+            .first(
+                read_sql!("SELECT count(*) FROM git.provenance WHERE generation_id = ?"),
                 duckdb::params![first_id],
-                |row| row.get(0),
+                |row| -> Result<i64, AtlasError> { Ok(row.get(0)?) },
             )
-            .expect("count");
+            .expect("count")
+            .expect("one row");
         assert_eq!(
             orphaned, 0,
             "the evicted generation's provenance row was deleted"
@@ -7894,8 +8376,14 @@ mod tests {
         record(&mut db, &scan_of("notes", "# Notes\n"), "evt-1");
         let count: i64 = db
             .conn
-            .query_row("SELECT count(*) FROM git.provenance", [], |row| row.get(0))
-            .expect("count");
+            .reader()
+            .first(
+                read_sql!("SELECT count(*) FROM git.provenance"),
+                duckdb::params![],
+                |row| -> Result<i64, AtlasError> { Ok(row.get(0)?) },
+            )
+            .expect("count")
+            .expect("one row");
         assert_eq!(count, 0);
     }
 

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -8958,6 +8958,249 @@ mod tests {
             "reindex_lexical must backfill the generation's postings"
         );
     }
+
+    // -----------------------------------------------------------------
+    // ROUND 3 ATTACK — item 6 (documented gap, confirmed): a hand-written
+    // `impl SqlText` with write-shaped text, handed to `ReadSql::of`
+    // directly, trips a generic associated const evaluated at
+    // monomorphization rather than eagerly. Measured: `cargo check --lib
+    // --tests` on this exact code passed clean; `cargo test --lib` (which
+    // must link) failed with E0080 at
+    // `ReadSql::of::<EvilWrite>::Check::<EvilWrite>::OK` before any test
+    // body could run. No write ever executes — the gap is a `cargo check`
+    // blind spot, not a build/test/CI one, exactly as db.rs's module doc
+    // claims. Left out of the tree (this comment is the record); the code
+    // that reproduces it is in the round-3 report.
+    //
+    // ROUND 3 ATTACK — item 1: `Box::leak`/`String::leak` into `Sql` via
+    // the real `sql!` macro, feeding a runtime string that only exists
+    // because a test constructed it (standing in for "caller text").
+    // -----------------------------------------------------------------
+    #[test]
+    fn round3_item1_box_leak_into_sql_via_macro() {
+        let runtime_text: String = format!("{}{}", "DELETE FROM ", "source.generations");
+        // Measured (uncommented one line at a time, `cargo check --lib
+        // --tests`, then reverted — this comment is the record):
+        //
+        // sql!(Box::leak(runtime_text.into_boxed_str())) — E0435, "attempt
+        // to use a non-constant value in a constant", pointing at
+        // `runtime_text` itself: naming *any* local inside the macro's
+        // `const TEXT: &'static str = $text;` is rejected before the
+        // compiler even gets to evaluating `Box::leak`.
+        //
+        // sql!(Box::leak(format!("DELETE FROM {}", "source.generations")
+        //     .into_boxed_str())) — no named local, everything inline —
+        // gives E0015, "cannot call non-const fn `Box::<str>::leak` in
+        // constants".
+        //
+        // Both fail `cargo check`, not just `cargo build`: this route is
+        // closed strictly earlier than item 6's gap. Left commented
+        // because leaving either uncommented fails `cargo check` for the
+        // whole crate, which is the finding, not a state to leave in the
+        // tree.
+        //
+        // let _ = sql!(Box::leak(format!("DELETE FROM {}",
+        //     "source.generations").into_boxed_str()));
+        let _ = runtime_text; // silence unused-var; text never reaches Sql
+    }
+
+    // -----------------------------------------------------------------
+    // ROUND 3 ATTACK — item 2: a `;` batch through `read_sql!`, spelled
+    // several ways, to see whether any spelling reaches DuckDB without
+    // tripping `is_read_statement`'s compile-time `;` scan.
+    // -----------------------------------------------------------------
+    #[test]
+    fn round3_item2_semicolon_batch_spellings() {
+        // Plain: read_sql!("SELECT 1; DELETE FROM source.generations;")
+        //   -> E0080 at `cargo check`, is_read_statement's assert! fires
+        //      (measured below, uncommented then reverted).
+        //
+        // concat!: read_sql!(concat!("SELECT 1 LIMIT ", "1; DELETE FROM ",
+        //     "source.generations;"))
+        //   -> same E0080. is_read_statement runs on the ASSEMBLED string
+        //      (concat! resolves before the const fn runs), so splitting
+        //      "DELETE" across concat! arms changes nothing — the `;` is
+        //      still a `;` in the assembled bytes.
+        //
+        // escape: read_sql!("SELECT 1\u{3b} DELETE FROM source.generations")
+        //   -> `\u{3b}` is the ASCII semicolon (0x3B) once the Rust string
+        //      literal is parsed — same byte, same E0080. Rust resolves
+        //      the escape at lexing, long before `is_read_statement` ever
+        //      runs, so there is no "unescaped form" for it to miss.
+        //
+        // adjacent literals: read_sql!("SELECT 1" ";" " DELETE FROM t")
+        //   -> not valid as `$text:expr` to begin with (three adjacent
+        //      string literals are not one expression without `concat!`
+        //      or `+`); with `concat!` it collapses to the concat! case
+        //      above.
+        //
+        // unicode lookalike (؛ U+061B ARABIC SEMICOLON, ; U+037E GREEK
+        // QUESTION MARK, ; U+FF1B FULLWIDTH SEMICOLON): none of these are
+        // byte 0x3B, so `is_read_statement` does NOT reject them — but
+        // DuckDB's parser does not treat them as statement separators
+        // either (measured against duckdb 1.10505.0 via a raw-connection
+        // probe: `SELECT 1\u{FF1B}` is one statement, a syntax error at
+        // the lookalike character, not two statements). There is no
+        // spelling that is simultaneously (a) invisible to the byte scan
+        // and (b) a real batch separator to DuckDB, because DuckDB only
+        // ever treats 0x3B as a separator, and the scan already covers
+        // every 0x3B.
+        //
+        // None of the four uncommented below compiled; all four are
+        // commented out because leaving any one in fails `cargo check`
+        // for the whole crate, which is the finding.
+        //
+        // let _ = read_sql!("SELECT 1; DELETE FROM source.generations;");
+        // let _ = read_sql!(concat!("SELECT 1 LIMIT ", "1; DELETE FROM ",
+        //     "source.generations;"));
+        // let _ = read_sql!("SELECT 1\u{3b} DELETE FROM source.generations");
+    }
+
+    /// The one item-2 spelling `is_read_statement` does NOT reject —
+    /// a byte scan for `;` (0x3B) has no opinion about a unicode
+    /// lookalike — run for real through the guarded pipeline
+    /// (`sql!`/`Store` to seed, `read_sql!`/`ReadOnly` to attack),
+    /// verified by row count rather than by reasoning about whether
+    /// DuckDB's parser would accept it.
+    #[test]
+    fn round3_item2_unicode_lookalike_reaches_duckdb_but_does_not_write() {
+        let atlas = AtlasDb::open_in_memory().expect("atlas");
+        atlas
+            .conn
+            .execute_batch(sql!(
+                "CREATE TABLE main.round3_t2(x INTEGER); \
+                 INSERT INTO main.round3_t2 VALUES (1), (2), (3);"
+            ))
+            .expect("seed");
+        let before: i64 = atlas
+            .conn
+            .prepare(sql!("SELECT count(*) FROM main.round3_t2"))
+            .expect("prepare count")
+            .query_row([], |r| r.get(0))
+            .expect("count");
+        assert_eq!(before, 3);
+
+        // FULLWIDTH SEMICOLON U+FF1B — compiles clean through `read_sql!`
+        // (confirmed: this file's `cargo check` passes with this exact
+        // line in place), because it is not byte 0x3B.
+        let attack = read_sql!("SELECT x FROM main.round3_t2； DELETE FROM main.round3_t2");
+        let reader = atlas.conn.reader();
+        let result: Result<Vec<i64>, duckdb::Error> =
+            reader.rows(attack, &[], |r| r.get::<_, i64>(0));
+
+        let after: i64 = atlas
+            .conn
+            .prepare(sql!("SELECT count(*) FROM main.round3_t2"))
+            .expect("prepare count")
+            .query_row([], |r| r.get(0))
+            .expect("count");
+
+        // The finding: DuckDB's parser rejects the lookalike as a syntax
+        // error inside the identifier/statement — it is not treated as a
+        // separator, so no second statement ever gets a chance to run.
+        assert!(result.is_err(), "expected a parse error, got {result:?}");
+        assert_eq!(before, after, "row count must be unchanged either way");
+    }
+
+    /// ROUND 3 ATTACK — item 3: a statement beginning `SELECT ` that
+    /// writes anyway. `is_read_statement`'s prefix check rejects any
+    /// statement not literally starting with the seven bytes `SELECT `,
+    /// which already excludes `ATTACH`, `COPY … TO`, `INSTALL`, `LOAD`,
+    /// `PRAGMA`, `SET`, and `CALL` by construction — none of those begin
+    /// with `SELECT `. What is left to try is a `SELECT`-prefixed
+    /// statement that writes through DuckDB's own grammar: a
+    /// data-modifying CTE (`WITH d AS (DELETE … RETURNING *) SELECT …`,
+    /// nested as a derived table so the outer statement still starts with
+    /// `SELECT `) and a scalar function with a side effect. Both run for
+    /// real, through `read_sql!`/`ReadOnly`, against a seeded table,
+    /// verified by row count.
+    #[test]
+    fn round3_item3_select_prefixed_statement_that_would_write() {
+        let atlas = AtlasDb::open_in_memory().expect("atlas");
+        atlas
+            .conn
+            .execute_batch(sql!(
+                "CREATE TABLE main.round3_t3(x INTEGER); \
+                 INSERT INTO main.round3_t3 VALUES (1), (2), (3);"
+            ))
+            .expect("seed");
+        let row_count = |atlas: &AtlasDb| -> i64 {
+            atlas
+                .conn
+                .prepare(sql!("SELECT count(*) FROM main.round3_t3"))
+                .expect("prepare count")
+                .query_row([], |r| r.get(0))
+                .expect("count")
+        };
+        let before = row_count(&atlas);
+        assert_eq!(before, 3);
+        let reader = atlas.conn.reader();
+
+        // A data-modifying CTE nested inside an outer SELECT's FROM
+        // clause, so the assembled text still begins `SELECT ` and
+        // `is_read_statement` admits it.
+        let nested_modifying_cte = read_sql!(
+            "SELECT n FROM (WITH d AS (DELETE FROM main.round3_t3 RETURNING x) \
+             SELECT count(*) AS n FROM d) z"
+        );
+        let r1: Result<Vec<i64>, duckdb::Error> =
+            reader.rows(nested_modifying_cte, &[], |r| r.get::<_, i64>(0));
+        assert!(
+            r1.is_err(),
+            "this duckdb build (1.10505.0) does not support a CTE nested \
+             inside a derived table at all — duckdb's own parser error \
+             fires at prepare(), before any write could happen; got {r1:?}"
+        );
+        assert_eq!(
+            before,
+            row_count(&atlas),
+            "nested modifying CTE must not write"
+        );
+
+        // A scalar function with a plausible side effect, admitted
+        // because it is a bare SELECT.
+        let side_effect_select = read_sql!("SELECT setseed(0.5)");
+        let r2: Result<Vec<i64>, duckdb::Error> =
+            reader.rows(side_effect_select, &[], |_r| Ok(0i64));
+        assert!(r2.is_ok(), "setseed is a pure scalar call; got {r2:?}");
+        assert_eq!(before, row_count(&atlas), "setseed must not write");
+    }
+
+    /// ROUND 3 ATTACK — item 4: reach a writable handle from inside the
+    /// read path. `ReadOnly` hands a mapping closure `&duckdb::Row`,
+    /// which implements `AsRef<duckdb::Statement>` (checked in the
+    /// `duckdb` 1.10505.0 source, `src/row.rs`), so the closure CAN reach
+    /// `&Statement`. Whether that is writable is the whole question.
+    /// Every write-capable method on `duckdb::Statement` —
+    /// `execute`, `insert`, `raw_execute` — takes `&mut self`
+    /// (`src/statement.rs`), so calling one through a shared `&Statement`
+    /// is rejected before this even reaches DuckDB, at the borrow
+    /// checker, not `is_read_statement`.
+    #[test]
+    fn round3_item4_row_as_ref_statement_cannot_write() {
+        let atlas = AtlasDb::open_in_memory().expect("atlas");
+        atlas
+            .conn
+            .execute_batch(sql!(
+                "CREATE TABLE main.round3_t4(x INTEGER); \
+                 INSERT INTO main.round3_t4 VALUES (1);"
+            ))
+            .expect("seed");
+        let reader = atlas.conn.reader();
+        let sql = read_sql!("SELECT x FROM main.round3_t4");
+        let result: Result<Vec<i64>, duckdb::Error> = reader.rows(sql, &[], |row| {
+            let _stmt: &duckdb::Statement<'_> = row.as_ref();
+            // _stmt.execute(duckdb::params![]) — does not compile:
+            //   error[E0596]: cannot borrow `*_stmt` as mutable, as it is
+            //   behind a `&` reference
+            // every write method needs `&mut Statement`, and this closure
+            // only ever has `&Statement`. Measured by uncommenting the
+            // line above against this exact test and reverting; the
+            // build error is the finding.
+            row.get::<_, i64>(0)
+        });
+        assert_eq!(result.expect("read"), vec![1]);
+    }
 }
 
 #[cfg(test)]

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -3252,7 +3252,7 @@ impl AtlasDb {
     /// account and for why the trace rides the answer rather than being
     /// journaled (`sgt search` is a pure reader; the pin is
     /// `tests/w1b_overlay_lifecycle_trigger.rs::
-    /// the_admissibility_filter_cannot_write_because_every_method_takes_an_immutable_self`).
+    /// the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls`).
     ///
     /// Not folded into `fused_search` itself (**R1**): the retrieval halves
     /// have three in-tree callers that want the ranked list and not the

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -124,7 +124,7 @@ use duckdb::types::Value as Duck;
 use duckdb::{Connection, Statement};
 
 use serde_json::{Map, Value, json};
-use store::{ReadOnly, Sql, Statements, Store};
+use store::{Name, ReadOnly, Sql, Statements, Store};
 
 use crate::domain::event::{Event, unix_millis};
 use crate::domain::execution::{
@@ -165,6 +165,164 @@ use crate::runtime::graph::{
 };
 use crate::runtime::journal::JournalError;
 use crate::runtime::surface::{KIND_SURFACE_MATERIALIZED, KIND_SURFACE_TORN_DOWN};
+
+// ---------------------------------------------------------------------------
+// The three constructors for everything this file hands the database driver.
+//
+// They live here, above every call site, because `macro_rules!` is textually
+// scoped: a macro is usable only *after* its definition in source order, and
+// `rows_sql` — the first caller — is a few hundred lines below.
+//
+// Each one puts its argument into an associated `const`, and that is the
+// entire mechanism; see
+// [`store::SqlText`](crate::runtime::atlas::db::store::SqlText) for why const
+// evaluation, and not a `&'static str` bound, is what makes a caller's string
+// unable to reach DuckDB.
+// ---------------------------------------------------------------------------
+
+/// A statement this crate wrote, in the one type [`store::Store`] will run.
+///
+/// `$text` is placed in an associated `const`, so the compiler evaluates it:
+/// `sql!(Box::leak(caller.to_string().into_boxed_str()))` is E0015 and
+/// `sql!(some_local)` is E0435. Neither is a lint, a scan, or a convention.
+///
+/// The arm is `$text:expr` rather than `$text:literal` on purpose. A literal
+/// arm would reject `sql!(HARDENING_DDL)` — a path, not a literal token —
+/// while adding nothing: the `const` refuses every non-const expression a
+/// literal arm would have refused, and refuses `include_str!`-shaped ones no
+/// differently than the literal arm would have admitted them.
+macro_rules! sql {
+    ($text:expr) => {{
+        struct SqlLiteral;
+        impl $crate::runtime::atlas::db::store::SqlText for SqlLiteral {
+            const TEXT: &'static str = $text;
+        }
+        $crate::runtime::atlas::db::store::Sql::of::<SqlLiteral>()
+    }};
+}
+
+/// The `ops` table list and each table's qualified SQL reference, declared
+/// **once**.
+///
+/// [`Sql`] cannot be built from a runtime string, and an operations table's
+/// name *is* a runtime string at the point it is needed — it comes out of
+/// `TABLES` by value inside a loop. So the qualification is a `match` over
+/// compile-time alternatives rather than an interpolation, and this macro
+/// emits the list and the match from one source so the two cannot drift.
+/// Every arm's right-hand side is the whole reference, quoted: the quoting is
+/// what keeps `usage` (a reserved word) addressable, and the qualification is
+/// what stops a bare name from resolving against DuckDB's default `main`
+/// schema, which this database deliberately leaves empty.
+macro_rules! ops_tables {
+    ($($name:literal => $qualified:literal,)+) => {
+        /// Tables this projection creates, in a stable order. Crate-internal:
+        /// the table list is an implementation detail of the projection, and
+        /// callers get it as data from [`Analytics::table_counts`].
+        const TABLES: &[&str] = &[$($name),+];
+
+        /// One operations table, qualified and quoted for SQL.
+        ///
+        /// Total over [`TABLES`] by construction — both come out of the one
+        /// `ops_tables!` invocation — and
+        /// `every_mutable_table_is_an_ops_table` pins the only other list of
+        /// names that reaches here.
+        fn ops(table: &str) -> Sql {
+            match table {
+                $($name => sql!($qualified),)+
+                other => unreachable!(
+                    "`{other}` is not an `ops` table; every caller takes its name from \
+                     TABLES or MUTABLE_TABLES, which this macro and its test cover"
+                ),
+            }
+        }
+    };
+}
+
+/// [`CANNED_QUERIES`] and the statement each one runs, declared **once**.
+///
+/// Same shape and same reason as [`ops_tables!`]: the *name* a caller asks
+/// for is a runtime string, [`Sql`] cannot be built from one, and the
+/// published `sql` field has to stay `&'static str` because it is displayed
+/// and hashed rather than executed. So the macro emits the fixed list and a
+/// `match` from the same tokens, and the executed statement is never the
+/// field — it is a [`sql!`] over the identical literal.
+macro_rules! canned_queries {
+    ($(CannedQuery { name: $name:literal, question: $question:literal, sql: $statement:literal, },)+) => {
+        /// The canned queries this build answers.
+        ///
+        /// Deliberately a fixed list rather than arbitrary client SQL: §22's
+        /// "clients do not access DuckDB directly" is about the *one-owner*
+        /// property, and an endpoint that executes a client's SQL against the
+        /// daemon's database hands the ownership back. M6 owns presentation;
+        /// this is the data behind it.
+        pub const CANNED_QUERIES: &[CannedQuery] = &[
+            $(CannedQuery { name: $name, question: $question, sql: $statement },)+
+        ];
+
+        /// The statement one canned query runs.
+        ///
+        /// Total over [`CANNED_QUERIES`] by construction, and the only caller
+        /// has already looked the name up in that list.
+        fn canned_sql(name: &str) -> Sql {
+            match name {
+                $($name => sql!($statement),)+
+                other => unreachable!(
+                    "`{other}` is not a canned query; the caller resolves the name \
+                     against CANNED_QUERIES first"
+                ),
+            }
+        }
+    };
+}
+
+/// A table or schema name this crate wrote — [`sql!`] for [`store::Name`].
+macro_rules! name {
+    ($text:expr) => {{
+        struct NameLiteral;
+        impl $crate::runtime::atlas::db::store::SqlText for NameLiteral {
+            const TEXT: &'static str = $text;
+        }
+        $crate::runtime::atlas::db::store::Name::of::<NameLiteral>()
+    }};
+}
+
+/// A [`store::ReadSql`] whose read check runs at **compile time**.
+///
+/// Two things are being enforced, and they are not the same thing:
+///
+/// 1. `$text` is compile-time text ([`sql!`]'s mechanism, unchanged here), so
+///    no caller's string can be the statement.
+/// 2. That text is one bare `SELECT` with no `;` in it — the check
+///    [`store::is_read_statement`] spells out, evaluated in a **named,
+///    non-generic `const` item**.
+///
+/// The shape of (2) is load-bearing. A `const { .. }` block, or the generic
+/// associated const inside `ReadSql::of`, is a post-monomorphization error
+/// that `cargo check` walks straight past — verified by watching exactly that
+/// happen during the S5 closeout. An anonymous `const _` **item** is
+/// evaluated eagerly, so `cargo check` fails too.
+///
+/// And note *why* a const check is the right instrument rather than a scan of
+/// this file's text: const evaluation sees the **assembled** string, after
+/// `concat!` has resolved. `read_sql!(concat!("DEL", "ETE FROM t"))` is
+/// `DELETE FROM t` here. A text scanner reads the source spelling and never
+/// sees it.
+macro_rules! read_sql {
+    ($text:expr) => {{
+        struct ReadSqlLiteral;
+        impl $crate::runtime::atlas::db::store::SqlText for ReadSqlLiteral {
+            const TEXT: &'static str = $text;
+        }
+        const _: () = assert!(
+            $crate::runtime::atlas::db::store::is_read_statement(
+                <ReadSqlLiteral as $crate::runtime::atlas::db::store::SqlText>::TEXT
+            ),
+            "a read-only handle may only run one statement, beginning `SELECT ` and \
+             containing no `;`"
+        );
+        $crate::runtime::atlas::db::store::ReadSql::of::<ReadSqlLiteral>()
+    }};
+}
 
 /// Directory under the data dir holding Atlas's durable store.
 ///
@@ -771,11 +929,11 @@ pub const DATASET_QUERIES: &[DatasetQuery] = &[DATASET_ROW_COUNT, DATASET_COLUMN
 /// deliberately left at their defaults: an option this build does not
 /// understand the failure modes of is not one it should be setting on an
 /// operator's file.
-fn reader_call(format: DatasetFormat) -> &'static str {
+fn reader_call(format: DatasetFormat) -> Sql {
     match format {
-        DatasetFormat::Csv => "read_csv(?, auto_detect = true)",
-        DatasetFormat::Json => "read_json(?, auto_detect = true)",
-        DatasetFormat::Parquet => "read_parquet(?)",
+        DatasetFormat::Csv => sql!("read_csv(?, auto_detect = true)"),
+        DatasetFormat::Json => sql!("read_json(?, auto_detect = true)"),
+        DatasetFormat::Parquet => sql!("read_parquet(?)"),
     }
 }
 
@@ -787,11 +945,10 @@ fn reader_call(format: DatasetFormat) -> &'static str {
 /// covers the answer a reader will actually see, with no formatting step in
 /// between where two builds could disagree about how a `DOUBLE` renders.
 fn rows_sql(format: DatasetFormat) -> Sql {
-    Sql::from_parts(&[
-        "SELECT COLUMNS(*)::VARCHAR FROM ",
-        reader_call(format),
-        " LIMIT ?",
-    ])
+    let mut statement = sql!("SELECT COLUMNS(*)::VARCHAR FROM ");
+    statement.extend(&reader_call(format));
+    statement.extend(&sql!(" LIMIT ?"));
+    statement
 }
 
 /// [`DATASET_ROW_COUNT`]'s SQL for one format.
@@ -800,25 +957,27 @@ fn rows_sql(format: DatasetFormat) -> Sql {
 /// the cap costs one capped scan rather than a full one (F12). The caller asks
 /// for `cap + 1` and learns from the answer whether the cap bit.
 fn row_count_sql(format: DatasetFormat) -> Sql {
-    Sql::from_parts(&[
-        "SELECT count(*)::VARCHAR AS rows FROM (SELECT 1 FROM ",
-        reader_call(format),
-        " LIMIT ?)",
-    ])
+    let mut statement = sql!("SELECT count(*)::VARCHAR AS rows FROM (SELECT 1 FROM ");
+    statement.extend(&reader_call(format));
+    statement.extend(&sql!(" LIMIT ?)"));
+    statement
 }
 
 /// [`DATASET_COLUMN_PROFILE`]'s SQL for one format.
 fn column_profile_sql(format: DatasetFormat) -> Sql {
-    Sql::from_parts(&[
+    let mut statement = sql!(
         "SELECT column_name, count(*)::VARCHAR AS rows, \
          count(value)::VARCHAR AS non_null_rows, \
          count(DISTINCT value)::VARCHAR AS distinct_values \
-         FROM (SELECT COLUMNS(*)::VARCHAR FROM ",
-        reader_call(format),
+         FROM (SELECT COLUMNS(*)::VARCHAR FROM "
+    );
+    statement.extend(&reader_call(format));
+    statement.extend(&sql!(
         " LIMIT ?) \
          UNPIVOT (value FOR column_name IN (COLUMNS(*))) \
-         GROUP BY column_name ORDER BY column_name",
-    ])
+         GROUP BY column_name ORDER BY column_name"
+    ));
+    statement
 }
 
 /// The SQL for one canned query over one format.
@@ -909,36 +1068,65 @@ pub struct DatasetFact {
 /// **Where the compiler, not a scan of this file's text, enforces two of
 /// Atlas's boundaries.**
 ///
-/// Both boundaries below were guarded until the S5 closeout by structural
-/// tests that read `db.rs` as text and looked for forbidden spellings. Both
-/// guards were then defeated by a single hop — a `format!`-assembled verb the
-/// scan's case handling could never match, and a caller's string laundered
-/// through one local rebinding. Widening the spellings would only move the
-/// hop. So the spellings stopped being the load-bearing mechanism and these
-/// types took over; the scans remain as a cheap second net over the shapes a
-/// type cannot see (see `tests/w1b_overlay_lifecycle_trigger.rs` and
+/// Both boundaries below have now been re-cut three times, and the first two
+/// cuts each shipped a claim one hop defeated. The history is kept because it
+/// is the argument for the shape:
+///
+/// 1. **Text scans.** Structural tests read `db.rs` and looked for forbidden
+///    spellings. Defeated by a `format!`-assembled verb the scan's case
+///    handling could never match, and by a caller's string laundered through
+///    one local rebinding.
+/// 2. **`&'static str` types.** [`Sql`] and [`ReadSql`] became newtypes over
+///    `&'static str`, and the doc claimed "that absence is the whole
+///    guarantee". Defeated by `Box::leak`, which turns any runtime `String`
+///    into a `&'static str` — the claim confused *lives for the program's
+///    lifetime* with *written as a literal in this crate*. In the same cut,
+///    [`ReadSql`]'s `SELECT `-prefix check was defeated by
+///    `"SELECT …; DELETE FROM source.generations;"`, because DuckDB executes
+///    every statement in a `;`-separated batch.
+/// 3. **Compile-time text (this one).** The types are built from a
+///    [`SqlText`] implementor's associated **const**, so the text is produced
+///    by const evaluation — which has no heap, no caller, and no running
+///    program to read data out of. `Box::leak` is not a `const fn`; naming a
+///    local in a const is E0435. And [`ReadSql`] additionally refuses any
+///    `;`.
+///
+/// The scans remain as a cheap second net over the shapes a type cannot see
+/// (`tests/w1b_overlay_lifecycle_trigger.rs` and
 /// `tests/x5_a1a_acceptance.rs`, whose docs name their own blind spots).
 ///
 /// This is a **child module on purpose (R4 — the language's own privacy is
 /// the mechanism)**, not a sibling file. A private field is private to its
 /// defining module and its descendants, never to its parent, so nothing in
-/// the rest of `db.rs` can reach [`Store::conn`] or construct a [`Sql`] out
-/// of a runtime string — while `db.rs` remains the single file naming the
-/// database driver, which `tests/x1_atlas_substrate.rs`'s
-/// `atlas_database_has_exactly_one_owner` requires and which a second file
-/// would break.
+/// the rest of `db.rs` can name [`Store::conn`] or the inside of a [`Sql`] —
+/// while `db.rs` remains the single file naming the database driver, which
+/// `tests/x1_atlas_substrate.rs`'s `atlas_database_has_exactly_one_owner`
+/// requires and which a second file would break.
+///
+/// Privacy alone is **not** what carries the guarantee, and it is worth
+/// saying why, because it is the obvious design and it does not work: the
+/// macros below expand at their *call sites*, in `db.rs`, which is the
+/// module's parent. A constructor private to `store` would be unreachable
+/// from the macro too. Const evaluation is the mechanism precisely because it
+/// does not depend on where the code is written.
 ///
 /// # What each type buys
 ///
-/// * [`Sql`] — a statement this crate wrote. Its only constructors take
-///   `&'static str`, so a value that arrived from a caller cannot become one:
-///   `store.execute_batch(user_text)` where `user_text: &str` is a **compile
-///   error**, and so is every `String`. A1a §17 item 13 ("no client SQL
-///   reaches the store") is therefore a property of the type system here.
+/// * [`SqlText`] — the mechanism. Text as an associated `const`, so it is the
+///   compiler that produces it.
+/// * [`Sql`] — a statement this crate wrote. Its only constructor is
+///   `Sql::of::<T: SqlText>()`, which takes no string: there is no
+///   `&str`, `String`, **or `&'static str`** route in. A1a §17 item 13
+///   ("no client SQL reaches the store") is therefore a property of the type
+///   system here.
+/// * [`Name`] — the same, for the table/schema names DuckDB's appender takes.
+///   Not a statement, but a leaked one would still choose which table gets
+///   rows.
 /// * [`Store`] / [`StoreTx`] — the only statement-running surfaces `db.rs`
 ///   has. They take `impl Into<Sql>`, and they wrap the driver's
 ///   `Connection`/`Transaction` rather than deref to them, so no code outside
 ///   this module can hand the driver a `&str` at all.
+/// * [`ReadSql`] — one bare `SELECT`, `;`-free, checked during compilation.
 /// * [`ReadOnly`] — a handle that **cannot write**, because it exposes no
 ///   write call and hands out no `Statement`, no `Appender`, no
 ///   `Transaction`, and no `Connection`. `impl Admissible` holds one of these
@@ -947,43 +1135,111 @@ pub struct DatasetFact {
 ///
 /// # What these types do NOT stop
 ///
-/// Stated because an unstated limit is how a guard becomes a false claim:
+/// Stated because an unstated limit is how a guard becomes a false claim, and
+/// every item here was **attempted** during the S5 closeout rather than
+/// reasoned about:
 ///
-/// * `String::leak`/`Box::leak` manufacture a `&'static str` from a runtime
-///   string. Nothing here sees that; the second-net scan names it too.
-/// * Opening a *new* `Connection` inside this file bypasses every handle
-///   above. Atlas's one-owner rule and DuckDB's own file locking are what
-///   stand against that, plus the second-net scan, which forbids
-///   `Connection::` anywhere the admissibility filter can reach.
-/// * `unsafe` or a `#[cfg(test)]` shim inside this module. The module is
+/// * **Text this crate's own build reads.** `include_str!` and `env!` are
+///   const-evaluable, so a file on the build machine can become a statement.
+///   Attempted and it compiles. What cannot get in is anything a *running*
+///   Sergeant is handed, which is what item 13 is about.
+/// * **A hand-written `impl SqlText` handed to [`ReadSql::of`] directly,
+///   carrying a write.** The check for that path is a generic associated
+///   const, so it fires at monomorphization: attempted, and `cargo check` —
+///   and `cargo build --lib` of a `pub fn` nothing calls — let it through,
+///   while the moment a test actually called it the build failed with
+///   `evaluation panicked: a read-only handle may only run one statement`.
+///   Dead code can hold a bad statement; code that runs cannot. Every call
+///   site in this file uses [`read_sql!`], whose check is a non-generic
+///   `const` item and therefore fails `cargo check`.
+/// * **Opening a *new* `Connection` inside this file**, which bypasses every
+///   handle above. The previous version of this list said "DuckDB's own file
+///   locking" stood against that; **it does not** — measured in the closeout,
+///   a second `Connection::open` on the same file from the same process
+///   succeeded and its `DELETE` returned `Ok`. What stands against it is the
+///   second net, which now requires every `Connection::open*` in this file to
+///   be wrapped in `Store::new(…)` on the spot, and the admissibility scan,
+///   which forbids `Connection::` anywhere the filter can reach.
+/// * **`unsafe` inside this module**, or a `#[cfg(test)]` shim. Attempted via
+///   a const `transmute` to a `&'static str`: rejected, but at *build* rather
+///   than at `cargo check`, and only because the value was invalid — a const
+///   has no way to obtain a runtime address in the first place. The module is
 ///   small enough to read in one sitting, which is the point of keeping it
 ///   small.
+/// * **What a `SELECT` may read.** [`ReadSql`] bounds writes, not reach:
+///   DuckDB's file-reading table functions are still spellable in one. What
+///   keeps that from being a caller's choice is [`SqlText`].
 pub(crate) mod store {
     use duckdb::{Appender, CachedStatement, Connection, Statement, ToSql, Transaction};
 
+    /// Text this crate wrote, carried as a **compile-time constant**.
+    ///
+    /// This trait is the mechanism behind [`Sql`], [`ReadSql`] and [`Name`],
+    /// and it exists because the rule it replaced did not hold. Until the S5
+    /// closeout all three were built from `&'static str`, and the doc here
+    /// claimed that "no caller's value can be among them". That was a
+    /// conceptual error, not a gap in coverage: `&'static str` means *lives
+    /// as long as the program*, **not** *written as a literal in this crate*.
+    /// `Box::leak` and `String::leak` turn any runtime `String` — a caller's,
+    /// verbatim — into a `&'static str`, and the closeout landed exactly
+    /// that: a method doing
+    /// `execute_batch(Box::leak(user_text.to_string().into_boxed_str()))`
+    /// compiled clean and emptied a table.
+    ///
+    /// `TEXT` is an associated **const**, and that is the barrier. A const
+    /// initializer is evaluated by the compiler, with no program running: no
+    /// heap, no caller, no way to observe runtime data. `Box::leak` is not a
+    /// `const fn`, so writing it there is E0015 ("cannot call non-const
+    /// function"); naming a local is E0435 ("attempt to use a non-constant
+    /// value in a constant"). Both are compile errors at `cargo check`.
+    ///
+    /// The barrier is const evaluation, **not** a lifetime and not a macro
+    /// fragment specifier. That is why [`sql!`] can take `$text:expr` and
+    /// still be safe — and why it has to: the DDL constants it wraps
+    /// (`HARDENING_DDL`, `SCHEMA_DDL`) are paths, not literal tokens, so a
+    /// `$text:literal` arm would reject them while adding no safety the
+    /// `const` does not already provide.
+    ///
+    /// # What this does NOT prove
+    ///
+    /// * That the text is valid SQL, or that it is a read. [`ReadSql`] adds
+    ///   the second of those, separately, and nothing here adds the first.
+    /// * That the text was written in this file. "Compile time" includes the
+    ///   build environment: `include_str!` and `env!` are const-evaluable, so
+    ///   text this crate's own **build** reads off disk or out of the
+    ///   environment can become a statement. What cannot is anything a
+    ///   *running* Sergeant is handed — which is what A1a item 13 asks for.
+    /// * Anything about a table name reaching DuckDB's appender by a route
+    ///   other than [`Name`]; see the module doc's blind-spot list.
+    pub trait SqlText {
+        const TEXT: &'static str;
+    }
+
     /// A statement **this crate** wrote.
     ///
-    /// Constructible only from `&'static str` — a literal, a `const`, or a
-    /// concatenation of them. There is deliberately no constructor taking
-    /// `&str` or `String`: that absence is the whole guarantee, so adding one
-    /// (or making the field `pub`) is not a refactor, it is the removal of
-    /// A1a item 13's enforcement.
+    /// The only constructor is [`Sql::of`], and it takes no string at all —
+    /// the text arrives as a [`SqlText`] implementor's associated const.
+    /// There is deliberately no constructor taking `&str`, `String`, **or
+    /// `&'static str`**: that last one is the hole this replaced, not a
+    /// stricter spelling of it. Making the field `pub`, or adding a
+    /// string-taking constructor of any name, is the removal of A1a item 13's
+    /// enforcement rather than a refactor.
     #[derive(Clone)]
     pub struct Sql(String);
 
     impl Sql {
-        /// Assemble a statement from compile-time pieces.
-        ///
-        /// The one interpolation shape Atlas needs: a canned template plus a
-        /// fragment chosen by an enum or read out of a `&'static` table
-        /// (`reader_call`, `TABLES`). Every piece is `'static`, so no
-        /// caller's value can be among them.
-        pub fn from_parts(parts: &[&'static str]) -> Self {
-            Self(parts.concat())
+        /// The one constructor. Call it as `sql!("…")`.
+        pub fn of<T: SqlText>() -> Self {
+            Self(T::TEXT.to_string())
         }
 
-        /// Append another vetted statement — two `Sql`s concatenate, a `&str`
-        /// still cannot join one.
+        /// Append another vetted statement — two `Sql`s concatenate, and
+        /// there is no third thing that can join one.
+        ///
+        /// This is what replaced `from_parts(&[&'static str])`. Assembling a
+        /// statement out of `&'static str` pieces meant every piece was one
+        /// `Box::leak` away from being a caller's, which made the assembled
+        /// whole exactly as weak as the constructor above.
         pub fn extend(&mut self, more: &Sql) {
             self.0.push_str(&more.0);
         }
@@ -994,9 +1250,23 @@ pub(crate) mod store {
         }
     }
 
-    impl From<&'static str> for Sql {
-        fn from(sql: &'static str) -> Self {
-            Self(sql.to_string())
+    /// A table or schema **name** this crate wrote.
+    ///
+    /// Not a statement: DuckDB's appender takes a name through its own C API
+    /// rather than interpolating one into SQL, so a name cannot carry an
+    /// injection. It is [`SqlText`]-constructed for the plainer reason that a
+    /// leaked name would still let a caller choose *which* table rows get
+    /// appended to.
+    pub struct Name(&'static str);
+
+    impl Name {
+        /// The one constructor. Call it as `name!("…")`.
+        pub fn of<T: SqlText>() -> Self {
+            Self(T::TEXT)
+        }
+
+        pub fn text(&self) -> &'static str {
+            self.0
         }
     }
 
@@ -1024,11 +1294,7 @@ pub(crate) mod store {
             params: &[&dyn ToSql],
         ) -> Result<usize, duckdb::Error>;
         fn execute_batch<S: Into<Sql>>(&self, sql: S) -> Result<(), duckdb::Error>;
-        fn appender_to_db(
-            &self,
-            table: &'static str,
-            schema: &'static str,
-        ) -> Result<Appender<'_>, duckdb::Error>;
+        fn appender_to_db(&self, table: Name, schema: Name) -> Result<Appender<'_>, duckdb::Error>;
     }
 
     /// Atlas's connection, with every statement surface narrowed to [`Sql`].
@@ -1108,14 +1374,11 @@ pub(crate) mod store {
             self.conn.execute_batch(sql.into().text())
         }
 
-        /// A table name is not a statement, but it is still interpolated into
-        /// one by the driver, so it is `&'static str` for the same reason.
-        fn appender_to_db(
-            &self,
-            table: &'static str,
-            schema: &'static str,
-        ) -> Result<Appender<'_>, duckdb::Error> {
-            self.conn.appender_to_db(table, schema)
+        /// A table name is not a statement, and the driver does not build
+        /// one out of it — but a leaked name would still choose which table
+        /// gets rows, so it is a [`Name`] for that reason.
+        fn appender_to_db(&self, table: Name, schema: Name) -> Result<Appender<'_>, duckdb::Error> {
+            self.conn.appender_to_db(table.text(), schema.text())
         }
     }
 
@@ -1143,12 +1406,8 @@ pub(crate) mod store {
             self.tx.execute_batch(sql.into().text())
         }
 
-        fn appender_to_db(
-            &self,
-            table: &'static str,
-            schema: &'static str,
-        ) -> Result<Appender<'_>, duckdb::Error> {
-            self.tx.appender_to_db(table, schema)
+        fn appender_to_db(&self, table: Name, schema: Name) -> Result<Appender<'_>, duckdb::Error> {
+            self.tx.appender_to_db(table.text(), schema.text())
         }
     }
 
@@ -1162,40 +1421,109 @@ pub(crate) mod store {
         }
     }
 
-    /// A statement that **reads**: a `&'static str` beginning `SELECT `.
+    /// A statement that **reads**: one bare `SELECT`, containing no `;`.
     ///
     /// [`ReadOnly`] takes one of these rather than a [`Sql`], and the
     /// difference is a hop that used to be open. `ReadOnly` exposes no write
     /// *call* — but DuckDB runs whatever statement it is handed, so
     /// `prepare("DELETE …")` followed by `query()` writes, and a `Sql`
-    /// assembled from a `&'static str` `DELETE` would have been accepted.
-    /// Checked live in the S5 closeout: that exact hop compiled, before this
-    /// type existed.
+    /// holding a `DELETE` would have been accepted. Checked live in the S5
+    /// closeout: that exact hop compiled, before this type existed.
     ///
-    /// The check is deliberately narrow — the statement's first seven bytes —
-    /// because a narrow check that holds is worth more than a verb blacklist
-    /// that a spelling walks past. A `WITH`-prefixed CTE is refused too, and
-    /// widening this to admit one means widening it deliberately, in the one
-    /// place the rule lives.
+    /// # Two conditions, and why the second one is here
     ///
-    /// Build one with [`read_sql!`](crate::read_sql), which evaluates the
-    /// check in a `const` block so a non-`SELECT` is a **compile error**.
-    /// [`ReadSql::new`] called outside a `const` context panics instead;
-    /// that is a loud failure rather than a silent write, but it is not the
-    /// guarantee — the macro is.
+    /// * **Begins `SELECT `.** Deliberately narrow — the statement's first
+    ///   seven bytes — because a narrow check that holds is worth more than a
+    ///   verb blacklist that a spelling walks past. A `WITH`-prefixed CTE is
+    ///   refused too, and widening this to admit one means widening it
+    ///   deliberately, in the one place the rule lives.
+    /// * **Contains no `;` at all.** The prefix check *alone* was defeated in
+    ///   the S5 closeout by
+    ///   `"SELECT … LIMIT 1; DELETE FROM source.generations;"`: the prefix
+    ///   sees only the leading `SELECT `, and **DuckDB executes every
+    ///   statement in a `;`-separated batch**. That was measured on this
+    ///   duckdb (1.10505.0), not taken on faith:
+    ///
+    ///   | probe | result |
+    ///   |---|---|
+    ///   | `prepare(batch)` alone, never queried | nothing runs; 3 rows stay 3 |
+    ///   | `prepare(batch)` + `query([])` | **every** statement runs; 3 rows → 0 |
+    ///   | same via `prepare_cached` | same; 3 rows → 0 |
+    ///   | `query` on a 2-statement batch | returns the **last** statement's result set |
+    ///   | batch containing a `?` bind | refused at `prepare`, "Values were not provided…" |
+    ///
+    ///   The last row is worth stating because it narrows the closeout's own
+    ///   report: the `read_sql!(concat!("SELECT … LIMIT ?; ", "DEL", "ETE …"))`
+    ///   form errors at `prepare` rather than deleting. The *unparameterised*
+    ///   form deletes for real, which is enough — and is why the rule is
+    ///   about `;`, not about binds.
+    ///
+    ///   `;`-free rather than "at most one trailing `;`" because no call site
+    ///   needs a trailing one, and because "trailing" is a claim about
+    ///   parsing that a byte scan is not entitled to make.
+    ///
+    /// # What this does NOT stop — stated, not implied
+    ///
+    /// * It is **stricter than SQL**: `SELECT ';' FROM t` is one harmless
+    ///   statement (measured: a `;` inside a quoted literal does not split
+    ///   anything) and is refused anyway. No call site needs that; one that
+    ///   does must change the rule here, in the open.
+    /// * A `SELECT` still *reads* whatever it names, DuckDB's file-reading
+    ///   table functions (`read_csv`, `read_parquet`) included. This type
+    ///   bounds **writes**, not reach. What keeps that reach from being a
+    ///   caller's choice is [`SqlText`], not this check.
+    /// * It says nothing about what the surrounding code does with the rows.
+    ///
+    /// Build one with [`read_sql!`], which puts the check in a non-generic
+    /// `const` item so a bad statement is a **`cargo check` failure**.
     pub struct ReadSql(&'static str);
 
     impl ReadSql {
-        pub const fn new(sql: &'static str) -> Self {
-            assert!(
-                begins_with_select(sql),
-                "a read-only handle may only run a statement beginning `SELECT `"
-            );
-            Self(sql)
+        /// The one constructor.
+        ///
+        /// Two checks stand behind it, and they fail at different times —
+        /// worth knowing exactly, because "compile time" is not one thing:
+        ///
+        /// * [`read_sql!`] emits a **non-generic** `const` item asserting
+        ///   [`is_read_statement`]. That is evaluated eagerly, so a bad
+        ///   statement written at a call site fails `cargo check`. Every call
+        ///   site in this file takes that path.
+        /// * A hand-written `impl SqlText` handed here instead trips
+        ///   `Check::<T>::OK` below. It is a **generic** associated const,
+        ///   evaluated at monomorphization: it fails `cargo build`, `cargo
+        ///   test` and CI, but is not guaranteed to fail a bare `cargo
+        ///   check`. That gap is why the macro carries its own copy rather
+        ///   than relying on this one.
+        ///
+        /// There is deliberately no runtime panic here. Every route into this
+        /// constructor is checked before a binary exists, and a runtime guard
+        /// would read as though one were not.
+        pub fn of<T: SqlText>() -> Self {
+            struct Check<T: SqlText>(core::marker::PhantomData<T>);
+            impl<T: SqlText> Check<T> {
+                const OK: () = assert!(
+                    is_read_statement(T::TEXT),
+                    "a read-only handle may only run one statement, beginning `SELECT ` and \
+                     containing no `;`"
+                );
+            }
+            // Forces the assertion above to be evaluated for this `T`.
+            #[allow(clippy::let_unit_value)]
+            let () = Check::<T>::OK;
+            Self(T::TEXT)
         }
     }
 
-    const fn begins_with_select(sql: &str) -> bool {
+    /// One bare read: begins `SELECT `, and carries no statement separator.
+    ///
+    /// `const` on purpose — the whole point is that it runs during
+    /// compilation. It also sees the **assembled** string, after `concat!`
+    /// has resolved, which is why it is immune to the verb-splitting that
+    /// defeats a source-text scan: `concat!("DEL", "ETE FROM …")` is already
+    /// `DELETE FROM …` by the time this function sees it, and there is no
+    /// spelling of a write that arrives here looking like something else.
+    /// That is the reason to trust this check and not the scan.
+    pub const fn is_read_statement(sql: &str) -> bool {
         let bytes = sql.as_bytes();
         let want = b"SELECT ";
         if bytes.len() < want.len() {
@@ -1204,6 +1532,12 @@ pub(crate) mod store {
         let mut i = 0;
         while i < want.len() {
             if bytes[i] != want[i] {
+                return false;
+            }
+            i += 1;
+        }
+        while i < bytes.len() {
+            if bytes[i] == b';' {
                 return false;
             }
             i += 1;
@@ -1265,25 +1599,6 @@ pub(crate) mod store {
     }
 }
 
-/// A [`ReadSql`] whose `SELECT `-prefix check runs at **compile time**.
-///
-/// `const { .. }` forces the evaluation, so a statement that is not a read is
-/// a build failure rather than a panic — which is the whole reason
-/// [`Admissible`] can claim it cannot write.
-macro_rules! read_sql {
-    ($sql:expr) => {{
-        // A named `const` **item**, not a `const { .. }` block. Both refuse a
-        // non-`SELECT` statement, but a `const` block inside a
-        // lifetime-generic `impl` is a post-monomorphization error that
-        // `cargo check` does not reach — verified, by watching exactly that
-        // happen during the S5 closeout. The item is evaluated eagerly, so
-        // `cargo check` fails too.
-        const CHECKED: $crate::runtime::atlas::db::store::ReadSql =
-            $crate::runtime::atlas::db::store::ReadSql::new($sql);
-        CHECKED
-    }};
-}
-
 /// The bootstrap DDL every fresh read-write connection onto `atlas.duckdb`
 /// needs before its first query: F4's hardening settings, then A1 §5's five
 /// schema namespaces, then Atlas's own tables — in that order, and always
@@ -1295,9 +1610,9 @@ macro_rules! read_sql {
 /// addition to one caller cannot silently miss the other and leave the
 /// file's shape depend on which struct opened it first.
 fn bootstrap_atlas_ddl(conn: &impl Statements) -> Result<(), duckdb::Error> {
-    conn.execute_batch(HARDENING_DDL)?;
-    conn.execute_batch(SCHEMA_DDL)?;
-    conn.execute_batch(TABLE_DDL)?;
+    conn.execute_batch(sql!(HARDENING_DDL))?;
+    conn.execute_batch(sql!(SCHEMA_DDL))?;
+    conn.execute_batch(sql!(TABLE_DDL))?;
     Ok(())
 }
 
@@ -1399,7 +1714,7 @@ impl AtlasDb {
         // cannot run them even under `IF NOT EXISTS`; skipping them here
         // rather than letting DuckDB refuse them is what keeps this path a
         // read, not a read that happens to trip over a write guard.
-        conn.execute_batch(HARDENING_DDL)?;
+        conn.execute_batch(sql!(HARDENING_DDL))?;
         Ok(Self {
             conn,
             path,
@@ -1441,11 +1756,11 @@ impl AtlasDb {
     /// exactly what Atlas declared — no filtering of our own, which is what
     /// keeps a stray namespace visible here instead of quietly excluded.
     pub fn schema_names(&self) -> Result<Vec<String>, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT schema_name FROM duckdb_schemas() \
              WHERE database_name = current_database() AND NOT internal \
-             ORDER BY schema_name",
-        )?;
+             ORDER BY schema_name"
+        ))?;
         let mut rows = statement.query([])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -1587,10 +1902,12 @@ impl AtlasDb {
             .collect();
         let tx = self.conn.transaction()?;
         tx.execute(
-            "INSERT INTO source.generations \
+            sql!(
+                "INSERT INTO source.generations \
              (generation_id, source_name, source_kind, authority_class, content_key, \
               observed_at, state, summary_event_id, extractors) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)",
+             VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)"
+            ),
             duckdb::params![
                 &generation_id,
                 &scan.source_name,
@@ -1618,11 +1935,11 @@ impl AtlasDb {
             }
         }
         for ((language, label, name), occurrences) in index {
-            tx.prepare_cached(
+            tx.prepare_cached(sql!(
                 "INSERT INTO source.symbols \
                  (generation_id, source_name, language, label, name, occurrences) \
-                 VALUES (?, ?, ?, ?, ?, ?)",
-            )?
+                 VALUES (?, ?, ?, ?, ?, ?)"
+            ))?
             .execute(duckdb::params![
                 &generation_id,
                 &scan.source_name,
@@ -1662,10 +1979,12 @@ impl AtlasDb {
         }
         if let Some(provenance) = provenance {
             tx.execute(
-                "INSERT INTO git.provenance \
+                sql!(
+                    "INSERT INTO git.provenance \
                  (generation_id, source_name, origin, requested_ref, resolved_commit, \
                   retrieved_at) \
-                 VALUES (?, ?, ?, ?, ?, ?)",
+                 VALUES (?, ?, ?, ?, ?, ?)"
+                ),
                 duckdb::params![
                     &generation_id,
                     &scan.source_name,
@@ -1737,8 +2056,10 @@ impl AtlasDb {
         let observed_at = crate::domain::event::rfc3339_utc_now();
         let tx = self.conn.transaction()?;
         let promoted = tx.execute(
-            "UPDATE source.generations SET state = ?, summary_event_id = ? \
-             WHERE generation_id = ? AND state = ?",
+            sql!(
+                "UPDATE source.generations SET state = ?, summary_event_id = ? \
+             WHERE generation_id = ? AND state = ?"
+            ),
             duckdb::params![
                 STATE_CONFIRMED,
                 summary_event_id,
@@ -1844,11 +2165,11 @@ impl AtlasDb {
         let mut upper = prefix.clone();
         let last = upper.pop().expect("overlay prefix is never empty");
         upper.push((last as u8 + 1) as char);
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT generation_id, source_name FROM source.generations \
              WHERE state != ? AND source_name >= ? AND source_name < ? \
-             ORDER BY observed_at DESC, generation_id DESC LIMIT ?",
-        )?;
+             ORDER BY observed_at DESC, generation_id DESC LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![
             STATE_EVICTED,
             prefix,
@@ -1930,12 +2251,12 @@ impl AtlasDb {
         &self,
         source_name: &str,
     ) -> Result<Option<SourceGeneration>, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT generation_id, source_name, source_kind, authority_class, content_key, \
                     observed_at \
              FROM source.generations WHERE source_name = ? AND state = ? \
-             ORDER BY observed_at DESC, generation_id DESC LIMIT 1",
-        )?;
+             ORDER BY observed_at DESC, generation_id DESC LIMIT 1"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED])?;
         let Some(row) = rows.next()? else {
             return Ok(None);
@@ -1970,10 +2291,10 @@ impl AtlasDb {
         generation_id: &str,
         relative_path: &str,
     ) -> Result<Option<String>, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT content_hash FROM source.files \
-             WHERE generation_id = ? AND relative_path = ?",
-        )?;
+             WHERE generation_id = ? AND relative_path = ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![generation_id, relative_path])?;
         match rows.next()? {
             Some(row) => Ok(Some(row.get(0)?)),
@@ -1985,13 +2306,13 @@ impl AtlasDb {
     /// order, bounded by `limit` (capped at [`MAX_ROWS`], F12).
     pub fn units(&self, source_name: &str, limit: usize) -> Result<Vec<StoredUnit>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT u.relative_path, u.local_key, u.ordinal, u.unit_kind, u.heading_level, \
                     u.title, u.byte_start, u.byte_end, u.body \
              FROM source.units u JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state = ? \
-             ORDER BY u.relative_path, u.ordinal LIMIT ?",
-        )?;
+             ORDER BY u.relative_path, u.ordinal LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2023,12 +2344,12 @@ impl AtlasDb {
         limit: usize,
     ) -> Result<Vec<StoredSymbol>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT s.language, s.label, s.name, s.occurrences \
              FROM source.symbols s JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state = ? \
-             ORDER BY s.language, s.label, s.name LIMIT ?",
-        )?;
+             ORDER BY s.language, s.label, s.name LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2050,13 +2371,13 @@ impl AtlasDb {
         limit: usize,
     ) -> Result<Vec<StoredOccurrence>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT o.relative_path, o.syntax_key, o.extractor, o.language, o.ordinal, \
                     o.label, o.name, o.byte_start, o.byte_end \
              FROM source.occurrences o JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state = ? \
-             ORDER BY o.relative_path, o.ordinal LIMIT ?",
-        )?;
+             ORDER BY o.relative_path, o.ordinal LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2079,13 +2400,13 @@ impl AtlasDb {
     /// order, bounded by `limit` (capped at [`MAX_ROWS`], F12).
     pub fn edges(&self, source_name: &str, limit: usize) -> Result<Vec<StoredEdge>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT e.relative_path, e.syntax_key, e.extractor, e.language, e.ordinal, \
                     e.edge_kind, e.target, e.byte_start, e.byte_end \
              FROM source.edges e JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state = ? \
-             ORDER BY e.relative_path, e.ordinal LIMIT ?",
-        )?;
+             ORDER BY e.relative_path, e.ordinal LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2116,12 +2437,12 @@ impl AtlasDb {
         limit: usize,
     ) -> Result<Vec<StoredCoverage>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT c.generation_id, c.path, c.status, c.detail, c.bytes, c.observed_at \
              FROM meta.coverage c JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state IN (?, ?) \
-             ORDER BY c.observed_at DESC, c.path NULLS FIRST LIMIT ?",
-        )?;
+             ORDER BY c.observed_at DESC, c.path NULLS FIRST LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![
             source_name,
             STATE_CONFIRMED,
@@ -2151,11 +2472,11 @@ impl AtlasDb {
     /// Coverage counts by status for one source's confirmed generation —
     /// what `sgt intelligence status` and the doctor row will read (F8).
     pub fn coverage_counts(&self, source_name: &str) -> Result<BTreeMap<String, u64>, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT c.status, count(*) FROM meta.coverage c \
              JOIN source.generations g USING (generation_id) \
-             WHERE g.source_name = ? AND g.state = ? GROUP BY c.status ORDER BY c.status",
-        )?;
+             WHERE g.source_name = ? AND g.state = ? GROUP BY c.status ORDER BY c.status"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED])?;
         let mut out = BTreeMap::new();
         while let Some(row) = rows.next()? {
@@ -2177,12 +2498,12 @@ impl AtlasDb {
     /// autoloading, so the refusal is a property of the connection instead of
     /// a convention its callers are trusted to keep.
     pub fn hardening(&self) -> Result<Hardening, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT current_setting('autoinstall_known_extensions')::BOOLEAN, \
                     current_setting('autoload_known_extensions')::BOOLEAN, \
                     current_setting('allow_community_extensions')::BOOLEAN, \
-                    current_setting('lock_configuration')::BOOLEAN",
-        )?;
+                    current_setting('lock_configuration')::BOOLEAN"
+        ))?;
         let mut rows = statement.query([])?;
         let row = rows.next()?.ok_or_else(|| AtlasError::UnknownValue {
             column: "current_setting".to_string(),
@@ -2197,11 +2518,11 @@ impl AtlasDb {
         };
         drop(rows);
         drop(statement);
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT extension_name FROM duckdb_extensions() \
              WHERE loaded AND install_mode = 'STATICALLY_LINKED' \
-             ORDER BY extension_name LIMIT ?",
-        )?;
+             ORDER BY extension_name LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![MAX_ROWS as i64])?;
         let mut statically_linked = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2303,7 +2624,7 @@ impl AtlasDb {
         limit: usize,
     ) -> Result<Vec<StoredChildResource>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT c.relative_path, c.local_key, c.parent_relative_path, c.parent_key, \
                     c.entry_path, coalesce(f.content_hash, d.content_hash), \
                     coalesce(f.extractor, d.reader), \
@@ -2320,8 +2641,8 @@ impl AtlasDb {
               AND d.source_name = c.source_name \
               AND d.relative_path = c.relative_path \
              WHERE g.source_name = ? AND g.state = ? \
-             ORDER BY c.relative_path LIMIT ?",
-        )?;
+             ORDER BY c.relative_path LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2347,13 +2668,13 @@ impl AtlasDb {
         limit: usize,
     ) -> Result<Vec<StoredDataset>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT d.relative_path, d.format, d.content_hash, d.reader, d.dataset_key, \
                     d.byte_len, d.columns, d.row_count, d.truncated, d.row_units \
              FROM source.datasets d JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state = ? \
-             ORDER BY d.relative_path LIMIT ?",
-        )?;
+             ORDER BY d.relative_path LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2386,13 +2707,13 @@ impl AtlasDb {
         limit: usize,
     ) -> Result<Vec<DatasetFact>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT f.relative_path, f.dataset_key, f.query, f.query_identity, f.row_limit, \
                     f.truncated, f.columns, f.rows, f.output_hash \
              FROM source.dataset_facts f JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state = ? \
-             ORDER BY f.relative_path, f.query LIMIT ?",
-        )?;
+             ORDER BY f.relative_path, f.query LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2423,13 +2744,13 @@ impl AtlasDb {
         limit: usize,
     ) -> Result<Vec<StoredRowUnit>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT r.relative_path, r.dataset_key, r.ordinal, r.row_key, r.key_basis, \
                     r.fields, r.body \
              FROM context.row_units r JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state = ? \
-             ORDER BY r.relative_path, r.ordinal LIMIT ?",
-        )?;
+             ORDER BY r.relative_path, r.ordinal LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2458,7 +2779,7 @@ impl AtlasDb {
     /// separate statements, so a source's numbers all describe the same world.
     /// Bounded by [`MAX_ROWS`] (F12).
     pub fn indexed_sources(&self) -> Result<Vec<SourceStatus>, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT g.source_name, g.source_kind, g.authority_class, g.generation_id, \
                     g.content_key, g.observed_at, g.extractors, \
                     (SELECT count(*) FROM source.files f \
@@ -2479,8 +2800,8 @@ impl AtlasDb {
              FROM source.generations g \
              LEFT JOIN git.provenance p ON p.generation_id = g.generation_id \
              WHERE g.state = ? \
-             ORDER BY g.source_name LIMIT ?",
-        )?;
+             ORDER BY g.source_name LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![STATE_CONFIRMED, MAX_ROWS as i64])?;
         let mut out: Vec<SourceStatus> = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2551,13 +2872,13 @@ impl AtlasDb {
     /// `limit` (capped at [`MAX_ROWS`], F12).
     pub fn outline(&self, source_name: &str, limit: usize) -> Result<Vec<StoredUnit>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT u.relative_path, u.local_key, u.ordinal, u.unit_kind, u.heading_level, \
                     u.title, u.byte_start, u.byte_end \
              FROM source.units u JOIN source.generations g USING (generation_id) \
              WHERE g.source_name = ? AND g.state = ? AND u.title IS NOT NULL \
-             ORDER BY u.relative_path, u.ordinal LIMIT ?",
-        )?;
+             ORDER BY u.relative_path, u.ordinal LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![source_name, STATE_CONFIRMED, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2596,12 +2917,12 @@ impl AtlasDb {
         limit: usize,
     ) -> Result<Vec<StoredSymbolHit>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT g.source_name, s.language, s.label, s.name, s.occurrences \
              FROM source.symbols s JOIN source.generations g USING (generation_id) \
              WHERE g.state = ? AND s.name = ? \
-             ORDER BY g.source_name, s.language, s.label LIMIT ?",
-        )?;
+             ORDER BY g.source_name, s.language, s.label LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![STATE_CONFIRMED, name, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2628,13 +2949,13 @@ impl AtlasDb {
     /// Bounded by `limit` (capped at [`MAX_ROWS`], F12).
     pub fn references(&self, name: &str, limit: usize) -> Result<Vec<StoredReference>, AtlasError> {
         let limit = limit.min(MAX_ROWS) as i64;
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT g.source_name, o.relative_path, o.language, o.label, o.name, o.ordinal, \
                     o.byte_start, o.byte_end \
              FROM source.occurrences o JOIN source.generations g USING (generation_id) \
              WHERE g.state = ? AND o.name = ? \
-             ORDER BY g.source_name, o.relative_path, o.ordinal LIMIT ?",
-        )?;
+             ORDER BY g.source_name, o.relative_path, o.ordinal LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![STATE_CONFIRMED, name, limit])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -2852,7 +3173,7 @@ impl AtlasDb {
         let mut binds = admissibility.clone();
         binds.push(optional_text(family));
         binds.push(optional_text(family));
-        let mut statement = self.conn.prepare(LEXICAL_CORPUS_SQL)?;
+        let mut statement = self.conn.prepare(sql!(LEXICAL_CORPUS_SQL))?;
         let mut rows = statement.query(duckdb::params_from_iter(binds))?;
         let (units, tokens) = match rows.next()? {
             Some(row) => (
@@ -2881,7 +3202,7 @@ impl AtlasDb {
             binds.push(optional_text(family));
             binds.push(optional_text(family));
             binds.push(Duck::Text(term.clone()));
-            let mut statement = self.conn.prepare(LEXICAL_DOCUMENT_FREQUENCY_SQL)?;
+            let mut statement = self.conn.prepare(sql!(LEXICAL_DOCUMENT_FREQUENCY_SQL))?;
             let mut rows = statement.query(duckdb::params_from_iter(binds))?;
             let document_frequency = match rows.next()? {
                 Some(row) => row.get::<usize, i64>(0)? as u64,
@@ -2900,7 +3221,7 @@ impl AtlasDb {
             binds.push(optional_text(family));
             binds.push(Duck::Text(term.clone()));
             binds.push(Duck::BigInt(remaining as i64 + 1));
-            let mut statement = self.conn.prepare(LEXICAL_POSTINGS_SQL)?;
+            let mut statement = self.conn.prepare(sql!(LEXICAL_POSTINGS_SQL))?;
             let mut rows = statement.query(duckdb::params_from_iter(binds))?;
             while let Some(row) = rows.next()? {
                 if seen >= MAX_ROWS {
@@ -3414,7 +3735,7 @@ impl AtlasDb {
         let mut referencing_paths: BTreeSet<String> = BTreeSet::new();
         let mut anchor_targets: BTreeSet<String> = BTreeSet::new();
         if let Some(symbol) = &anchor_symbol {
-            let mut statement = self.conn.prepare(EDGES_TO_TARGET_SQL)?;
+            let mut statement = self.conn.prepare(sql!(EDGES_TO_TARGET_SQL))?;
             let mut rows =
                 statement.query(duckdb::params![anchor_generation, symbol, MAX_ROWS as i64])?;
             while let Some(row) = rows.next()? {
@@ -3422,7 +3743,7 @@ impl AtlasDb {
             }
         }
         {
-            let mut statement = self.conn.prepare(EDGES_FROM_PATH_SQL)?;
+            let mut statement = self.conn.prepare(sql!(EDGES_FROM_PATH_SQL))?;
             let mut rows = statement.query(duckdb::params![
                 anchor_generation,
                 anchor_coordinate.relative_path(),
@@ -3507,10 +3828,10 @@ impl AtlasDb {
     /// [`ReindexOutcome::truncated`] says so, the same bound and the same
     /// disclosure `lexical_search` uses for its posting scan.
     pub fn reindex_lexical(&mut self) -> Result<ReindexOutcome, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT generation_id FROM source.generations WHERE state != ? \
-             ORDER BY observed_at, generation_id LIMIT ?",
-        )?;
+             ORDER BY observed_at, generation_id LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![STATE_EVICTED, MAX_ROWS as i64 + 1])?;
         let mut targets: Vec<String> = Vec::new();
         while let Some(row) = rows.next()? {
@@ -3524,11 +3845,11 @@ impl AtlasDb {
         let mut indexed = 0u64;
         for generation_id in &targets {
             tx.execute(
-                "DELETE FROM context.lexical_postings WHERE generation_id = ?",
+                sql!("DELETE FROM context.lexical_postings WHERE generation_id = ?"),
                 duckdb::params![generation_id],
             )?;
             tx.execute(
-                "DELETE FROM context.lexical_units WHERE generation_id = ?",
+                sql!("DELETE FROM context.lexical_units WHERE generation_id = ?"),
                 duckdb::params![generation_id],
             )?;
             indexed += index_generation(&tx, generation_id)?;
@@ -3544,14 +3865,14 @@ impl AtlasDb {
     /// safe to call every startup rather than only once at a version
     /// boundary this crate has no other way to detect (F-SF-01).
     pub fn lexical_index_needs_rebuild(&self) -> Result<bool, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT COUNT(*) FROM source.generations g \
              WHERE g.state != ? \
                AND NOT EXISTS ( \
                  SELECT 1 FROM context.lexical_units l \
                  WHERE l.generation_id = g.generation_id \
-               )",
-        )?;
+               )"
+        ))?;
         let mut rows = statement.query(duckdb::params![STATE_EVICTED])?;
         let count: i64 = match rows.next()? {
             Some(row) => row.get(0)?,
@@ -3563,10 +3884,10 @@ impl AtlasDb {
     /// Every generation's state, keyed by id — a diagnostic read, and what a
     /// crash-window test inspects.
     pub fn generation_states(&self) -> Result<BTreeMap<String, String>, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT generation_id, state FROM source.generations \
-             ORDER BY observed_at, generation_id LIMIT ?",
-        )?;
+             ORDER BY observed_at, generation_id LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![MAX_ROWS as i64])?;
         let mut out = BTreeMap::new();
         while let Some(row) = rows.next()? {
@@ -3577,10 +3898,10 @@ impl AtlasDb {
 
     /// Ids and source names of every generation in one state.
     fn generations_in_state(&self, state: &str) -> Result<Vec<(String, String)>, AtlasError> {
-        let mut statement = self.conn.prepare(
+        let mut statement = self.conn.prepare(sql!(
             "SELECT generation_id, source_name FROM source.generations WHERE state = ? \
-             ORDER BY observed_at DESC, generation_id DESC LIMIT ?",
-        )?;
+             ORDER BY observed_at DESC, generation_id DESC LIMIT ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![state, MAX_ROWS as i64])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -3591,9 +3912,9 @@ impl AtlasDb {
 
     /// Which source a generation belongs to.
     fn generation_source(&self, generation_id: &str) -> Result<Option<String>, AtlasError> {
-        let mut statement = self
-            .conn
-            .prepare("SELECT source_name FROM source.generations WHERE generation_id = ?")?;
+        let mut statement = self.conn.prepare(sql!(
+            "SELECT source_name FROM source.generations WHERE generation_id = ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![generation_id])?;
         match rows.next()? {
             Some(row) => Ok(Some(row.get(0)?)),
@@ -3611,9 +3932,9 @@ impl AtlasDb {
     /// empty set, which is the same answer a scan that ran none produces —
     /// correct in both cases, because neither could have derived a row.
     fn generation_extractors(&self, generation_id: &str) -> Result<BTreeSet<String>, AtlasError> {
-        let mut statement = self
-            .conn
-            .prepare("SELECT extractors FROM source.generations WHERE generation_id = ?")?;
+        let mut statement = self.conn.prepare(sql!(
+            "SELECT extractors FROM source.generations WHERE generation_id = ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![generation_id])?;
         let Some(row) = rows.next()? else {
             return Ok(BTreeSet::new());
@@ -3628,9 +3949,9 @@ impl AtlasDb {
     /// [`Self::confirm_scan`] needs it to say honestly why the predecessor is
     /// going.
     fn generation_content_key(&self, generation_id: &str) -> Result<Option<String>, AtlasError> {
-        let mut statement = self
-            .conn
-            .prepare("SELECT content_key FROM source.generations WHERE generation_id = ?")?;
+        let mut statement = self.conn.prepare(sql!(
+            "SELECT content_key FROM source.generations WHERE generation_id = ?"
+        ))?;
         let mut rows = statement.query(duckdb::params![generation_id])?;
         match rows.next()? {
             Some(row) => Ok(Some(row.get(0)?)),
@@ -3666,12 +3987,12 @@ fn insert_file(
     source_name: &str,
     file: &ScannedFile,
 ) -> Result<(), AtlasError> {
-    conn.prepare_cached(
+    conn.prepare_cached(sql!(
         "INSERT INTO source.files \
          (generation_id, source_name, relative_path, content_hash, extractor, local_key, \
           byte_len, mtime_millis, unit_count) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )?
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ))?
     .execute(duckdb::params![
         generation_id,
         source_name,
@@ -3730,12 +4051,12 @@ fn insert_syntax(
     syntax: &ScannedSyntax,
 ) -> Result<(), AtlasError> {
     for symbol in &syntax.symbols {
-        conn.prepare_cached(
+        conn.prepare_cached(sql!(
             "INSERT INTO source.occurrences \
              (generation_id, source_name, relative_path, syntax_key, extractor, language, \
               ordinal, label, name, byte_start, byte_end) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )?
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        ))?
         .execute(duckdb::params![
             generation_id,
             source_name,
@@ -3751,12 +4072,12 @@ fn insert_syntax(
         ])?;
     }
     for edge in &syntax.edges {
-        conn.prepare_cached(
+        conn.prepare_cached(sql!(
             "INSERT INTO source.edges \
              (generation_id, source_name, relative_path, syntax_key, extractor, language, \
               ordinal, edge_kind, target, byte_start, byte_end) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )?
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        ))?
         .execute(duckdb::params![
             generation_id,
             source_name,
@@ -3782,12 +4103,12 @@ fn insert_unit(
     file: &ScannedFile,
     unit: &ScannedUnit,
 ) -> Result<(), AtlasError> {
-    conn.prepare_cached(
+    conn.prepare_cached(sql!(
         "INSERT INTO source.units \
          (generation_id, source_name, relative_path, local_key, ordinal, unit_kind, \
           heading_level, title, byte_start, byte_end, body) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )?
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ))?
     .execute(duckdb::params![
         generation_id,
         source_name,
@@ -3810,11 +4131,11 @@ fn insert_unit(
     // unit, whose byte span is already its address; a row of `NULL` here
     // would be a declared-but-empty promise for those.
     if let Some(coordinate) = unit.coordinate.as_deref() {
-        conn.prepare_cached(
+        conn.prepare_cached(sql!(
             "INSERT INTO source.unit_coordinates \
              (generation_id, source_name, relative_path, local_key, ordinal, coordinate) \
-             VALUES (?, ?, ?, ?, ?, ?)",
-        )?
+             VALUES (?, ?, ?, ?, ?, ?)"
+        ))?
         .execute(duckdb::params![
             generation_id,
             source_name,
@@ -4255,12 +4576,12 @@ fn write_dataset(
     dataset: &ScannedDataset,
     read: &IngestedDataset,
 ) -> Result<CoverageRow, AtlasError> {
-    conn.prepare_cached(
+    conn.prepare_cached(sql!(
         "INSERT INTO source.datasets \
          (generation_id, source_name, relative_path, format, content_hash, reader, dataset_key, \
           byte_len, mtime_millis, columns, row_count, truncated, row_units) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )?
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ))?
     .execute(duckdb::params![
         generation_id,
         &scan.source_name,
@@ -4333,12 +4654,12 @@ fn insert_child_resource(
     key: &str,
     parent: &crate::runtime::atlas::scan::ChildProvenance,
 ) -> Result<(), AtlasError> {
-    conn.prepare_cached(
+    conn.prepare_cached(sql!(
         "INSERT INTO source.child_resources \
          (generation_id, source_name, relative_path, local_key, parent_relative_path, \
           parent_key, entry_path) \
-         VALUES (?, ?, ?, ?, ?, ?, ?)",
-    )?
+         VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ))?
     .execute(duckdb::params![
         generation_id,
         source_name,
@@ -4358,12 +4679,12 @@ fn insert_dataset_fact(
     source_name: &str,
     fact: &DatasetFact,
 ) -> Result<(), AtlasError> {
-    conn.prepare_cached(
+    conn.prepare_cached(sql!(
         "INSERT INTO source.dataset_facts \
          (generation_id, source_name, relative_path, dataset_key, query, query_identity, \
           row_limit, truncated, columns, rows, output_hash, observed_at) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )?
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ))?
     .execute(duckdb::params![
         generation_id,
         source_name,
@@ -4389,12 +4710,12 @@ fn insert_row_unit(
     dataset: &ScannedDataset,
     unit: &RowUnit,
 ) -> Result<(), AtlasError> {
-    conn.prepare_cached(
+    conn.prepare_cached(sql!(
         "INSERT INTO context.row_units \
          (generation_id, source_name, relative_path, dataset_key, ordinal, row_key, key_basis, \
           fields, body) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )?
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ))?
     .execute(duckdb::params![
         generation_id,
         source_name,
@@ -4466,7 +4787,7 @@ fn indexable_units(
     let mut units: Vec<IndexableUnit> = Vec::new();
 
     let [doc_a, doc_b, doc_c, doc_d] = DOCUMENT_EXTRACTOR_IDENTITIES;
-    let mut statement = conn.prepare(
+    let mut statement = conn.prepare(sql!(
         "SELECT u.source_name, u.relative_path, u.ordinal, u.title, u.byte_start, u.byte_end, \
                 u.body, f.extractor, c.coordinate \
          FROM source.units u \
@@ -4476,8 +4797,8 @@ fn indexable_units(
                                              AND c.relative_path = u.relative_path \
                                              AND c.ordinal = u.ordinal \
          WHERE u.generation_id = ? AND f.extractor IN (?, ?, ?, ?) \
-         ORDER BY u.relative_path, u.ordinal",
-    )?;
+         ORDER BY u.relative_path, u.ordinal"
+    ))?;
     let mut rows = statement.query(duckdb::params![generation_id, doc_a, doc_b, doc_c, doc_d])?;
     while let Some(row) = rows.next()? {
         let extractor: String = row.get(7)?;
@@ -4516,12 +4837,12 @@ fn indexable_units(
     drop(rows);
     drop(statement);
 
-    let mut statement = conn.prepare(
+    let mut statement = conn.prepare(sql!(
         "SELECT source_name, relative_path, ordinal, language, label, name, byte_start, byte_end \
          FROM source.occurrences \
          WHERE generation_id = ? AND extractor LIKE ? \
-         ORDER BY relative_path, ordinal",
-    )?;
+         ORDER BY relative_path, ordinal"
+    ))?;
     let mut rows = statement.query(duckdb::params![generation_id, CODE_EXTRACTOR_LIKE])?;
     while let Some(row) = rows.next()? {
         let relative_path: String = row.get(1)?;
@@ -4549,10 +4870,10 @@ fn indexable_units(
     drop(rows);
     drop(statement);
 
-    let mut statement = conn.prepare(
+    let mut statement = conn.prepare(sql!(
         "SELECT source_name, relative_path, dataset_key, ordinal, row_key, fields, body \
-         FROM context.row_units WHERE generation_id = ? ORDER BY relative_path, ordinal",
-    )?;
+         FROM context.row_units WHERE generation_id = ? ORDER BY relative_path, ordinal"
+    ))?;
     let mut rows = statement.query(duckdb::params![generation_id])?;
     while let Some(row) = rows.next()? {
         let relative_path: String = row.get(1)?;
@@ -4626,8 +4947,18 @@ fn index_generation(conn: &impl Statements, generation_id: &str) -> Result<u64, 
         }
     }
     let indexed = unit_rows.len() as u64;
-    append_rows(conn, CONTEXT_SCHEMA, "lexical_units", unit_rows)?;
-    append_rows(conn, CONTEXT_SCHEMA, "lexical_postings", posting_rows)?;
+    append_rows(
+        conn,
+        name!(CONTEXT_SCHEMA),
+        name!("lexical_units"),
+        unit_rows,
+    )?;
+    append_rows(
+        conn,
+        name!(CONTEXT_SCHEMA),
+        name!("lexical_postings"),
+        posting_rows,
+    )?;
     Ok(indexed)
 }
 
@@ -4835,11 +5166,11 @@ fn insert_coverage(
     row: &CoverageRow,
     observed_at: &str,
 ) -> Result<(), AtlasError> {
-    conn.prepare_cached(
+    conn.prepare_cached(sql!(
         "INSERT INTO meta.coverage \
          (generation_id, source_name, path, status, detail, bytes, observed_at) \
-         VALUES (?, ?, ?, ?, ?, ?, ?)",
-    )?
+         VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ))?
     .execute(duckdb::params![
         generation_id,
         source_name,
@@ -4866,39 +5197,39 @@ fn evict(
     observed_at: &str,
 ) -> Result<(), AtlasError> {
     conn.execute(
-        "DELETE FROM source.units WHERE generation_id = ?",
+        sql!("DELETE FROM source.units WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM source.unit_coordinates WHERE generation_id = ?",
+        sql!("DELETE FROM source.unit_coordinates WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM source.occurrences WHERE generation_id = ?",
+        sql!("DELETE FROM source.occurrences WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM source.edges WHERE generation_id = ?",
+        sql!("DELETE FROM source.edges WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM source.symbols WHERE generation_id = ?",
+        sql!("DELETE FROM source.symbols WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM source.child_resources WHERE generation_id = ?",
+        sql!("DELETE FROM source.child_resources WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM source.files WHERE generation_id = ?",
+        sql!("DELETE FROM source.files WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM source.datasets WHERE generation_id = ?",
+        sql!("DELETE FROM source.datasets WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM source.dataset_facts WHERE generation_id = ?",
+        sql!("DELETE FROM source.dataset_facts WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     // The F10a-gated units go with everything else an eviction takes. That
@@ -4907,7 +5238,7 @@ fn evict(
     // evicts this one — and *this* delete is what actually retracts the text
     // the wider allowlist exposed.
     conn.execute(
-        "DELETE FROM context.row_units WHERE generation_id = ?",
+        sql!("DELETE FROM context.row_units WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     // S5 W2: the lexical index is derived evidence over the rows deleted
@@ -4917,11 +5248,11 @@ fn evict(
     // gone is an orphan, and there is no window in which one exists (this
     // runs inside the caller's transaction).
     conn.execute(
-        "DELETE FROM context.lexical_postings WHERE generation_id = ?",
+        sql!("DELETE FROM context.lexical_postings WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM context.lexical_units WHERE generation_id = ?",
+        sql!("DELETE FROM context.lexical_units WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     // A no-op DELETE for every non-`external_git` generation (the table has
@@ -4929,15 +5260,15 @@ fn evict(
     // atomicity promise for one that is: a superseded external source's old
     // origin/ref/commit does not linger once its rows are gone.
     conn.execute(
-        "DELETE FROM git.provenance WHERE generation_id = ?",
+        sql!("DELETE FROM git.provenance WHERE generation_id = ?"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "DELETE FROM meta.coverage WHERE generation_id = ? AND path IS NOT NULL",
+        sql!("DELETE FROM meta.coverage WHERE generation_id = ? AND path IS NOT NULL"),
         duckdb::params![generation_id],
     )?;
     conn.execute(
-        "UPDATE source.generations SET state = ? WHERE generation_id = ?",
+        sql!("UPDATE source.generations SET state = ? WHERE generation_id = ?"),
         duckdb::params![STATE_EVICTED, generation_id],
     )?;
     insert_coverage(
@@ -6418,28 +6749,19 @@ const OPS_SCHEMA: &str = "ops";
 /// text, `context.row_units`'s own namespace.
 const CONTEXT_SCHEMA: &str = "context";
 
-/// One operations table, qualified and quoted for SQL.
-///
-/// The quoting is what keeps `usage` (a reserved word) addressable; the
-/// qualification is what stops a bare name from resolving against DuckDB's
-/// default `main` schema, which this database deliberately leaves empty.
-fn ops(table: &'static str) -> Sql {
-    Sql::from_parts(&[OPS_SCHEMA, ".\"", table, "\""])
-}
-
 /// `DELETE FROM <ops table>` — [`ops`] behind a `DELETE`, assembled from
 /// compile-time pieces because [`Sql`] admits no other kind.
-fn delete_from(table: &'static str) -> Sql {
-    let mut sql = Sql::from("DELETE FROM ");
-    sql.extend(&ops(table));
-    sql
+fn delete_from(table: &str) -> Sql {
+    let mut statement = sql!("DELETE FROM ");
+    statement.extend(&ops(table));
+    statement
 }
 
 /// `SELECT COUNT(*) FROM <ops table>` — see [`delete_from`].
-fn count_of(table: &'static str) -> Sql {
-    let mut sql = Sql::from("SELECT COUNT(*) FROM ");
-    sql.extend(&ops(table));
-    sql
+fn count_of(table: &str) -> Sql {
+    let mut statement = sql!("SELECT COUNT(*) FROM ");
+    statement.extend(&ops(table));
+    statement
 }
 
 /// The §22 schema, in the [`OPS_SCHEMA`] namespace. Written on every rebuild;
@@ -6594,13 +6916,7 @@ pub struct CannedQuery {
     pub sql: &'static str,
 }
 
-/// The canned queries this build answers.
-///
-/// Deliberately a fixed list rather than arbitrary client SQL: §22's "clients
-/// do not access DuckDB directly" is about the *one-owner* property, and an
-/// endpoint that executes a client's SQL against the daemon's database hands
-/// the ownership back. M6 owns presentation; this is the data behind it.
-pub const CANNED_QUERIES: &[CannedQuery] = &[
+canned_queries! {
     CannedQuery {
         name: "blocked_time_per_work",
         question: "How long does work remain blocked?",
@@ -6688,7 +7004,7 @@ pub const CANNED_QUERIES: &[CannedQuery] = &[
                    COALESCE(SUM(total_cost_usd), 0) AS total_cost_usd \
             FROM ops.\"usage\" GROUP BY work_id ORDER BY work_id",
     },
-];
+}
 
 /// The result of one canned query: columns and rows as plain JSON.
 #[derive(Debug, Clone, PartialEq)]
@@ -7129,7 +7445,7 @@ impl Analytics {
 
     fn over(conn: Store, path: PathBuf) -> Result<Self, AnalyticsError> {
         conn.set_statement_cache_capacity(STATEMENT_CACHE);
-        conn.execute_batch(OPS_DDL)?;
+        conn.execute_batch(sql!(OPS_DDL))?;
         Ok(Self {
             conn,
             path,
@@ -7220,13 +7536,21 @@ impl Analytics {
 
     /// Write the buffered append-only rows.
     fn flush(&self, appended: &mut Appended) -> Result<(), AnalyticsError> {
-        append_all(&self.conn, "events", std::mem::take(&mut appended.events))?;
         append_all(
             &self.conn,
-            "messages",
+            name!("events"),
+            std::mem::take(&mut appended.events),
+        )?;
+        append_all(
+            &self.conn,
+            name!("messages"),
             std::mem::take(&mut appended.messages),
         )?;
-        append_all(&self.conn, "usage", std::mem::take(&mut appended.usage))?;
+        append_all(
+            &self.conn,
+            name!("usage"),
+            std::mem::take(&mut appended.usage),
+        )?;
         Ok(())
     }
 
@@ -7251,17 +7575,17 @@ impl Analytics {
         }
         append_all(
             &self.conn,
-            "work",
+            name!("work"),
             self.rows.work.values().map(WorkRow::row).collect(),
         )?;
         append_all(
             &self.conn,
-            "stages",
+            name!("stages"),
             self.rows.stages.values().map(StageRow::row).collect(),
         )?;
         append_all(
             &self.conn,
-            "executions",
+            name!("executions"),
             self.rows
                 .executions
                 .values()
@@ -7270,7 +7594,7 @@ impl Analytics {
         )?;
         append_all(
             &self.conn,
-            "tool_calls",
+            name!("tool_calls"),
             self.rows
                 .tool_calls
                 .values()
@@ -7279,7 +7603,7 @@ impl Analytics {
         )?;
         append_all(
             &self.conn,
-            "repositories",
+            name!("repositories"),
             self.rows
                 .repositories
                 .values()
@@ -7288,12 +7612,12 @@ impl Analytics {
         )?;
         append_all(
             &self.conn,
-            "graph_nodes",
+            name!("graph_nodes"),
             self.rows.nodes.values().map(NodeRow::row).collect(),
         )?;
         append_all(
             &self.conn,
-            "graph_edges",
+            name!("graph_edges"),
             self.rows.edges.values().map(EdgeRow::row).collect(),
         )?;
         self.materialized_seq = self.last_seq;
@@ -7670,7 +7994,7 @@ impl Analytics {
             .ok_or_else(|| AnalyticsError::UnknownQuery {
                 name: name.to_string(),
             })?;
-        let (columns, rows) = self.select(canned.sql, duckdb::params![])?;
+        let (columns, rows) = self.select(canned_sql(canned.name), duckdb::params![])?;
         Ok(QueryResult {
             name: canned.name.to_string(),
             question: canned.question.to_string(),
@@ -7718,7 +8042,7 @@ impl Analytics {
                 name: table.to_string(),
             })?;
         self.materialize()?;
-        let mut sql = Sql::from("SELECT * FROM ");
+        let mut sql = sql!("SELECT * FROM ");
         sql.extend(&ops(table));
         let (columns, rows) = self.select(&sql, duckdb::params![])?;
         Ok(QueryResult {
@@ -7739,16 +8063,20 @@ impl Analytics {
     pub fn graph_neighborhood(&mut self, work_id: &str) -> Result<GraphView, AnalyticsError> {
         self.materialize()?;
         let (node_columns, node_rows) = self.select(
-            "SELECT node_id, kind, label, work_id, source_seq FROM ops.graph_nodes \
-             WHERE work_id = ?1 \
-                OR node_id IN (SELECT from_node FROM ops.graph_edges WHERE work_id = ?1) \
-                OR node_id IN (SELECT to_node FROM ops.graph_edges WHERE work_id = ?1) \
-             ORDER BY source_seq, node_id",
+            sql!(
+                "SELECT node_id, kind, label, work_id, source_seq FROM ops.graph_nodes \
+                 WHERE work_id = ?1 \
+                    OR node_id IN (SELECT from_node FROM ops.graph_edges WHERE work_id = ?1) \
+                    OR node_id IN (SELECT to_node FROM ops.graph_edges WHERE work_id = ?1) \
+                 ORDER BY source_seq, node_id"
+            ),
             duckdb::params![work_id],
         )?;
         let (edge_columns, edge_rows) = self.select(
-            "SELECT edge_id, relation, from_node, to_node, source_seq FROM ops.graph_edges \
-             WHERE work_id = ?1 ORDER BY source_seq, edge_id",
+            sql!(
+                "SELECT edge_id, relation, from_node, to_node, source_seq FROM ops.graph_edges \
+                 WHERE work_id = ?1 ORDER BY source_seq, edge_id"
+            ),
             duckdb::params![work_id],
         )?;
         Ok(GraphView {
@@ -7840,21 +8168,18 @@ impl AnalyticsFold<'_> {
     }
 }
 
-/// Tables this projection creates, in a stable order. Crate-internal: the
-/// table list is an implementation detail of the projection, and callers get
-/// it as data from [`Analytics::table_counts`].
-const TABLES: &[&str] = &[
-    "events",
-    "work",
-    "stages",
-    "executions",
-    "messages",
-    "tool_calls",
-    "usage",
-    "repositories",
-    "graph_nodes",
-    "graph_edges",
-];
+ops_tables! {
+    "events" => "ops.\"events\"",
+    "work" => "ops.\"work\"",
+    "stages" => "ops.\"stages\"",
+    "executions" => "ops.\"executions\"",
+    "messages" => "ops.\"messages\"",
+    "tool_calls" => "ops.\"tool_calls\"",
+    "usage" => "ops.\"usage\"",
+    "repositories" => "ops.\"repositories\"",
+    "graph_nodes" => "ops.\"graph_nodes\"",
+    "graph_edges" => "ops.\"graph_edges\"",
+}
 
 /// Bulk-load `rows` into `table` through DuckDB's appender.
 ///
@@ -7863,10 +8188,10 @@ const TABLES: &[&str] = &[
 /// ~4 µs. An empty batch is a no-op rather than an open-and-close.
 fn append_all(
     conn: &impl Statements,
-    table: &'static str,
+    table: Name,
     rows: Vec<Vec<Duck>>,
 ) -> Result<(), AnalyticsError> {
-    append_rows(conn, OPS_SCHEMA, table, rows)?;
+    append_rows(conn, name!(OPS_SCHEMA), table, rows)?;
     Ok(())
 }
 
@@ -7876,8 +8201,8 @@ fn append_all(
 /// DuckDB, not of the `ops` schema.
 fn append_rows(
     conn: &impl Statements,
-    schema: &'static str,
-    table: &'static str,
+    schema: Name,
+    table: Name,
     rows: Vec<Vec<Duck>>,
 ) -> Result<(), duckdb::Error> {
     if rows.is_empty() {
@@ -8006,8 +8331,8 @@ impl Analytics {
         // posture is verified rather than assumed: a clone that somehow
         // reached an unhardened instance is refused here, not left to reach
         // the network later.
-        conn.execute_batch(SCHEMA_DDL)?;
-        conn.execute_batch(TABLE_DDL)?;
+        conn.execute_batch(sql!(SCHEMA_DDL))?;
+        conn.execute_batch(sql!(TABLE_DDL))?;
         let db = AtlasDb {
             conn,
             path: self.path.clone(),
@@ -8063,7 +8388,7 @@ impl Analytics {
         // this connection or any other. Every other read on this type goes
         // through the same call for the same reason.
         self.materialize()?;
-        let mut statement = self.conn.prepare(WORK_GENERATION_JOIN_SQL)?;
+        let mut statement = self.conn.prepare(sql!(WORK_GENERATION_JOIN_SQL))?;
         let mut rows = statement.query([repository])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
@@ -8584,13 +8909,13 @@ mod tests {
         // reproduce the exact shape a pre-W2 store would have.
         db.conn
             .execute(
-                "DELETE FROM context.lexical_postings WHERE generation_id = ?",
+                sql!("DELETE FROM context.lexical_postings WHERE generation_id = ?"),
                 duckdb::params![generation_id],
             )
             .expect("strip postings");
         db.conn
             .execute(
-                "DELETE FROM context.lexical_units WHERE generation_id = ?",
+                sql!("DELETE FROM context.lexical_units WHERE generation_id = ?"),
                 duckdb::params![generation_id],
             )
             .expect("strip units");
@@ -8683,6 +9008,69 @@ mod ops_tests {
         ));
     }
 
+    /// The read rule, as a table — because the two rounds this replaces both
+    /// shipped a rule whose *stated* scope was wider than the bytes it
+    /// checked.
+    ///
+    /// Note the last two rows: this rule is deliberately stricter than SQL,
+    /// and that is a cost, not an oversight.
+    #[test]
+    fn is_read_statement_admits_exactly_one_bare_select() {
+        for (statement, expected) in [
+            ("SELECT 1", true),
+            (
+                "SELECT count(*) FROM source.generations WHERE state = ?",
+                true,
+            ),
+            // Exploit B, and the concat!-split spelling of it: const
+            // evaluation sees the assembled string, so both are one input.
+            ("SELECT 1; DELETE FROM source.generations", false),
+            ("SELECT 1 LIMIT ?; DELETE FROM source.generations;", false),
+            // A trailing separator, on its own.
+            ("SELECT 1;", false),
+            // The prefix rule, unchanged: seven bytes, case-sensitive.
+            ("DELETE FROM source.generations", false),
+            ("select 1", false),
+            (" SELECT 1", false),
+            ("WITH x AS (SELECT 1) SELECT * FROM x", false),
+            ("SELECT", false),
+            ("", false),
+            // Stricter than SQL: one harmless statement, refused anyway.
+            ("SELECT ';' FROM source.generations", false),
+        ] {
+            assert_eq!(
+                store::is_read_statement(statement),
+                expected,
+                "is_read_statement({statement:?})"
+            );
+        }
+    }
+
+    /// [`ops`] is generated from the same tokens as [`TABLES`], so it is total
+    /// over that list by construction. [`MUTABLE_TABLES`] is the one *other*
+    /// list of names that reaches it, and it is written by hand — so a name
+    /// there that is not an `ops` table would reach `ops`'s `unreachable!`
+    /// arm at runtime, during a reset. This is the check that stops that.
+    #[test]
+    fn every_mutable_table_is_an_ops_table() {
+        for table in MUTABLE_TABLES {
+            assert!(
+                TABLES.contains(table),
+                "`{table}` is in MUTABLE_TABLES but not in the ops_tables! list, so \
+                 `delete_from(\"{table}\")` would hit `ops`'s unreachable arm"
+            );
+        }
+        // And `ops` really does answer for every name in the list — the arm
+        // and the entry come from one macro invocation, and this is what
+        // proves that stayed true.
+        for table in TABLES {
+            assert!(
+                ops(table).text().starts_with("ops.\""),
+                "`{table}` must qualify into the ops namespace"
+            );
+        }
+    }
+
     #[test]
     fn the_schema_declares_exactly_the_tables_it_advertises() {
         let mut analytics = Analytics::in_memory(Vec::new()).expect("projection");
@@ -8702,8 +9090,10 @@ mod ops_tests {
         let analytics = Analytics::in_memory(Vec::new()).expect("projection");
         let (columns, rows) = analytics
             .select(
-                "SELECT schema_name, table_name FROM duckdb_tables() \
-                 WHERE database_name = current_database() ORDER BY table_name",
+                sql!(
+                    "SELECT schema_name, table_name FROM duckdb_tables() \
+                     WHERE database_name = current_database() ORDER BY table_name"
+                ),
                 duckdb::params![],
             )
             .expect("select");
@@ -8759,7 +9149,7 @@ mod ops_tests {
         analytics.materialize().expect("materialize");
         let (columns, rows) = analytics
             .select(
-                "SELECT work_id, estate_root FROM ops.work ORDER BY work_id",
+                sql!("SELECT work_id, estate_root FROM ops.work ORDER BY work_id"),
                 duckdb::params![],
             )
             .expect("select");
@@ -8786,7 +9176,7 @@ mod ops_tests {
         let mut analytics = Analytics::in_memory(Vec::new()).expect("projection");
         analytics
             .conn
-            .execute_batch("DROP TABLE ops.events")
+            .execute_batch(sql!("DROP TABLE ops.events"))
             .expect("drop the events table to force the next append to fail");
 
         let mut fold = analytics.fold().expect("fold");
@@ -8813,7 +9203,7 @@ mod ops_tests {
         let mut analytics = Analytics::in_memory(events(vec![odd])).expect("projection");
         analytics.materialize().expect("materialize");
         let (_, rows) = analytics
-            .select("SELECT ts_ms FROM ops.events", duckdb::params![])
+            .select(sql!("SELECT ts_ms FROM ops.events"), duckdb::params![])
             .expect("select");
         assert_eq!(rows, vec![vec![Value::Null]]);
     }
@@ -8961,7 +9351,7 @@ mod ops_tests {
         analytics.materialize().expect("materialize");
         let (_, rows) = analytics
             .select(
-                "SELECT reconcile_disposition FROM ops.executions WHERE execution_id = 'e1'",
+                sql!("SELECT reconcile_disposition FROM ops.executions WHERE execution_id = 'e1'"),
                 duckdb::params![],
             )
             .expect("select");

--- a/src/runtime/atlas/lexical.rs
+++ b/src/runtime/atlas/lexical.rs
@@ -489,6 +489,16 @@ pub enum UnitCoordinate {
         byte_start: u64,
         /// End offset into the original file bytes, exclusive.
         byte_end: u64,
+        /// A2 §9's *native coordinate* — the normalizer's own address for
+        /// this unit inside the document it was extracted from, when the
+        /// byte span cannot be one.
+        ///
+        /// `None` for a Markdown/text unit, whose span IS its address.
+        /// `Some` for a unit an adapter had to decode a container to reach:
+        /// an Office section carries the block address its normalizer
+        /// assigned, and the span is `0`/`0` because no offset into the
+        /// compressed original corresponds to it.
+        native: Option<String>,
     },
     /// A2 §3's email coordinate, as far as A1's stored rows carry it: the
     /// `.eml` resource's path, the unit within it, and its byte span.
@@ -499,10 +509,19 @@ pub enum UnitCoordinate {
         ordinal: u64,
         /// The unit's title — the subject, for a message's own body unit.
         title: Option<String>,
-        /// Start offset into the original file bytes.
+        /// Start offset into the original file bytes — `0`/`0` for a
+        /// message body, which is not byte-recoverable into the original
+        /// wire bytes (a decoded Content-Transfer-Encoding is a transform).
         byte_start: u64,
         /// End offset into the original file bytes, exclusive.
         byte_end: u64,
+        /// A2 §9's *native coordinate*: which body of the message this unit
+        /// is (`text-body`/`html-body`, A1 §6.5's `text/html body`).
+        ///
+        /// This is the **only** thing that distinguishes a message's two
+        /// bodies — they share a path, and neither has a byte span — so a
+        /// mail hit without it does not cite its evidence.
+        native: Option<String>,
     },
     /// A2 §3's structured-text coordinate:
     /// `source/generation/dataset/row-id/field-set`.

--- a/src/runtime/atlas/scan.rs
+++ b/src/runtime/atlas/scan.rs
@@ -245,6 +245,17 @@ pub struct ScannedUnit {
     pub byte_start: u64,
     /// End offset into the original file bytes, exclusive.
     pub byte_end: u64,
+    /// The normalizer's own native address for this unit, when
+    /// `byte_start`/`byte_end` cannot say where it is (A2 §9's *"native
+    /// coordinate"*).
+    ///
+    /// `None` for every in-process text/Markdown unit, whose byte span is
+    /// the address. `Some` for a unit an adapter extracted out of a
+    /// container it had to decode first — an Office section's `block:<n>`,
+    /// a mail body's `text-body`/`html-body` — where no offset into the
+    /// original bytes corresponds to the unit. The full contract the value
+    /// satisfies is [`crate::runtime::atlas::worker::WorkerUnit::coordinate`]'s.
+    pub coordinate: Option<String>,
     /// The unit's own text, exactly as it appears in the original.
     pub text: String,
 }
@@ -1373,13 +1384,20 @@ fn dispatch_worker_resource_at_depth(
                 .units
                 .into_iter()
                 .enumerate()
+                // S5 closeout (F-AC-02): everything the adapter knew about
+                // the unit lands, not just its span. Dropping `title`,
+                // `heading_level` and the native `coordinate` here is what
+                // left every worker-routed family (mail, Office, archive
+                // children) without the provenance A2 §17 item 2 and §9
+                // require, while the in-process path below kept it.
                 .map(|(ordinal, unit)| ScannedUnit {
                     ordinal: ordinal as u64,
                     kind: unit.kind,
-                    heading_level: None,
-                    title: None,
+                    heading_level: unit.heading_level,
+                    title: unit.title,
                     byte_start: unit.byte_start,
                     byte_end: unit.byte_end,
+                    coordinate: unit.coordinate,
                     text: unit.text,
                 })
                 .collect();
@@ -1846,6 +1864,9 @@ pub fn extract_units(text: &str, extractor: &str) -> Vec<ScannedUnit> {
             title: unit.title,
             byte_start: unit.byte_start as u64,
             byte_end: unit.byte_end as u64,
+            // A text/Markdown unit's byte span IS its address, so there is
+            // no second, native one to carry (`ScannedUnit::coordinate`).
+            coordinate: None,
             text: text[unit.byte_start..unit.byte_end].to_string(),
         })
         .collect()

--- a/src/runtime/atlas/trace.rs
+++ b/src/runtime/atlas/trace.rs
@@ -463,6 +463,7 @@ pub fn coordinate_json(coordinate: &UnitCoordinate) -> serde_json::Value {
             title,
             byte_start,
             byte_end,
+            native,
         } => serde_json::json!({
             "family": "document",
             "path": relative_path,
@@ -470,6 +471,10 @@ pub fn coordinate_json(coordinate: &UnitCoordinate) -> serde_json::Value {
             "title": title,
             "byte_start": byte_start,
             "byte_end": byte_end,
+            // A2 §9: a result cites the original source path *and native
+            // coordinate*. `null` where the byte span already is the
+            // address (every Markdown/text unit).
+            "native": native,
         }),
         UnitCoordinate::Mail {
             relative_path,
@@ -477,6 +482,7 @@ pub fn coordinate_json(coordinate: &UnitCoordinate) -> serde_json::Value {
             title,
             byte_start,
             byte_end,
+            native,
         } => serde_json::json!({
             "family": "mail",
             "path": relative_path,
@@ -484,6 +490,9 @@ pub fn coordinate_json(coordinate: &UnitCoordinate) -> serde_json::Value {
             "title": title,
             "byte_start": byte_start,
             "byte_end": byte_end,
+            // Which body of the message this is — the only thing telling a
+            // message's two bodies apart (A1 §6.5).
+            "native": native,
         }),
         UnitCoordinate::RowText {
             relative_path,

--- a/src/runtime/atlas/trace.rs
+++ b/src/runtime/atlas/trace.rs
@@ -41,7 +41,7 @@
 //! destination, not an oversight.** `sgt search` is a pure reader — H13.2
 //! rejected query-time scanning specifically to keep it one, and
 //! `tests/w1b_overlay_lifecycle_trigger.rs::
-//! the_admissibility_filter_cannot_write_because_every_method_takes_an_immutable_self`
+//! the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls`
 //! pins it structurally. Journaling a row per query would make every search a
 //! write, which is the property that pin exists to forbid (**J5** — the pin
 //! is a governing constraint, and a lower rung cannot override it). §13's

--- a/src/runtime/atlas/worker.rs
+++ b/src/runtime/atlas/worker.rs
@@ -160,6 +160,18 @@ pub struct WorkerUnit {
     /// `"text-body"`/`"html-body"` — see [`super::mail`]'s own module doc.
     #[serde(default)]
     pub coordinate: Option<String>,
+    /// Heading depth, when the extractor knows the unit sits under one.
+    ///
+    /// Present for the same reason [`Self::title`] is: the daemon-side
+    /// landing path stores exactly what arrives here, so a field an
+    /// extractor knows and this wire shape drops is a field the store can
+    /// never hold (S5 closeout, F-AC-02).
+    #[serde(default)]
+    pub heading_level: Option<u8>,
+    /// The unit's own title — an Office section's heading text, a mail
+    /// message's subject (A1 §6.5's `subject`).
+    #[serde(default)]
+    pub title: Option<String>,
     /// The unit's own text.
     pub text: String,
 }

--- a/tests/w1_deterministic_filter.rs
+++ b/tests/w1_deterministic_filter.rs
@@ -608,6 +608,89 @@ fn an_authority_filter_for_external_admits_only_the_external_source() {
     assert_eq!(names, vec!["widget_vendor".to_string()], "{names:?}");
 }
 
+/// **A2 §2 stage 2 ships with no caller, and that is only honest while the
+/// authority axis is degenerate** (S5 closeout F-AC-01).
+///
+/// `Admissibility::authority` is `None` at the one production construction
+/// site (`SearchQuery::admissibility`, serving both `/v1/search` and
+/// `/v1/related`), so the two tests above exercise a stage nothing in
+/// production can ask for. That is defensible today for exactly one reason:
+/// every producer in this build pairs a source kind with one fixed authority
+/// class, so `authority_class` is a *total function* of `source_kind` and
+/// `--type repo|knowledge|external` already names every world an
+/// `--authority` selector could name. A2 §14's selector list carries no
+/// authority flag either, so the CLI is complete against the contract, and a
+/// second spelling of `--type` is the abstraction R1 exists to refuse.
+///
+/// None of that is a property of the *design* — A1 keeps the two columns
+/// apart deliberately — so it is pinned rather than assumed. The moment a
+/// producer lands a generation whose authority is not implied by its kind
+/// (a read-only estate mount, an externally-authored local knowledge
+/// source), this test fails, and at that point the selector has to ship:
+/// `--type` would no longer be able to express what stage 2 filters on.
+///
+/// Read from the producers themselves, not from a list maintained beside
+/// them, so a new producer cannot be added without this seeing it.
+#[test]
+fn the_authority_axis_earns_no_selector_only_while_it_is_a_function_of_source_kind() {
+    let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut pairs: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut walked = 0usize;
+    let mut stack = vec![src.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read src") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("read source file");
+            // A `SourceScan` literal spells the two fields adjacently, in
+            // this order, in every producer. A producer that spells them
+            // apart is itself a change to this stage and is meant to be
+            // noticed here.
+            let mut rest = text.as_str();
+            while let Some(at) = rest.find("kind: SourceKind::") {
+                rest = &rest[at + "kind: SourceKind::".len()..];
+                let Some(comma) = rest.find(',') else { break };
+                let kind = rest[..comma].trim().to_string();
+                let after = &rest[comma + 1..];
+                let head: String = after.chars().take(64).collect();
+                let Some(auth_at) = head.find("authority: AuthorityClass::") else {
+                    continue;
+                };
+                let tail = &head[auth_at + "authority: AuthorityClass::".len()..];
+                let Some(end) = tail.find(',') else { continue };
+                walked += 1;
+                pairs.insert((kind, tail[..end].trim().to_string()));
+            }
+        }
+    }
+    assert!(
+        walked >= 4,
+        "the scan must actually find the producers it is about; found {walked}"
+    );
+    let expected: BTreeSet<(String, String)> = [
+        ("LocalKnowledge", "EstateReadonly"),
+        ("EstateGit", "EstateMutable"),
+        ("ExternalGit", "External"),
+    ]
+    .into_iter()
+    .map(|(k, a)| (k.to_string(), a.to_string()))
+    .collect();
+    assert_eq!(
+        pairs, expected,
+        "a source kind is paired with a new authority class somewhere in `src/`. \
+         `authority_class` is no longer a function of `source_kind`, so `--type` can no \
+         longer express what A2 §2's stage 2 filters on, and `Admissibility::authority` \
+         needs the production caller it has never had (`SearchQuery::admissibility` sets \
+         it to `None`). Wire the selector — do not extend this list."
+    );
+}
+
 /// A bare `Admissibility::default()` — `SourceSelector::Any`, no authority
 /// — is "every confirmed generation this store holds": the un-narrowed
 /// case has to stay complete, or every negative test above would be

--- a/tests/w1_deterministic_filter.rs
+++ b/tests/w1_deterministic_filter.rs
@@ -62,6 +62,7 @@ fn document(text: &str) -> ScannedUnit {
         title: None,
         byte_start: 0,
         byte_end: text.len() as u64,
+        coordinate: None,
         text: text.to_string(),
     }
 }

--- a/tests/w1b_overlay_lifecycle_trigger.rs
+++ b/tests/w1b_overlay_lifecycle_trigger.rs
@@ -498,7 +498,32 @@ fn an_overlay_scan_failure_degrades_to_base_only_and_is_reported() {
 /// | `self.conn.execute_batch(&v)` | `no field 'conn' on type &Admissible` |
 /// | `self.reader.execute_batch(&v)` | `no method named 'execute_batch'` |
 /// | `self.reader.rows(&v, …)` | `Sql: From<&String> is not satisfied` |
-/// | `self.reader.rows(read_sql!("DELETE FROM source.units"), …)` | `evaluation panicked: … must begin 'SELECT '` |
+/// | `self.reader.rows(read_sql!("DELETE FROM source.units"), …)` | `evaluation panicked: … beginning 'SELECT ' and containing no ';'` |
+///
+/// # The prefix check alone was not enough, and that was proven too
+///
+/// A third round of this closeout landed a write **through** the
+/// `SELECT `-prefix check:
+///
+/// ```ignore
+/// self.reader.rows(read_sql!("SELECT 1; DELETE FROM source.generations"), …)
+/// ```
+///
+/// The prefix sees only the leading `SELECT `, and DuckDB executes **every**
+/// statement in a `;`-separated batch — measured directly against a raw
+/// connection on duckdb 1.10505.0: `prepare` alone runs nothing, `prepare` +
+/// `query` runs the whole batch and returns the *last* statement's result,
+/// and a three-row table came back empty. (A batch containing a `?` bind is
+/// refused at `prepare` instead, so the parameterised spelling of this
+/// exploit errors rather than deleting — the unparameterised one is the real
+/// one.) `ReadSql` now refuses any `;` at all, checked in the same `const`
+/// evaluation as the prefix.
+///
+/// That the check is a `const` and not a scan is the point: const evaluation
+/// sees the **assembled** string, after `concat!` has resolved, so
+/// `read_sql!(concat!("DEL", "ETE FROM t"))` is `DELETE FROM t` by the time
+/// the check runs. A text scanner reads the source spelling and never sees
+/// it. Attempted, and it fails the build.
 ///
 /// # What THIS test is, now
 ///
@@ -591,15 +616,42 @@ fn the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls() {
     );
 
     // (d) And `ReadSql` really is checked, at compile time. `read_sql!` builds
-    //     a named `const` item rather than a `const { .. }` block on purpose:
-    //     a const block inside the lifetime-generic `impl Admissible<'_>` is a
-    //     post-monomorphization error that `cargo check` walks straight past,
-    //     which was observed during the closeout before this shape was chosen.
+    //     an anonymous `const` **item** rather than a `const { .. }` block on
+    //     purpose: a const block — and the generic associated const inside
+    //     `ReadSql::of`, which covers the non-macro path — is a
+    //     post-monomorphization error that `cargo check` walks straight past.
+    //     That was observed during the closeout, twice: once before this
+    //     shape was chosen, and once again when a hand-written `impl SqlText`
+    //     carrying a `DELETE` passed `cargo check` and only failed the moment
+    //     a test actually called it.
     assert!(
-        source.contains("        const CHECKED: $crate::runtime::atlas::db::store::ReadSql =")
-            && source.contains("begins_with_select(sql),"),
-        "`read_sql!` must evaluate `ReadSql::new` as a `const` item, so a statement that is \
-         not a `SELECT` fails the build rather than reaching DuckDB"
+        source.contains("        const _: () = assert!(\n")
+            && source.contains("$crate::runtime::atlas::db::store::is_read_statement("),
+        "`read_sql!` must evaluate `is_read_statement` as a non-generic `const` item, so a \
+         statement that is not one bare `SELECT` fails `cargo check` rather than reaching \
+         DuckDB"
+    );
+
+    // (e) And the rule that `const` enforces is BOTH conditions. The `;` half
+    //     is not decoration: the prefix half alone was defeated during this
+    //     closeout by `"SELECT 1; DELETE FROM source.generations"`, which
+    //     DuckDB runs in full. `is_read_statement`'s own behaviour is pinned
+    //     by a table in `db.rs`'s unit tests
+    //     (`is_read_statement_admits_exactly_one_bare_select`); what is
+    //     checked here is that the function the macro calls still tests both.
+    let read_rule = block_after(
+        &source,
+        "    pub const fn is_read_statement(sql: &str) -> bool {",
+    );
+    assert!(
+        read_rule.contains("let want = b\"SELECT \";"),
+        "`is_read_statement` must still check the seven-byte `SELECT ` prefix"
+    );
+    assert!(
+        read_rule.contains("if bytes[i] == b';' {"),
+        "`is_read_statement` must still refuse a `;` anywhere — DuckDB executes every \
+         statement in a `;`-separated batch, which is how the prefix-only check was \
+         defeated"
     );
 
     // ---------------------------------------------------------------- part 2

--- a/tests/w1b_overlay_lifecycle_trigger.rs
+++ b/tests/w1b_overlay_lifecycle_trigger.rs
@@ -13,7 +13,7 @@
 //! H13.2's chosen mechanism is the daemon-side surface-lifecycle hook. Not
 //! query-time scanning: that would make a read verb a writer, against the
 //! daemon-is-sole-writer boundary. `sgt search` stays a pure reader —
-//! [`the_admissibility_filter_cannot_write_because_every_method_takes_an_immutable_self`]
+//! [`the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls`]
 //! is the structural half of that claim, and the daemon-sole-writer /
 //! no-client-SQL suites own the rest.
 //!
@@ -464,34 +464,172 @@ fn an_overlay_scan_failure_degrades_to_base_only_and_is_reported() {
     );
 }
 
-/// `sgt search` cannot write, structurally: every admissibility method takes
-/// `&self`.
+/// `sgt search` cannot write, structurally — and this test proves the
+/// *absence of a write*, not a Rust borrow shape.
 ///
 /// H13.2 rejected query-time scanning because it would make a read verb a
 /// writer. That decision is worth exactly as much as what enforces it, and
-/// this is the cheapest thing that does: a `&self` method cannot reach
-/// `stage_scan`, `confirm_scan`, `evict_work_overlays` or
-/// `record_overlay_unavailable`, all of which need `&mut self`. Wiring the
-/// overlay into a query path would not compile without first changing a
-/// signature this test reads.
+/// what enforced it until the S5 closeout was `&self` vs `&mut self` — which
+/// is **not** proof of anything about writing, because duckdb's own
+/// `Connection::execute`, `execute_batch` and `prepare` all take `&self`
+/// (verified against the vendored crate). A future `admissible_*` method
+/// could have called `self.conn.execute("UPDATE ...")` and satisfied the old
+/// assertion while performing a real write.
+///
+/// So both properties are checked, and the second is the load-bearing one:
+///
+/// 1. every `pub fn admissible_*` still takes `&self` — it cannot reach
+///    `stage_scan`, `confirm_scan`, `evict_work_overlays` or
+///    `record_overlay_unavailable`, which need `&mut self`;
+/// 2. **no code any of them can reach inside `db.rs` writes.** The bodies are
+///    walked transitively through every `db.rs`-local function they call, and
+///    none may contain a write-capable connection call (`execute`,
+///    `execute_batch`, `appender`) or an SQL write verb. `prepare` is
+///    admissible only because a statement that reaches this closure carries
+///    no write verb to prepare.
+///
+/// The transitive walk is what makes it unevadable by one hop: moving the
+/// write into a private helper the method calls fails exactly as loudly as
+/// writing it inline. **R2** — the mechanism is this suite's own
+/// read-the-source structural test, not new machinery; a read-only
+/// connection newtype was weighed and rejected, because duckdb hands out
+/// `Statement::execute` from a `&self` `prepare` too, so the type would
+/// carry a guarantee it could not keep while costing a refactor of all four
+/// methods and their statements.
 #[test]
-fn the_admissibility_filter_cannot_write_because_every_method_takes_an_immutable_self() {
-    let db = std::fs::read_to_string(
+fn the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls() {
+    let source = std::fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR")).join("src/runtime/atlas/db.rs"),
     )
     .expect("read db.rs");
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Every function defined in db.rs, by name, with the body text a caller
+    // of it would actually run. Bodies end at the closing brace on the
+    // function's own indentation — brace counting would trip over the `{}`
+    // in a `format!`, and this file has many.
+    let mut bodies: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        let indent = &line[..line.len() - trimmed.len()];
+        let Some(rest) = trimmed
+            .strip_prefix("pub fn ")
+            .or_else(|| trimmed.strip_prefix("fn "))
+            .or_else(|| trimmed.strip_prefix("pub(crate) fn "))
+        else {
+            continue;
+        };
+        let Some(name) = rest.split(['(', '<', ' ']).next() else {
+            continue;
+        };
+        let closing = format!("{indent}}}");
+        let mut body = String::new();
+        for next in lines.iter().skip(index + 1) {
+            if *next == closing {
+                break;
+            }
+            // Prose is not code: a comment naming a `DELETE` this function
+            // does not perform must not fail the scan.
+            if !next.trim_start().starts_with("//") {
+                body.push_str(next);
+                body.push('\n');
+            }
+        }
+        bodies.insert(name.to_string(), body);
+    }
+
+    /// A call into duckdb that can write, or an SQL verb that does.
+    const WRITE_CAPABLE: [&str; 12] = [
+        ".execute(",
+        ".execute_batch(",
+        ".appender(",
+        "INSERT ",
+        "UPDATE ",
+        "DELETE ",
+        "DROP ",
+        "CREATE ",
+        "ALTER ",
+        "ATTACH ",
+        "COPY ",
+        "TRUNCATE ",
+    ];
+
+    /// Does `body` call `name` — as a free function, or on `self`?
+    ///
+    /// The receiver matters: `statement.query(...)` is duckdb's `query`, not
+    /// this file's `Analytics::query`, and following that name would walk
+    /// the closure into every unrelated method that happens to share a
+    /// spelling. `self.` and no-receiver calls are the ones that really are
+    /// this file's own code.
+    fn calls(body: &str, name: &str) -> bool {
+        let needle = format!("{name}(");
+        if body.contains(&format!("self.{needle}")) {
+            return true;
+        }
+        let bytes = body.as_bytes();
+        let mut from = 0;
+        while let Some(at) = body[from..].find(&needle) {
+            let at = from + at;
+            let before = at.checked_sub(1).map(|i| bytes[i] as char);
+            match before {
+                // A receiver, or a longer identifier ending in this name.
+                Some(c) if c == '.' || c == '_' || c.is_alphanumeric() => {}
+                _ => return true,
+            }
+            from = at + needle.len();
+        }
+        false
+    }
+
     let mut checked = 0;
-    for (index, line) in db.lines().enumerate() {
+    for (index, line) in lines.iter().enumerate() {
         let Some(name) = line.trim().strip_prefix("pub fn admissible_") else {
             continue;
         };
+        let name = format!(
+            "admissible_{}",
+            name.split(['(', '<', ' ']).next().unwrap_or(name)
+        );
         checked += 1;
-        let signature: String = db.lines().skip(index).take(6).collect::<Vec<_>>().join(" ");
+
+        let signature: String = lines
+            .iter()
+            .skip(index)
+            .take(6)
+            .copied()
+            .collect::<Vec<_>>()
+            .join(" ");
         assert!(
             signature.contains("&self,") && !signature.contains("&mut self"),
-            "admissible_{name} must take &self — a query path that could write is exactly what \
-             H13.2 rejected when it chose the lifecycle hook over query-time scanning"
+            "{name} must take &self — a query path that could write is exactly what H13.2 \
+             rejected when it chose the lifecycle hook over query-time scanning"
         );
+
+        // Everything this method can reach inside db.rs, transitively.
+        let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let mut queue = vec![name.clone()];
+        while let Some(current) = queue.pop() {
+            if !seen.insert(current.clone()) {
+                continue;
+            }
+            let Some(body) = bodies.get(&current) else {
+                continue;
+            };
+            for verb in WRITE_CAPABLE {
+                assert!(
+                    !body.to_uppercase().contains(verb),
+                    "{name} reaches {current}, which contains {verb:?} — the admissibility \
+                     filter is the read side of H13.2's decision, and `&self` is no proof it \
+                     cannot write: duckdb's Connection::execute/execute_batch/prepare all take \
+                     &self"
+                );
+            }
+            for callee in bodies.keys() {
+                if calls(body, callee) {
+                    queue.push(callee.clone());
+                }
+            }
+        }
     }
     assert_eq!(
         checked, 4,

--- a/tests/w1b_overlay_lifecycle_trigger.rs
+++ b/tests/w1b_overlay_lifecycle_trigger.rs
@@ -464,38 +464,62 @@ fn an_overlay_scan_failure_degrades_to_base_only_and_is_reported() {
     );
 }
 
-/// `sgt search` cannot write, structurally — and this test proves the
-/// *absence of a write*, not a Rust borrow shape.
+/// `sgt search` cannot write — **and since the S5 closeout that is enforced
+/// by the compiler, not by this scan.**
+///
+/// # What changed, and why
 ///
 /// H13.2 rejected query-time scanning because it would make a read verb a
-/// writer. That decision is worth exactly as much as what enforces it, and
-/// what enforced it until the S5 closeout was `&self` vs `&mut self` — which
-/// is **not** proof of anything about writing, because duckdb's own
-/// `Connection::execute`, `execute_batch` and `prepare` all take `&self`
-/// (verified against the vendored crate). A future `admissible_*` method
-/// could have called `self.conn.execute("UPDATE ...")` and satisfied the old
-/// assertion while performing a real write.
+/// writer. Through S5 that decision was guarded two ways, and both were
+/// weaker than they read:
 ///
-/// So both properties are checked, and the second is the load-bearing one:
+/// 1. `&self` vs `&mut self` — no proof of anything, because DuckDB's own
+///    `Connection::execute`, `execute_batch` and `prepare` all take `&self`.
+/// 2. A transitive scan of `admissible_*` bodies for write-capable
+///    spellings — which the closeout re-verify **defeated in one hop**. Its
+///    `WRITE_CAPABLE` list mixed lowercase call syntax (`.execute_batch(`)
+///    with uppercase SQL verbs (`DELETE `) and tested
+///    `body.to_uppercase().contains(verb)`, so the three call-syntax entries
+///    could never match anything: uppercasing the body turns `.execute_batch(`
+///    into `.EXECUTE_BATCH(`. Inserting
+///    `let v = format!("{}ETE FROM source.units", "DEL"); self.conn.execute_batch(&v);`
+///    into `admissible_datasets` left this test **green**.
 ///
-/// 1. every `pub fn admissible_*` still takes `&self` — it cannot reach
-///    `stage_scan`, `confirm_scan`, `evict_work_overlays` or
-///    `record_overlay_unavailable`, which need `&mut self`;
-/// 2. **no code any of them can reach inside `db.rs` writes.** The bodies are
-///    walked transitively through every `db.rs`-local function they call, and
-///    none may contain a write-capable connection call (`execute`,
-///    `execute_batch`, `appender`) or an SQL write verb. `prepare` is
-///    admissible only because a statement that reaches this closure carries
-///    no write verb to prepare.
+/// So the mechanism moved. `db.rs` now implements the whole A2 §2 filter on
+/// `Admissible`, a struct whose only field is a `ReadOnly` — a handle with no
+/// write call on it, which hands out no `Statement`, `Appender`,
+/// `Transaction` or `Connection`, and whose two query methods take a
+/// `ReadSql` that a `const` item proves begins `SELECT `. **A write inside
+/// the admissibility filter is a compile error**, verified by inserting each
+/// of these and watching the build fail:
 ///
-/// The transitive walk is what makes it unevadable by one hop: moving the
-/// write into a private helper the method calls fails exactly as loudly as
-/// writing it inline. **R2** — the mechanism is this suite's own
-/// read-the-source structural test, not new machinery; a read-only
-/// connection newtype was weighed and rejected, because duckdb hands out
-/// `Statement::execute` from a `&self` `prepare` too, so the type would
-/// carry a guarantee it could not keep while costing a refactor of all four
-/// methods and their statements.
+/// | inserted into `Admissible::datasets` | result |
+/// |---|---|
+/// | `self.conn.execute_batch(&v)` | `no field 'conn' on type &Admissible` |
+/// | `self.reader.execute_batch(&v)` | `no method named 'execute_batch'` |
+/// | `self.reader.rows(&v, …)` | `Sql: From<&String> is not satisfied` |
+/// | `self.reader.rows(read_sql!("DELETE FROM source.units"), …)` | `evaluation panicked: … must begin 'SELECT '` |
+///
+/// # What THIS test is, now
+///
+/// The compiler owns the claim. This test owns two things the compiler
+/// cannot state for a future reader: that the wiring is still in place (part
+/// 1), and a cheap second net over the shapes a type does not see (part 2).
+/// Part 1 is the one that must never be relaxed — deleting it would let
+/// someone quietly reintroduce a `Connection` field on `Admissible` and lose
+/// the guarantee with no test going red.
+///
+/// # What the second net cannot see — stated, not implied
+///
+/// The scan reads source text, so it is blind to exactly what source text is
+/// blind to. It does **not** see: a write assembled from pieces no single
+/// line spells (`concat!`, a `const` defined elsewhere in the file and named
+/// here, a byte array); a call reached through a trait object or a function
+/// pointer; anything in another file. Those are the hops that defeated its
+/// predecessor, and the reason it is no longer the load-bearing check. It is
+/// kept because it is nearly free and because it *does* catch the one shape
+/// the type system still permits: a literal SQL write verb sitting in a
+/// method the filter can reach.
 #[test]
 fn the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls() {
     let source = std::fs::read_to_string(
@@ -503,6 +527,83 @@ fn the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls() {
     )
     .expect("read db.rs");
     let lines: Vec<&str> = source.lines().collect();
+
+    // ---------------------------------------------------------------- part 1
+    // The compile-time guarantee is still wired. Each assertion below is a
+    // load-bearing piece of it; none is cosmetic.
+
+    // (a) The filter's own type holds a read-only handle and NOTHING else. A
+    //     second field of any connection-ish type would restore the hop the
+    //     closeout closed, and would not change one character of the scan
+    //     below.
+    assert!(
+        source.contains("struct Admissible<'conn> {\n    reader: ReadOnly<'conn>,\n}"),
+        "`Admissible` must hold exactly one field, a `ReadOnly` — that single field is the \
+         whole reason a write inside the admissibility filter does not compile"
+    );
+
+    // (b) The public methods are delegates onto it, so the public path cannot
+    //     do anything the filter's own type forbids.
+    for family in ["generations", "units", "occurrences", "datasets"] {
+        let delegate = format!("        self.admissible().{family}(filter, limit)\n    }}");
+        assert!(
+            source.contains(&delegate),
+            "`AtlasDb::admissible_{family}` must be a one-line delegate onto `Admissible`; \
+             any logic that stays on `AtlasDb` runs with `self.conn` in scope and is \
+             therefore outside the guarantee"
+        );
+    }
+
+    // (c) The read-only handle really is write-free: it exposes exactly two
+    //     operations, and neither hands back a value with a write on it. This
+    //     is spelled as an allowlist of `pub fn`s in the `ReadOnly` impl
+    //     rather than a denylist of forbidden method names, because a
+    //     denylist is what the old scan was.
+    let read_only_impl = block_after(&source, "    impl ReadOnly<'_> {");
+    let exposed: Vec<&str> = read_only_impl
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("pub fn "))
+        .filter_map(|rest| rest.split(['(', '<', ' ']).next())
+        .collect();
+    assert_eq!(
+        exposed,
+        vec!["rows", "first"],
+        "`ReadOnly` must expose only its two mapping queries; anything else — a `prepare`, a \
+         `connection`, a `Statement` accessor — is a write one dot away"
+    );
+    for handed_out in [
+        "-> Statement",
+        "-> CachedStatement",
+        "-> Appender",
+        "-> Connection",
+    ] {
+        assert!(
+            !read_only_impl.contains(handed_out),
+            "`ReadOnly` must hand out no {handed_out} — a value with a write on it defeats \
+             the whole type"
+        );
+    }
+    assert_eq!(
+        read_only_impl.matches("sql: ReadSql,").count(),
+        2,
+        "both `ReadOnly` queries must take a `ReadSql`, never a `Sql`: a `Sql` may be any \
+         statement this crate wrote, DELETE included, and DuckDB runs what it is handed"
+    );
+
+    // (d) And `ReadSql` really is checked, at compile time. `read_sql!` builds
+    //     a named `const` item rather than a `const { .. }` block on purpose:
+    //     a const block inside the lifetime-generic `impl Admissible<'_>` is a
+    //     post-monomorphization error that `cargo check` walks straight past,
+    //     which was observed during the closeout before this shape was chosen.
+    assert!(
+        source.contains("        const CHECKED: $crate::runtime::atlas::db::store::ReadSql =")
+            && source.contains("begins_with_select(sql),"),
+        "`read_sql!` must evaluate `ReadSql::new` as a `const` item, so a statement that is \
+         not a `SELECT` fails the build rather than reaching DuckDB"
+    );
+
+    // ---------------------------------------------------------------- part 2
+    // The second net. Cheap, honest, and explicitly NOT the guarantee.
 
     // Every function defined in db.rs, by name, with the body text a caller
     // of it would actually run. Bodies end at the closing brace on the
@@ -538,11 +639,24 @@ fn the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls() {
         bodies.insert(name.to_string(), body);
     }
 
-    /// A call into duckdb that can write, or an SQL verb that does.
-    const WRITE_CAPABLE: [&str; 12] = [
+    /// A call into the driver that can write. Matched **case-sensitively
+    /// against the body as written**, which is the bug the closeout found:
+    /// these were previously compared against `body.to_uppercase()`, where
+    /// `.execute_batch(` had become `.EXECUTE_BATCH(` and could never match.
+    const WRITE_CALLS: [&str; 6] = [
         ".execute(",
         ".execute_batch(",
         ".appender(",
+        ".appender_to_db(",
+        // Reaching for a connection of its own is how a read path would get
+        // around the read-only handle without ever naming a write.
+        "Connection::",
+        "Store::new(",
+    ];
+
+    /// An SQL verb that writes. Matched against the **uppercased** body, so
+    /// `delete from` in a runtime-built string is caught too.
+    const WRITE_VERBS: [&str; 9] = [
         "INSERT ",
         "UPDATE ",
         "DELETE ",
@@ -581,33 +695,36 @@ fn the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls() {
         false
     }
 
-    let mut checked = 0;
-    for (index, line) in lines.iter().enumerate() {
-        let Some(name) = line.trim().strip_prefix("pub fn admissible_") else {
-            continue;
-        };
-        let name = format!(
-            "admissible_{}",
-            name.split(['(', '<', ' ']).next().unwrap_or(name)
-        );
-        checked += 1;
+    // Seeded from the *implementation*, not from the delegates. Seeding on
+    // `pub fn admissible_` would now walk four one-line bodies and prove
+    // nothing — a vacuous net is worse than none, because it reads like one
+    // that works.
+    let admissible_impl = block_after(&source, "impl Admissible<'_> {");
+    let mut seeds: Vec<String> = admissible_impl
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("fn "))
+        .filter_map(|rest| rest.split(['(', '<', ' ']).next())
+        .map(str::to_string)
+        .collect();
+    seeds.sort();
+    assert_eq!(
+        seeds,
+        vec![
+            "datasets",
+            "generations",
+            "newest_overlay_observed_at",
+            "occurrences",
+            "units",
+            "work_scope",
+        ],
+        "the four A2 §2 content-family methods and their two helpers must all be covered; a \
+         new one must be added here"
+    );
 
-        let signature: String = lines
-            .iter()
-            .skip(index)
-            .take(6)
-            .copied()
-            .collect::<Vec<_>>()
-            .join(" ");
-        assert!(
-            signature.contains("&self,") && !signature.contains("&mut self"),
-            "{name} must take &self — a query path that could write is exactly what H13.2 \
-             rejected when it chose the lifecycle hook over query-time scanning"
-        );
-
+    for seed in &seeds {
         // Everything this method can reach inside db.rs, transitively.
         let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-        let mut queue = vec![name.clone()];
+        let mut queue = vec![seed.clone()];
         while let Some(current) = queue.pop() {
             if !seen.insert(current.clone()) {
                 continue;
@@ -615,13 +732,17 @@ fn the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls() {
             let Some(body) = bodies.get(&current) else {
                 continue;
             };
-            for verb in WRITE_CAPABLE {
+            for call in WRITE_CALLS {
+                assert!(
+                    !body.contains(call),
+                    "{seed} reaches {current}, which contains {call:?} — the admissibility \
+                     filter is the read side of H13.2's decision"
+                );
+            }
+            for verb in WRITE_VERBS {
                 assert!(
                     !body.to_uppercase().contains(verb),
-                    "{name} reaches {current}, which contains {verb:?} — the admissibility \
-                     filter is the read side of H13.2's decision, and `&self` is no proof it \
-                     cannot write: duckdb's Connection::execute/execute_batch/prepare all take \
-                     &self"
+                    "{seed} reaches {current}, which contains the SQL verb {verb:?}"
                 );
             }
             for callee in bodies.keys() {
@@ -631,8 +752,19 @@ fn the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls() {
             }
         }
     }
-    assert_eq!(
-        checked, 4,
-        "the four A2 §2 content-family methods must all be covered; a new one must be added here"
-    );
+}
+
+/// The text of the `{ .. }` block opened by the line `header`, up to the
+/// closing brace at that line's own indentation.
+fn block_after(source: &str, header: &str) -> String {
+    let at = source
+        .find(header)
+        .unwrap_or_else(|| panic!("db.rs must still contain `{header}`"));
+    let indent = header.len() - header.trim_start().len();
+    let closing = format!("\n{}}}", " ".repeat(indent));
+    let rest = &source[at + header.len()..];
+    let end = rest
+        .find(&closing)
+        .unwrap_or_else(|| panic!("`{header}` must close at its own indentation"));
+    rest[..end].to_string()
 }

--- a/tests/w1c_one_atlas_database.rs
+++ b/tests/w1c_one_atlas_database.rs
@@ -88,6 +88,7 @@ fn scan(source_name: &str, content_key: &str, body: &str) -> SourceScan {
             title: None,
             byte_start: 0,
             byte_end: body.len() as u64,
+            coordinate: None,
             text: body.to_string(),
         }],
         syntax: None,

--- a/tests/w2_lexical_retrieval.rs
+++ b/tests/w2_lexical_retrieval.rs
@@ -23,17 +23,19 @@
 //! real three-step `record_scan` path — so their byte ranges are the real
 //! offsets into real files, and the tests slice the files with them.
 //!
-//! The mail family is a hand-built [`SourceScan`] carrying
-//! [`MAIL_EXTRACTOR`] units. That is deliberate and is not a gap in what is
-//! proved: `.eml` extraction routes through a supervised **worker
-//! subprocess** (`scan.rs`'s `worker_extractor_for`), which this suite
-//! deliberately does not spawn — spawning is `tests/y4_mail_adapter.rs`'s
-//! job, and it already proves the parse. What W2 owns is what happens to a
-//! stored mail unit once it exists, and a hand-built `source.units` row under
-//! the mail extractor identity is byte-for-byte the row that adapter writes.
+//! The mail family comes from a **real** `.eml` fixture walked through the
+//! real supervised worker subprocess (`scan_local_knowledge_with_worker`, the
+//! shape `scan.rs`'s `worker_extractor_for` routes `.eml` into) and recorded
+//! through the same `record_scan`. It was hand-built until the S5 closeout
+//! (F-AC-02) and that was the defect: the hand-built row set `title` and a
+//! real byte span by hand, which the worker landing path cannot produce, so
+//! the test pinned values production never emits and would have passed with
+//! the whole mail adapter deleted. A family's provenance test has to land the
+//! family the way production lands it.
 
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use tempfile::TempDir;
 
@@ -47,10 +49,12 @@ use sergeant_rs::runtime::atlas::mail::MAIL_EXTRACTOR;
 use sergeant_rs::runtime::atlas::record::{ScanRecord, record_scan, scan_and_record};
 use sergeant_rs::runtime::atlas::scan::{
     KnowledgeSource, ScannedFile, ScannedSymbol, ScannedSyntax, ScannedUnit, SourceScan,
+    scan_local_knowledge_with_worker,
 };
 use sergeant_rs::runtime::atlas::semantic::SemanticRequest;
 use sergeant_rs::runtime::atlas::tabular::ContextFields;
 use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+use sergeant_rs::runtime::atlas::worker::WorkerRuntime;
 use sergeant_rs::runtime::journal::Journal;
 
 // ---------------------------------------------------------------- fixtures
@@ -106,6 +110,7 @@ fn document_unit(title: Option<&str>, text: &str) -> ScannedUnit {
         title: title.map(str::to_string),
         byte_start: 0,
         byte_end: text.len() as u64,
+        coordinate: None,
         text: text.to_string(),
     }
 }
@@ -179,14 +184,16 @@ fn rust_symbol(name: &str) -> ScannedSyntax {
 /// * `knowledge` (local-knowledge, estate-readonly) — a REAL walk over a real
 ///   directory: `docs/forms.md`, `src/lib.rs`, `tickets.csv` with
 ///   `number`/`short_description` allowlisted (F10a).
-/// * `mailbox` (local-knowledge, estate-readonly) — one hand-built
-///   [`MAIL_EXTRACTOR`] unit (see the module doc for why it is hand-built).
+/// * `mailbox` (local-knowledge, estate-readonly) — a REAL walk over a
+///   directory holding this repo's own `02-multipart-alternative.eml`
+///   fixture, dispatched through the real supervised worker subprocess.
 /// * `vendor-lib` (external-git, external) — the decoy: a document whose body
 ///   is a *better* lexical match for the queries below than anything
 ///   admissible, planted so the negative-admission test has something real to
 ///   fail on.
 struct Estate {
     _data: TempDir,
+    _mailbox: TempDir,
     root: TempDir,
     journal: Journal,
     db: AtlasDb,
@@ -245,19 +252,37 @@ fn estate() -> Estate {
     };
     scan_and_record(&mut db, &mut journal, &knowledge, None).expect("record knowledge");
 
-    let mailbox = hand_built_scan(
-        "mailbox",
-        SourceKind::LocalKnowledge,
-        AuthorityClass::EstateReadonly,
-        "mailbox@key-1",
-        vec![scanned_file(
-            "inbox/message.eml",
-            MAIL_EXTRACTOR,
-            vec![document_unit(
-                Some("Payment retry policy failure"),
-                "The PaymentRetryPolicy raised INC0012345 during settlement.",
-            )],
-        )],
+    // The mail source is REAL: this repo's own `.eml` fixture, walked
+    // through the real supervised worker subprocess the production `.eml`
+    // route uses. See the module doc for why it is not hand-built.
+    let mailbox_root = tempfile::tempdir().expect("mailbox root");
+    std::fs::create_dir_all(mailbox_root.path().join("inbox")).expect("inbox");
+    std::fs::write(
+        mailbox_root.path().join("inbox/message.eml"),
+        std::fs::read(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/mail_corpus/02-multipart-alternative.eml"),
+        )
+        .expect("read the mail fixture"),
+    )
+    .expect("write the mail fixture");
+    let mailbox = scan_local_knowledge_with_worker(
+        &KnowledgeSource {
+            name: "mailbox".to_string(),
+            root: mailbox_root.path().to_path_buf(),
+            ignore: Vec::new(),
+            context_fields: ContextFields::none(),
+        },
+        &WorkerRuntime {
+            program: PathBuf::from(env!("CARGO_BIN_EXE_sgt-atlas-worker")),
+            deadline: Duration::from_secs(20),
+        },
+    )
+    .expect("scan the mailbox through the real worker");
+    assert!(
+        mailbox.extractors.contains(MAIL_EXTRACTOR),
+        "the mail fixture must have routed through the real mail adapter: {:?}",
+        mailbox.extractors
     );
     record_scan(&mut db, &mut journal, &mailbox, None).expect("record mailbox");
 
@@ -277,6 +302,7 @@ fn estate() -> Estate {
 
     Estate {
         _data: data,
+        _mailbox: mailbox_root,
         root,
         journal,
         db,
@@ -455,33 +481,75 @@ fn lexical_search_returns_a_document_unit_with_exact_a1_provenance() {
     );
 }
 
-/// Family 3 of 4 — **mail**. A2 §3's email coordinate, as far as A1's stored
-/// rows carry it: the `.eml` resource's path, the unit inside it, and the
-/// span of the message bytes.
+/// Family 3 of 4 — **mail**, landed the way production lands it: this
+/// repo's own `.eml` fixture through the real worker subprocess.
+///
+/// **What a mail hit actually carries, and why.** The message has two
+/// bodies (A1 §6.5's `text/html body`), so it lands two `Document`-kind
+/// units at one path. Neither is byte-recoverable into the original wire
+/// bytes — a decoded Content-Transfer-Encoding is a transform — so both
+/// carry `0`/`0`, the honest "not applicable" the worker's own comment
+/// names, and the *only* thing that tells them apart is the normalizer's
+/// native coordinate (`text-body`/`html-body`). The subject is the unit
+/// title. Those three facts are what A2 §17 item 2's "exact A1 provenance"
+/// and §9's "still cite the original source path/native coordinate" mean
+/// for this family; asserting a byte span here would be asserting a value
+/// production cannot produce, which is precisely what the pre-F-AC-02
+/// version of this test did.
 #[test]
-fn lexical_search_returns_a_mail_unit_with_exact_a1_provenance() {
+fn lexical_search_returns_mail_units_with_exact_a1_provenance() {
     let estate = estate();
     let filter = Admissibility {
         source: SourceSelector::Named("mailbox".to_string()),
         kind: None,
         authority: None,
     };
-    let answer = estate.search("INC0012345", &filter, Some(LexicalFamily::Mail));
-    let hit = hit_at(&answer, "inbox/message.eml");
-    assert_eq!(hit.source_name, "mailbox");
-    let UnitCoordinate::Mail {
-        title,
-        byte_start,
-        byte_end,
-        ..
-    } = &hit.coordinate
-    else {
-        panic!("expected a mail coordinate, got {:?}", hit.coordinate);
-    };
-    assert_eq!(title.as_deref(), Some("Payment retry policy failure"));
-    assert!(
-        byte_end > byte_start,
-        "a mail unit's span must be a real range: {byte_start}..{byte_end}"
+    let answer = estate.search("alternative", &filter, Some(LexicalFamily::Mail));
+
+    let mut seen: Vec<String> = Vec::new();
+    for hit in &answer.hits {
+        assert_eq!(hit.source_name, "mailbox");
+        let UnitCoordinate::Mail {
+            relative_path,
+            title,
+            byte_start,
+            byte_end,
+            native,
+            ordinal: _,
+        } = &hit.coordinate
+        else {
+            panic!("expected a mail coordinate, got {:?}", hit.coordinate);
+        };
+        assert_eq!(relative_path, "inbox/message.eml");
+        assert_eq!(
+            title.as_deref(),
+            Some("Alternative body demo"),
+            "the message subject is the unit's title (A1 §6.5), and the worker landing path \
+             must carry it: {:?}",
+            hit.coordinate
+        );
+        assert_eq!(
+            (*byte_start, *byte_end),
+            (0, 0),
+            "a mail body is not byte-recoverable into the original wire bytes; 0/0 is the \
+             honest not-applicable, and no other value is truthful: {:?}",
+            hit.coordinate
+        );
+        seen.push(native.clone().unwrap_or_else(|| {
+            panic!(
+                "a mail unit must carry its native coordinate — it is \
+                     the only thing telling the two bodies apart: {:?}",
+                hit.coordinate
+            )
+        }));
+    }
+    seen.sort();
+    assert_eq!(
+        seen,
+        vec!["html-body".to_string(), "text-body".to_string()],
+        "the fixture has a text body and an html body; both are indexed units, and the native \
+         coordinate is what distinguishes them: {:?}",
+        answer.hits
     );
 }
 
@@ -989,6 +1057,7 @@ fn a_bounded_answer_reports_true_when_the_posting_scan_is_actually_capped() {
             title: None,
             byte_start: 0,
             byte_end: 8,
+            coordinate: None,
             text: "needleterm".to_string(),
         })
         .collect();

--- a/tests/w3_semantic_degradation.rs
+++ b/tests/w3_semantic_degradation.rs
@@ -134,6 +134,7 @@ fn estate() -> Estate {
                 title: None,
                 byte_start: 0,
                 byte_end: NOTE_MD.len() as u64,
+                coordinate: None,
                 text: NOTE_MD.to_string(),
             }],
             syntax: None,

--- a/tests/w3b_semantic_retrieval.rs
+++ b/tests/w3b_semantic_retrieval.rs
@@ -206,6 +206,7 @@ fn document_unit(text: &str) -> ScannedUnit {
         title: None,
         byte_start: 0,
         byte_end: text.len() as u64,
+        coordinate: None,
         text: text.to_string(),
     }
 }

--- a/tests/w3b_semantic_scan_measurement.rs
+++ b/tests/w3b_semantic_scan_measurement.rs
@@ -78,6 +78,7 @@ fn scan(units: usize) -> SourceScan {
                 title: None,
                 byte_start: 0,
                 byte_end: body(i).len() as u64,
+                coordinate: None,
                 text: body(i),
             }],
             syntax: None,

--- a/tests/w4_rrf_fusion.rs
+++ b/tests/w4_rrf_fusion.rs
@@ -474,6 +474,7 @@ fn document_unit(text: &str) -> ScannedUnit {
         title: None,
         byte_start: 0,
         byte_end: text.len() as u64,
+        coordinate: None,
         text: text.to_string(),
     }
 }

--- a/tests/w5_search_surface.rs
+++ b/tests/w5_search_surface.rs
@@ -635,6 +635,30 @@ fn item_3s_relational_read_is_reachable_from_outside_the_process() {
 ///   [`UnitCoordinate::Document`]'s `native` — the normalizer's own address,
 ///   `block:<n>` — and that is what this test holds an Office section to.
 ///
+/// # "Office", in this build, means `.docx` — and nothing else
+///
+/// A2 §9's own example output shows a `.pptx` slide and a `.docx` section
+/// side by side, and §9's prose names Word, PowerPoint, Excel, PDF and mail
+/// as things a local knowledge Source *may contain*. This build claims one
+/// of them: `.docx`. `office::extractor_for` routes `.docx` (case-
+/// insensitively) and nothing else — `book.xlsx`, `deck.pptx`, `notes.odt`
+/// and `report.pdf` are all explicitly unclaimed, pinned by
+/// `office::tests::extractor_for_claims_only_docx`, and a knowledge Source
+/// holding them gets an honest `unsupported` coverage row per path rather
+/// than a unit. So item 6's "span" is proven here for the one Office format
+/// that exists, and a Source of `.pptx`/`.xlsx`/PDF cannot be spanned at
+/// all today.
+///
+/// That is a deliberate, pre-existing scope boundary, not a gap this test
+/// discovered: the Y2 wave brief scoped the gate to one Office format
+/// ("NOT in scope: ... a second Office format beyond the one the gate
+/// adopts"), and `tests/fixtures/anydoc_corpus/MANIFEST.md` records the
+/// corpus carrying no spreadsheet/presentation/PDF fixtures for that
+/// reason. It is restated here because this is where a reader checking
+/// item 6 looks, and "normalized Office/docs" in the contract's own words
+/// reads wider than the adapter is. Adding a second format is adapter
+/// work, not a doc fix.
+///
 /// An earlier version of this test asserted `byte_end > byte_start` for "a
 /// document coordinate" of *both* files and passed only because the one hit
 /// it happened to pick per path was the whole-document one. That prose

--- a/tests/w5_search_surface.rs
+++ b/tests/w5_search_surface.rs
@@ -120,6 +120,7 @@ fn document_unit(title: Option<&str>, text: &str) -> ScannedUnit {
         title: title.map(str::to_string),
         byte_start: 0,
         byte_end: text.len() as u64,
+        coordinate: None,
         text: text.to_string(),
     }
 }

--- a/tests/w5_search_surface.rs
+++ b/tests/w5_search_surface.rs
@@ -8,6 +8,7 @@
 //! | §17 item 8 — external evidence is visibly external **from the answer alone** | [`an_external_hit_is_identifiable_as_external_from_the_answer_alone`] |
 //! | §17 item 8 — and the same is true of a fused answer, not only a lexical one | [`a_fused_answer_carries_the_source_kind_and_authority_class_of_every_hit`] |
 //! | §17 item 3 — a relational aggregate **joins to retrieved row evidence** | [`a_relational_aggregate_and_a_retrieved_row_join_on_one_shared_row_identity`] |
+//! | §17 item 3 — and that relational read is **reachable outside the test binary** | [`item_3s_relational_read_is_reachable_from_outside_the_process`] |
 //! | §17 item 6 — one query **spans** a normalized Office document and a Markdown one | [`one_local_knowledge_query_spans_a_normalized_docx_and_a_markdown_file`] |
 //! | §13 — all nine trace fields are recorded | [`the_trace_records_every_one_of_a2_section_13s_nine_fields`] |
 //! | §13 — the tokenizer version is not a promise to remember | [`the_lexical_tokenizer_version_is_pinned_to_the_tokenizers_actual_output`] |
@@ -497,6 +498,105 @@ fn a_relational_aggregate_and_a_retrieved_row_join_on_one_shared_row_identity() 
     assert!(
         !row_key.is_empty(),
         "the row also carries its own stable identity, so two answers about it join"
+    );
+}
+
+/// **A2 §17 item 3, the reachability half** (S5 closeout F-AC-03).
+///
+/// [`a_relational_aggregate_and_a_retrieved_row_join_on_one_shared_row_identity`]
+/// really performs the join — but it performed it entirely through `pub`
+/// library functions that, at the close of S5, had no caller anywhere in
+/// `src/`: `dataset_probe`, `dataset_facts` and `admissible_datasets`. An
+/// acceptance item met only inside the test binary is this program's
+/// signature defect, and it is what this test exists to make impossible to
+/// repeat. It pins two things:
+///
+/// 1. the aggregate half of the join is served by the read the daemon route
+///    actually calls — `dataset_facts`, which reads only rows the store
+///    already holds — and that read joins to a retrieved row on
+///    `dataset_key`, A2 §4's shared row identity;
+/// 2. that read has a daemon route AND a CLI verb, in the shape
+///    `GET /v1/map/children` / `sgt map children` set in W7.
+///
+/// `dataset_probe` is deliberately *not* reachable and is asserted so: its
+/// own doc says `path` is a file path this process will open, *"so this is
+/// not, and must not become, an HTTP-reachable surface"*. The distinction is
+/// the point — one of these two reads is safe to expose and one is not, and
+/// "neither is exposed" was not the same as "the unsafe one is not".
+#[test]
+fn item_3s_relational_read_is_reachable_from_outside_the_process() {
+    let estate = estate();
+
+    // (1) The aggregate, through the read the route calls — no probe, no
+    // path, no client-named file: rows the store already holds.
+    let facts = estate
+        .db
+        .dataset_facts("library", 100)
+        .expect("stored relational evidence");
+    assert!(
+        !facts.is_empty(),
+        "a scanned dataset lands its canned queries' answers"
+    );
+
+    // The retrieval half, and the join key.
+    let answer = estate.search("INC0012345", &only_library(), Some(LexicalFamily::RowText));
+    let hit = answer
+        .hits
+        .iter()
+        .find(|hit| hit.coordinate.relative_path() == "tickets.csv")
+        .expect("a row-text hit for the ticket");
+    let UnitCoordinate::RowText {
+        relative_path,
+        dataset_key,
+        ..
+    } = &hit.coordinate
+    else {
+        panic!("expected a row-text coordinate, got {:?}", hit.coordinate);
+    };
+    let fact = facts
+        .iter()
+        .find(|f| &f.dataset_key == dataset_key)
+        .unwrap_or_else(|| {
+            panic!("the retrieved row's dataset key must name stored evidence: {dataset_key}")
+        });
+    assert_eq!(
+        &fact.relative_path, relative_path,
+        "the aggregate and the retrieved row cite one file"
+    );
+    assert!(
+        !fact.query_identity.is_empty() && !fact.output_hash.is_empty(),
+        "and the aggregate is checkable, not merely present: {fact:?}"
+    );
+
+    // (2) The surface. Without this, (1) is another green test for a
+    // capability nothing can call.
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let api = std::fs::read_to_string(manifest.join("src/api.rs")).expect("read src/api.rs");
+    let cli = std::fs::read_to_string(manifest.join("src/cli.rs")).expect("read src/cli.rs");
+    assert!(
+        api.contains("atlas.dataset_facts("),
+        "item 3's relational read must have a daemon route that calls it — \
+         `dataset_facts` reached no production caller at the close of S5"
+    );
+    assert!(
+        api.contains(r#".route("/map/facts", get(map_facts))"#),
+        "and that route must be mounted, not merely written"
+    );
+    assert!(
+        cli.contains("/v1/map/facts?source="),
+        "and a CLI verb must reach it, in the shape `sgt map children` set"
+    );
+    // The negative half: the producer that opens a file the caller names
+    // stays off the wire, exactly as its own doc requires. A *call*, not a
+    // mention — the route's own doc names it to say why it is absent.
+    assert!(
+        !api.contains(".dataset_probe("),
+        "`dataset_probe` opens a path the caller supplies and must never \
+         become an HTTP-reachable surface (its own doc)"
+    );
+    assert!(
+        !cli.contains("dataset_probe"),
+        "and no CLI verb may reach it either"
     );
 }
 

--- a/tests/w5_search_surface.rs
+++ b/tests/w5_search_surface.rs
@@ -614,6 +614,32 @@ fn item_3s_relational_read_is_reachable_from_outside_the_process() {
 ///
 /// The `.docx` here is a real Office file read by the real adapter in a real
 /// subprocess (see [`estate`]); the Markdown is a real file on the same root.
+///
+/// # Which coordinates carry a real byte span, and which honestly do not
+///
+/// *"Coordinates intact"* is not *"every hit cites a byte range"*, and this
+/// test asserts the true version rather than the convenient one:
+///
+/// * **Markdown** is its own bytes, so every document-family unit of
+///   `notes.md` carries a real span into the original file and no native
+///   coordinate — the span **is** the address. (The same file also produces
+///   a `Code`-family hit, its tree-sitter heading; item 6 is about the
+///   document family, so the span claims below skip it.)
+/// * **A `.docx`** can promise that for exactly one unit. The whole-document
+///   unit truthfully spans the whole input, in any container format. Every
+///   **section** unit carries `0`/`0` **by design** — `sgt-atlas-worker`'s
+///   own `normal_batch` calls that "not applicable" honestly, because the
+///   original bytes are a compressed ZIP/XML container and no offset into
+///   them corresponds to a position in the normalized text
+///   (`office::OfficeUnit`'s own doc). What a section cites instead is
+///   [`UnitCoordinate::Document`]'s `native` — the normalizer's own address,
+///   `block:<n>` — and that is what this test holds an Office section to.
+///
+/// An earlier version of this test asserted `byte_end > byte_start` for "a
+/// document coordinate" of *both* files and passed only because the one hit
+/// it happened to pick per path was the whole-document one. That prose
+/// claimed a guarantee the adapter does not make; this one states the
+/// guarantee the adapter actually makes, and checks both halves of it.
 #[test]
 fn one_local_knowledge_query_spans_a_normalized_docx_and_a_markdown_file() {
     let estate = estate();
@@ -633,35 +659,107 @@ fn one_local_knowledge_query_spans_a_normalized_docx_and_a_markdown_file() {
         "and the Markdown one, from the SAME query: {paths:?}"
     );
 
-    // "without losing original path/source coordinates": both coordinates
-    // still name the original resource — the `.docx` path, not a normalized
-    // intermediate — and both cite the one source they came from.
-    for path in ["report.docx", "notes.md"] {
-        let hit = answer
+    // "without losing original path/source coordinates": every hit from
+    // either file still names the original resource — the `.docx` path, not
+    // a normalized intermediate — and cites the one source it came from.
+    let hits_for = |path: &str| {
+        answer
             .hits
             .iter()
-            .find(|hit| hit.coordinate.relative_path() == path)
-            .expect("hit for the path just asserted present");
-        assert_eq!(hit.source_name, "library");
-        assert_eq!(hit.source_kind, SourceKind::LocalKnowledge);
-        assert!(
-            matches!(hit.coordinate, UnitCoordinate::Document { .. }),
-            "both are document-family units: {:?}",
-            hit.coordinate
-        );
+            .filter(|hit| hit.coordinate.relative_path() == path)
+            .collect::<Vec<_>>()
+    };
+    for path in ["report.docx", "notes.md"] {
+        for hit in hits_for(path) {
+            assert_eq!(hit.source_name, "library");
+            assert_eq!(hit.source_kind, SourceKind::LocalKnowledge);
+        }
+    }
+
+    // The Markdown half: the span IS the address, for every document unit.
+    let mut markdown_documents = 0;
+    for hit in hits_for("notes.md") {
         let UnitCoordinate::Document {
             byte_start,
             byte_end,
+            native,
             ..
         } = &hit.coordinate
         else {
-            unreachable!("asserted above")
+            // The same file's tree-sitter heading is a `Code` coordinate;
+            // the document-family claim is what item 6 is about.
+            continue;
         };
         assert!(
-            byte_end > byte_start,
-            "a document coordinate cites a real span of the original resource"
+            native.is_none(),
+            "a Markdown unit needs no native coordinate — its span is its \
+             address: {:?}",
+            hit.coordinate
         );
+        assert!(
+            byte_end > byte_start,
+            "and that span is a real one: {:?}",
+            hit.coordinate
+        );
+        markdown_documents += 1;
     }
+    assert!(
+        markdown_documents > 0,
+        "the Markdown half of the span must not be vacuous"
+    );
+
+    // The Office half: one byte-recoverable whole-document unit, and
+    // sections that cite `block:<n>` rather than inventing a span.
+    let office = hits_for("report.docx");
+    let (mut whole_document, mut sections) = (0, 0);
+    for hit in &office {
+        let UnitCoordinate::Document {
+            byte_start,
+            byte_end,
+            native,
+            ..
+        } = &hit.coordinate
+        else {
+            panic!(
+                "an Office hit is a document-family unit: {:?}",
+                hit.coordinate
+            )
+        };
+        match native {
+            None => {
+                assert!(
+                    byte_end > byte_start,
+                    "the whole-document unit spans the whole `.docx`: {:?}",
+                    hit.coordinate
+                );
+                whole_document += 1;
+            }
+            Some(native) => {
+                assert_eq!(
+                    (*byte_start, *byte_end),
+                    (0, 0),
+                    "an Office section is not byte-recoverable and must not \
+                     claim a span: {:?}",
+                    hit.coordinate
+                );
+                assert!(
+                    !native.is_empty(),
+                    "so its native coordinate is the only address it has: {:?}",
+                    hit.coordinate
+                );
+                sections += 1;
+            }
+        }
+    }
+    assert_eq!(
+        whole_document, 1,
+        "exactly one `.docx` unit carries a real span — the whole-document \
+         one: {office:?}"
+    );
+    assert!(
+        sections >= 1,
+        "and the honest-`0`/`0` half is not vacuous either: {office:?}"
+    );
 }
 
 // ============================================================ §13 the trace

--- a/tests/w5_search_surface.rs
+++ b/tests/w5_search_surface.rs
@@ -956,7 +956,7 @@ fn the_search_cli_exposes_a2_section_14s_selectors_and_no_weight_knob() {
 ///
 /// H13.2 rejected query-time scanning specifically to keep it one, and
 /// `tests/w1b_overlay_lifecycle_trigger.rs::
-/// the_admissibility_filter_cannot_write_because_every_method_takes_an_immutable_self`
+/// the_admissibility_filter_cannot_write_and_neither_can_anything_it_calls`
 /// pins the store side. This pins the *route* side: both handlers reach Atlas
 /// through the read-only `with_atlas`, never `with_atlas_write` or
 /// `with_existing_atlas_write`, so no index-on-demand, scan-if-stale or

--- a/tests/x1_atlas_substrate.rs
+++ b/tests/x1_atlas_substrate.rs
@@ -114,9 +114,23 @@ fn atlas_database_has_exactly_one_owner() {
     // would compile and be reachable estate-wide — and a consumer written
     // against it names the lowercase crate token nowhere, so the scan above
     // would not see it either. The field declaration is pinned directly.
+    //
+    // Since the S5 closeout the field is a `Store` — `db.rs`'s own child
+    // module wrapping the driver's `Connection` so that every statement
+    // surface takes a `Sql` (A1a §17 item 13's compile-time half). The
+    // one-owner rule is unchanged and is why that wrapper is a *child
+    // module of this file* rather than a sibling file: a sibling would be a
+    // second module naming the driver, which the loop above forbids and
+    // which no "these two files may both touch the driver" exception is
+    // going to be added for.
     assert!(
-        db.contains("\n    conn: Connection,"),
+        db.contains("\n    conn: Store,"),
         "the Atlas connection must stay a private field"
+    );
+    assert!(
+        db.contains("\n        conn: Connection,\n    }"),
+        "the raw driver connection must stay a private field of the `store` child module — \
+         that privacy is what stops the rest of db.rs handing the driver a runtime string"
     );
     assert!(
         !db.contains("pub fn conn") && !db.contains("-> &Connection"),

--- a/tests/x4_tabular_map.rs
+++ b/tests/x4_tabular_map.rs
@@ -883,18 +883,24 @@ fn a_dataset_with_no_path_to_read_in_place_is_named_rather_than_mislabelled() {
 // -------------------------------------------------------------- F11
 
 /// **F11's named deferral, pinned.** `map` ships F11's own five verbs, plus
-/// exactly one verb a later wave's own consumer earned, and nothing else.
+/// exactly the verbs a later wave's own consumer earned, and nothing else.
 ///
 /// `neighbors` and `changed` are deferred to S5/S6, where their consumers
 /// exist. A verb that shipped now would answer from nothing — the same false
 /// promise the empty-table doctrine refuses — so the absence is asserted
-/// rather than left to a reviewer to notice. `children` is the counterpart
-/// case and belongs in the same list for the same reason: S5 W7 (F-SF-03)
-/// landed `source.child_resources` rows with no read path at all, which is
-/// the same false promise from the other direction, so the verb shipped when
-/// the rows did.
+/// rather than left to a reviewer to notice. `children` and `facts` are the
+/// counterpart case and belong in the same list for the same reason: S5 W7
+/// (F-SF-03) landed `source.child_resources` rows with no read path at all,
+/// and the S5 closeout (F-AC-03) found `source.dataset_facts` in the same
+/// state while A2 §17 item 3 was claimed met on it — the same false promise
+/// from the other direction, so each verb shipped when its rows became
+/// evidence someone outside this process was owed.
+///
+/// The list stays exact in both directions. It is not a floor a new verb may
+/// be added under quietly; a verb added here without rows behind it, or rows
+/// landed without the verb, fails this test.
 #[test]
-fn f11_map_ships_five_verbs_and_defers_neighbors_and_changed() {
+fn map_ships_only_the_verbs_whose_rows_exist_and_defers_neighbors_and_changed() {
     let output = Command::new(env!("CARGO_BIN_EXE_sgt"))
         .args(["map", "--help"])
         .output()
@@ -923,10 +929,11 @@ fn f11_map_ships_five_verbs_and_defers_neighbors_and_changed() {
             "stats",
             "outline",
             "children",
+            "facts",
             "symbol",
             "references",
         ]),
-        "`sgt map` ships F11's five verbs plus `children`, and nothing else"
+        "`sgt map` ships F11's five verbs plus `children` and `facts`, and nothing else"
     );
 
     let status = Command::new(env!("CARGO_BIN_EXE_sgt"))
@@ -1158,6 +1165,35 @@ async fn f11_the_map_surface_answers_over_http_and_through_the_verb() {
         titles.iter().any(|t| t == "Guide"),
         "the verb must return the same rows the route does: {titles:?}"
     );
+
+    // A2 §17 item 3's relational read, over the wire and through the verb.
+    // Before the S5 closeout (F-AC-03) the stored aggregates had no caller in
+    // `src/` at all, so the item was met only inside the test binary.
+    let (status, body) = get(&handle, "/v1/map/facts?source=team%20notes").await;
+    assert_eq!(status, reqwest::StatusCode::OK, "body: {body}");
+    let facts = body["facts"].as_array().expect("facts");
+    assert!(
+        facts.iter().any(|f| f["path"] == "rows.csv"),
+        "the scanned dataset's canned answers reach a client: {body}"
+    );
+    let facts_out = sgt_while_serving(
+        cwd.path(),
+        data.path(),
+        &["--json", "map", "facts", "team notes"],
+    )
+    .await;
+    facts_out.assert_ok("sgt map facts");
+    let keys: Vec<String> = facts_out.json()["facts"]
+        .as_array()
+        .expect("facts")
+        .iter()
+        .filter_map(|f| f["dataset_key"].as_str().map(str::to_string))
+        .collect();
+    assert!(
+        keys.iter().all(|k| !k.is_empty()),
+        "every aggregate carries the key a row-text hit joins on: {keys:?}"
+    );
+    assert!(!keys.is_empty(), "and there is at least one to join to");
 
     let status_out = sgt_while_serving(
         cwd.path(),

--- a/tests/x5_a1a_acceptance.rs
+++ b/tests/x5_a1a_acceptance.rs
@@ -1688,9 +1688,32 @@ fn statement_arguments(lines: &[&str], index: usize) -> Vec<(String, String)> {
         while let Some(at) = body[from..].find(call) {
             let at = from + at;
             let start = at + call.len();
+            // String-literal aware, and the SQL text itself is then dropped
+            // from what gets compared. Before the S5 closeout this loop
+            // counted brackets over the raw bytes, so an argument that was a
+            // bare SQL literal got truncated at the first comma *inside* the
+            // statement — which hid the rest of the argument from the check
+            // AND, once every literal moved inside a `sql!(..)`, started
+            // reporting SQL column names as Rust parameters. Both directions
+            // of that bug are the same missing rule: a name written inside a
+            // statement's text is not a value being passed to it.
             let mut depth = 0i32;
             let mut end = body.len();
-            for (offset, c) in body[start..].char_indices() {
+            let mut argument = String::new();
+            let mut chars = body[start..].char_indices();
+            while let Some((offset, c)) = chars.next() {
+                if c == '"' {
+                    while let Some((_, inner)) = chars.next() {
+                        if inner == '\\' {
+                            chars.next();
+                            continue;
+                        }
+                        if inner == '"' {
+                            break;
+                        }
+                    }
+                    continue;
+                }
                 match c {
                     '(' | '[' | '<' => depth += 1,
                     ')' | ']' | '>' => {
@@ -1706,8 +1729,10 @@ fn statement_arguments(lines: &[&str], index: usize) -> Vec<(String, String)> {
                     }
                     _ => {}
                 }
+                argument.push(c);
             }
-            found.push((call.to_string(), body[start..end].to_string()));
+            let _ = end;
+            found.push((call.to_string(), argument));
             from = start;
         }
     }
@@ -1790,30 +1815,46 @@ fn sql_literal_holes(source: &str, lines: &[&str]) -> Vec<String> {
 ///
 /// # The load-bearing half is the compiler
 ///
-/// Read part 0 first. Since the S5 closeout, `db.rs` runs every statement
-/// through a `Store`/`StoreTx` whose methods take `impl Into<Sql>`, and `Sql`
-/// is constructible **only** from `&'static str`. A caller's string therefore
-/// cannot become a statement: it is a type error, checked by `rustc`, not a
-/// spelling absent from a scan.
+/// Read part 0 first. `db.rs` runs every statement through a `Store`/`StoreTx`
+/// whose methods take `impl Into<Sql>`, and a `Sql` can only be built by
+/// `Sql::of::<T: SqlText>()` — which takes **no string at all**. The text
+/// arrives as `T`'s associated `const`, so it is produced by const
+/// evaluation: no heap, no caller, no running program to read data out of.
 ///
-/// That replaced a check this suite genuinely shipped and that the closeout
-/// re-verify defeated in one hop. Check (b) below looked for a write call
-/// whose *literal first-argument text* named one of the enclosing function's
-/// own string parameters. Adding
+/// # Two rounds of this claim were wrong, and the second is why `&'static str`
+/// # is not the rule
 ///
-/// ```ignore
-/// pub fn evil_run(&self, user_text: &str) -> Result<(), AtlasError> {
-///     let renamed = user_text;
-///     self.conn.execute_batch(renamed)?;
-///     Ok(())
-/// }
-/// ```
+/// * **Round one** looked for a write call whose *literal first-argument
+///   text* named one of the enclosing function's own string parameters.
+///   `let renamed = user_text; self.conn.execute_batch(renamed)` left it
+///   green. One local rebinding was the whole evasion.
+/// * **Round two** made `Sql` a newtype constructible only from
+///   `&'static str` and claimed "that absence is the whole guarantee". It is
+///   not. `&'static str` means *lives for the program's lifetime*, **not**
+///   *written as a literal in this crate*, and
+///   `execute_batch(Box::leak(user_text.to_string().into_boxed_str()))`
+///   compiled clean and took `source.generations` from one row to zero.
 ///
-/// to `db.rs` left this test **green** — a public SQL-taking entry point
-/// handing caller text straight to `execute_batch`, which is exactly what
-/// item 13 forbids. One local rebinding was the whole evasion. The same
-/// method now fails to compile: `argument requires that '1 must outlive
-/// 'static`.
+/// Round three moves the barrier to const evaluation, which does not care
+/// where the code is written or what its lifetime says. Re-attempted against
+/// this build, with the exact compiler error each one now produces:
+///
+/// | attempt | result |
+/// |---|---|
+/// | `execute_batch(Box::leak(user.to_string().into_boxed_str()))` | `Sql: From<&str> is not satisfied` |
+/// | `execute_batch(sql!(leaked))` | E0435 `attempt to use a non-constant value in a constant` |
+/// | `impl SqlText for E { const TEXT = Box::leak(..) }` | E0015 `cannot call non-const associated function Box::<str>::leak` |
+/// | `String::leak` in place of `Box::leak` | E0435, as above |
+/// | `store::Sql(user_text.to_string())` — the struct literal, from `db.rs` | E0603 `tuple struct constructor Sql is private` |
+/// | `name!(leaked)` into the appender | E0435 |
+/// | `const TEXT = unsafe { transmute(..) }` | E0080 at build; a const cannot obtain a runtime address at all |
+/// | `const TEXT = ONCE_LOCK.get()...` | E0015 `cannot call non-const method OnceLock::get` |
+///
+/// Two attempts **compiled**, and both are named in `db.rs`'s own blind-spot
+/// list rather than left for a later round to find:
+/// `const TEXT = include_str!(..)` (build-time text, not runtime text), and a
+/// second raw `Connection::open` inside `db.rs` — which part 4 below is the
+/// net for.
 ///
 /// # What the remaining scans are, and are not
 ///
@@ -1851,6 +1892,16 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
     );
     let store = block_after(&db, "pub(crate) mod store {");
 
+    //    The mechanism itself: text as an associated `const`. This is the one
+    //    assertion that carries the claim — if `TEXT` stops being a const,
+    //    every attempt in the table above starts compiling again.
+    assert!(
+        store.contains("    pub trait SqlText {\n        const TEXT: &'static str;\n    }"),
+        "`SqlText::TEXT` must be an associated `const`: const evaluation is what a runtime \
+         string cannot survive, and a `fn text() -> &'static str` in its place would take \
+         `Box::leak` output happily"
+    );
+
     //    Every `pub fn` on `Sql`, exhaustively — not a list of *expected*
     //    names, which is how the guard this replaces was evaded: a
     //    constructor spelled `from_owned(text: String)` matches no
@@ -1866,12 +1917,13 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
     assert_eq!(
         sql_methods,
         vec![
-            "pub fn from_parts(parts: &[&'static str]) -> Self {",
+            "pub fn of<T: SqlText>() -> Self {",
             "pub fn extend(&mut self, more: &Sql) {",
             "pub fn text(&self) -> &str {",
         ],
-        "`Sql` may gain no method that turns a runtime string into a statement; every \
-         constructor here takes `&'static str` or another already-vetted `Sql`"
+        "`Sql` may gain no method that takes a string of any kind — `&str`, `String`, and \
+         `&'static str` alike. The last of those is the round-two hole, not a stricter \
+         spelling of the rule"
     );
 
     //    And the conversions, which are constructors by another name.
@@ -1882,12 +1934,10 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
         .collect();
     assert_eq!(
         sql_conversions,
-        vec![
-            "impl From<&'static str> for Sql {",
-            "impl From<&Sql> for Sql {"
-        ],
-        "an `impl From<String> for Sql` (or `From<&str>`) is client SQL reaching the store, \
-         however it is spelled"
+        vec!["impl From<&Sql> for Sql {"],
+        "`Sql` converts from an already-vetted `Sql` and from nothing else. An \
+         `impl From<&'static str> for Sql` is exactly what round two shipped, and \
+         `Box::leak` walks through it"
     );
 
     //    `ReadSql` — the read-only handle's own statement type — the same way.
@@ -1899,9 +1949,40 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
         .collect();
     assert_eq!(
         read_sql_methods,
-        vec!["pub const fn new(sql: &'static str) -> Self {"],
-        "`ReadSql` has one constructor and it takes `&'static str`"
+        vec!["pub fn of<T: SqlText>() -> Self {"],
+        "`ReadSql` has one constructor and it takes no string, the same as `Sql::of`"
     );
+
+    //    `Name` too — a table name is not a statement, but a leaked one still
+    //    chooses which table DuckDB's appender writes to.
+    let name_impl = block_after(&db, "    impl Name {");
+    let name_methods: Vec<&str> = name_impl
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("pub fn ") || line.starts_with("pub const fn "))
+        .collect();
+    assert_eq!(
+        name_methods,
+        vec![
+            "pub fn of<T: SqlText>() -> Self {",
+            "pub fn text(&self) -> &'static str {",
+        ],
+        "`Name` is constructed the same way as `Sql`; a `&'static str` constructor here \
+         re-opens the appender to a leaked table name"
+    );
+
+    //    And the three macros are the only way any of that is reached, each
+    //    putting its argument into a `const`. A macro that passed `$text`
+    //    along as a value instead would be the round-two hole again, with the
+    //    call sites unchanged.
+    for macro_name in ["sql", "name", "read_sql"] {
+        let body = block_after(&db, &format!("macro_rules! {macro_name} {{"));
+        assert!(
+            body.contains("const TEXT: &'static str = $text;"),
+            "`{macro_name}!` must bind `$text` to an associated `const`; that binding is \
+             the check, not the type it produces"
+        );
+    }
 
     for surface in [
         "fn prepare<S: Into<Sql>>",
@@ -1921,6 +2002,28 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
         2,
         "`AtlasDb` and `Analytics` must both hold the wrapper, never a raw `Connection`"
     );
+
+    // 0b. The one hop that compiled. A second `Connection::open` inside this
+    //     file bypasses `Store` entirely, and DuckDB does NOT stop it — a
+    //     second open on the same file from the same process succeeded in the
+    //     closeout, and its `DELETE` returned `Ok`. So every `Connection::`
+    //     construction in this file must be wrapped in `Store::new(..)` on
+    //     the spot. This is a text scan and therefore a second net, but it is
+    //     the only net there is for this hop.
+    for (index, line) in lines.iter().enumerate() {
+        if line.trim_start().starts_with("//") || line.trim_start().starts_with("///") {
+            continue;
+        }
+        for at in line.match_indices("Connection::open").map(|(at, _)| at) {
+            assert!(
+                line[..at].ends_with("Store::new("),
+                "db.rs:{} opens a raw duckdb Connection that is not immediately wrapped in \
+                 `Store::new(..)` — an unwrapped one takes a `&str` statement and answers \
+                 to nothing in the store module: {line}",
+                index + 1
+            );
+        }
+    }
 
     // 1. No public API takes SQL. The scan walks whole `pub fn` *signatures* —
     //    accumulating lines until the parameter list's parentheses close —
@@ -2010,31 +2113,22 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
     //    wherever it sits, and the resulting list is pinned exhaustively — the
     //    same discipline item 12 applies to the CLI's `AtlasDb::` call list.
     //
-    //    **S5 W1c added four holes to this list, and none of them widens the
-    //    surface.** The operations projection moved into this file when A1
-    //    §5's one database absorbed `ops`, and it addresses its own tables by
-    //    name through `ops(table)`. The four fillers are `MUTABLE_TABLES` and
-    //    `TABLES` — `&'static [&'static str]` constants in this same file —
-    //    never a caller's string: `Analytics::table_rows` is the only one of
-    //    them that takes a name from outside, and it looks that name up in
-    //    `TABLES` and returns `UnknownTable` before any formatting happens.
-    //    Item 13 forbids handing the store a query; a fixed set of table
-    //    names chosen by the module that declared them is not one.
-    // **The list is now empty, and that is the S5 closeout's doing.** Every
-    // fragment that used to be interpolated into a SQL literal at runtime —
-    // `reader_call(format)` in the three dataset statements, `ops(table)` in
-    // the projection's own DELETE/COUNT/SELECT — is now assembled by
-    // `Sql::from_parts`, which takes `&[&'static str]` and nothing else. So
-    // there is no interpolation in any SQL literal in this file to pin: the
-    // shape this check existed to bound cannot occur, rather than occurring
-    // in a list someone keeps up to date. A new hole appearing here is a
-    // regression to be argued for, not a line to append.
+    //    **The list is empty, and that is the closeout's doing.** Every
+    //    fragment that used to be interpolated into a SQL literal at runtime
+    //    — `reader_call(format)` in the three dataset statements, `ops(table)`
+    //    in the projection's own DELETE/COUNT/SELECT — is now a vetted `Sql`
+    //    concatenated onto another with `Sql::extend`, and each piece is its
+    //    own `sql!(..)` over compile-time text. So there is no interpolation
+    //    in any SQL literal in this file to pin: the shape this check existed
+    //    to bound cannot occur, rather than occurring in a list someone keeps
+    //    up to date. A new hole appearing here is a regression to be argued
+    //    for, not a line to append.
     let holes = sql_literal_holes(&db, &lines);
     assert_eq!(
         holes,
         Vec::<String>::new(),
         "no SQL literal in db.rs may interpolate anything; assemble the statement from \
-         `&'static str` pieces with `Sql::from_parts` instead"
+         vetted `sql!(..)` pieces with `Sql::extend` instead"
     );
 
     // 3. The verb set is closed, and the two deferred verbs stay deferred. The

--- a/tests/x5_a1a_acceptance.rs
+++ b/tests/x5_a1a_acceptance.rs
@@ -1568,6 +1568,151 @@ fn string_literals(source: &str) -> Vec<Literal> {
     }
     out
 }
+/// The parameter names an SQL-taking entry point plausibly uses.
+///
+/// A list of spellings is a weak check on its own — that is exactly why the
+/// old one-spelling version of item 13's API check was evadable — so it is
+/// the *cheap* half here, standing beside [`statement_arguments`], which
+/// does not care what anything is called.
+const SQL_PARAMETER_SPELLINGS: [&str; 10] = [
+    "sql",
+    "stmt",
+    "statement",
+    "query",
+    "raw",
+    "expr",
+    "expression",
+    "command",
+    "ddl",
+    "dml",
+];
+
+/// Every string-typed parameter of one whole `pub fn` signature, by name.
+///
+/// String-typed is the filter that matters: `lexical_search(&self, query:
+/// &LexicalQuery)` takes a name from the list above and is not a query
+/// surface, because a typed request is not a statement.
+fn string_parameters(signature: &str) -> Vec<String> {
+    let Some(open) = signature.find('(') else {
+        return Vec::new();
+    };
+    let mut depth = 0i32;
+    let mut close = signature.len();
+    for (at, c) in signature[open..].char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    close = open + at;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut names = Vec::new();
+    let mut depth = 0i32;
+    for part in signature[open + 1..close].split(|c| {
+        match c {
+            '<' | '(' | '[' => depth += 1,
+            '>' | ')' | ']' => depth -= 1,
+            _ => {}
+        }
+        c == ',' && depth == 0
+    }) {
+        let Some((name, typing)) = part.split_once(':') else {
+            continue;
+        };
+        let name = name.trim();
+        if name.is_empty() || name == "&self" || name == "self" {
+            continue;
+        }
+        if typing.contains("str") || typing.contains("String") {
+            names.push(name.trim_start_matches("mut ").to_string());
+        }
+    }
+    names
+}
+
+/// Whether `text` names `parameter` as an identifier rather than as part of
+/// a longer one — `sql` must not match `sql_for_table`.
+fn mentions(text: &str, parameter: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut from = 0;
+    while let Some(at) = text[from..].find(parameter) {
+        let at = from + at;
+        let before = at.checked_sub(1).map(|i| bytes[i] as char);
+        let after = text[at + parameter.len()..].chars().next();
+        let boundary = |c: Option<char>| !matches!(c, Some(c) if c == '_' || c.is_alphanumeric());
+        if boundary(before) && boundary(after) {
+            return true;
+        }
+        from = at + parameter.len();
+    }
+    false
+}
+
+/// The first argument of every statement-running call in the function that
+/// starts at `index` — the SQL each one hands to duckdb.
+///
+/// The body ends at the closing brace on the function's own indentation:
+/// brace counting would trip over the `{}` in this file's many `format!`s.
+fn statement_arguments(lines: &[&str], index: usize) -> Vec<(String, String)> {
+    let indent_of = |line: &str| line.len() - line.trim_start().len();
+    let closing = format!("{}}}", " ".repeat(indent_of(lines[index])));
+    let mut body = String::new();
+    for line in lines.iter().skip(index + 1) {
+        if *line == closing {
+            break;
+        }
+        if !line.trim_start().starts_with("//") {
+            body.push_str(line.trim());
+            body.push(' ');
+        }
+    }
+    let mut found = Vec::new();
+    // Only the calls whose FIRST argument is the statement. A
+    // `Statement::execute`/`query`/`query_row` takes bound parameters there,
+    // and binding a caller's value is the shape item 13 wants, not the one
+    // it forbids — `conn`/`tx` name the `Connection`/`Transaction` receivers
+    // whose `execute` really does take SQL first.
+    for call in [
+        "prepare(",
+        "prepare_cached(",
+        "execute_batch(",
+        "conn.execute(",
+        "tx.execute(",
+    ] {
+        let mut from = 0;
+        while let Some(at) = body[from..].find(call) {
+            let at = from + at;
+            let start = at + call.len();
+            let mut depth = 0i32;
+            let mut end = body.len();
+            for (offset, c) in body[start..].char_indices() {
+                match c {
+                    '(' | '[' | '<' => depth += 1,
+                    ')' | ']' | '>' => {
+                        if depth == 0 {
+                            end = start + offset;
+                            break;
+                        }
+                        depth -= 1;
+                    }
+                    ',' if depth == 0 => {
+                        end = start + offset;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            found.push((call.to_string(), body[start..end].to_string()));
+            from = start;
+        }
+    }
+    found
+}
 
 /// Every interpolation hole in every SQL-carrying string literal in `source`,
 /// rendered as `<enclosing fn>: <hole> <- <filler>` in file order.
@@ -1683,10 +1828,38 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
         if signature.contains("pub fn query_identity(") {
             continue;
         }
-        assert!(
-            !signature.contains("sql:"),
-            "Atlas exposes an SQL-taking entry point, which item 13 forbids: {signature}"
-        );
+        // The predicate is what item 13 MEANS, not one parameter spelling.
+        // Until the S5 closeout this was `!signature.contains("sql:")`, so a
+        // `pub fn run(&self, stmt: &str)` — or `query:`, or `raw:` — was an
+        // SQL-taking entry point that compiled and passed. Two checks now
+        // stand in its place, and neither depends on a name being chosen
+        // honestly:
+        //
+        //   a. no public signature takes a string-typed parameter under any
+        //      of the names an SQL-taking one plausibly uses, and
+        //   b. no public function hands one of its OWN string parameters to
+        //      the store as a statement — the flow item 13 actually forbids,
+        //      whatever the parameter is called.
+        for spelling in SQL_PARAMETER_SPELLINGS {
+            for typing in [": &str", ": String", ": &String", ": Option<&str>"] {
+                assert!(
+                    !signature.contains(&format!("{spelling}{typing}")),
+                    "Atlas exposes an SQL-taking entry point, which item 13 forbids: \
+                     {signature}"
+                );
+            }
+        }
+        for (call, argument) in statement_arguments(&lines, index) {
+            for parameter in string_parameters(&signature) {
+                assert!(
+                    !mentions(&argument, &parameter),
+                    "a public Atlas function hands its own `{parameter}` parameter to \
+                     {call} as the statement to run — that is client SQL reaching the \
+                     store, which item 13 forbids, and no parameter name makes it not \
+                     one: {signature}"
+                );
+            }
+        }
     }
     assert!(
         signatures > 20,

--- a/tests/x5_a1a_acceptance.rs
+++ b/tests/x5_a1a_acceptance.rs
@@ -1788,14 +1788,139 @@ fn sql_literal_holes(source: &str, lines: &[&str]) -> Vec<String> {
 /// §17.13 — the map and status surfaces answer in source/generation/coverage
 /// terms, and there is no way to hand the store a query.
 ///
-/// Three things have to be true at once, and each is checked here: the store
-/// exposes no "run this SQL" entry point; the SQL that does exist is canned,
-/// with the only varying fragment chosen by an enum; and the shipped verb set
-/// is closed.
+/// # The load-bearing half is the compiler
+///
+/// Read part 0 first. Since the S5 closeout, `db.rs` runs every statement
+/// through a `Store`/`StoreTx` whose methods take `impl Into<Sql>`, and `Sql`
+/// is constructible **only** from `&'static str`. A caller's string therefore
+/// cannot become a statement: it is a type error, checked by `rustc`, not a
+/// spelling absent from a scan.
+///
+/// That replaced a check this suite genuinely shipped and that the closeout
+/// re-verify defeated in one hop. Check (b) below looked for a write call
+/// whose *literal first-argument text* named one of the enclosing function's
+/// own string parameters. Adding
+///
+/// ```ignore
+/// pub fn evil_run(&self, user_text: &str) -> Result<(), AtlasError> {
+///     let renamed = user_text;
+///     self.conn.execute_batch(renamed)?;
+///     Ok(())
+/// }
+/// ```
+///
+/// to `db.rs` left this test **green** — a public SQL-taking entry point
+/// handing caller text straight to `execute_batch`, which is exactly what
+/// item 13 forbids. One local rebinding was the whole evasion. The same
+/// method now fails to compile: `argument requires that '1 must outlive
+/// 'static`.
+///
+/// # What the remaining scans are, and are not
+///
+/// Parts 1–3 stay, as second nets over what a type does not see, and their
+/// limits are named rather than implied:
+///
+/// * (1a) is a name-based scan of public signatures. It sees a
+///   string-typed parameter under a *plausible* SQL name. It cannot see one
+///   under an implausible one — and it no longer has to, because such a
+///   parameter cannot reach a statement.
+/// * (1b) follows no dataflow. One local rebinding hides a parameter from
+///   it; so does a struct field, a closure capture, or a helper call. It is
+///   kept because it is nearly free, not because it is sound.
+/// * (2) pins every interpolation hole in every SQL literal. It reads
+///   literals character by character and is the strongest of the three, but
+///   it still only sees this one file.
+/// * (3) pins the shipped verb set, which is a contract about the API
+///   surface rather than about SQL.
 #[test]
 fn a1a_item_13_no_client_sql_reaches_the_store() {
     let db = read("src/runtime/atlas/db.rs");
     let lines: Vec<&str> = db.lines().collect();
+
+    // 0. **The guarantee.** `Sql` is the only thing the store will run, and
+    //    it cannot be built out of a caller's string.
+    //
+    //    Each assertion here is load-bearing. Removing any one of them is
+    //    removing item 13's enforcement, not tidying a test — which is the
+    //    whole reason they are spelled out rather than left to "the code
+    //    compiles".
+    assert!(
+        db.contains("    pub struct Sql(String);"),
+        "`Sql`'s field must stay private to the `store` child module — a `pub` field, or a \
+         move to a sibling module, hands the rest of db.rs a String-to-Sql conversion"
+    );
+    let store = block_after(&db, "pub(crate) mod store {");
+
+    //    Every `pub fn` on `Sql`, exhaustively — not a list of *expected*
+    //    names, which is how the guard this replaces was evaded: a
+    //    constructor spelled `from_owned(text: String)` matches no
+    //    "plausible SQL name" and would have slipped past a filtered scan.
+    //    The whole set is pinned, so a new constructor of ANY name fails
+    //    here and has to be argued for.
+    let sql_impl = block_after(&db, "    impl Sql {");
+    let sql_methods: Vec<&str> = sql_impl
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("pub fn ") || line.starts_with("pub const fn "))
+        .collect();
+    assert_eq!(
+        sql_methods,
+        vec![
+            "pub fn from_parts(parts: &[&'static str]) -> Self {",
+            "pub fn extend(&mut self, more: &Sql) {",
+            "pub fn text(&self) -> &str {",
+        ],
+        "`Sql` may gain no method that turns a runtime string into a statement; every \
+         constructor here takes `&'static str` or another already-vetted `Sql`"
+    );
+
+    //    And the conversions, which are constructors by another name.
+    let sql_conversions: Vec<&str> = store
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.ends_with("for Sql {"))
+        .collect();
+    assert_eq!(
+        sql_conversions,
+        vec![
+            "impl From<&'static str> for Sql {",
+            "impl From<&Sql> for Sql {"
+        ],
+        "an `impl From<String> for Sql` (or `From<&str>`) is client SQL reaching the store, \
+         however it is spelled"
+    );
+
+    //    `ReadSql` — the read-only handle's own statement type — the same way.
+    let read_sql_impl = block_after(&db, "    impl ReadSql {");
+    let read_sql_methods: Vec<&str> = read_sql_impl
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("pub fn ") || line.starts_with("pub const fn "))
+        .collect();
+    assert_eq!(
+        read_sql_methods,
+        vec!["pub const fn new(sql: &'static str) -> Self {"],
+        "`ReadSql` has one constructor and it takes `&'static str`"
+    );
+
+    for surface in [
+        "fn prepare<S: Into<Sql>>",
+        "fn prepare_cached<S: Into<Sql>>",
+        "fn execute<S: Into<Sql>>",
+        "fn execute_batch<S: Into<Sql>>",
+    ] {
+        assert!(
+            store.contains(surface),
+            "every statement surface must take `impl Into<Sql>`: {surface}"
+        );
+    }
+    // And nothing outside that module holds the driver's own connection, so
+    // there is no second route to a `&str` statement.
+    assert_eq!(
+        db.matches("\n    conn: Store,").count(),
+        2,
+        "`AtlasDb` and `Analytics` must both hold the wrapper, never a raw `Connection`"
+    );
 
     // 1. No public API takes SQL. The scan walks whole `pub fn` *signatures* —
     //    accumulating lines until the parameter list's parentheses close —
@@ -1840,6 +1965,12 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
         //   b. no public function hands one of its OWN string parameters to
         //      the store as a statement — the flow item 13 actually forbids,
         //      whatever the parameter is called.
+        //
+        // (b) is a SECOND NET and is documented as one at the top of this
+        // test: it compares literal argument text and follows no dataflow, so
+        // one local rebinding hides a parameter from it. It caught nothing
+        // the type system does not already refuse; it is kept because it is
+        // free, and because it fails loudly if someone widens `Sql`.
         for spelling in SQL_PARAMETER_SPELLINGS {
             for typing in [": &str", ": String", ": &String", ": Option<&str>"] {
                 assert!(
@@ -1889,24 +2020,21 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
     //    `TABLES` and returns `UnknownTable` before any formatting happens.
     //    Item 13 forbids handing the store a query; a fixed set of table
     //    names chosen by the module that declared them is not one.
+    // **The list is now empty, and that is the S5 closeout's doing.** Every
+    // fragment that used to be interpolated into a SQL literal at runtime —
+    // `reader_call(format)` in the three dataset statements, `ops(table)` in
+    // the projection's own DELETE/COUNT/SELECT — is now assembled by
+    // `Sql::from_parts`, which takes `&[&'static str]` and nothing else. So
+    // there is no interpolation in any SQL literal in this file to pin: the
+    // shape this check existed to bound cannot occur, rather than occurring
+    // in a list someone keeps up to date. A new hole appearing here is a
+    // regression to be argued for, not a line to append.
     let holes = sql_literal_holes(&db, &lines);
     assert_eq!(
-        holes.iter().map(String::as_str).collect::<Vec<_>>(),
-        vec![
-            "rows_sql: {} <- reader_call(format)",
-            "row_count_sql: {} <- reader_call(format)",
-            "column_profile_sql: {} <- reader_call(format)",
-            "reset: {} <- }",
-            "materialize: {} <- }",
-            concat!(
-                "table_counts: {} <- let count: i64 = ",
-                "statement.query_row(duckdb::params![], |row| row.get(0))?;"
-            ),
-            "table_rows: {} <- let (columns, rows) = self.select(&sql, duckdb::params![])?;",
-        ],
-        "the exhaustive list of (function, hole, filler) triples for every interpolation in \
-         every SQL literal in db.rs. A new hole — positional or named, on any line — is a \
-         query-surface decision, not a refactor"
+        holes,
+        Vec::<String>::new(),
+        "no SQL literal in db.rs may interpolate anything; assemble the statement from \
+         `&'static str` pieces with `Sql::from_parts` instead"
     );
 
     // 3. The verb set is closed, and the two deferred verbs stay deferred. The
@@ -2004,4 +2132,19 @@ fn a1a_item_14_the_inherited_contract_pins_still_exist() {
             "the {family} pin `{test}` is gone from {file}; §17.14 is about these surviving"
         );
     }
+}
+
+/// The text of the `{ .. }` block opened by the line `header`, up to the
+/// closing brace at that line's own indentation.
+fn block_after(source: &str, header: &str) -> String {
+    let at = source
+        .find(header)
+        .unwrap_or_else(|| panic!("db.rs must still contain `{header}`"));
+    let indent = header.len() - header.trim_start().len();
+    let closing = format!("\n{}}}", " ".repeat(indent));
+    let rest = &source[at + header.len()..];
+    let end = rest
+        .find(&closing)
+        .unwrap_or_else(|| panic!("`{header}` must close at its own indentation"));
+    rest[..end].to_string()
 }

--- a/tests/x5_a1a_acceptance.rs
+++ b/tests/x5_a1a_acceptance.rs
@@ -887,7 +887,7 @@ const WALK: &[Item] = &[
             ),
             at(
                 "tests/x4_tabular_map.rs",
-                "f11_map_ships_five_verbs_and_defers_neighbors_and_changed",
+                "map_ships_only_the_verbs_whose_rows_exist_and_defers_neighbors_and_changed",
             ),
             at(
                 "tests/x4_tabular_map.rs",
@@ -1936,12 +1936,15 @@ fn a1a_item_13_no_client_sql_reaches_the_store() {
             "stats",
             "outline",
             "children",
+            "facts",
             "symbol",
             "references",
         ]),
         "`sgt map` ships F11's five verbs plus `children` (S5 W7 F-SF-03, the canned read \
-         `source.child_resources` had no consumer for) and no others — `neighbors` and \
-         `changed` land with the waves whose consumers need them: {text}"
+         `source.child_resources` had no consumer for) and `facts` (S5 closeout F-AC-03, \
+         the same for `source.dataset_facts`, which A2 §17 item 3 was claimed met on) and \
+         no others — `neighbors` and `changed` land with the waves whose consumers need \
+         them: {text}"
     );
     for forbidden in ["--sql", "--query", "--where"] {
         assert!(

--- a/tests/y8_adapter_dispatch.rs
+++ b/tests/y8_adapter_dispatch.rs
@@ -188,6 +188,42 @@ fn a_real_scan_dispatches_docx_zip_and_eml_through_the_worker_and_the_recorded_g
         eml.units
     );
 
+    // ------------------------------------ what a worker-landed unit carries
+    // S5 closeout (F-AC-02). The landing path used to build every
+    // worker-routed unit with `heading_level: None, title: None` and to drop
+    // the adapter's native `coordinate` entirely, so the two families that
+    // can only be addressed by that coordinate landed unaddressable. This is
+    // the pin at the exact place it was lost: the scan, before any store or
+    // index is involved.
+    assert!(
+        docx.units
+            .iter()
+            .any(|u| u.coordinate.is_some() && u.title.is_some()),
+        "an Office section unit is not byte-recoverable, so its native coordinate and heading \
+         title are the whole of its provenance: {:?}",
+        docx.units
+    );
+    let mut bodies: Vec<&str> = eml
+        .units
+        .iter()
+        .map(|u| {
+            assert_eq!(
+                u.title.as_deref(),
+                Some("Report attached"),
+                "A1 §6.5 keeps a message's subject; a body unit's title is where it lands: {u:?}"
+            );
+            u.coordinate
+                .as_deref()
+                .unwrap_or_else(|| panic!("a mail body unit must name which body it is: {u:?}"))
+        })
+        .collect();
+    bodies.sort();
+    assert_eq!(
+        bodies,
+        vec!["text-body"],
+        "this fixture has one body, and the native coordinate names it"
+    );
+
     // A ZIP's own body carries no text unit of its own (its content is its
     // children) — the honest empty [`atlas_worker.rs`]'s own doc states,
     // not a bug.


### PR DESCRIPTION
## Why this PR exists

I declared S5 complete after #348. The closeout walk — A2 §17's ten items checked against the **merged code** in the contract's own vocabulary, not against the wave ledger — found it wasn't. Seven findings, all confirmed under adversarial refutation. Fixing two of them surfaced two more. Twelve commits.

Every wave in S5 was panelled and green. The closeout found more real defects than the panels did, and the last four were found by **inserting a real violation and watching the guard pass** — not by reading code.

## The blocker: §17 item 2 was not met for mail

`dispatch_worker_resource_at_depth` built every unit for **every** worker-routed adapter (mail, docx, zip) with `heading_level: None, title: None`, and never read `unit.coordinate`. The in-process path carried all three — so Markdown kept its provenance and Office/mail lost it. `source.units` had no coordinate column at all. The mail worker emits `text-body`/`html-body`, the only thing distinguishing two bodies of one message, and the daemon discarded it.

**And the test pinning that item was vacuous** — the sixth found this sprint. It hand-built a fixture that never touched the worker and asserted a title and byte span production cannot produce; it would have passed with the entire mail adapter deleted. Replaced with one that lands a real `.eml` through the real worker subprocess and asserts what a production hit actually carries — including the honest `0/0` where a mail body genuinely has no byte span.

## The SQL boundary: three rounds, two false claims, one real guarantee

**Round 1** — `the_admissibility_filter_cannot_write` checked `&self` vs `&mut self`. But duckdb's `Connection::execute`, `execute_batch` and `prepare` all take `&self`, so `&self` proved nothing. I cited that test as proof `sgt search` is a pure reader in three PR bodies.

**Round 2** — replaced with a source-text scan. Its `WRITE_CAPABLE` list mixed lowercase call syntax with uppercase SQL verbs and tested `body.to_uppercase()`, so `.execute(` became `.EXECUTE(` and **the call-syntax checks were dead code**. Proven live: a real `DELETE FROM source.units` inside `admissible_datasets` passed. The commit claimed it had been "VERIFIED EVADABLE-PROOF".

Item 13's pin fell the same way — `let renamed = user_text; self.conn.execute_batch(renamed)` walked past it.

**Round 3** — a type wrapper. `Box::leak` defeated it: `&'static str` means *lives forever*, not *written as a literal*. Landed end to end — 1 row to 0. And a semicolon batch defeated the SELECT-prefix check, because DuckDB executes **every** statement in a batch.

**What actually holds:** `store::SqlText { const TEXT: &'static str }`, with `Sql::of::<T>()` taking no string at all. `Box::leak` is `E0015` (not const), a local is `E0435`. `is_read_statement` checks the `SELECT ` prefix **and refuses any `;`** — in a const, which sees the *assembled* string after `concat!` resolves, so it is immune to the spelling tricks that beat a scan.

**The fix seat refused my prescribed design and was right to.** I specified a `$s:literal` macro with a module-private constructor; `macro_rules!` expands at the **call site** — `db.rs`, the *parent* of `mod store` — so that constructor is unreachable from the macro too, and "the macro is the only way" would have been convention, not enforcement.

**Sixteen probes, each recorded with its result.** Three landed and are stated as gaps in the code, not hidden: dead code can hold a bad statement (the generic check fires at monomorphization — *code that runs cannot*); `include_str!`/`env!` make build-time text a statement (nothing a **running** Sergeant is handed can); and a second raw `Connection::open` bypasses everything, now covered by a scan that is honestly labelled the only net for that hop.

**The independent attack seat then failed to land a write** — every attempt run for real and verified by row count. The one spelling that beats the byte scan, a fullwidth `；` (U+FF1B), is rejected by DuckDB's own grammar; the report credits DuckDB rather than the check.

## Two measurements that corrected existing claims

- **A second `Connection::open` on the same file from the same process succeeds**, and its `DELETE` returns `Ok`. The module doc's "DuckDB's own file locking stands against that" was false and is struck.
- The brief's own exploit-B repro errors at `prepare` on this version — *any* batch carrying a `?` bind does. The unparameterised batch is the one that deletes.

## The rest

- **§17 item 3** — `dataset_probe`/`dataset_facts`/`admissible_datasets` were `pub`, documented and called only from tests. Fifth instance of the signature defect. The safe read now has a bounded surface in the shape W7 set.
- **§2 stage 2** — the authority filter is test-only because `authority_class` is a total function of `source_kind` today, so `--type` already names every world it could. That is a property of today's *producers*, not the design, so it is pinned: the test fails the moment a producer breaks the pairing, which is when the field needs a caller. **Recovered mid-proof** — the interrupted agent had left the pairing deliberately broken to watch the pin fire; I reproduced the red, restored `scan.rs` byte-identical, and committed with the proof.
- **§17 item 6** — the span claim now names which units carry a real span and which honestly carry `0/0`; the test walks every hit per path instead of `.find()`, and is pinned non-vacuous both ways.
- **Office is `.docx`-only**, now stated where a reader of item 6 looks. Swept CHANGELOG, docs, README, AGENTS.md, skills and the register: **no broader Office claim exists.**

## Verification

fmt clean, clippy `-D warnings` clean. All eight boundary tripwires plus the touched suites: **84/84**. Full suite deliberately not run locally — CI is the exhaustive pass by SHA, and a local full run alongside another lane's build took this host down mid-wave.

`w3b_semantic_retrieval::a_host_without_assets_still_answers_lexically_and_reports_not_installed` fails in a whole-file run on this host and was **confirmed pre-existing** by stashing all changes and reproducing it on `215b4773`; it passes in isolation on both. Shared global asset state across parallel tests.

R4 (the language's own module privacy and const evaluation are the mechanism — no new machinery). R2 (the text scans kept as cheap second nets, demoted from load-bearing). J5 (item 13 and H13.2 govern; this changes what enforces them, never what they say).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4