### PR TITLE
feat(context): S6 C1a — the compilation step, and §5's order as a runtime gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1582,6 +1582,58 @@ them were dead code in every real installation.
   today; if either earns a surface it is S6's intelligence read, and no §17
   item is claimed met by their existence.
 
+### Compiled actor context (S6)
+
+- **A stage that launches a fresh actor now compiles its world first.** C1
+  §3's compilation step is one call inserted into the existing stage launch
+  path (`Engine::reserve_stage`), between the execution id being allocated
+  and the adapter being asked to PREPARE — not a second execution pipeline.
+  The compiled world is *appended* to the stage's authored `CONTEXT.md` by
+  the same rule the branch-status fact already used: the authored bytes are
+  untouched, and the appended section carries evidence **coordinates**,
+  never resource bodies (C1 §20's first non-goal).
+- **§5's nine research steps are enforceable runtime order, not advice.**
+  `ResearchLedger::enter` refuses any step that is not §5's next one, and
+  reports a fuzzy step (A2 lexical/semantic retrieval) that jumps a
+  deterministic one as `CognitionBeforeComputation`, naming both steps.
+  Every step is entered even when it has nothing to contribute, recording
+  why, so skipping is unrepresentable and C1 §18's degradation stays
+  visible. Contribution is first-contributor-wins at resource granularity,
+  so a resource that is both an exact Work-changed resource (step 2) and a
+  top lexical hit (step 6) is attributed to step 2 and step 6's record shows
+  it offered and lost — which is what makes the order observable in the
+  snapshot rather than only in the call order.
+- **Retrieval is consumed, not reimplemented.** Steps 6 and 7 are S5's
+  `AtlasDb::traced_search`/`fused_search` and its A2 §13 nine-field trace,
+  retained on the snapshot. No new SQL statement was added: every read this
+  step needs already existed on `AtlasDb`, so S5's rebuilt statement
+  boundary is untouched.
+- **The snapshot pins generations, and a pin re-resolves.** One field per
+  line of C1 §15's list, in §15's order, journaled as a new
+  `context.compiled` event (also on the SSE event-kind list) once per fresh
+  execution: snapshot id, estate/work/stage/execution coordinate, journal
+  watermark, Work base + overlay generation, source generations (by id
+  *and* content key), coverage states, retrieval generation/model, profile,
+  selection-plan hash, Bound and Referenced evidence, the Reachable scope
+  descriptor, and the rendered size. The lines a later wave fills
+  (`query_result_ids`, `payload_pointer`, `budget`) are present and empty
+  rather than absent.
+- **Scoped to actor launches.** Only a `StageKind::Actor` launch compiles;
+  an `Execute` (container) stage never reaches an actor, never reads
+  `StartRequest.context`, and is left exactly as it was.
+- **An estate with no intelligence still launches on the existing path**
+  (C1 §21 item 13). With no Atlas database on this host no compiler is
+  installed, so nothing is compiled, nothing is journaled, and the
+  `StartRequest` is byte-identical to the one built before C1 existed —
+  a property of the installed-or-not `Option`, not of a branch. An estate
+  that *has* Atlas but no confirmed generation still receives its authored
+  `CONTEXT.md` byte for byte, with the degradation stated in the journal
+  instead of left as an empty snapshot to interpret.
+- Budget and tier resolution, structured query results, authority and
+  provenance, and attribution/nesting/audit are **not** in this change;
+  they are C1b/C1c/C1d, and the places that under-deliver until then say so
+  where they under-deliver.
+
 
 ## [0.2.4] - 2026-08-25
 

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -381,9 +381,10 @@ cov_run cargo llvm-cov --no-report --test w5_search_surface --locked || cov_fail
 cov_stage_end 1 "the w5_search_surface test binary must write its own profile"
 
 # S6 C1a — C1 §3's compilation step and §5's enforceable runtime order.
-# Fifteen in-process tests over a real Atlas built by the ordinary
-# `record_scan` path (the compiler, the §5 gate, §15's snapshot), plus two
-# live-daemon tests over a real estate for §21 items 1 and 13. Floor 1.
+# Fourteen in-process tests over a real Atlas built by the ordinary
+# `record_scan` path (the compiler, the §5 gate, §15's snapshot), plus three
+# live-daemon tests over a real estate for §21 items 1 and 13 and for the
+# actor-only scoping of the step. Floor 1.
 cov_stage_begin c2-c1a_compiled_context
 cov_run cargo llvm-cov --no-report --test c1a_compiled_context --locked || cov_fail "c1a_compiled_context failed under instrumentation"
 cov_stage_end 1 "the c1a_compiled_context test binary must write its own profile"

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -379,3 +379,11 @@ cov_stage_end 1 "the w4_rrf_fusion test binary must write its own profile"
 cov_stage_begin c2-w5_search_surface
 cov_run cargo llvm-cov --no-report --test w5_search_surface --locked || cov_fail "w5_search_surface failed under instrumentation"
 cov_stage_end 1 "the w5_search_surface test binary must write its own profile"
+
+# S6 C1a — C1 §3's compilation step and §5's enforceable runtime order.
+# Fifteen in-process tests over a real Atlas built by the ordinary
+# `record_scan` path (the compiler, the §5 gate, §15's snapshot), plus two
+# live-daemon tests over a real estate for §21 items 1 and 13. Floor 1.
+cov_stage_begin c2-c1a_compiled_context
+cov_run cargo llvm-cov --no-report --test c1a_compiled_context --locked || cov_fail "c1a_compiled_context failed under instrumentation"
+cov_stage_end 1 "the c1a_compiled_context test binary must write its own profile"

--- a/src/api.rs
+++ b/src/api.rs
@@ -51,8 +51,8 @@ use crate::domain::work::{
     KIND_WORK_WAITING, ScopeRequest, Work, WorkState,
 };
 use crate::domain::workflow::{
-    self, KIND_STAGE_BLOCKED, KIND_STAGE_CANCELED, KIND_STAGE_COMPLETED, KIND_STAGE_ENTERED,
-    KIND_STAGE_FAILED, KIND_STAGE_INPUT_RECEIVED, KIND_STAGE_NEEDS_INPUT,
+    self, KIND_CONTEXT_COMPILED, KIND_STAGE_BLOCKED, KIND_STAGE_CANCELED, KIND_STAGE_COMPLETED,
+    KIND_STAGE_ENTERED, KIND_STAGE_FAILED, KIND_STAGE_INPUT_RECEIVED, KIND_STAGE_NEEDS_INPUT,
     KIND_STAGE_OUTPUT_MISSING, KIND_STAGE_RESUMED, KIND_STAGE_WAITING, KIND_WORKFLOW_BOUND,
     WorkflowDefinition,
 };
@@ -6793,6 +6793,10 @@ pub const SSE_EVENT_KINDS: &[&str] = &[
     KIND_STAGE_FAILED,
     KIND_STAGE_CANCELED,
     KIND_STAGE_OUTPUT_MISSING,
+    // C1 §15: the compiled-context snapshot, journaled at stage entry. One
+    // kind per fresh execution, never one per evidence unit — the same
+    // affordability argument `source.scanned` makes below.
+    KIND_CONTEXT_COMPILED,
     KIND_EXECUTION_RESERVED,
     KIND_EXECUTION_STARTED,
     KIND_EXECUTION_STOPPED,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1203,6 +1203,36 @@ pub async fn start_with(
     if let Some(cap) = config.intelligence_lane_cap {
         engine = engine.with_intelligence_lane_cap(cap);
     }
+    // C1 §3: install the compilation step, so a stage launch actually
+    // compiles a world instead of the capability shipping green and
+    // unreachable.
+    //
+    // Derived from `analytics`, never `AtlasDb::open` — one file is one
+    // DuckDB instance, and a second `open` is a second instance whose writes
+    // and the projection's silently overwrite each other (`Analytics::atlas`,
+    // and this module's own Atlas startup-reconciliation doc). This is the
+    // same `Connection::try_clone` handle `ApiState::atlas` is derived from,
+    // taken once and held for the process because a compilation happens on
+    // every stage entry.
+    //
+    // A host that cannot produce a handle installs no compiler and therefore
+    // keeps §18's first rung: the existing stage launch path, unchanged
+    // (§21 item 13). That is reported, not silent.
+    if crate::runtime::atlas::db::atlas_db_path(data_dir).exists() {
+        match analytics.atlas() {
+            Ok(atlas) => {
+                engine = engine.with_context_compiler(Arc::new(
+                    crate::runtime::context::AtlasContextCompiler::new(atlas),
+                ));
+            }
+            Err(e) => tracing::warn!(
+                target: "sergeant::atlas",
+                error = %e,
+                "atlas could not be opened for C1 context compilation; stages launch on the \
+                 existing context path with no compiled snapshot"
+            ),
+        }
+    }
     let engine = Arc::new(engine);
     let reconciled = recovery::reconcile(&engine, &estates, &mut core)?;
     // Backstop, not load-bearing: `reconcile` already leaves nothing open on

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -119,6 +119,24 @@ pub const KIND_STAGE_CANCELED: &str = "stage.canceled";
 /// re-prompted once this attempt" from "first time seeing this" without
 /// re-deriving it from raw journal replay at every `StageCompleted`.
 pub const KIND_STAGE_OUTPUT_MISSING: &str = "stage.output_missing";
+/// **C1 §15's snapshot provenance**, journaled at the instant the world was
+/// compiled — between the execution id being allocated and the adapter being
+/// asked to PREPARE, so it names the exact fresh execution it was compiled
+/// for (§21 item 1).
+///
+/// Journaled rather than written to a new store, because C1-09 says so:
+/// *"Reuse existing artifact/blob/output mechanics for large snapshot
+/// payloads... Split-hardening landed artifact/output lifecycle; no new
+/// payload store needed."* The journal is the estate's durable record of what
+/// happened, and *"what world did Sergeant present?"* (§15) is a fact about
+/// what happened.
+///
+/// Present even for a **degraded** compilation — §18's degradation is
+/// *"visible, not fatal or fabricated"*, and a snapshot that says
+/// `intelligence_disabled` is the visible form of it. An engine with no
+/// compiler installed journals nothing at all, which is the other, stronger
+/// half of §21 item 13: the existing stage launch path with nothing added.
+pub const KIND_CONTEXT_COMPILED: &str = "context.compiled";
 /// The named `needs_input` reason #260 Q3 requires when a stage's declared
 /// `output/` artifact is still missing after its one bounded re-prompt:
 /// carried in the `stage.needs_input`/`work.needs_input` payload's

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1443,29 +1443,34 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
         // Expansion out of what retrieval found, along stored structure —
         // deterministic, and bounded by the same constant everything else is.
         // The `false` from `contribute` is the point: an edge step 5 already
-        // held is not re-contributed here.
-        let mut offered = 0usize;
-        if let Some((answer, _)) = &retrieval {
-            let paths: BTreeSet<&str> = answer
-                .hits
-                .iter()
-                .map(|hit| hit.coordinate.relative_path())
-                .collect();
-            for pin in &source_generations {
-                for edge in atlas
-                    .edges(&pin.source_name, STEP_ROW_CAP)
-                    .unwrap_or_default()
-                {
-                    if !paths.contains(edge.relative_path.as_str()) {
-                        continue;
-                    }
-                    offered += 1;
-                    step.contribute(Tier::Referenced, edge_relationship(pin, &edge));
-                }
+        // held is not re-contributed here. Shares step 3/5's per-generation
+        // loop (`contribute_generation_rows`, **R2**); the retrieval-hit
+        // filter folds into the fetch closure instead of a second hand-rolled
+        // loop.
+        match &retrieval {
+            Some((answer, _)) => {
+                let paths: BTreeSet<&str> = answer
+                    .hits
+                    .iter()
+                    .map(|hit| hit.coordinate.relative_path())
+                    .collect();
+                contribute_generation_rows(
+                    &mut step,
+                    &source_generations,
+                    Tier::Referenced,
+                    "no stored structure to expand from what retrieval found",
+                    |source_name| {
+                        atlas.edges(source_name, STEP_ROW_CAP).map(|edges| {
+                            edges
+                                .into_iter()
+                                .filter(|edge| paths.contains(edge.relative_path.as_str()))
+                                .collect()
+                        })
+                    },
+                    edge_relationship,
+                );
             }
-        }
-        if offered == 0 {
-            step.note("no stored structure to expand from what retrieval found");
+            None => step.note("no stored structure to expand from what retrieval found"),
         }
     }
     // ---- 9. pack Bound; emit useful remainder as Referenced

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1,0 +1,1670 @@
+//! C1 — compiled actor context: the compilation step (§3) and §5's
+//! **enforceable runtime order**.
+//!
+//! # What this is, in the contract's own words
+//!
+//! > *"C1 is **not a second execution pipeline**. The existing engine already
+//! > binds a workflow/stage and launches a fresh actor. C1 inserts a
+//! > deterministic compilation step before the actor start."* (§3)
+//!
+//! ```text
+//! stage about to enter
+//!    ↓
+//! resolve Work/estate/source generations
+//!    ↓
+//! run deterministic research plan
+//!    ↓
+//! compile Bound + Referenced + Reachable snapshot
+//!    ↓
+//! launch ordinary fresh execution
+//! ```
+//!
+//! So there is no pipeline here. There is one function
+//! ([`compile`]) called from one place —
+//! [`crate::runtime::engine::Engine::reserve_stage`], between the point where
+//! the stage's `CONTEXT.md` is resolved and the point where the adapter is
+//! asked to PREPARE. That call site is the existing stage launch path
+//! (**R2**, decision C1-01: *"Existing stage launch already owns fresh actor
+//! context/execution"*), and the mechanism that appends to a stage's context
+//! is the one Amendment 9 Q5 / #260 already built for the branch-status fact
+//! ([`crate::runtime::engine`]'s `branch_status_context`) — reused, not
+//! re-invented.
+//!
+//! # §5's nine steps are an ordered runtime sequence, not a listing
+//!
+//! > *"Before fuzzy retrieval or model dispatch, use the strongest local
+//! > evidence operations available:"*
+//! >
+//! > ```text
+//! > 1. explicit stage inputs / prior declared artifacts
+//! > 2. exact Work bindings/changed resources
+//! > 3. exact structural/document/tabular/mail relationships
+//! > 4. deterministic dataset aggregates/joins/diffs declared by the
+//! >    profile/workflow
+//! > 5. exact Referenced neighbors
+//! > 6. A2 lexical retrieval
+//! > 7. A2 semantic retrieval if installed/needed
+//! > 8. bounded structural/provenance expansion
+//! > 9. pack Bound; emit useful remainder as Referenced
+//! > ```
+//! >
+//! > *"This is where **spend computation before cognition** becomes
+//! > enforceable runtime order."* (§5)
+//!
+//! **Enforceable** is implemented by [`ResearchLedger`], and it is a gate, not
+//! a convention. Every step must be *entered* through
+//! [`ResearchLedger::enter`], which refuses any step that is not §5's next
+//! one. A step with nothing to do is entered and records zero units with a
+//! stated reason — degradation stays *visible* (§18), and skipping stays
+//! unrepresentable, which is what keeps the order total.
+//!
+//! The refusal has two names because the two failures are different mistakes:
+//! [`OrderViolation::OutOfOrder`] is a sequencing bug, and
+//! [`OrderViolation::CognitionBeforeComputation`] is the one §5's sentence is
+//! about — a *fuzzy* step (6, 7) entered while a *deterministic* step it is
+//! supposed to follow has not run. Same gate, two diagnoses; the fuzzy one is
+//! reported whenever it applies, because that is the sentence a reader of the
+//! failure needs.
+//!
+//! # Why a gate alone would not be enough, and what else proves the order
+//!
+//! A gate proves the steps *ran* in order. It cannot prove the order *mattered
+//! to the answer* — a compiler that ran them in order and then let a late step
+//! overwrite an early one would pass it. So the ledger also enforces
+//! **first-contributor-wins**: an evidence coordinate contributed by an
+//! earlier step is not re-contributed by a later one
+//! ([`StepWriter::contribute`] answers `false`). A resource that is both an
+//! exact Work-changed resource (step 2) and the top lexical hit (step 6) is
+//! attributed to **step 2**, and the snapshot says so. Run retrieval first and
+//! the same resource would carry `step: 6` — an *observable state difference*,
+//! not a matter of reasoning, which is what
+//! `tests/c1a_compiled_context.rs` asserts.
+//!
+//! # Steps 6 and 7 are consumed, never reimplemented
+//!
+//! S5 shipped the retrieval pipeline: the deterministic filter, BM25,
+//! exact-cosine semantic retrieval, RRF + rerank, and A2 §13's trace.
+//! [`AtlasDb::traced_search`] is steps 6 and 7 (**R2**) — it runs
+//! `lexical_search` and then `semantic_search` inside one snapshot-isolated
+//! transaction, so §5's own 6-then-7 ordering is that function's, already
+//! pinned by S5's suites. This module calls it once and reads which halves
+//! actually contributed off the answer's own [`SemanticStatus`], which is how
+//! *"semantic retrieval **if installed/needed**"* stays honest rather than
+//! assumed.
+//!
+//! Its [`SearchTrace`] is retained on the snapshot. That closes the
+//! destination [`crate::runtime::atlas::trace`] named in S5: *"persisting the
+//! trace of a **managed** search — one a Work's own execution issued — is
+//! C1/S6's, where a managed retrieval call has a Work execution to attach the
+//! row to. Named destination: the C1 compiled-context wave."*
+//!
+//! # No new SQL, and that is deliberate
+//!
+//! Every read this module needs already exists on [`AtlasDb`]:
+//! `admissible_generations`, `confirmed_generation`, `units`,
+//! `child_resources`, `edges`, `coverage`, `traced_search`. S5's closeout
+//! rebuilt the SQL boundary over three rounds — statement text is an
+//! associated `const` (`store::SqlText`), `Sql::of::<T>()` takes no string,
+//! and reads go through `ReadOnly` + `read_sql!`. This module adds no
+//! statement to that surface at all, so there is nothing here for a runtime
+//! string to get into (**R2/R3**).
+//!
+//! # What this wave does NOT do
+//!
+//! §14's budget and the three tiers' resolution are C1b (items 3, 4, 5);
+//! authority, provenance and structured query results are C1c (items 6–9);
+//! attribution, nesting and audit are C1d (items 11, 12, 14). Fields §15 asks
+//! for that those waves fill are present and empty, each naming its wave —
+//! never absent, because an absent field is indistinguishable from a
+//! forgotten one.
+//!
+//! §20's non-goals this step is closest to are named and refused: **no raw
+//! corpus stuffing** ([`ContextSnapshot::render_onto`] renders *coordinates*,
+//! never resource bodies — §2's Referenced shape, applied to Bound too until
+//! C1b's budget exists to render content safely), **no automatic Work scope
+//! expansion** (§4: *"The compiler does not silently add repos to Work
+//! mutation scope because a search result is relevant"* — nothing here
+//! touches [`crate::runtime::surface::WorkSurface`] or a binding), **no
+//! learned context policy or live self-tuning** (every bound in this file is a
+//! constant a human wrote), and **no automatic workflow→script conversion**
+//! (the stage's authored `CONTEXT.md` is appended to, never rewritten).
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use serde_json::{Value, json};
+
+use crate::backend::BindingSummary;
+use crate::domain::source::SourceGeneration;
+use crate::domain::workflow::{StageDefinition, StageRecord};
+use crate::runtime::atlas::db::{
+    Admissibility, AtlasDb, LexicalQuery, SourceSelector, StoredChildResource, StoredEdge,
+    StoredUnit,
+};
+use crate::runtime::atlas::overlay::overlay_source_name;
+use crate::runtime::atlas::semantic::{SemanticRequest, SemanticStatus};
+use crate::runtime::atlas::trace::{Attribution, SearchTrace};
+
+// ===================================================================
+// §5's nine steps
+// ===================================================================
+
+/// *"spend computation before cognition"* (§5) — which side of that sentence
+/// a step is on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cognition {
+    /// A local evidence operation: exact, cheap, and answerable without a
+    /// ranker or a model.
+    Computation,
+    /// Fuzzy retrieval or model dispatch — §5's steps 6 and 7.
+    Cognition,
+}
+
+impl Cognition {
+    /// The word a trace, a journal payload or an error message uses.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Computation => "deterministic",
+            Self::Cognition => "fuzzy",
+        }
+    }
+}
+
+/// §5's nine steps, **in the contract's own order**, one variant per line of
+/// its list.
+///
+/// The declaration order *is* the runtime order — [`ResearchLedger::enter`]
+/// reads [`Self::PLAN`], and `tests/c1a_compiled_context.rs::
+/// the_nine_steps_are_section_5s_own_list_in_section_5s_own_order` compares
+/// that array against the contract's nine lines. Reordering the enum without
+/// reordering §5 turns that test red.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ResearchStep {
+    /// 1. explicit stage inputs / prior declared artifacts
+    StageInputs,
+    /// 2. exact Work bindings/changed resources
+    WorkBindings,
+    /// 3. exact structural/document/tabular/mail relationships
+    ExactRelationships,
+    /// 4. deterministic dataset aggregates/joins/diffs declared by the
+    ///    profile/workflow
+    DeclaredDataOperations,
+    /// 5. exact Referenced neighbors
+    ReferencedNeighbors,
+    /// 6. A2 lexical retrieval
+    LexicalRetrieval,
+    /// 7. A2 semantic retrieval if installed/needed
+    SemanticRetrieval,
+    /// 8. bounded structural/provenance expansion
+    BoundedExpansion,
+    /// 9. pack Bound; emit useful remainder as Referenced
+    Pack,
+}
+
+impl ResearchStep {
+    /// §5's list, in §5's order. The single source of the runtime sequence.
+    pub const PLAN: [ResearchStep; 9] = [
+        Self::StageInputs,
+        Self::WorkBindings,
+        Self::ExactRelationships,
+        Self::DeclaredDataOperations,
+        Self::ReferencedNeighbors,
+        Self::LexicalRetrieval,
+        Self::SemanticRetrieval,
+        Self::BoundedExpansion,
+        Self::Pack,
+    ];
+
+    /// §5's own 1-based numbering.
+    pub fn number(self) -> usize {
+        Self::PLAN
+            .iter()
+            .position(|s| *s == self)
+            .expect("every step is in PLAN")
+            + 1
+    }
+
+    /// §5's own wording for this step.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::StageInputs => "explicit stage inputs / prior declared artifacts",
+            Self::WorkBindings => "exact Work bindings/changed resources",
+            Self::ExactRelationships => "exact structural/document/tabular/mail relationships",
+            Self::DeclaredDataOperations => {
+                "deterministic dataset aggregates/joins/diffs declared by the profile/workflow"
+            }
+            Self::ReferencedNeighbors => "exact Referenced neighbors",
+            Self::LexicalRetrieval => "A2 lexical retrieval",
+            Self::SemanticRetrieval => "A2 semantic retrieval if installed/needed",
+            Self::BoundedExpansion => "bounded structural/provenance expansion",
+            Self::Pack => "pack Bound; emit useful remainder as Referenced",
+        }
+    }
+
+    /// Which side of *"spend computation before cognition"* this step is on.
+    ///
+    /// Exactly steps 6 and 7 are [`Cognition::Cognition`], because exactly
+    /// those two are §5's *"fuzzy retrieval"*. Step 8 is deterministic even
+    /// though it runs after them — it walks `source.edges`, which is stored
+    /// structure, not a ranker — and §5 puts it there on purpose: it expands
+    /// from what retrieval found.
+    pub fn cognition(self) -> Cognition {
+        match self {
+            Self::LexicalRetrieval | Self::SemanticRetrieval => Cognition::Cognition,
+            _ => Cognition::Computation,
+        }
+    }
+}
+
+/// The gate's refusal — §5's order violated.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum OrderViolation {
+    /// A step was entered that is not §5's next one.
+    #[error(
+        "§5 step {attempted} ({attempted_label:?}) was entered while step {expected} \
+         ({expected_label:?}) had not run: the deterministic research plan is an ordered \
+         runtime sequence, not a listing"
+    )]
+    OutOfOrder {
+        /// §5's number for the step that was attempted.
+        attempted: usize,
+        /// §5's wording for it.
+        attempted_label: &'static str,
+        /// §5's number for the step that should have run.
+        expected: usize,
+        /// §5's wording for it.
+        expected_label: &'static str,
+    },
+    /// The refusal §5's own sentence is about: fuzzy before deterministic.
+    #[error(
+        "§5's fuzzy step {fuzzy} ({fuzzy_label:?}) was entered before deterministic step \
+         {deterministic} ({deterministic_label:?}) ran: \"spend computation before cognition\" \
+         is enforceable runtime order, not advice about sequencing"
+    )]
+    CognitionBeforeComputation {
+        /// §5's number for the fuzzy step that jumped ahead.
+        fuzzy: usize,
+        /// §5's wording for it.
+        fuzzy_label: &'static str,
+        /// §5's number for the deterministic step it jumped over.
+        deterministic: usize,
+        /// §5's wording for it.
+        deterministic_label: &'static str,
+    },
+}
+
+// ===================================================================
+// Evidence: coordinates and tiers (§2)
+// ===================================================================
+
+/// §2's tiers, as they apply to one unit of evidence.
+///
+/// A `Reachable` variant is deliberately **not** here: §2 defines it as *"the
+/// broader admissible Atlas map/search/query **surface**"*, which is a
+/// descriptor of what remains available ([`ReachableScope`]), not a list of
+/// units. A `Reachable` variant would invite a wave to enumerate it, which is
+/// the raw-corpus-stuffing non-goal wearing a tier's name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tier {
+    /// *"Evidence deliberately rendered into the actor's initial context
+    /// because the stage needs it now."*
+    Bound,
+    /// *"Known-relevant exact coordinates not rendered in full."*
+    Referenced,
+}
+
+impl Tier {
+    /// The word the snapshot and the rendered section use.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Bound => "BOUND",
+            Self::Referenced => "REFERENCED",
+        }
+    }
+}
+
+/// Where one piece of evidence actually is — four shapes, because the four
+/// things §5's steps produce are genuinely different coordinates and a single
+/// flattened shape would have to invent fields for three of them (the same
+/// argument [`crate::runtime::atlas::trace::coordinate_json`] makes about A2
+/// §3's families).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvidenceCoordinate {
+    /// §5 step 1: this run's own stage record — an explicit stage input or a
+    /// prior declared artifact.
+    Stage {
+        /// The stage's id.
+        stage_id: String,
+        /// Its position in the workflow's stage order.
+        index: usize,
+        /// Which attempt.
+        attempt: u32,
+        /// Its status, as the projection folded it.
+        status: String,
+        /// The summary/reason that status change carried, when there was one.
+        summary: Option<String>,
+    },
+    /// §5 step 2: one of the Work's exact repository bindings.
+    Binding {
+        /// The repository this Work is bound to.
+        repository: String,
+        /// The durable output branch.
+        work_branch: String,
+        /// §15's *"Work base"* for this binding.
+        base_sha: String,
+    },
+    /// An exact Atlas resource or unit, with its generation pinned.
+    Atlas {
+        /// The declared source.
+        source_name: String,
+        /// The exact generation.
+        generation_id: String,
+        /// That generation's content identity.
+        content_key: String,
+        /// Path relative to the source root.
+        relative_path: String,
+        /// The index's own per-generation unit identity, when the coordinate
+        /// names a unit rather than a whole resource.
+        unit_key: Option<String>,
+        /// Position within the resource, when there is one.
+        ordinal: Option<u64>,
+    },
+    /// An exact stored relationship — §5 step 3's *"structural/document/
+    /// tabular/mail relationships"* and step 5/8's edges.
+    Relationship {
+        /// The declared source both ends belong to.
+        source_name: String,
+        /// The exact generation.
+        generation_id: String,
+        /// What kind of relationship (`child_resource`, `import`, …).
+        kind: String,
+        /// The end it leaves from.
+        from: String,
+        /// The end it names. **Unresolved** for a syntax edge, exactly as
+        /// [`StoredEdge::target`] is.
+        to: String,
+    },
+}
+
+impl EvidenceCoordinate {
+    /// The identity first-contributor-wins is keyed on.
+    ///
+    /// Two steps that would contribute *the same evidence* must collide here,
+    /// or the ordering the ledger enforces would not be visible in the
+    /// snapshot at all — the whole point of first-contributor-wins is that a
+    /// deterministic step and a fuzzy one reaching for the same thing is a
+    /// *contest*, and a contest needs both entrants in the same ring.
+    ///
+    /// So an Atlas coordinate is keyed at **resource** granularity —
+    /// `(generation_id, relative_path)` — not at unit granularity. The two
+    /// steps that contest a resource address it differently by construction:
+    /// step 2 reads `source.units` and has an ordinal but no index unit key,
+    /// while steps 6/7 return `context.lexical_units` hits that have one. A
+    /// unit-keyed identity would let those two *never collide*, which would
+    /// make the ordering unobservable and this whole mechanism decorative.
+    ///
+    /// The cost is stated rather than hidden: a resource bound by an early
+    /// step absorbs every later hit inside it, so C1a binds resources, not
+    /// spans. §14's budget (C1b) is what makes span-level selection
+    /// meaningful, and that is the wave to refine this in.
+    pub fn dedup_key(&self) -> String {
+        match self {
+            Self::Stage {
+                stage_id,
+                index,
+                attempt,
+                ..
+            } => format!("stage/{index}/{stage_id}/{attempt}"),
+            Self::Binding { repository, .. } => format!("binding/{repository}"),
+            Self::Atlas {
+                generation_id,
+                relative_path,
+                ..
+            } => format!("atlas/{generation_id}/{relative_path}"),
+            Self::Relationship {
+                generation_id,
+                kind,
+                from,
+                to,
+                ..
+            } => format!("rel/{generation_id}/{kind}/{from}->{to}"),
+        }
+    }
+
+    /// One line, for the rendered section and for a human reading the journal.
+    pub fn render(&self) -> String {
+        match self {
+            Self::Stage {
+                stage_id,
+                index,
+                attempt,
+                status,
+                summary,
+            } => match summary {
+                Some(summary) => {
+                    format!("stage {index}/{stage_id} attempt {attempt} [{status}] — {summary}")
+                }
+                None => format!("stage {index}/{stage_id} attempt {attempt} [{status}]"),
+            },
+            Self::Binding {
+                repository,
+                work_branch,
+                base_sha,
+            } => format!("binding {repository} — branch {work_branch}, base {base_sha}"),
+            Self::Atlas {
+                source_name,
+                content_key,
+                relative_path,
+                unit_key,
+                ordinal,
+                ..
+            } => {
+                let mut line = format!("{source_name}@{content_key}:{relative_path}");
+                if let Some(ordinal) = ordinal {
+                    line.push_str(&format!("#{ordinal}"));
+                }
+                if let Some(key) = unit_key {
+                    line.push_str(&format!(" [{key}]"));
+                }
+                line
+            }
+            Self::Relationship {
+                source_name,
+                kind,
+                from,
+                to,
+                ..
+            } => format!("{source_name}:{from} —{kind}→ {to}"),
+        }
+    }
+
+    /// The coordinate as JSON, one shape per variant.
+    pub fn json(&self) -> Value {
+        match self {
+            Self::Stage {
+                stage_id,
+                index,
+                attempt,
+                status,
+                summary,
+            } => json!({
+                "shape": "stage",
+                "stage_id": stage_id,
+                "index": index,
+                "attempt": attempt,
+                "status": status,
+                "summary": summary,
+            }),
+            Self::Binding {
+                repository,
+                work_branch,
+                base_sha,
+            } => json!({
+                "shape": "binding",
+                "repository": repository,
+                "work_branch": work_branch,
+                "base_sha": base_sha,
+            }),
+            Self::Atlas {
+                source_name,
+                generation_id,
+                content_key,
+                relative_path,
+                unit_key,
+                ordinal,
+            } => json!({
+                "shape": "atlas",
+                "source": source_name,
+                "generation_id": generation_id,
+                "content_key": content_key,
+                "relative_path": relative_path,
+                "unit_key": unit_key,
+                "ordinal": ordinal,
+            }),
+            Self::Relationship {
+                source_name,
+                generation_id,
+                kind,
+                from,
+                to,
+            } => json!({
+                "shape": "relationship",
+                "source": source_name,
+                "generation_id": generation_id,
+                "kind": kind,
+                "from": from,
+                "to": to,
+            }),
+        }
+    }
+}
+
+/// One unit of compiled evidence: what it is, which tier it landed in, and
+/// **which §5 step contributed it**.
+///
+/// The step is not decoration. It is the field that makes §5's order visible
+/// in the snapshot rather than only in the code that produced it — see this
+/// module's doc on first-contributor-wins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceUnit {
+    /// The §5 step that contributed it, first-contributor-wins.
+    pub step: ResearchStep,
+    /// §2's tier it landed in.
+    pub tier: Tier,
+    /// Where the evidence actually is.
+    pub coordinate: EvidenceCoordinate,
+}
+
+impl EvidenceUnit {
+    /// The unit as JSON, step and tier included.
+    pub fn json(&self) -> Value {
+        json!({
+            "step": self.step.number(),
+            "step_label": self.step.label(),
+            "cognition": self.step.cognition().as_str(),
+            "tier": self.tier.as_str(),
+            "coordinate": self.coordinate.json(),
+        })
+    }
+}
+
+// ===================================================================
+// The gate
+// ===================================================================
+
+/// What one entered step did — recorded whether or not it contributed
+/// anything, because §18's degradation must be *visible, not fatal or
+/// fabricated*.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepRecord {
+    /// Which step.
+    pub step: ResearchStep,
+    /// How many evidence units it contributed (after first-contributor-wins).
+    pub contributed: usize,
+    /// How many it offered that an earlier step had already contributed.
+    pub already_held: usize,
+    /// Why it contributed nothing, when it contributed nothing. `None` when
+    /// it contributed something.
+    pub note: Option<String>,
+}
+
+impl StepRecord {
+    /// The record as JSON.
+    pub fn json(&self) -> Value {
+        json!({
+            "step": self.step.number(),
+            "label": self.step.label(),
+            "cognition": self.step.cognition().as_str(),
+            "contributed": self.contributed,
+            "already_held": self.already_held,
+            "note": self.note,
+        })
+    }
+}
+
+/// **§5's order, enforced.**
+///
+/// The ledger is the only way to add evidence to a compilation, and the only
+/// way to open a step is [`Self::enter`], which refuses anything but §5's next
+/// step. There is no bypass: [`StepWriter`] borrows the ledger mutably for as
+/// long as the step is open, so a second step cannot be opened while one is,
+/// and a step cannot be re-entered once closed.
+#[derive(Debug, Default)]
+pub struct ResearchLedger {
+    /// Steps entered, in the order they were entered.
+    executed: Vec<StepRecord>,
+    /// Evidence contributed, in contribution order.
+    units: Vec<EvidenceUnit>,
+    /// Every dedup key already contributed — first-contributor-wins.
+    held: BTreeSet<String>,
+}
+
+impl ResearchLedger {
+    /// A ledger with no step run.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// §5's next step — the only one [`Self::enter`] will accept.
+    pub fn expected(&self) -> Option<ResearchStep> {
+        ResearchStep::PLAN.get(self.executed.len()).copied()
+    }
+
+    /// Open `step`, or refuse.
+    ///
+    /// Refuses with [`OrderViolation::CognitionBeforeComputation`] whenever
+    /// the attempted step is fuzzy and a deterministic step it is supposed to
+    /// follow has not run — §5's own sentence, reported as itself — and with
+    /// [`OrderViolation::OutOfOrder`] for every other mis-sequencing.
+    pub fn enter(&mut self, step: ResearchStep) -> Result<StepWriter<'_>, OrderViolation> {
+        let expected = self.expected().ok_or(OrderViolation::OutOfOrder {
+            attempted: step.number(),
+            attempted_label: step.label(),
+            expected: 0,
+            expected_label: "the plan is already complete",
+        })?;
+        if step != expected {
+            // The fuzzy diagnosis first: it is the one §5's sentence names,
+            // and a reader of the failure needs *that* sentence, not the
+            // generic one. Applies whenever the step jumping ahead is fuzzy
+            // and something deterministic below it has not run.
+            if step.cognition() == Cognition::Cognition {
+                let skipped = ResearchStep::PLAN
+                    .iter()
+                    .take(step.number() - 1)
+                    .find(|s| {
+                        s.cognition() == Cognition::Computation
+                            && !self.executed.iter().any(|r| r.step == **s)
+                    })
+                    .copied();
+                if let Some(deterministic) = skipped {
+                    return Err(OrderViolation::CognitionBeforeComputation {
+                        fuzzy: step.number(),
+                        fuzzy_label: step.label(),
+                        deterministic: deterministic.number(),
+                        deterministic_label: deterministic.label(),
+                    });
+                }
+            }
+            return Err(OrderViolation::OutOfOrder {
+                attempted: step.number(),
+                attempted_label: step.label(),
+                expected: expected.number(),
+                expected_label: expected.label(),
+            });
+        }
+        Ok(StepWriter {
+            ledger: self,
+            step,
+            contributed: 0,
+            already_held: 0,
+            note: None,
+        })
+    }
+
+    /// Every step entered, in the order it was entered.
+    pub fn executed(&self) -> &[StepRecord] {
+        &self.executed
+    }
+
+    /// Every evidence unit, in contribution order.
+    pub fn units(&self) -> &[EvidenceUnit] {
+        &self.units
+    }
+
+    /// Whether all nine of §5's steps ran.
+    pub fn complete(&self) -> bool {
+        self.executed.len() == ResearchStep::PLAN.len()
+    }
+}
+
+/// One open §5 step. Dropping it closes the step and records what it did.
+#[derive(Debug)]
+pub struct StepWriter<'a> {
+    ledger: &'a mut ResearchLedger,
+    step: ResearchStep,
+    contributed: usize,
+    already_held: usize,
+    note: Option<String>,
+}
+
+impl StepWriter<'_> {
+    /// Offer one coordinate at one tier.
+    ///
+    /// Answers `false` when an **earlier** step already contributed this
+    /// coordinate — first-contributor-wins, which is what makes §5's order
+    /// observable in the compiled snapshot rather than only in the call order.
+    pub fn contribute(&mut self, tier: Tier, coordinate: EvidenceCoordinate) -> bool {
+        let key = coordinate.dedup_key();
+        if !self.ledger.held.insert(key) {
+            self.already_held += 1;
+            return false;
+        }
+        self.ledger.units.push(EvidenceUnit {
+            step: self.step,
+            tier,
+            coordinate,
+        });
+        self.contributed += 1;
+        true
+    }
+
+    /// State why this step contributed nothing — §18's *visible* degradation.
+    pub fn note(&mut self, note: impl Into<String>) {
+        self.note = Some(note.into());
+    }
+}
+
+impl Drop for StepWriter<'_> {
+    fn drop(&mut self) {
+        self.ledger.executed.push(StepRecord {
+            step: self.step,
+            contributed: self.contributed,
+            already_held: self.already_held,
+            note: self.note.take(),
+        });
+    }
+}
+
+// ===================================================================
+// The snapshot (§15)
+// ===================================================================
+
+/// §2's third tier: *"the broader admissible Atlas map/search/query surface
+/// available on demand"* — a **descriptor**, never an enumeration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReachableScope {
+    /// The A2 §2 stage-1 selector that bounds it, rendered.
+    pub selector: String,
+    /// The source name it names, when it names one.
+    pub source_name: Option<String>,
+    /// The Work it is scoped to, when it is Work-scoped.
+    pub work_id: Option<String>,
+    /// The managed verbs this surface offers.
+    pub capabilities: Vec<&'static str>,
+}
+
+impl ReachableScope {
+    /// The descriptor as JSON.
+    pub fn json(&self) -> Value {
+        json!({
+            "selector": self.selector,
+            "source": self.source_name,
+            "work": self.work_id,
+            "capabilities": self.capabilities,
+        })
+    }
+}
+
+/// Why a compilation produced no compiled world — §18's degradation ladder,
+/// stated rather than inferred from an empty snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Degradation {
+    /// §18's first rung: *"intelligence disabled → existing stage CONTEXT +
+    /// Work bindings"*. No Atlas handle was installed on this engine at all.
+    IntelligenceDisabled,
+    /// An Atlas handle exists but this host has confirmed no generation for
+    /// this Work's world — nothing has been indexed. Item 13's other half:
+    /// unavailable, not merely off.
+    NoConfirmedGeneration,
+    /// An Atlas read failed. The launch is not failed for it; the compilation
+    /// is, and says so.
+    AtlasUnavailable(String),
+}
+
+impl Degradation {
+    /// The word the journal payload uses.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::IntelligenceDisabled => "intelligence_disabled",
+            Self::NoConfirmedGeneration => "no_confirmed_generation",
+            Self::AtlasUnavailable(_) => "atlas_unavailable",
+        }
+    }
+
+    /// The detail, when there is one.
+    pub fn detail(&self) -> Option<&str> {
+        match self {
+            Self::AtlasUnavailable(detail) => Some(detail),
+            _ => None,
+        }
+    }
+}
+
+/// **§15's snapshot provenance** — *"Every fresh execution can answer 'what
+/// world did Sergeant present?'"*
+///
+/// One field per line of §15's list, in §15's own order. That discipline is
+/// [`crate::runtime::atlas::trace::SearchTrace`]'s, applied for the same
+/// reason: a listing order the contract supplies is the only ordering that is
+/// not invented here, and a field per line is what makes an omission visible.
+/// Lines a later wave fills are present and empty, each naming its wave.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContextSnapshot {
+    /// **1.** `context_snapshot_id`.
+    pub snapshot_id: String,
+    /// **2.** `estate/work/stage/execution`.
+    pub coordinate: SnapshotCoordinate,
+    /// **3.** `journal watermark` — the journal's next sequence number at the
+    /// instant the compilation ran, so the snapshot names the exact prefix of
+    /// the journal it could have seen.
+    pub journal_watermark: u64,
+    /// **4.** `Work base + overlay generation`.
+    pub work_world: WorkWorld,
+    /// **5.** `source generations (estate/local knowledge/external)` — the
+    /// exact generations the admissibility filter admitted, pinned by id and
+    /// content key.
+    pub source_generations: Vec<GenerationPin>,
+    /// **6.** `coverage states` — per admitted source, the coverage statuses
+    /// its generation carries and how many rows each has.
+    pub coverage: Vec<CoverageState>,
+    /// **7.** `structured query-result IDs`. **Empty this wave**: §10's
+    /// structured query results are C1c's (item 7), which is the wave that
+    /// binds a compact result and references its underlying rows.
+    pub query_result_ids: Vec<String>,
+    /// **8.** `retrieval generation/model if used` — A2 §13's full trace, the
+    /// managed-search persistence `crate::runtime::atlas::trace` named C1 as
+    /// the destination for. `None` when steps 6/7 ran no search.
+    pub retrieval: Option<SearchTrace>,
+    /// **9.** `profile + version` — §6's context profile. `None` until §6's
+    /// `[context] profile` grammar exists; this wave carries the stage's
+    /// **launch** profile name where the run has one, and never invents a
+    /// context profile that no workflow declared.
+    pub profile: Option<String>,
+    /// **10.** `selection-plan hash` — a content hash over §5's executed step
+    /// records and every contributed coordinate, in order. Two compilations
+    /// that selected the same evidence by the same plan hash the same; one
+    /// that ran the steps in a different order does not.
+    pub selection_plan_hash: String,
+    /// **11.** `Bound evidence IDs`.
+    pub bound: Vec<EvidenceUnit>,
+    /// **12.** `Referenced evidence IDs`.
+    pub referenced: Vec<EvidenceUnit>,
+    /// **13.** `Reachable capability/scope descriptor`.
+    pub reachable: Option<ReachableScope>,
+    /// **14.** `rendered payload blob/artifact pointer`. **`None` this
+    /// wave**: C1b owns §14's budget and therefore owns rendering resource
+    /// *content*, which is the only payload big enough to need decision
+    /// C1-09's blob seam. What this wave renders is coordinates, inline.
+    pub payload_pointer: Option<String>,
+    /// **15/16.** `budget + rendered size` — the size actually appended to the
+    /// stage's context, in bytes. The **budget** half is `None` until C1b
+    /// (item 3), which owns §14's hard automatic-render budget; the rendered
+    /// size is measured here because it is a fact this wave produces.
+    pub budget: Option<u64>,
+    /// How many bytes this snapshot appended to the stage's `CONTEXT.md`.
+    pub rendered_bytes: u64,
+    /// §5's executed steps, in the order the ledger let them run.
+    pub plan: Vec<StepRecord>,
+    /// Why nothing was compiled, when nothing was — §18.
+    pub degradation: Option<Degradation>,
+}
+
+/// §15's *"estate/work/stage/execution"*.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotCoordinate {
+    /// The Work's own canonical estate root, when it recorded one.
+    pub estate_root: Option<String>,
+    /// The Work.
+    pub work_id: String,
+    /// The stage.
+    pub stage_id: String,
+    /// Its position in the workflow's stage order.
+    pub stage_index: usize,
+    /// Which attempt this snapshot was compiled for.
+    pub attempt: u32,
+    /// The execution the reservation allocated — the fresh actor this world
+    /// is being compiled for.
+    pub execution_id: String,
+}
+
+/// §15's *"Work base + overlay generation"*.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkWorld {
+    /// The repository the compilation scoped to, and its admission-pinned
+    /// base SHA.
+    pub repository: Option<String>,
+    /// That binding's `base_sha`.
+    pub base_sha: Option<String>,
+    /// The Work's own overlay generation over that repository, when one
+    /// stands. `None` is A2 §2's base-only answer, and is not an error.
+    pub overlay_generation: Option<GenerationPin>,
+}
+
+/// One exact source generation, pinned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationPin {
+    /// The declared source.
+    pub source_name: String,
+    /// The generation's own id.
+    pub generation_id: String,
+    /// Its content identity — what makes the pin re-resolvable rather than a
+    /// description.
+    pub content_key: String,
+    /// How it was acquired.
+    pub kind: &'static str,
+    /// What the estate may do with it.
+    pub authority: &'static str,
+    /// When the observation completed.
+    pub observed_at: String,
+}
+
+impl GenerationPin {
+    /// Pin one [`SourceGeneration`].
+    pub fn of(generation: &SourceGeneration) -> Self {
+        Self {
+            source_name: generation.source_name.clone(),
+            generation_id: generation.id.clone(),
+            content_key: generation.content_key.clone(),
+            kind: generation.kind.as_str(),
+            authority: generation.authority.as_str(),
+            observed_at: generation.observed_at.clone(),
+        }
+    }
+
+    /// The pin as JSON.
+    pub fn json(&self) -> Value {
+        json!({
+            "source": self.source_name,
+            "generation_id": self.generation_id,
+            "content_key": self.content_key,
+            "source_kind": self.kind,
+            "authority_class": self.authority,
+            "observed_at": self.observed_at,
+        })
+    }
+}
+
+/// §15's *"coverage states"*, per admitted source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverageState {
+    /// The declared source.
+    pub source_name: String,
+    /// One coverage status this source's generation carries.
+    pub status: String,
+    /// How many rows carry it.
+    pub rows: usize,
+}
+
+impl CoverageState {
+    /// The state as JSON.
+    pub fn json(&self) -> Value {
+        json!({"source": self.source_name, "status": self.status, "rows": self.rows})
+    }
+}
+
+impl ContextSnapshot {
+    /// §15's sixteen lines, as field names, in §15's own order — what a test
+    /// compares the contract's list against, and what [`Self::json`] emits as
+    /// keys.
+    pub const FIELDS: [&'static str; 16] = [
+        "context_snapshot_id",
+        "coordinate",
+        "journal_watermark",
+        "work_world",
+        "source_generations",
+        "coverage",
+        "query_result_ids",
+        "retrieval",
+        "profile",
+        "selection_plan_hash",
+        "bound",
+        "referenced",
+        "reachable",
+        "payload_pointer",
+        "budget",
+        "rendered_bytes",
+    ];
+
+    /// Whether anything was compiled at all.
+    pub fn is_empty(&self) -> bool {
+        self.bound.is_empty() && self.referenced.is_empty()
+    }
+
+    /// The snapshot as JSON — the payload the journal carries, and the shape
+    /// an inspector reads.
+    pub fn json(&self) -> Value {
+        json!({
+            "context_snapshot_id": self.snapshot_id,
+            "coordinate": {
+                "estate_root": self.coordinate.estate_root,
+                "work": self.coordinate.work_id,
+                "stage": self.coordinate.stage_id,
+                "stage_index": self.coordinate.stage_index,
+                "attempt": self.coordinate.attempt,
+                "execution": self.coordinate.execution_id,
+            },
+            "journal_watermark": self.journal_watermark,
+            "work_world": {
+                "repository": self.work_world.repository,
+                "base_sha": self.work_world.base_sha,
+                "overlay_generation": self.work_world.overlay_generation.as_ref().map(GenerationPin::json),
+            },
+            "source_generations": self
+                .source_generations
+                .iter()
+                .map(GenerationPin::json)
+                .collect::<Vec<_>>(),
+            "coverage": self.coverage.iter().map(CoverageState::json).collect::<Vec<_>>(),
+            "query_result_ids": self.query_result_ids,
+            "retrieval": self.retrieval.as_ref().map(SearchTrace::json),
+            "profile": self.profile,
+            "selection_plan_hash": self.selection_plan_hash,
+            "bound": self.bound.iter().map(EvidenceUnit::json).collect::<Vec<_>>(),
+            "referenced": self.referenced.iter().map(EvidenceUnit::json).collect::<Vec<_>>(),
+            "reachable": self.reachable.as_ref().map(ReachableScope::json),
+            "payload_pointer": self.payload_pointer,
+            "budget": self.budget,
+            "rendered_bytes": self.rendered_bytes,
+            "plan": self.plan.iter().map(StepRecord::json).collect::<Vec<_>>(),
+            "degradation": self.degradation.as_ref().map(|d| json!({
+                "reason": d.as_str(),
+                "detail": d.detail(),
+            })),
+        })
+    }
+
+    /// Append the compiled world to a stage's authored `CONTEXT.md`.
+    ///
+    /// **Appended, never substituted**, exactly as the branch-status fact is
+    /// (`crate::runtime::engine`'s `branch_status_context`): the stage's
+    /// authored content is untouched and a reader can tell at a glance which
+    /// part sergeant added. §12's *"procedure is data"* survives — this adds
+    /// evidence beside the procedure, it does not interpret it.
+    ///
+    /// **Coordinates, never bodies.** §20's first non-goal is *"raw corpus
+    /// stuffing"*, and §14's hard automatic-render budget — the thing that
+    /// would make rendering resource *content* safe — is C1b's. So Bound
+    /// renders in Referenced's own shape for now (*"exact coordinates not
+    /// rendered in full"*), which under-delivers §2's Bound tier and cannot
+    /// over-deliver §20. The under-delivery is C1b's to close and is named
+    /// there rather than left implicit.
+    ///
+    /// A snapshot that compiled nothing returns the context **unchanged, byte
+    /// for byte** — §3's *"If intelligence is disabled/unavailable and the
+    /// workflow does not require it, the existing stage context path still
+    /// executes"* (§21 item 13).
+    pub fn render_onto(&self, context: &str) -> String {
+        if self.is_empty() {
+            return context.to_string();
+        }
+        let mut out = String::from(context);
+        out.push_str("\n\n## Compiled context (Sergeant)\n\nsnapshot: ");
+        out.push_str(&self.snapshot_id);
+        out.push('\n');
+        for (tier, units) in [
+            (Tier::Bound, &self.bound),
+            (Tier::Referenced, &self.referenced),
+        ] {
+            if units.is_empty() {
+                continue;
+            }
+            out.push_str(&format!("\n{}\n", tier.as_str()));
+            for unit in units {
+                out.push_str(&format!(
+                    "  [{}] {}\n",
+                    unit.step.number(),
+                    unit.coordinate.render()
+                ));
+            }
+        }
+        if let Some(reachable) = &self.reachable {
+            out.push_str(&format!(
+                "\nREACHABLE\n  {} ({})\n",
+                reachable.selector,
+                reachable.capabilities.join(", ")
+            ));
+        }
+        out
+    }
+}
+
+// ===================================================================
+// The compiler port
+// ===================================================================
+
+/// Everything §4 lists that the compiler is given, borrowed from the stage
+/// launch that is about to happen.
+#[derive(Debug)]
+pub struct CompileRequest<'a> {
+    /// The Work's own canonical estate root.
+    pub estate_root: Option<&'a Path>,
+    /// The Work.
+    pub work_id: &'a str,
+    /// §4's *"Work intent"* — also the query text steps 6/7 answer.
+    pub intent: &'a str,
+    /// §4's *"workflow + stage definition/content identity"*.
+    pub stage: &'a StageDefinition,
+    /// Its position in the workflow's stage order.
+    pub stage_index: usize,
+    /// Which attempt.
+    pub attempt: u32,
+    /// The execution the reservation just allocated.
+    pub execution_id: &'a str,
+    /// The journal's next sequence number, read before the compilation.
+    pub journal_watermark: u64,
+    /// §4's *"exact repo authority/scope"* — the surface's own bindings.
+    pub bindings: &'a [BindingSummary],
+    /// §5 step 1's *"prior declared artifacts"* — this run's stage records.
+    pub prior_stages: &'a [StageRecord],
+    /// The launch profile the stage was bound with, when it has one.
+    pub profile: Option<&'a str>,
+}
+
+/// The port [`crate::runtime::engine::Engine`] calls before an actor starts.
+///
+/// A port rather than a direct `AtlasDb` field on the engine, for two reasons
+/// that are both about §3: an engine with no compiler installed runs **the
+/// existing stage launch path with nothing added** — item 13's degradation is
+/// then a property of the type, not of a branch someone has to remember to
+/// write — and the engine keeps knowing nothing about Atlas, which is what
+/// keeps `runtime::atlas`'s dependency arrows pointing one way (see that
+/// module's own doc).
+pub trait ContextCompiler: std::fmt::Debug + Send + Sync {
+    /// Compile the world for the fresh execution described by `request`.
+    ///
+    /// **Infallible by signature.** A compilation failure is a degraded
+    /// snapshot ([`Degradation`]), never a failed launch: §18's whole posture
+    /// is that degradation is *"visible, not fatal or fabricated"*, and a
+    /// stage that could not have its world compiled still has a `CONTEXT.md`
+    /// and a Work binding to run on.
+    fn compile(&self, request: &CompileRequest<'_>) -> ContextSnapshot;
+}
+
+/// The production compiler: [`compile`] over a live Atlas handle.
+///
+/// The handle is behind a plain [`std::sync::Mutex`] rather than the async one
+/// [`crate::api::ApiState`] uses, because the one caller
+/// ([`crate::runtime::engine::Engine::reserve_stage`]) is synchronous. It is a
+/// **second handle on the same database instance** (`Analytics::atlas`'s
+/// `Connection::try_clone`), never a second `Connection::open` — see
+/// [`AtlasDb::open`]'s own doc for why that distinction is the whole ballgame.
+#[derive(Debug)]
+pub struct AtlasContextCompiler {
+    atlas: std::sync::Mutex<AtlasDb>,
+}
+
+impl AtlasContextCompiler {
+    /// Wrap a handle derived from the operations projection.
+    pub fn new(atlas: AtlasDb) -> Self {
+        Self {
+            atlas: std::sync::Mutex::new(atlas),
+        }
+    }
+}
+
+impl ContextCompiler for AtlasContextCompiler {
+    fn compile(&self, request: &CompileRequest<'_>) -> ContextSnapshot {
+        let atlas = self
+            .atlas
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        compile(Some(&atlas), request)
+    }
+}
+
+// ===================================================================
+// The plan runner
+// ===================================================================
+
+/// How many rows any one §5 step may read or contribute.
+///
+/// A constant a human wrote, not a policy anything learns (§20: *"learned
+/// context policy/live self-tuning"*). It bounds the compilation's cost and
+/// its output; §14's real automatic-render budget is C1b's and will bound the
+/// rendered payload, which is a different bound over a different quantity.
+pub const STEP_ROW_CAP: usize = 32;
+
+/// **§5's nine steps, run in §5's order, through the gate that enforces it.**
+///
+/// `atlas` is `None` for §18's first rung — intelligence disabled — and the
+/// result is a degraded snapshot that renders nothing. Everything else is one
+/// pass down [`ResearchStep::PLAN`].
+pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> ContextSnapshot {
+    let coordinate = SnapshotCoordinate {
+        estate_root: request
+            .estate_root
+            .map(|root| root.to_string_lossy().into_owned()),
+        work_id: request.work_id.to_string(),
+        stage_id: request.stage.id.clone(),
+        stage_index: request.stage_index,
+        attempt: request.attempt,
+        execution_id: request.execution_id.to_string(),
+    };
+    let Some(atlas) = atlas else {
+        return degraded(request, coordinate, Degradation::IntelligenceDisabled);
+    };
+    // §3's own order: resolve Work/estate/source generations FIRST, then run
+    // the research plan. A world with no confirmed generation is §18's
+    // "unavailable" rung, answered before a single step runs.
+    let repository = request.bindings.first().map(|b| b.repository.clone());
+    let filter = match &repository {
+        Some(repository) => Admissibility {
+            source: SourceSelector::WorkBase {
+                work_id: request.work_id.to_string(),
+                repository: repository.clone(),
+            },
+            kind: None,
+            authority: None,
+        },
+        None => Admissibility::default(),
+    };
+    let admitted = match atlas.admissible_generations(&filter, STEP_ROW_CAP) {
+        Ok(admitted) => admitted,
+        Err(e) => {
+            return degraded(
+                request,
+                coordinate,
+                Degradation::AtlasUnavailable(e.to_string()),
+            );
+        }
+    };
+    if admitted.hits.is_empty() {
+        return degraded(request, coordinate, Degradation::NoConfirmedGeneration);
+    }
+    let source_generations: Vec<GenerationPin> =
+        admitted.hits.iter().map(GenerationPin::of).collect();
+    let overlay_generation = repository.as_deref().and_then(|repository| {
+        let name = overlay_source_name(request.work_id, repository);
+        admitted
+            .hits
+            .iter()
+            .find(|g| g.source_name == name)
+            .map(GenerationPin::of)
+    });
+    let coverage = coverage_states(atlas, &admitted.hits);
+
+    let mut ledger = ResearchLedger::new();
+    // ---- 1. explicit stage inputs / prior declared artifacts
+    {
+        let mut step = ledger
+            .enter(ResearchStep::StageInputs)
+            .expect("step 1 is the plan's first");
+        for record in request.prior_stages {
+            if record.index >= request.stage_index {
+                continue;
+            }
+            step.contribute(
+                Tier::Bound,
+                EvidenceCoordinate::Stage {
+                    stage_id: record.stage_id.clone(),
+                    index: record.index,
+                    attempt: record.attempt,
+                    status: record.status.as_str().to_string(),
+                    summary: record.detail.clone(),
+                },
+            );
+        }
+        if request
+            .prior_stages
+            .iter()
+            .all(|r| r.index >= request.stage_index)
+        {
+            step.note("this stage has no prior stage in the run");
+        }
+    }
+    // ---- 2. exact Work bindings/changed resources
+    {
+        let mut step = ledger
+            .enter(ResearchStep::WorkBindings)
+            .expect("step 2 follows step 1");
+        for binding in request.bindings {
+            step.contribute(
+                Tier::Bound,
+                EvidenceCoordinate::Binding {
+                    repository: binding.repository.clone(),
+                    work_branch: binding.work_branch.clone(),
+                    base_sha: binding.base_sha.clone(),
+                },
+            );
+        }
+        // "changed resources" is exactly the Work's own overlay generation —
+        // a worktree scanned against its base holds only what the Work
+        // changed (S5 W1b/W1d). Nothing here reads the surface: the overlay
+        // is already derived evidence, and `sgt search` staying a pure reader
+        // (H13.2) applies to this path for the same reason.
+        match &overlay_generation {
+            Some(pin) => {
+                let units = atlas
+                    .units(&pin.source_name, STEP_ROW_CAP)
+                    .unwrap_or_default();
+                if units.is_empty() {
+                    step.note("the Work's overlay generation stands but holds no unit");
+                }
+                for unit in &units {
+                    step.contribute(Tier::Bound, atlas_unit(pin, unit));
+                }
+            }
+            None => step.note(
+                "no overlay generation stands for this Work: its surface has not been scanned \
+                 since it was bound, or it has none",
+            ),
+        }
+    }
+    // ---- 3. exact structural/document/tabular/mail relationships
+    {
+        let mut step = ledger
+            .enter(ResearchStep::ExactRelationships)
+            .expect("step 3 follows step 2");
+        let mut found = 0usize;
+        for pin in &source_generations {
+            for child in atlas
+                .child_resources(&pin.source_name, STEP_ROW_CAP)
+                .unwrap_or_default()
+            {
+                found += 1;
+                step.contribute(Tier::Bound, child_relationship(pin, &child));
+            }
+        }
+        if found == 0 {
+            step.note("no container/document/mail parent-child relationship in this world");
+        }
+    }
+    // ---- 4. deterministic dataset aggregates/joins/diffs DECLARED by the
+    //         profile/workflow
+    {
+        let mut step = ledger
+            .enter(ResearchStep::DeclaredDataOperations)
+            .expect("step 4 follows step 3");
+        // §21 item 2's own qualifier: "where the profile declares such
+        // operations". §6's `[context] profile` grammar does not exist yet
+        // and this wave does not invent it, so nothing declares an operation
+        // and this step runs none. Recorded rather than skipped: the step is
+        // entered, the reason is stated, and the order stays total.
+        step.note(
+            "no workflow or profile declared a deterministic dataset operation (§6's \
+             `[context]` grammar is not part of this wave)",
+        );
+    }
+    // ---- 5. exact Referenced neighbors
+    {
+        let mut step = ledger
+            .enter(ResearchStep::ReferencedNeighbors)
+            .expect("step 5 follows step 4");
+        let mut found = 0usize;
+        for pin in &source_generations {
+            for edge in atlas
+                .edges(&pin.source_name, STEP_ROW_CAP)
+                .unwrap_or_default()
+            {
+                found += 1;
+                step.contribute(Tier::Referenced, edge_relationship(pin, &edge));
+            }
+        }
+        if found == 0 {
+            step.note("no stored structural edge in this world");
+        }
+    }
+    // ---- 6/7. A2 lexical retrieval, then A2 semantic retrieval if
+    //           installed/needed — S5's own pipeline, consumed (R2).
+    let attribution = match &repository {
+        Some(repository) => Attribution::Work {
+            work_id: request.work_id.to_string(),
+            repository: repository.clone(),
+        },
+        None => Attribution::Unmanaged,
+    };
+    let retrieval = atlas
+        .traced_search(
+            &LexicalQuery {
+                text: request.intent,
+                filter: &filter,
+                family: None,
+                limit: STEP_ROW_CAP,
+                semantic: SemanticRequest::Requested,
+            },
+            attribution,
+        )
+        .ok();
+    {
+        let mut step = ledger
+            .enter(ResearchStep::LexicalRetrieval)
+            .expect("step 6 follows step 5");
+        match &retrieval {
+            Some((answer, _)) => {
+                if answer.hits.is_empty() {
+                    step.note("lexical retrieval returned no hit inside the admissible set");
+                }
+                for hit in &answer.hits {
+                    step.contribute(
+                        Tier::Bound,
+                        EvidenceCoordinate::Atlas {
+                            source_name: hit.source_name.clone(),
+                            generation_id: hit.generation_id.clone(),
+                            content_key: hit.content_key.clone(),
+                            relative_path: hit.coordinate.relative_path().to_string(),
+                            unit_key: Some(hit.unit_key.clone()),
+                            ordinal: Some(hit.coordinate.ordinal()),
+                        },
+                    );
+                }
+            }
+            None => step.note("the retrieval read failed; the launch is not failed for it"),
+        }
+    }
+    {
+        let mut step = ledger
+            .enter(ResearchStep::SemanticRetrieval)
+            .expect("step 7 follows step 6");
+        // §5's "if installed/needed", answered by the pipeline rather than
+        // assumed: `fused_search` runs `lexical_search` then
+        // `semantic_search` inside one snapshot-isolated transaction, and
+        // `SemanticStatus` is A2 §15's required, non-omittable honesty about
+        // whether the semantic half actually contributed.
+        match &retrieval {
+            Some((answer, _)) => match answer.semantic {
+                SemanticStatus::Applied => step.note(
+                    "the semantic half ran inside step 6's one fused answer; every unit it \
+                     ranked was already contributed there",
+                ),
+                other => step.note(format!(
+                    "semantic retrieval did not run: {}",
+                    other.as_str()
+                )),
+            },
+            None => step.note("no retrieval answer to take a semantic half from"),
+        }
+    }
+    // ---- 8. bounded structural/provenance expansion
+    {
+        let mut step = ledger
+            .enter(ResearchStep::BoundedExpansion)
+            .expect("step 8 follows step 7");
+        // Expansion out of what retrieval found, along stored structure —
+        // deterministic, and bounded by the same constant everything else is.
+        // The `false` from `contribute` is the point: an edge step 5 already
+        // held is not re-contributed here.
+        let mut offered = 0usize;
+        if let Some((answer, _)) = &retrieval {
+            let paths: BTreeSet<&str> = answer
+                .hits
+                .iter()
+                .map(|hit| hit.coordinate.relative_path())
+                .collect();
+            for pin in &source_generations {
+                for edge in atlas
+                    .edges(&pin.source_name, STEP_ROW_CAP)
+                    .unwrap_or_default()
+                {
+                    if !paths.contains(edge.relative_path.as_str()) {
+                        continue;
+                    }
+                    offered += 1;
+                    step.contribute(Tier::Referenced, edge_relationship(pin, &edge));
+                }
+            }
+        }
+        if offered == 0 {
+            step.note("no stored structure to expand from what retrieval found");
+        }
+    }
+    // ---- 9. pack Bound; emit useful remainder as Referenced
+    {
+        let mut step = ledger.enter(ResearchStep::Pack).expect("step 9 is last");
+        step.note("packing adds no evidence: it partitions what steps 1-8 contributed");
+    }
+
+    let bound: Vec<EvidenceUnit> = ledger
+        .units()
+        .iter()
+        .filter(|u| u.tier == Tier::Bound)
+        .cloned()
+        .collect();
+    let referenced: Vec<EvidenceUnit> = ledger
+        .units()
+        .iter()
+        .filter(|u| u.tier == Tier::Referenced)
+        .cloned()
+        .collect();
+    let plan = ledger.executed().to_vec();
+    let selection_plan_hash = selection_plan_hash(&plan, ledger.units());
+
+    ContextSnapshot {
+        snapshot_id: ulid::Ulid::generate().to_string(),
+        coordinate,
+        journal_watermark: request.journal_watermark,
+        work_world: WorkWorld {
+            repository,
+            base_sha: request.bindings.first().map(|b| b.base_sha.clone()),
+            overlay_generation,
+        },
+        source_generations,
+        coverage,
+        query_result_ids: Vec::new(),
+        retrieval: retrieval.map(|(_, trace)| trace),
+        profile: request.profile.map(str::to_string),
+        selection_plan_hash,
+        bound,
+        referenced,
+        reachable: Some(reachable_scope(&filter, request.work_id)),
+        payload_pointer: None,
+        budget: None,
+        rendered_bytes: 0,
+        plan,
+        degradation: None,
+    }
+}
+
+/// §18's degraded answer: the coordinate, the reason, and nothing compiled.
+fn degraded(
+    request: &CompileRequest<'_>,
+    coordinate: SnapshotCoordinate,
+    degradation: Degradation,
+) -> ContextSnapshot {
+    ContextSnapshot {
+        snapshot_id: ulid::Ulid::generate().to_string(),
+        coordinate,
+        journal_watermark: request.journal_watermark,
+        work_world: WorkWorld {
+            repository: request.bindings.first().map(|b| b.repository.clone()),
+            base_sha: request.bindings.first().map(|b| b.base_sha.clone()),
+            overlay_generation: None,
+        },
+        source_generations: Vec::new(),
+        coverage: Vec::new(),
+        query_result_ids: Vec::new(),
+        retrieval: None,
+        profile: request.profile.map(str::to_string),
+        selection_plan_hash: selection_plan_hash(&[], &[]),
+        bound: Vec::new(),
+        referenced: Vec::new(),
+        reachable: None,
+        payload_pointer: None,
+        budget: None,
+        rendered_bytes: 0,
+        plan: Vec::new(),
+        degradation: Some(degradation),
+    }
+}
+
+/// §15's *"selection-plan hash"*: a content hash over the executed plan and
+/// every contributed coordinate, **in order**.
+///
+/// The step number goes into the hash beside the coordinate, so two
+/// compilations that selected the same evidence by different plans — the same
+/// resource attributed to step 2 in one and step 6 in the other — do not hash
+/// the same. A hash over the selected set alone could not tell those apart,
+/// which would make it a hash of the answer rather than of the plan.
+fn selection_plan_hash(plan: &[StepRecord], units: &[EvidenceUnit]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"sergeant.c1.selection-plan/v1\n");
+    for record in plan {
+        hasher.update(record.step.number().to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(record.contributed.to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(record.already_held.to_string().as_bytes());
+        hasher.update(b"\n");
+    }
+    for unit in units {
+        hasher.update(unit.step.number().to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(unit.tier.as_str().as_bytes());
+        hasher.update(b":");
+        hasher.update(unit.coordinate.dedup_key().as_bytes());
+        hasher.update(b"\n");
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+/// §15's *"coverage states"* for the admitted generations, rolled up per
+/// source and status.
+fn coverage_states(atlas: &AtlasDb, admitted: &[SourceGeneration]) -> Vec<CoverageState> {
+    let mut out = Vec::new();
+    for generation in admitted {
+        let rows = atlas
+            .coverage(&generation.source_name, STEP_ROW_CAP)
+            .unwrap_or_default();
+        let mut counts: std::collections::BTreeMap<String, usize> = Default::default();
+        for row in rows {
+            *counts
+                .entry(row.row.status.as_str().to_string())
+                .or_default() += 1;
+        }
+        for (status, rows) in counts {
+            out.push(CoverageState {
+                source_name: generation.source_name.clone(),
+                status,
+                rows,
+            });
+        }
+    }
+    out
+}
+
+/// One stored unit, as an exact Atlas coordinate under its pinned generation.
+fn atlas_unit(pin: &GenerationPin, unit: &StoredUnit) -> EvidenceCoordinate {
+    EvidenceCoordinate::Atlas {
+        source_name: pin.source_name.clone(),
+        generation_id: pin.generation_id.clone(),
+        content_key: pin.content_key.clone(),
+        relative_path: unit.relative_path.clone(),
+        unit_key: None,
+        ordinal: Some(unit.ordinal),
+    }
+}
+
+/// One container/document/mail parent-child relationship (§6.6's preserved
+/// coordinates), as evidence.
+fn child_relationship(pin: &GenerationPin, child: &StoredChildResource) -> EvidenceCoordinate {
+    EvidenceCoordinate::Relationship {
+        source_name: pin.source_name.clone(),
+        generation_id: pin.generation_id.clone(),
+        kind: "child_resource".to_string(),
+        from: child.parent_relative_path.clone(),
+        to: child.relative_path.clone(),
+    }
+}
+
+/// One stored syntax edge, as evidence. Its target stays **unresolved**,
+/// exactly as [`StoredEdge::target`] is — resolving it here would be inventing
+/// a fact the extractor did not derive.
+fn edge_relationship(pin: &GenerationPin, edge: &StoredEdge) -> EvidenceCoordinate {
+    EvidenceCoordinate::Relationship {
+        source_name: pin.source_name.clone(),
+        generation_id: pin.generation_id.clone(),
+        kind: edge.kind.clone(),
+        from: edge.relative_path.clone(),
+        to: edge.target.clone(),
+    }
+}
+
+/// §2's Reachable tier, as the descriptor it is.
+fn reachable_scope(filter: &Admissibility, work_id: &str) -> ReachableScope {
+    let (selector, source_name, work) = match &filter.source {
+        SourceSelector::Any => ("any", None, None),
+        SourceSelector::Named(name) => ("named", Some(name.clone()), None),
+        SourceSelector::Exact { source_name, .. } => ("exact", Some(source_name.clone()), None),
+        SourceSelector::WorkBase { repository, .. } => (
+            "work_base",
+            Some(repository.clone()),
+            Some(work_id.to_string()),
+        ),
+    };
+    ReachableScope {
+        selector: selector.to_string(),
+        source_name,
+        work_id: work,
+        capabilities: vec!["map", "search", "related", "query"],
+    }
+}

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -138,8 +138,8 @@ use crate::backend::BindingSummary;
 use crate::domain::source::SourceGeneration;
 use crate::domain::workflow::{StageDefinition, StageRecord};
 use crate::runtime::atlas::db::{
-    Admissibility, AtlasDb, LexicalQuery, SourceSelector, StoredChildResource, StoredEdge,
-    StoredUnit,
+    Admissibility, AtlasDb, AtlasError, LexicalQuery, SourceSelector, StoredChildResource,
+    StoredEdge, StoredUnit,
 };
 use crate::runtime::atlas::overlay::overlay_source_name;
 use crate::runtime::atlas::semantic::{SemanticRequest, SemanticStatus};
@@ -1326,19 +1326,14 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
         let mut step = ledger
             .enter(ResearchStep::ExactRelationships)
             .expect("step 3 follows step 2");
-        let mut found = 0usize;
-        for pin in &source_generations {
-            for child in atlas
-                .child_resources(&pin.source_name, STEP_ROW_CAP)
-                .unwrap_or_default()
-            {
-                found += 1;
-                step.contribute(Tier::Bound, child_relationship(pin, &child));
-            }
-        }
-        if found == 0 {
-            step.note("no container/document/mail parent-child relationship in this world");
-        }
+        contribute_generation_rows(
+            &mut step,
+            &source_generations,
+            Tier::Bound,
+            "no container/document/mail parent-child relationship in this world",
+            |source_name| atlas.child_resources(source_name, STEP_ROW_CAP),
+            child_relationship,
+        );
     }
     // ---- 4. deterministic dataset aggregates/joins/diffs DECLARED by the
     //         profile/workflow
@@ -1361,19 +1356,14 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
         let mut step = ledger
             .enter(ResearchStep::ReferencedNeighbors)
             .expect("step 5 follows step 4");
-        let mut found = 0usize;
-        for pin in &source_generations {
-            for edge in atlas
-                .edges(&pin.source_name, STEP_ROW_CAP)
-                .unwrap_or_default()
-            {
-                found += 1;
-                step.contribute(Tier::Referenced, edge_relationship(pin, &edge));
-            }
-        }
-        if found == 0 {
-            step.note("no stored structural edge in this world");
-        }
+        contribute_generation_rows(
+            &mut step,
+            &source_generations,
+            Tier::Referenced,
+            "no stored structural edge in this world",
+            |source_name| atlas.edges(source_name, STEP_ROW_CAP),
+            edge_relationship,
+        );
     }
     // ---- 6/7. A2 lexical retrieval, then A2 semantic retrieval if
     //           installed/needed — S5's own pipeline, consumed (R2).
@@ -1610,6 +1600,31 @@ fn coverage_states(atlas: &AtlasDb, admitted: &[SourceGeneration]) -> Vec<Covera
         }
     }
     out
+}
+
+/// Step 3 and step 5's shared shape (**R2**): for every pinned source
+/// generation, fetch its rows through `fetch`, contribute each one at `tier`
+/// via `map`, and note `empty_note` once if nothing was found across every
+/// pin. `fetch`'s own `STEP_ROW_CAP`/limit argument stays the caller's, same
+/// as before this was factored out.
+fn contribute_generation_rows<T>(
+    step: &mut StepWriter<'_>,
+    source_generations: &[GenerationPin],
+    tier: Tier,
+    empty_note: &str,
+    fetch: impl Fn(&str) -> Result<Vec<T>, AtlasError>,
+    map: impl Fn(&GenerationPin, &T) -> EvidenceCoordinate,
+) {
+    let mut found = 0usize;
+    for pin in source_generations {
+        for item in fetch(&pin.source_name).unwrap_or_default() {
+            found += 1;
+            step.contribute(tier, map(pin, &item));
+        }
+    }
+    if found == 0 {
+        step.note(empty_note);
+    }
 }
 
 /// One stored unit, as an exact Atlas coordinate under its pinned generation.

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -48,12 +48,12 @@ use crate::domain::work::{
     KIND_WORK_RESUMED, KIND_WORK_STARTED, KIND_WORK_WAITING, Work, WorkState,
 };
 use crate::domain::workflow::{
-    DEFAULT_WORKFLOW, KIND_STAGE_BLOCKED, KIND_STAGE_CANCELED, KIND_STAGE_COMPLETED,
-    KIND_STAGE_ENTERED, KIND_STAGE_FAILED, KIND_STAGE_INPUT_RECEIVED, KIND_STAGE_NEEDS_INPUT,
-    KIND_STAGE_OUTPUT_MISSING, KIND_STAGE_RESUMED, KIND_STAGE_WAITING, KIND_WORKFLOW_BOUND,
-    REASON_STAGE_OUTPUT_MISSING, SOURCE_EMBEDDED, StageBinding, StageDefinition, StageKind,
-    StageRecord, StageStatus, WorkflowDefinition, WorkflowError, declared_output_artifact,
-    declared_required_columns, has_required_table_columns,
+    DEFAULT_WORKFLOW, KIND_CONTEXT_COMPILED, KIND_STAGE_BLOCKED, KIND_STAGE_CANCELED,
+    KIND_STAGE_COMPLETED, KIND_STAGE_ENTERED, KIND_STAGE_FAILED, KIND_STAGE_INPUT_RECEIVED,
+    KIND_STAGE_NEEDS_INPUT, KIND_STAGE_OUTPUT_MISSING, KIND_STAGE_RESUMED, KIND_STAGE_WAITING,
+    KIND_WORKFLOW_BOUND, REASON_STAGE_OUTPUT_MISSING, SOURCE_EMBEDDED, StageBinding,
+    StageDefinition, StageKind, StageRecord, StageStatus, WorkflowDefinition, WorkflowError,
+    declared_output_artifact, declared_required_columns, has_required_table_columns,
 };
 use crate::runtime::preflight::{self, GitPreflight, PreflightRefusal};
 use crate::runtime::projection::{WorkRegistry, WorkRun, is_absorbing};
@@ -1300,6 +1300,19 @@ pub struct Engine {
     pub intelligence_lane: Arc<Semaphore>,
     /// The cap [`Self::intelligence_lane`] was built with.
     pub intelligence_lane_cap: usize,
+    /// **C1 §3's compilation step**, installed or not.
+    ///
+    /// `None` is §18's first rung — *"intelligence disabled → existing stage
+    /// CONTEXT + Work bindings"* — and it is `None` by construction for every
+    /// engine nobody installed one on, which is what makes §21 item 13 a
+    /// property of the type rather than a branch someone has to remember to
+    /// write: with no compiler there is no compilation, no journaled
+    /// snapshot, and a `StartRequest` byte-identical to the one this engine
+    /// built before C1 existed.
+    ///
+    /// A port rather than an `AtlasDb`, so the engine keeps knowing nothing
+    /// about Atlas — see [`crate::runtime::context::ContextCompiler`].
+    context_compiler: Option<Arc<dyn crate::runtime::context::ContextCompiler>>,
 }
 
 /// Whose declared output contract one [`Engine::check_output_contract`] pass
@@ -1351,6 +1364,7 @@ impl Engine {
             execution_permits: Arc::new(Mutex::new(BTreeMap::new())),
             intelligence_lane: Arc::new(Semaphore::new(default_intelligence_lane_cap())),
             intelligence_lane_cap: default_intelligence_lane_cap(),
+            context_compiler: None,
         }
     }
 
@@ -1392,6 +1406,20 @@ impl Engine {
     pub fn with_intelligence_lane_cap(mut self, cap: usize) -> Self {
         self.intelligence_lane = Arc::new(Semaphore::new(cap));
         self.intelligence_lane_cap = cap;
+        self
+    }
+
+    /// Install C1 §3's compilation step (`daemon::run_until_signal`).
+    ///
+    /// A builder rather than a `new` parameter for the reason every other
+    /// builder here is one: an engine nobody installs one on keeps exactly
+    /// the behaviour it had, which is §21 item 13's requirement and every
+    /// existing test's assumption at once.
+    pub fn with_context_compiler(
+        mut self,
+        compiler: Arc<dyn crate::runtime::context::ContextCompiler>,
+    ) -> Self {
+        self.context_compiler = Some(compiler);
         self
     }
 
@@ -3934,6 +3962,46 @@ impl Engine {
         };
 
         let execution_id = ulid::Ulid::generate().to_string();
+        // §12: procedure is data. The stage's own `CONTEXT.md`, plus the one
+        // opt-in fact #260 mechanism 3 already appends (see below).
+        let authored = if stage.receives_branch_status {
+            branch_status_context(&stage.context, &surface)
+        } else {
+            stage.context.clone()
+        };
+        // ---------------------------------------------------------------
+        // C1 §3's compilation step — here, and nowhere else.
+        //
+        //   stage about to enter → resolve Work/estate/source generations →
+        //   run deterministic research plan → compile Bound + Referenced +
+        //   Reachable snapshot → launch ordinary fresh execution
+        //
+        // *"C1 is not a second execution pipeline"* (§3, decision C1-01,
+        // **R2**): this is one call, inserted between the execution id being
+        // allocated and the adapter being asked to PREPARE, on the launch
+        // path that already existed. Nothing below it changed — the same
+        // `StartRequest`, the same `prepare`, the same reservation, the same
+        // `Next::Launch`.
+        //
+        // With no compiler installed it is `(authored, None)` and the rest of
+        // this function cannot tell C1 exists (§21 item 13).
+        // ---------------------------------------------------------------
+        let (context, snapshot) = self.compile_stage_context(
+            core,
+            work_id,
+            &stage,
+            index,
+            attempt,
+            &execution_id,
+            &intent,
+            &surface,
+            &run,
+            stage_profile.as_ref().map(|p| p.name.as_str()),
+            &authored,
+        );
+        if let Some(snapshot) = snapshot {
+            self.commit(core, work_id, KIND_CONTEXT_COMPILED, snapshot)?;
+        }
         let request = StartRequest {
             work_id: work_id.to_string(),
             execution_id: execution_id.clone(),
@@ -3945,15 +4013,12 @@ impl Engine {
             // the actor verbatim; sergeant never interprets it — except for
             // Amendment 9 Q5 / #260 mechanism 3's opt-in wire, where a stage
             // that declared `receives_branch_status = true` gets the
-            // engine's own commits-on-branch-since-base fact appended. The
-            // engine still shares no output vocabulary: this is a fact it
-            // already computes ([`WorkSurface::commits_since_base`]), not an
-            // interpretation of the stage's procedure.
-            context: if stage.receives_branch_status {
-                branch_status_context(&stage.context, &surface)
-            } else {
-                stage.context.clone()
-            },
+            // engine's own commits-on-branch-since-base fact appended, and
+            // C1 §3's compiled-context section, appended by exactly the same
+            // rule and for exactly the same reason: the authored content is
+            // untouched and a reader can tell which part sergeant added.
+            // Both are computed just above.
+            context,
             // §24.8: the profile carries the model, so the stage's profile
             // carries the stage's model. There is no per-stage model field.
             model: stage_profile.as_ref().and_then(|p| p.default_model.clone()),
@@ -5175,6 +5240,80 @@ fn handle_of(execution: &ExecutionRecord) -> ExecutionHandle {
     ExecutionHandle {
         execution_id: execution.execution_id.clone(),
         native_id: execution.native_id.clone(),
+    }
+}
+
+impl Engine {
+    /// **C1 §3's compilation step**: compile the world for the fresh
+    /// execution about to start, and return the context the actor will
+    /// actually receive plus the §15 snapshot to journal.
+    ///
+    /// `(authored.to_string(), None)` when no compiler is installed — §18's
+    /// first rung and §21 item 13, decided by whether the field is `Some`
+    /// and by nothing else. There is deliberately no second condition here: a
+    /// condition is a thing that can be got wrong, and "no compiler ⇒ nothing
+    /// added" must be the one case nobody can get wrong.
+    ///
+    /// A **degraded** snapshot (intelligence installed but this world has no
+    /// confirmed generation, or an Atlas read failed) is still journaled and
+    /// still renders nothing: §18's degradation is *"visible, not fatal or
+    /// fabricated"*, and `ContextSnapshot::render_onto` returns the authored
+    /// context byte-for-byte when there is nothing compiled.
+    ///
+    /// # Why this runs under the core lock, said rather than assumed
+    ///
+    /// §22.6's budget keeps *external effects* out from under the guard — a
+    /// process spawn, a container create, a repository walk (see
+    /// [`crate::api`]'s `spawn_work_overlay_hook`, which exists for exactly
+    /// that reason). This is none of those: it is a bounded set of reads of
+    /// already-derived local tables, every one of them capped at
+    /// [`crate::runtime::context::STEP_ROW_CAP`] or Atlas's own `MAX_ROWS`,
+    /// touching no filesystem the Work owns and spawning nothing (**J3** —
+    /// §22.6 names the effects it governs and a bounded local read is not
+    /// among them). It has to run here regardless: the compiled world must be
+    /// in the `StartRequest` before the adapter is asked to PREPARE, and
+    /// PREPARE is *"identity only — no process, no I/O"*, so there is no
+    /// later point at which the context could still be composed.
+    #[allow(clippy::too_many_arguments)]
+    fn compile_stage_context(
+        &self,
+        core: &Core,
+        work_id: &str,
+        stage: &StageDefinition,
+        index: usize,
+        attempt: u32,
+        execution_id: &str,
+        intent: &str,
+        surface: &WorkSurface,
+        run: &WorkRun,
+        profile: Option<&str>,
+        authored: &str,
+    ) -> (String, Option<Value>) {
+        let Some(compiler) = self.context_compiler.as_ref() else {
+            return (authored.to_string(), None);
+        };
+        let estate_root = Self::work_estate_root(core, work_id);
+        let bindings = surface.binding_summary();
+        let request = crate::runtime::context::CompileRequest {
+            estate_root: estate_root.as_deref(),
+            work_id,
+            intent,
+            stage,
+            stage_index: index,
+            attempt,
+            execution_id,
+            // §15's *"journal watermark"*: the next sequence this journal
+            // will write, read before the compilation, so the snapshot names
+            // the exact prefix of the journal its world could have reflected.
+            journal_watermark: core.journal.next_seq(),
+            bindings: &bindings,
+            prior_stages: &run.stages,
+            profile,
+        };
+        let mut snapshot = compiler.compile(&request);
+        let context = snapshot.render_onto(authored);
+        snapshot.rendered_bytes = context.len().saturating_sub(authored.len()) as u64;
+        (context, Some(snapshot.json()))
     }
 }
 

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -3985,20 +3985,32 @@ impl Engine {
         //
         // With no compiler installed it is `(authored, None)` and the rest of
         // this function cannot tell C1 exists (§21 item 13).
+        //
+        // Scoped to `StageKind::Actor` (§3: "The existing engine already
+        // binds a workflow/stage and launches a fresh actor... C1 inserts a
+        // deterministic compilation step before the actor start"; §21 item
+        // 1: "fresh ordinary actor stage launches"). An `Execute` stage
+        // launches a Docker container, never an actor, and the backend never
+        // reads `StartRequest.context` for it — compiling a snapshot it
+        // cannot see would be unasked-for scope doing unread work.
         // ---------------------------------------------------------------
-        let (context, snapshot) = self.compile_stage_context(
-            core,
-            work_id,
-            &stage,
-            index,
-            attempt,
-            &execution_id,
-            &intent,
-            &surface,
-            &run,
-            stage_profile.as_ref().map(|p| p.name.as_str()),
-            &authored,
-        );
+        let (context, snapshot) = if stage.kind == StageKind::Actor {
+            self.compile_stage_context(
+                core,
+                work_id,
+                &stage,
+                index,
+                attempt,
+                &execution_id,
+                &intent,
+                &surface,
+                &run,
+                stage_profile.as_ref().map(|p| p.name.as_str()),
+                &authored,
+            )
+        } else {
+            (authored.clone(), None)
+        };
         if let Some(snapshot) = snapshot {
             self.commit(core, work_id, KIND_CONTEXT_COMPILED, snapshot)?;
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod atlas;
 pub mod blob;
+pub mod context;
 pub mod engine;
 pub mod estates;
 pub(crate) mod fsutil;

--- a/tests/c1a_compiled_context.rs
+++ b/tests/c1a_compiled_context.rs
@@ -887,6 +887,141 @@ async fn an_unindexed_estate_launches_on_the_existing_stage_context_path() {
     handle.shutdown().await;
 }
 
+/// Whether the local Docker Engine answers at all — same probe and skip
+/// convention as `tests/m7_docker_executor.rs`/`tests/a4_blob_ref_pinning.rs`
+/// (CONTRIBUTING.md's environment posture): a host with no Docker reachable
+/// skips loudly rather than failing on a shape it cannot express.
+fn docker_unavailable() -> Option<&'static str> {
+    match std::process::Command::new("docker").arg("version").output() {
+        Ok(out) if out.status.success() => None,
+        Ok(_) => Some("SKIPPED-ENV: `docker version` exited nonzero on this host"),
+        Err(_) => Some("SKIPPED-ENV: no `docker` binary reachable on this host"),
+    }
+}
+
+macro_rules! require_docker {
+    () => {
+        if let Some(reason) = docker_unavailable() {
+            eprintln!("{reason}");
+            return;
+        }
+    };
+}
+
+/// **F-SF-01**: C1 §3 scopes the compilation step to *"the actor start"* —
+/// §21 item 1's *"fresh ordinary actor stage launches"* — never to an
+/// `Execute` (Docker) stage, which never reaches an actor and whose backend
+/// never reads `StartRequest.context` at all. Against a real daemon and a
+/// real Docker Engine, a mixed actor → execute → actor workflow must journal
+/// a `context.compiled` snapshot for its two actor stages and **none** for
+/// the execute stage in between.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_execute_stage_launch_is_never_compiled() {
+    require_docker!();
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    let (_repo, _head) = support::scaffold_solo_estate(&estate, "solo");
+
+    let workflow_dir = estate.join(".sergeant/workflows/mixed");
+    std::fs::create_dir_all(workflow_dir.join("00-first")).expect("stage dir");
+    std::fs::create_dir_all(workflow_dir.join("20-third")).expect("stage dir");
+    std::fs::write(
+        workflow_dir.join("00-first/CONTEXT.md"),
+        "first stage context",
+    )
+    .expect("context");
+    std::fs::write(
+        workflow_dir.join("20-third/CONTEXT.md"),
+        "third stage context",
+    )
+    .expect("context");
+    std::fs::write(
+        workflow_dir.join("workflow.toml"),
+        concat!(
+            "[workflow]\n",
+            "name = \"mixed\"\n",
+            "version = \"1\"\n",
+            "stages = [\"00-first\", \"10-second\", \"20-third\"]\n",
+            "\n",
+            "[stage.\"10-second\"]\n",
+            "kind = \"execute\"\n",
+            "image = \"alpine:3.24\"\n",
+            "command = [\"true\"]\n",
+            "workdir = \"/estate\"\n",
+            "workspace_access = \"read_only\"\n",
+            "network = \"none\"\n",
+        ),
+    )
+    .expect("workflow.toml");
+
+    let (registry, fake) = one_fake([
+        sergeant_rs::backend::fake::FakeStep::complete_with("first done"),
+        sergeant_rs::backend::fake::FakeStep::complete_with("third done"),
+    ]);
+    let handle = sergeant_rs::daemon::start_with(
+        data.path(),
+        sergeant_rs::daemon::DaemonConfig {
+            backends: std::sync::Arc::new(registry),
+            default_backend: Some(FAKE.to_string()),
+            claude: None,
+            docker: Some(sergeant_rs::backend::docker::DockerConfig::new(data.path())),
+            ..sergeant_rs::daemon::DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start");
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .expect("client");
+    let body = serde_json::json!({
+        "command_id": ulid::Ulid::generate().to_string(),
+        "intent": "prove an execute stage is never compiled",
+        "estate_root": &estate,
+        "origin": {"client": "cli", "cwd": &estate},
+        "workflow": "mixed",
+    });
+    let response = client
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = response.status();
+    let value: Value = response.json().await.expect("json body");
+    assert_eq!(status, 201, "submit rejected: {value}");
+    assert_eq!(value["work"]["state"], "completed", "{value}");
+    let work_id = value["work"]["id"].as_str().expect("work id").to_string();
+
+    let starts = fake.starts();
+    assert_eq!(
+        starts.len(),
+        2,
+        "only the two actor stages reach the fake: {starts:?}"
+    );
+
+    let snapshots = events_of(data.path(), &work_id, KIND_CONTEXT_COMPILED);
+    let compiled_stage_ids: BTreeSet<String> = snapshots
+        .iter()
+        .map(|e| {
+            e.payload["coordinate"]["stage"]
+                .as_str()
+                .expect("stage coordinate")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        compiled_stage_ids,
+        BTreeSet::from(["00-first".to_string(), "20-third".to_string()]),
+        "the execute stage must never appear among compiled stages: {compiled_stage_ids:?}"
+    );
+
+    handle.shutdown().await;
+}
+
 /// A two-stage workflow whose stage contexts are exactly the two strings the
 /// live tests compare against.
 fn write_two_stage_workflow(estate: &Path) {

--- a/tests/c1a_compiled_context.rs
+++ b/tests/c1a_compiled_context.rs
@@ -1,0 +1,907 @@
+//! S6 C1a — the compilation step (C1 §3) and §5's **enforceable runtime
+//! order**, with §15's snapshot provenance and §21 items 1, 2, 10 and 13.
+//!
+//! # What each test here is the evidence for
+//!
+//! | Claim | Test |
+//! |---|---|
+//! | §5's nine steps are §5's own nine lines, in §5's own order | [`the_nine_steps_are_section_5s_own_list_in_section_5s_own_order`] |
+//! | *"fuzzy"* means exactly A2 retrieval — steps 6 and 7 and nothing else | [`the_fuzzy_steps_are_exactly_a2_retrieval_and_every_other_step_precedes_them`] |
+//! | **item 2** — a fuzzy step entered early is REFUSED, by name | [`the_ledger_refuses_a_fuzzy_step_entered_before_the_deterministic_ones`] |
+//! | the refusal does not over-claim a cognition violation that did not happen | [`skipping_only_the_lexical_step_is_reported_as_sequencing_not_as_cognition_first`] |
+//! | every one of the nine steps is *entered*, in order, over a real Atlas | [`the_plan_enters_all_nine_steps_in_section_5s_order_over_a_real_atlas`] |
+//! | **item 2, decisively** — a resource retrieval also found is attributed to the deterministic step that held it first, and retrieval is observed **losing** it | [`a_resource_retrieval_also_finds_is_attributed_to_the_deterministic_step_that_held_it_first`] |
+//! | and that attribution is a function of the ORDER, not of the resource | [`the_same_resource_is_attributed_to_retrieval_when_no_deterministic_step_held_it_first`] |
+//! | **item 10** — the snapshot pins generations that **re-resolve** | [`the_snapshot_pins_generations_that_re_resolve_to_the_same_evidence`] |
+//! | **item 10** — the retrieval generation/model is pinned when retrieval ran | [`the_snapshot_pins_the_retrieval_generation_and_model_it_actually_used`] |
+//! | §15 — one field per line of §15's list, in §15's order | [`the_snapshot_carries_one_field_per_line_of_section_15s_list`] |
+//! | §20 — no raw corpus stuffing: coordinates render, bodies do not | [`the_rendered_section_carries_coordinates_and_never_a_resource_body`] |
+//! | §15 — the selection-plan hash is a hash of the PLAN, not of the selection | [`the_selection_plan_hash_separates_two_plans_that_selected_the_same_evidence`] |
+//! | **item 13** — no compiler installed ⇒ the stage context is byte-identical | [`a_stage_with_no_compiler_installed_gets_its_authored_context_byte_for_byte`] |
+//! | **item 13** — intelligence *unavailable* ⇒ the same, and it says why | [`an_estate_with_no_confirmed_generation_leaves_the_context_byte_identical_and_says_why`] |
+//! | **item 1** — a fresh ordinary actor stage launches with a snapshot pinned to **its own** execution | [`every_fresh_actor_stage_launch_journals_a_snapshot_for_its_own_execution`] |
+//! | **item 13**, live — an unindexed estate still launches on the existing path | [`an_unindexed_estate_launches_on_the_existing_stage_context_path`] |
+//!
+//! The two live tests at the bottom run a real daemon over a real estate;
+//! everything above them runs the compiler over a real Atlas built by the
+//! ordinary `record_scan` path. Neither substitutes for the other.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use sergeant_rs::domain::event::rfc3339_utc_now;
+use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
+use sergeant_rs::domain::workflow::{
+    KIND_CONTEXT_COMPILED, StageDefinition, StageKind, StageRecord, StageStatus,
+};
+use sergeant_rs::runtime::atlas::db::AtlasDb;
+use sergeant_rs::runtime::atlas::overlay::overlay_source_name;
+use sergeant_rs::runtime::atlas::record::record_scan;
+use sergeant_rs::runtime::atlas::scan::{ScannedFile, ScannedUnit, SourceScan};
+use sergeant_rs::runtime::atlas::tabular::ContextFields;
+use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+use sergeant_rs::runtime::context::{
+    Cognition, CompileRequest, ContextSnapshot, Degradation, EvidenceCoordinate, OrderViolation,
+    ResearchLedger, ResearchStep, Tier, compile,
+};
+use sergeant_rs::runtime::journal::Journal;
+
+mod support;
+
+// ===================================================================
+// §5's own nine lines, transcribed from C1-COMPILED-CONTEXT.md §5
+// ===================================================================
+
+/// The contract's list, copied verbatim. A test compares
+/// [`ResearchStep::PLAN`] against *this*, not against itself.
+const SECTION_5: [&str; 9] = [
+    "explicit stage inputs / prior declared artifacts",
+    "exact Work bindings/changed resources",
+    "exact structural/document/tabular/mail relationships",
+    "deterministic dataset aggregates/joins/diffs declared by the profile/workflow",
+    "exact Referenced neighbors",
+    "A2 lexical retrieval",
+    "A2 semantic retrieval if installed/needed",
+    "bounded structural/provenance expansion",
+    "pack Bound; emit useful remainder as Referenced",
+];
+
+// ===================================================================
+// Fixtures
+// ===================================================================
+
+const WORK_ID: &str = "01C1AWORK";
+const REPOSITORY: &str = "demo-repo";
+/// The body of the contested resource. Its terms appear in the Work's intent
+/// too, so lexical retrieval genuinely reaches for it — which is what stops
+/// the ordering test from being vacuous.
+const CONTESTED_BODY: &str = "The retention retention retention policy this Work changes.";
+
+fn unit(ordinal: u64, title: &str, text: &str) -> ScannedUnit {
+    ScannedUnit {
+        ordinal,
+        kind: UnitKind::Section,
+        heading_level: Some(1),
+        title: Some(title.to_string()),
+        byte_start: 0,
+        byte_end: text.len() as u64,
+        coordinate: None,
+        text: text.to_string(),
+    }
+}
+
+fn file(relative_path: &str, units: Vec<ScannedUnit>) -> ScannedFile {
+    let bytes: u64 = units.iter().map(|u| u.text.len() as u64).sum();
+    ScannedFile {
+        relative_path: relative_path.to_string(),
+        content_hash: format!("hash/{relative_path}"),
+        extractor: MARKDOWN_EXTRACTOR.to_string(),
+        local_key: format!("key/{relative_path}"),
+        byte_len: bytes,
+        mtime_millis: None,
+        units,
+        syntax: None,
+        parent: None,
+    }
+}
+
+fn scan(
+    source_name: &str,
+    kind: SourceKind,
+    authority: AuthorityClass,
+    files: Vec<ScannedFile>,
+) -> SourceScan {
+    let mut extractors = BTreeSet::new();
+    extractors.insert(MARKDOWN_EXTRACTOR.to_string());
+    SourceScan {
+        source_name: source_name.to_string(),
+        kind,
+        authority,
+        content_key: format!("{source_name}@generation-1"),
+        revision: None,
+        observed_at: rfc3339_utc_now(),
+        files,
+        coverage: Vec::new(),
+        extractors,
+        datasets: Vec::new(),
+        root: None,
+        context_fields: ContextFields::none(),
+    }
+}
+
+/// A real Atlas holding two confirmed generations: the Work's base repository
+/// and the Work's own overlay over it.
+///
+/// The overlay's `notes/plan.md` is the **contested** resource: it is one of
+/// the Work's exact changed resources (§5 step 2) *and* the best lexical
+/// answer to the Work's intent (§5 step 6). Both steps reach for it, which is
+/// what makes the ordering test non-vacuous.
+struct Fixture {
+    _data: TempDir,
+    db: AtlasDb,
+}
+
+fn fixture() -> Fixture {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    let base = scan(
+        REPOSITORY,
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![
+            file(
+                "docs/architecture.md",
+                vec![unit(
+                    0,
+                    "Architecture",
+                    "The daemon owns the journal and the projection it folds.",
+                )],
+            ),
+            file(
+                "docs/glossary.md",
+                vec![unit(0, "Glossary", "A surface is a linked worktree.")],
+            ),
+        ],
+    );
+    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+
+    let overlay = scan(
+        &overlay_source_name(WORK_ID, REPOSITORY),
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![file("notes/plan.md", vec![unit(0, "Plan", CONTESTED_BODY)])],
+    );
+    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+
+    Fixture { _data: data, db }
+}
+
+fn stage() -> StageDefinition {
+    StageDefinition {
+        id: "10-implement".to_string(),
+        context: "authored stage procedure".to_string(),
+        kind: StageKind::Actor,
+        harness: None,
+        profile: None,
+        requires_ask: false,
+        receives_branch_status: false,
+        execute: None,
+    }
+}
+
+fn bindings() -> Vec<sergeant_rs::backend::BindingSummary> {
+    vec![sergeant_rs::backend::BindingSummary {
+        repository: REPOSITORY.to_string(),
+        worktree_path: PathBuf::from("/surfaces").join(WORK_ID).join(REPOSITORY),
+        work_branch: format!("sergeant/{WORK_ID}"),
+        base_branch: Some("main".to_string()),
+        base_sha: "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f".to_string(),
+    }]
+}
+
+fn prior_stages() -> Vec<StageRecord> {
+    vec![StageRecord {
+        stage_id: "00-orient".to_string(),
+        index: 0,
+        attempt: 1,
+        status: StageStatus::Completed,
+        detail: Some("oriented".to_string()),
+        output_reprompts: 0,
+    }]
+}
+
+/// Compile against `atlas`, with the whole fixture world bound to this Work.
+fn compiled(atlas: Option<&AtlasDb>) -> ContextSnapshot {
+    let stage = stage();
+    let bindings = bindings();
+    let prior = prior_stages();
+    compile(
+        atlas,
+        &CompileRequest {
+            estate_root: Some(Path::new("/estates/demo")),
+            work_id: WORK_ID,
+            intent: "tighten the retention policy",
+            stage: &stage,
+            stage_index: 1,
+            attempt: 1,
+            execution_id: "01EXECUTION",
+            journal_watermark: 42,
+            bindings: &bindings,
+            prior_stages: &prior,
+            profile: Some("standard"),
+        },
+    )
+}
+
+// ============================================================ §5's order
+
+/// §5's nine steps are §5's nine lines, in §5's order — compared against the
+/// contract's own text, transcribed above, never against the code's own
+/// listing.
+#[test]
+fn the_nine_steps_are_section_5s_own_list_in_section_5s_own_order() {
+    let labels: Vec<&str> = ResearchStep::PLAN.iter().map(|s| s.label()).collect();
+    assert_eq!(labels, SECTION_5.to_vec());
+    for (index, step) in ResearchStep::PLAN.iter().enumerate() {
+        assert_eq!(step.number(), index + 1, "§5 numbers its list from 1");
+    }
+}
+
+/// *"Before **fuzzy retrieval or model dispatch**"* — the fuzzy half of §5 is
+/// exactly its two A2 retrieval steps, and every other step is deterministic.
+///
+/// The second assertion is the one that carries the sentence: every
+/// deterministic step §5 lists *before* a fuzzy one really is numbered before
+/// it. A classification that drifted (step 8 marked fuzzy, say, or step 5
+/// renumbered past step 6) turns this red.
+#[test]
+fn the_fuzzy_steps_are_exactly_a2_retrieval_and_every_other_step_precedes_them() {
+    let fuzzy: Vec<usize> = ResearchStep::PLAN
+        .iter()
+        .filter(|s| s.cognition() == Cognition::Cognition)
+        .map(|s| s.number())
+        .collect();
+    assert_eq!(fuzzy, vec![6, 7], "§5's steps 6 and 7, and nothing else");
+
+    let first_fuzzy = *fuzzy.first().expect("there is a fuzzy step");
+    let deterministic_before: Vec<usize> = ResearchStep::PLAN
+        .iter()
+        .filter(|s| s.cognition() == Cognition::Computation && s.number() < first_fuzzy)
+        .map(|s| s.number())
+        .collect();
+    assert_eq!(
+        deterministic_before,
+        vec![1, 2, 3, 4, 5],
+        "all five of §5's local-evidence operations come before the first fuzzy step"
+    );
+}
+
+/// **§21 item 2, as a gate.** A fuzzy step entered before the deterministic
+/// ones is REFUSED, and the refusal names §5's own sentence.
+///
+/// This is the technique, not an assertion about it: a real violation is
+/// inserted and the guard is watched. The second half is what keeps it
+/// non-vacuous — the legal order is accepted by the same call, so the gate is
+/// not simply refusing everything.
+#[test]
+fn the_ledger_refuses_a_fuzzy_step_entered_before_the_deterministic_ones() {
+    let mut ledger = ResearchLedger::new();
+    let refusal = ledger
+        .enter(ResearchStep::LexicalRetrieval)
+        .expect_err("§5's step 6 entered first must be refused");
+    assert_eq!(
+        refusal,
+        OrderViolation::CognitionBeforeComputation {
+            fuzzy: 6,
+            fuzzy_label: SECTION_5[5],
+            deterministic: 1,
+            deterministic_label: SECTION_5[0],
+        }
+    );
+    assert!(
+        refusal
+            .to_string()
+            .contains("spend computation before cognition"),
+        "the refusal quotes the sentence it enforces: {refusal}"
+    );
+
+    // Non-vacuous: the same gate accepts §5's actual order.
+    let mut ledger = ResearchLedger::new();
+    for step in ResearchStep::PLAN {
+        assert!(
+            ledger.enter(step).is_ok(),
+            "§5's own order must pass the gate that refused the reordering: {step:?}"
+        );
+    }
+    assert!(ledger.complete());
+}
+
+/// The refusal is honest about *which* rule was broken.
+///
+/// Steps 1–5 have run, so nothing deterministic is being jumped; entering
+/// step 7 before step 6 is a sequencing bug between two fuzzy steps, and it
+/// is reported as [`OrderViolation::OutOfOrder`]. A gate that reported every
+/// misordering as a cognition-before-computation violation would be a gate
+/// nobody could read.
+#[test]
+fn skipping_only_the_lexical_step_is_reported_as_sequencing_not_as_cognition_first() {
+    let mut ledger = ResearchLedger::new();
+    for step in ResearchStep::PLAN.iter().take(5) {
+        drop(ledger.enter(*step).expect("the first five are in order"));
+    }
+    let refusal = ledger
+        .enter(ResearchStep::SemanticRetrieval)
+        .expect_err("step 7 cannot precede step 6");
+    assert_eq!(
+        refusal,
+        OrderViolation::OutOfOrder {
+            attempted: 7,
+            attempted_label: SECTION_5[6],
+            expected: 6,
+            expected_label: SECTION_5[5],
+        }
+    );
+}
+
+/// Every one of §5's nine steps is *entered* on a real compilation, in §5's
+/// order — including the ones that contribute nothing, which record why
+/// (§18: degradation is *"visible, not fatal or fabricated"*).
+#[test]
+fn the_plan_enters_all_nine_steps_in_section_5s_order_over_a_real_atlas() {
+    let fixture = fixture();
+    let snapshot = compiled(Some(&fixture.db));
+    assert!(snapshot.degradation.is_none(), "{:?}", snapshot.degradation);
+
+    let executed: Vec<usize> = snapshot.plan.iter().map(|r| r.step.number()).collect();
+    assert_eq!(executed, (1..=9).collect::<Vec<_>>());
+    for record in &snapshot.plan {
+        assert!(
+            record.contributed > 0 || record.note.is_some(),
+            "a step that contributed nothing must say why: {record:?}"
+        );
+    }
+    // §21 item 2's own qualifier — *"where the profile declares such
+    // operations"* — is answered honestly rather than silently skipped.
+    let step_4 = &snapshot.plan[3];
+    assert_eq!(step_4.contributed, 0);
+    assert!(
+        step_4
+            .note
+            .as_deref()
+            .is_some_and(|n| n.contains("declared")),
+        "{step_4:?}"
+    );
+}
+
+// ============================================================ item 2, decisive
+
+/// **§21 item 2, decisively.** The contested resource is one the *fuzzy* step
+/// would have taken if it had run first — and it does not get it.
+///
+/// Three assertions, and all three are needed:
+///
+/// 1. `notes/plan.md` is bound, attributed to **step 2** (the exact Work
+///    changed resource), not step 6.
+/// 2. Step 6 **offered it and lost** — its `already_held` count is non-zero,
+///    which is only possible if lexical retrieval actually reached the same
+///    resource. Without this the test would pass on a world where retrieval
+///    never found it, which is the vacuity trap.
+/// 3. No evidence unit anywhere in the snapshot attributes that resource to a
+///    fuzzy step.
+#[test]
+fn a_resource_retrieval_also_finds_is_attributed_to_the_deterministic_step_that_held_it_first() {
+    let fixture = fixture();
+    let snapshot = compiled(Some(&fixture.db));
+
+    let contested: Vec<&sergeant_rs::runtime::context::EvidenceUnit> = snapshot
+        .bound
+        .iter()
+        .filter(|u| {
+            matches!(&u.coordinate,
+            EvidenceCoordinate::Atlas { relative_path, .. } if relative_path == "notes/plan.md")
+        })
+        .collect();
+    assert_eq!(
+        contested.len(),
+        1,
+        "exactly one unit binds the contested resource: {:?}",
+        snapshot.bound
+    );
+    assert_eq!(
+        contested[0].step,
+        ResearchStep::WorkBindings,
+        "§5 step 2 held it first, so §5 step 2 owns it"
+    );
+    assert_eq!(contested[0].tier, Tier::Bound);
+
+    let step_6 = snapshot
+        .plan
+        .iter()
+        .find(|r| r.step == ResearchStep::LexicalRetrieval)
+        .expect("step 6 ran");
+    assert!(
+        step_6.already_held > 0,
+        "lexical retrieval must actually have reached for evidence a deterministic step \
+         already held — otherwise this test proves nothing about order: {step_6:?}"
+    );
+
+    for unit in snapshot.bound.iter().chain(snapshot.referenced.iter()) {
+        if let EvidenceCoordinate::Atlas { relative_path, .. } = &unit.coordinate
+            && relative_path == "notes/plan.md"
+        {
+            assert_eq!(
+                unit.step.cognition(),
+                Cognition::Computation,
+                "no fuzzy step may end up owning the contested resource: {unit:?}"
+            );
+        }
+    }
+}
+
+/// The counterpart, and the reason the test above is about **order** rather
+/// than about this particular resource: contribute the identical coordinate
+/// from step 6 with no deterministic step having held it, and step 6 owns it.
+///
+/// Same ledger, same coordinate, same gate — only the order differs, and the
+/// recorded attribution follows the order. That is the observable state
+/// difference the brief asks for; it is not an argument about the code.
+#[test]
+fn the_same_resource_is_attributed_to_retrieval_when_no_deterministic_step_held_it_first() {
+    let coordinate = || EvidenceCoordinate::Atlas {
+        source_name: "s".to_string(),
+        generation_id: "g".to_string(),
+        content_key: "c".to_string(),
+        relative_path: "notes/plan.md".to_string(),
+        unit_key: None,
+        ordinal: Some(0),
+    };
+
+    // Deterministic step 2 holds it: step 6 offers and loses.
+    let mut held_first = ResearchLedger::new();
+    drop(held_first.enter(ResearchStep::StageInputs).expect("1"));
+    {
+        let mut step = held_first.enter(ResearchStep::WorkBindings).expect("2");
+        assert!(step.contribute(Tier::Bound, coordinate()));
+    }
+    for step in [
+        ResearchStep::ExactRelationships,
+        ResearchStep::DeclaredDataOperations,
+        ResearchStep::ReferencedNeighbors,
+    ] {
+        drop(held_first.enter(step).expect("3-5"));
+    }
+    {
+        let mut step = held_first.enter(ResearchStep::LexicalRetrieval).expect("6");
+        assert!(
+            !step.contribute(Tier::Bound, coordinate()),
+            "an earlier step already holds it"
+        );
+    }
+    assert_eq!(held_first.units().len(), 1);
+    assert_eq!(held_first.units()[0].step, ResearchStep::WorkBindings);
+
+    // Nothing deterministic held it: step 6 owns it, same coordinate.
+    let mut retrieval_first = ResearchLedger::new();
+    for step in ResearchStep::PLAN.iter().take(5) {
+        drop(retrieval_first.enter(*step).expect("1-5"));
+    }
+    {
+        let mut step = retrieval_first
+            .enter(ResearchStep::LexicalRetrieval)
+            .expect("6");
+        assert!(step.contribute(Tier::Bound, coordinate()));
+    }
+    assert_eq!(retrieval_first.units().len(), 1);
+    assert_eq!(
+        retrieval_first.units()[0].step,
+        ResearchStep::LexicalRetrieval,
+        "with no deterministic holder, the fuzzy step owns it — so the attribution above \
+         was produced by the ORDER, not by the resource"
+    );
+}
+
+// ============================================================ item 10 / §15
+
+/// **§21 item 10.** *"the snapshot pins exact source/Work/query/retrieval
+/// generations"* — and a pin is only a pin if it **re-resolves**.
+///
+/// Each pinned generation is looked back up in the store by its own source
+/// name and must answer with the same generation id and content key. A
+/// snapshot that merely *described* the world would pass a field-presence
+/// check and fail this one.
+#[test]
+fn the_snapshot_pins_generations_that_re_resolve_to_the_same_evidence() {
+    let fixture = fixture();
+    let snapshot = compiled(Some(&fixture.db));
+
+    assert!(
+        snapshot.source_generations.len() >= 2,
+        "the base and the overlay are both in this Work's world: {:?}",
+        snapshot.source_generations
+    );
+    for pin in &snapshot.source_generations {
+        let resolved = fixture
+            .db
+            .confirmed_generation(&pin.source_name)
+            .expect("read")
+            .unwrap_or_else(|| panic!("pin does not re-resolve: {pin:?}"));
+        assert_eq!(resolved.id, pin.generation_id);
+        assert_eq!(resolved.content_key, pin.content_key);
+    }
+
+    // §15's *"Work base + overlay generation"*, both halves.
+    let overlay = snapshot
+        .work_world
+        .overlay_generation
+        .as_ref()
+        .expect("this Work has an overlay generation");
+    assert_eq!(
+        overlay.source_name,
+        overlay_source_name(WORK_ID, REPOSITORY)
+    );
+    assert_eq!(
+        snapshot.work_world.base_sha.as_deref(),
+        Some("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")
+    );
+    assert_eq!(snapshot.journal_watermark, 42);
+    assert_eq!(snapshot.coordinate.execution_id, "01EXECUTION");
+}
+
+/// §15's *"retrieval generation/model if used"* — A2 §13's whole trace,
+/// persisted for a **managed** search, which is the destination
+/// `runtime::atlas::trace` named C1 for.
+#[test]
+fn the_snapshot_pins_the_retrieval_generation_and_model_it_actually_used() {
+    let fixture = fixture();
+    let snapshot = compiled(Some(&fixture.db));
+    let trace = snapshot.retrieval.as_ref().expect("steps 6/7 ran a search");
+
+    assert_eq!(trace.query.text, "tighten the retention policy");
+    assert_eq!(
+        trace.attribution,
+        sergeant_rs::runtime::atlas::trace::Attribution::Work {
+            work_id: WORK_ID.to_string(),
+            repository: REPOSITORY.to_string(),
+        },
+        "a search a Work's own execution issued is a MANAGED search (§13)"
+    );
+    assert!(
+        !trace.retrieval_generation.generations.is_empty(),
+        "the trace names the exact generations the answer was computed over"
+    );
+    // A2 §15's non-omittable honesty rides through onto the snapshot.
+    let json = snapshot.json();
+    assert!(json["retrieval"]["semantic"].is_string(), "{json}");
+}
+
+/// §15 lists sixteen lines. The snapshot has one field per line, in §15's own
+/// order — the discipline `SearchTrace` already applies to A2 §13.
+#[test]
+fn the_snapshot_carries_one_field_per_line_of_section_15s_list() {
+    let fixture = fixture();
+    let json = compiled(Some(&fixture.db)).json();
+    for field in ContextSnapshot::FIELDS {
+        assert!(
+            json.get(field).is_some(),
+            "§15's {field:?} is missing from the snapshot payload: {json}"
+        );
+    }
+    // The two lines a later wave fills are present and empty, never absent —
+    // an absent field cannot be told from a forgotten one.
+    assert_eq!(json["query_result_ids"], serde_json::json!([]));
+    assert_eq!(json["payload_pointer"], Value::Null);
+    assert_eq!(json["budget"], Value::Null);
+}
+
+// ============================================================ §20's non-goals
+
+/// §20's first non-goal: *"raw corpus stuffing"*.
+///
+/// The rendered section names the resource and never carries its body. The
+/// body text is in the fixture and in the store, so a renderer that reached
+/// for it would have it — this is a check that it does not, not that it
+/// could not.
+#[test]
+fn the_rendered_section_carries_coordinates_and_never_a_resource_body() {
+    let fixture = fixture();
+    let snapshot = compiled(Some(&fixture.db));
+    let rendered = snapshot.render_onto("authored stage procedure");
+
+    assert!(
+        rendered.starts_with("authored stage procedure"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("notes/plan.md"), "{rendered}");
+    assert!(
+        !rendered.contains(CONTESTED_BODY),
+        "a resource BODY reached the prompt: {rendered}"
+    );
+    assert!(
+        !rendered.contains("The daemon owns the journal"),
+        "a resource BODY reached the prompt: {rendered}"
+    );
+    assert!(rendered.contains("REACHABLE"), "{rendered}");
+}
+
+/// §15's *"selection-plan hash"* is a hash of the **plan**, not of the set it
+/// selected. Two ledgers that end up holding the identical coordinate hash
+/// differently when a different step contributed it.
+#[test]
+fn the_selection_plan_hash_separates_two_plans_that_selected_the_same_evidence() {
+    let fixture = fixture();
+    let a = compiled(Some(&fixture.db));
+    let b = compiled(Some(&fixture.db));
+    assert_eq!(
+        a.selection_plan_hash, b.selection_plan_hash,
+        "the same plan over the same world hashes the same"
+    );
+
+    // A different plan over the same world: no prior stage artifact, so step
+    // 1 contributes nothing and the executed record differs even though every
+    // Atlas coordinate selected is identical.
+    let stage = stage();
+    let bindings = bindings();
+    let c = compile(
+        Some(&fixture.db),
+        &CompileRequest {
+            estate_root: Some(Path::new("/estates/demo")),
+            work_id: WORK_ID,
+            intent: "tighten the retention policy",
+            stage: &stage,
+            stage_index: 1,
+            attempt: 1,
+            execution_id: "01EXECUTION",
+            journal_watermark: 42,
+            bindings: &bindings,
+            prior_stages: &[],
+            profile: Some("standard"),
+        },
+    );
+    assert_ne!(
+        a.selection_plan_hash, c.selection_plan_hash,
+        "a plan whose steps did different work hashes differently"
+    );
+}
+
+// ============================================================ item 13
+
+/// **§21 item 13, at the type.** No compiler installed ⇒ §18's first rung:
+/// *"intelligence disabled → existing stage CONTEXT + Work bindings"*.
+///
+/// The authored context comes back **byte for byte**, and the snapshot says
+/// which rung of §18 it is on rather than leaving an empty snapshot to be
+/// interpreted.
+#[test]
+fn a_stage_with_no_compiler_installed_gets_its_authored_context_byte_for_byte() {
+    let snapshot = compiled(None);
+    assert_eq!(
+        snapshot.degradation,
+        Some(Degradation::IntelligenceDisabled)
+    );
+    assert!(snapshot.bound.is_empty() && snapshot.referenced.is_empty());
+    let authored = "authored stage procedure";
+    assert_eq!(snapshot.render_onto(authored), authored);
+}
+
+/// **§21 item 13's other half**: intelligence *installed but unavailable* —
+/// an Atlas with no confirmed generation for this Work's world.
+///
+/// §3's degradation clause says *"the existing stage context path still
+/// executes"*, and that is what this asserts: the same bytes, and a stated
+/// reason that is **not** the disabled one, because the two are different
+/// facts about the estate.
+#[test]
+fn an_estate_with_no_confirmed_generation_leaves_the_context_byte_identical_and_says_why() {
+    let empty = AtlasDb::open_in_memory().expect("atlas");
+    let snapshot = compiled(Some(&empty));
+    assert_eq!(
+        snapshot.degradation,
+        Some(Degradation::NoConfirmedGeneration)
+    );
+    let authored = "authored stage procedure";
+    assert_eq!(snapshot.render_onto(authored), authored);
+    assert!(
+        snapshot.plan.is_empty(),
+        "no step runs in a world with no generation to run over"
+    );
+}
+
+// ============================================================ live estate
+
+const FAKE: &str = sergeant_rs::backend::fake::FAKE_BACKEND_NAME;
+
+/// Start a daemon over `data_dir` with one scripted fake backend.
+async fn start(
+    data_dir: &Path,
+    registry: sergeant_rs::backend::BackendRegistry,
+) -> sergeant_rs::daemon::DaemonHandle {
+    sergeant_rs::daemon::start_with(
+        data_dir,
+        sergeant_rs::daemon::DaemonConfig {
+            backends: std::sync::Arc::new(registry),
+            default_backend: Some(FAKE.to_string()),
+            claude: None,
+            ..sergeant_rs::daemon::DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start")
+}
+
+/// A registry holding one scripted fake.
+fn one_fake(
+    script: impl IntoIterator<Item = sergeant_rs::backend::fake::FakeStep>,
+) -> (
+    sergeant_rs::backend::BackendRegistry,
+    sergeant_rs::backend::fake::FakeBackend,
+) {
+    let fake = sergeant_rs::backend::fake::FakeBackend::scripted(FAKE, script);
+    (
+        sergeant_rs::backend::BackendRegistry::new().with(std::sync::Arc::new(fake.clone())),
+        fake,
+    )
+}
+
+/// Submit the two-stage `tiny` workflow against `estate`, and return the id
+/// of the Work it created.
+async fn submit_tiny(handle: &sergeant_rs::daemon::DaemonHandle, estate: &Path) -> String {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .expect("client");
+    let body = serde_json::json!({
+        "command_id": ulid::Ulid::generate().to_string(),
+        "intent": "compile a world for this stage",
+        "estate_root": estate,
+        "origin": {"client": "cli", "cwd": estate},
+        "workflow": "tiny",
+    });
+    let response = client
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = response.status();
+    let value: Value = response.json().await.expect("json body");
+    assert_eq!(status, 201, "submit rejected: {value}");
+    assert_eq!(value["work"]["state"], "completed", "{value}");
+    value["work"]["id"].as_str().expect("work id").to_string()
+}
+
+/// Every journaled event of one kind for one Work, in journal order.
+fn events_of(data_dir: &Path, work_id: &str, kind: &str) -> Vec<sergeant_rs::domain::event::Event> {
+    Journal::replay_data_dir(data_dir)
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.work_id.as_deref() == Some(work_id) && e.kind == kind)
+        .collect()
+}
+
+/// **§21 item 1**: *"fresh ordinary actor stage launches with a pinned
+/// context snapshot"* — against a real daemon, a real estate and a real
+/// stage launch.
+///
+/// The snapshot is journaled once per stage entry and names the exact
+/// execution the reservation then allocates, so *"what world did Sergeant
+/// present?"* is answerable for **that** fresh execution rather than for the
+/// Work in general (§15's *"Every fresh execution can answer…"*).
+#[tokio::test]
+async fn every_fresh_actor_stage_launch_journals_a_snapshot_for_its_own_execution() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    let (_repo, _head) = support::scaffold_solo_estate(&estate, "solo");
+    write_two_stage_workflow(&estate);
+
+    let (registry, fake) = one_fake([
+        sergeant_rs::backend::fake::FakeStep::complete_with("first done"),
+        sergeant_rs::backend::fake::FakeStep::complete_with("second done"),
+    ]);
+    let handle = start(data.path(), registry).await;
+    let work_id = submit_tiny(&handle, &estate).await;
+
+    let starts = fake.starts();
+    assert_eq!(starts.len(), 2, "{starts:?}");
+
+    let snapshots = events_of(data.path(), &work_id, KIND_CONTEXT_COMPILED);
+    assert_eq!(
+        snapshots.len(),
+        2,
+        "one snapshot per fresh actor stage launch, no more and no fewer"
+    );
+    for (snapshot, start) in snapshots.iter().zip(starts.iter()) {
+        let payload = &snapshot.payload;
+        assert_eq!(
+            payload["coordinate"]["execution"].as_str(),
+            Some(start.execution_id.as_str()),
+            "the snapshot names the execution it was compiled for: {payload}"
+        );
+        assert_eq!(
+            payload["coordinate"]["work"].as_str(),
+            Some(work_id.as_str())
+        );
+        assert_eq!(
+            payload["coordinate"]["stage"].as_str(),
+            Some(start.stage_id.as_str())
+        );
+        for field in ContextSnapshot::FIELDS {
+            assert!(payload.get(field).is_some(), "§15's {field:?}: {payload}");
+        }
+    }
+
+    handle.shutdown().await;
+}
+
+/// **§21 item 13, live.** An estate this host has indexed nothing for still
+/// launches on the existing stage context path: the actor receives the
+/// stage's authored `CONTEXT.md` **byte for byte**, and the journal states
+/// which rung of §18 that is instead of leaving an empty snapshot to be
+/// interpreted.
+#[tokio::test]
+async fn an_unindexed_estate_launches_on_the_existing_stage_context_path() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    let (_repo, _head) = support::scaffold_solo_estate(&estate, "solo");
+    write_two_stage_workflow(&estate);
+
+    let (registry, fake) = one_fake([
+        sergeant_rs::backend::fake::FakeStep::complete_with("first done"),
+        sergeant_rs::backend::fake::FakeStep::complete_with("second done"),
+    ]);
+    let handle = start(data.path(), registry).await;
+    let work_id = submit_tiny(&handle, &estate).await;
+
+    let starts = fake.starts();
+    assert_eq!(
+        starts[0].context, "first stage context",
+        "the authored CONTEXT.md, byte for byte — nothing appended"
+    );
+    assert_eq!(starts[1].context, "second stage context");
+
+    let snapshots = events_of(data.path(), &work_id, KIND_CONTEXT_COMPILED);
+    assert!(
+        !snapshots.is_empty(),
+        "the degradation is journaled, not silent"
+    );
+    for snapshot in &snapshots {
+        let reason = snapshot.payload["degradation"]["reason"].as_str();
+        assert!(
+            matches!(
+                reason,
+                Some("no_confirmed_generation") | Some("intelligence_disabled")
+            ),
+            "degradation must be stated: {}",
+            snapshot.payload
+        );
+        assert_eq!(snapshot.payload["rendered_bytes"], 0);
+    }
+
+    handle.shutdown().await;
+}
+
+/// A two-stage workflow whose stage contexts are exactly the two strings the
+/// live tests compare against.
+fn write_two_stage_workflow(estate: &Path) {
+    let root = estate.join(".sergeant").join("workflows").join("tiny");
+    std::fs::create_dir_all(&root).expect("workflow dir");
+    std::fs::write(
+        root.join("workflow.toml"),
+        "[workflow]\nname = \"tiny\"\nversion = \"1\"\nstages = [\"00-first\", \"10-second\"]\n",
+    )
+    .expect("workflow.toml");
+    for (id, context) in [
+        ("00-first", "first stage context"),
+        ("10-second", "second stage context"),
+    ] {
+        std::fs::create_dir_all(root.join(id)).expect("stage dir");
+        std::fs::write(root.join(id).join("CONTEXT.md"), context).expect("CONTEXT.md");
+    }
+}

--- a/tests/c1a_compiled_context.rs
+++ b/tests/c1a_compiled_context.rs
@@ -163,7 +163,13 @@ fn fixture() -> Fixture {
                 )],
             ),
             file(
-                "docs/glossary.md",
+                // A synthetic fixture path, deliberately not any real docs/
+                // path: `f_doctrine_skew`'s removed-path guard scans test
+                // sources for citations of files split-hardening W2c deleted,
+                // and it cannot tell a fixture from a citation. Naming a live
+                // doc here would also couple this fixture to that file's
+                // location. This name belongs to no real or removed file.
+                "docs/team-vocabulary.md",
                 vec![unit(0, "Glossary", "A surface is a linked worktree.")],
             ),
         ],


### PR DESCRIPTION
## What

C1 §3's compilation step, inserted into the **existing** stage launch path — not a second pipeline.

`Engine::reserve_stage` gains `compile_stage_context` between the execution id being allocated and the adapter being asked to PREPARE. Same `StartRequest`, same `prepare`, same reservation, same `Next::Launch`. `context_compiler: Option<Arc<dyn ContextCompiler>>` — `None` **is** the pre-C1 path, by construction (C1-01, **R2**).

## §5's nine steps are a gate, not a convention

> *"This is where **spend computation before cognition** becomes **enforceable runtime order**."*

`ResearchLedger::enter` refuses any step that is not §5's next one, and reports `CognitionBeforeComputation` **naming both steps** when a fuzzy step (6/7) jumps a deterministic one. Every step is entered even when it contributes nothing, so skipping is unrepresentable and §18's degradation stays visible.

**The decisive test is that the order changes the outcome**, not that the content looks right:

- `a_resource_retrieval_also_finds_is_attributed_to_the_deterministic_step_that_held_it_first` — a contested `notes/plan.md` is owned by step 2, and step 6's record shows `already_held > 0`.
- Its counterpart, `the_same_resource_is_attributed_to_retrieval_when_no_deterministic_step_held_it_first` — identical coordinate, no deterministic holder, step 6 owns it.

Asserting final content cannot see order. These two can.

## Non-vacuity proved by mutation, not by reading

`3714dc54` was recovered from staged work when the session died — it compiled but no test had run against it, which is exactly the shape that makes an attribution test go quietly vacuous. So:

1. **Deleted step 2's overlay contribution.** `..._attributed_to_the_deterministic_step_that_held_it_first` went **red**: `left: LexicalRetrieval, right: WorkBindings` — the fuzzy step genuinely *would* have won the contested resource.
2. **Swapped the step at position 5 to `LexicalRetrieval`.** The nine-step test went **red** with `CognitionBeforeComputation { fuzzy: 6 "A2 lexical retrieval", deterministic: 5 "exact Referenced neighbors" }`.

Both reverted from a byte-identical backup; tree and fmt clean after.

## Retrieval is consumed, not reimplemented

Steps 6/7 call `AtlasDb::traced_search` and keep A2 §13's trace on the snapshot. **`git diff 73deeb38..HEAD -- src/runtime/atlas/` is empty** — S5's rebuilt SQL boundary (`SqlText` / `Sql::of` / `ReadOnly` + `read_sql!`, three rounds to earn) is not merely intact, it is untouched. `context.rs` contains no `read_sql!`, `Sql::of`, `execute` or `prepare(`.

One Atlas database: the daemon derives the compiler's handle from `analytics.atlas()` (a `try_clone`), never a second `AtlasDb::open` — which matters because two opens on one path give two independent instances, last-close-wins, silently.

## Acceptance items closed

| # | Proof |
|---|---|
| **1** | `every_fresh_actor_stage_launch_journals_a_snapshot_for_its_own_execution` — real daemon, real estate, two stages, `coordinate.execution` == the reservation's id |
| **10** | `the_snapshot_pins_generations_that_re_resolve_to_the_same_evidence` — each pin looked back up by source name, same generation id **and** content key. A pin that re-resolves, not a description |
| **2** | the gate above, plus `the_nine_steps_are_section_5s_own_list_in_section_5s_own_order` |
| **13** | `a_stage_with_no_compiler_installed_gets_its_authored_context_byte_for_byte`, and live: `an_unindexed_estate_launches_on_the_existing_stage_context_path` |

Plus `an_execute_stage_launch_is_never_compiled` (real daemon + real Docker, mixed actor→execute→actor) and `the_rendered_section_carries_coordinates_and_never_a_resource_body` for §20's no-raw-corpus-stuffing — the body text *is* in the store, so a renderer reaching for it would have found it.

## Panel

2 raised, 1 confirmed: step 8 re-implemented the per-generation loop that `3714dc54` had just extracted. Fixed by reuse (R2), with the retrieval-hit path filter folded into the fetch closure.

## Verification

fmt clean, clippy `-D warnings` clean. `c1a_compiled_context` 18/18; with the one-Atlas-database boundary and the acceptance register: **32/32**. `m3_execution` (the launch path this wave modifies) 61/61 — one earlier failure in that binary passes in isolation and is the #258 binary-spawning flake class, flagged not swept.

Full suite deliberately not run locally: CI is the exhaustive pass by SHA, and local full runs alongside other work have twice taken this host down.

R2 (extends the existing path; consumes S5's retrieval; reuses the extracted loop). C1-01. J5 (§3 and §5 govern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4