### PR TITLE
feat(context): S6 C1b — the three tiers and §14's two hard budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1590,8 +1590,10 @@ them were dead code in every real installation.
   and the adapter being asked to PREPARE — not a second execution pipeline.
   The compiled world is *appended* to the stage's authored `CONTEXT.md` by
   the same rule the branch-status fact already used: the authored bytes are
-  untouched, and the appended section carries evidence **coordinates**,
-  never resource bodies (C1 §20's first non-goal).
+  untouched, and the appended section carries evidence **coordinates** — and,
+  once C1b's budget landed below, the body §14's hard budget allowed beside
+  them; C1a itself rendered no body at all, because C1 §20's first non-goal
+  is raw corpus stuffing and an unbudgeted body is exactly that.
 - **§5's nine research steps are enforceable runtime order, not advice.**
   `ResearchLedger::enter` refuses any step that is not §5's next one, and
   reports a fuzzy step (A2 lexical/semantic retrieval) that jumps a
@@ -1633,6 +1635,38 @@ them were dead code in every real installation.
   provenance, and attribution/nesting/audit are **not** in this change;
   they are C1b/C1c/C1d, and the places that under-deliver until then say so
   where they under-deliver.
+- **Bound evidence now renders its body, inside two hard budgets** (C1 §14,
+  C1b). §5 step 9 — *"pack Bound; emit useful remainder as Referenced"* — is
+  where the budget is spent: a Bound unit renders its coordinate *and* its
+  source text when the whole chunk fits what is left of the Bound budget,
+  and a unit that does not fit is never truncated into the prompt — it is
+  emitted as Referenced remainder, keeping the §5 step that selected it.
+  Referenced has its own **separate, smaller** budget, because a pointer is
+  far cheaper than a resource: exhausting either never spends or starves the
+  other. Both budgets are in bytes of rendered UTF-8, which is §14's
+  *"conservative documented estimate"* — no backend exposes a token count at
+  the launch boundary (`StartRequest` carries none, and `Capabilities::usage`
+  is post-turn reporting), and every tokenizer maps at least one byte per
+  token, so a byte bound can only over-state token cost. It adds no tokenizer
+  dependency. The two default numbers (8 KiB Bound, 2 KiB Referenced) are
+  traced in `RenderBudget`'s own doc to a dated measurement of this
+  repository's 55 shipped stage `CONTEXT.md` files and its own path lengths.
+- **A coordinate resolves by direct lookup, and the budget does not bound
+  the actor.** `AtlasDb::resolve_unit`/`resolve_relationship` are equality
+  lookups on the row identity a pinned coordinate already carries — C1 §21
+  item 4's *"without broad rediscovery"* — so resolving a Referenced pointer
+  never goes near retrieval, and two content-identical rows in two
+  generations resolve to their own rows. Nothing on that path can see a
+  budget: §14's *"the budget is for automatic prompt material, not a ban on
+  the actor resolving Reachable/Referenced evidence"* is a property of the
+  API rather than a promise. An exhausted budget still renders §2's
+  Reachable descriptor with all four managed verbs, and still leaves every
+  evidence id in the snapshot.
+- **External evidence renders as a coordinate only**, pending C1c's item 9
+  labeling: until external evidence can be shown as visibly external and
+  unable to alter instruction hierarchy, external prose does not enter an
+  actor's prompt from here. §15's `budget` line is no longer empty; it
+  carries both budgets and what each tier actually spent.
 
 
 ## [0.2.4] - 2026-08-25

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -388,3 +388,11 @@ cov_stage_end 1 "the w5_search_surface test binary must write its own profile"
 cov_stage_begin c2-c1a_compiled_context
 cov_run cargo llvm-cov --no-report --test c1a_compiled_context --locked || cov_fail "c1a_compiled_context failed under instrumentation"
 cov_stage_end 1 "the c1a_compiled_context test binary must write its own profile"
+
+# S6 C1b, wired at birth (the #231 lesson): C1 §2's three tiers and §14's two
+# hard rendering budgets — items 3, 4 and 5. Nine in-process tests over a real
+# Atlas built by the ordinary `record_scan` path, including a 64 KiB unit the
+# budget must refuse to render. No daemon, no estate, no subprocess. Floor 1.
+cov_stage_begin c2-c1b_tiers_and_budget
+cov_run cargo llvm-cov --no-report --test c1b_tiers_and_budget --locked || cov_fail "c1b_tiers_and_budget failed under instrumentation"
+cov_stage_end 1 "the c1b_tiers_and_budget test binary must write its own profile"

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -2335,6 +2335,115 @@ impl AtlasDb {
         Ok(out)
     }
 
+    /// **One exact unit, by its pinned coordinate** — C1 §21 item 4's
+    /// *"Referenced coordinates resolve **without broad rediscovery**"*, as a
+    /// keyed lookup.
+    ///
+    /// Every predicate is an equality on the coordinate a
+    /// [`crate::runtime::context::EvidenceCoordinate`] already carries:
+    /// `(generation_id, relative_path, ordinal)` is `source.units`' own
+    /// identity, so this reads one row and never ranks, scans a corpus, or
+    /// consults `context.lexical_units`. That is the difference item 4 is
+    /// about: [`Self::units`] lists a generation and [`Self::lexical_search`]
+    /// *searches* it; this resolves a pointer someone was already handed.
+    ///
+    /// Keyed on `generation_id` and **not** on `state = confirmed`, unlike
+    /// [`Self::units`]: a snapshot pins an exact generation precisely so it
+    /// re-resolves later, and a pin that stopped resolving the moment a newer
+    /// generation was confirmed would be a description rather than a pin
+    /// (§15). Nothing widens by it — a generation id only ever reaches a
+    /// caller through the admissibility filter that admitted it.
+    pub fn resolve_unit(
+        &self,
+        generation_id: &str,
+        relative_path: &str,
+        ordinal: u64,
+    ) -> Result<Option<StoredUnit>, AtlasError> {
+        let mut statement = self.conn.prepare(sql!(
+            "SELECT u.relative_path, u.local_key, u.ordinal, u.unit_kind, u.heading_level, \
+                    u.title, u.byte_start, u.byte_end, u.body \
+             FROM source.units u \
+             WHERE u.generation_id = ? AND u.relative_path = ? AND u.ordinal = ?"
+        ))?;
+        let mut rows = statement.query(duckdb::params![
+            generation_id,
+            relative_path,
+            ordinal as i64
+        ])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        let kind: String = row.get(3)?;
+        Ok(Some(StoredUnit {
+            relative_path: row.get(0)?,
+            local_key: row.get(1)?,
+            ordinal: row.get::<usize, i64>(2)? as u64,
+            kind: UnitKind::parse(&kind).ok_or_else(|| AtlasError::UnknownValue {
+                column: "unit_kind".to_string(),
+                value: kind.clone(),
+            })?,
+            heading_level: row.get::<usize, Option<i64>>(4)?.map(|v| v as u8),
+            title: row.get(5)?,
+            byte_start: row.get::<usize, i64>(6)? as u64,
+            byte_end: row.get::<usize, i64>(7)? as u64,
+            body: row.get(8)?,
+        }))
+    }
+
+    /// **One exact stored relationship, by its pinned coordinate** — item 4's
+    /// other coordinate shape, resolved the same keyed way as
+    /// [`Self::resolve_unit`].
+    ///
+    /// `kind` picks the table because the two relationships C1 §5 contributes
+    /// are stored in two: a container/document/mail parent-child row lives in
+    /// `source.child_resources` and every syntax-derived edge lives in
+    /// `source.edges`. Both lookups are equalities on the coordinate's own
+    /// fields; neither scans a generation.
+    pub fn resolve_relationship(
+        &self,
+        generation_id: &str,
+        kind: &str,
+        from: &str,
+        to: &str,
+    ) -> Result<Option<ResolvedRelationship>, AtlasError> {
+        if kind == CHILD_RESOURCE_RELATIONSHIP {
+            let mut statement = self.conn.prepare(sql!(
+                "SELECT c.parent_relative_path, c.relative_path, c.entry_path \
+                 FROM source.child_resources c \
+                 WHERE c.generation_id = ? AND c.parent_relative_path = ? \
+                   AND c.relative_path = ?"
+            ))?;
+            let mut rows = statement.query(duckdb::params![generation_id, from, to])?;
+            let Some(row) = rows.next()? else {
+                return Ok(None);
+            };
+            return Ok(Some(ResolvedRelationship {
+                kind: CHILD_RESOURCE_RELATIONSHIP.to_string(),
+                from: row.get(0)?,
+                to: row.get(1)?,
+                ordinal: None,
+                detail: row.get::<usize, Option<String>>(2)?,
+            }));
+        }
+        let mut statement = self.conn.prepare(sql!(
+            "SELECT e.relative_path, e.target, e.ordinal, e.language \
+             FROM source.edges e \
+             WHERE e.generation_id = ? AND e.edge_kind = ? AND e.relative_path = ? \
+               AND e.target = ?"
+        ))?;
+        let mut rows = statement.query(duckdb::params![generation_id, kind, from, to])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        Ok(Some(ResolvedRelationship {
+            kind: kind.to_string(),
+            from: row.get(0)?,
+            to: row.get(1)?,
+            ordinal: Some(row.get::<usize, i64>(2)? as u64),
+            detail: row.get::<usize, Option<String>>(3)?,
+        }))
+    }
+
     /// The symbol index of one source's confirmed generation, in
     /// `(language, label, name)` order, bounded by `limit` (capped at
     /// [`MAX_ROWS`], F12).
@@ -5399,6 +5508,41 @@ pub struct StoredEdge {
     pub byte_start: u64,
     /// End offset into the original file bytes, exclusive.
     pub byte_end: u64,
+}
+
+/// The relationship kind C1 §5 step 3 contributes for a container/document/
+/// mail parent-child row, and the one value of
+/// [`AtlasDb::resolve_relationship`]'s `kind` that reads
+/// `source.child_resources` rather than `source.edges`.
+///
+/// Declared here rather than spelled twice: the producer is
+/// [`crate::runtime::context`]'s `child_relationship` and the consumer is the
+/// resolver, and a literal in each is exactly the drift that would make a
+/// coordinate unresolvable while both files still looked right.
+pub const CHILD_RESOURCE_RELATIONSHIP: &str = "child_resource";
+
+/// One stored relationship, re-resolved from its exact coordinate by
+/// [`AtlasDb::resolve_relationship`].
+///
+/// Deliberately not [`StoredEdge`] or [`StoredChildResource`]: the two tables
+/// answer with different columns, and the thing item 4 asks for is that the
+/// pinned coordinate *resolves to the row it names* — the ends, and whatever
+/// one extra fact that table holds about them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRelationship {
+    /// The relationship's kind, as the coordinate named it.
+    pub kind: String,
+    /// The end it leaves from.
+    pub from: String,
+    /// The end it names — **unresolved** for a syntax edge, exactly as
+    /// [`StoredEdge::target`] is.
+    pub to: String,
+    /// Position within its file's edge list, for an edge. `None` for a
+    /// child-resource row, which has no ordinal.
+    pub ordinal: Option<u64>,
+    /// The one extra fact the storing table holds: §6.6's entry path for a
+    /// child resource, the grammar's language for an edge.
+    pub detail: Option<String>,
 }
 
 /// One coverage row read back out of the store, with the generation it

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -2399,12 +2399,22 @@ impl AtlasDb {
     /// `source.child_resources` and every syntax-derived edge lives in
     /// `source.edges`. Both lookups are equalities on the coordinate's own
     /// fields; neither scans a generation.
+    ///
+    /// `ordinal` (F-IN-01) discriminates two edges that legitimately share
+    /// every other field — e.g. the same file importing the same target
+    /// twice — which `(generation_id, edge_kind, relative_path, target)`
+    /// alone cannot: without it, `rows.next()` took whichever matching row
+    /// DuckDB returned first, non-deterministically. `None` widens back to
+    /// the old any-match behavior, which is correct for the child-resource
+    /// branch (no ordinal column) and for a coordinate pinned before this
+    /// field existed.
     pub fn resolve_relationship(
         &self,
         generation_id: &str,
         kind: &str,
         from: &str,
         to: &str,
+        ordinal: Option<u64>,
     ) -> Result<Option<ResolvedRelationship>, AtlasError> {
         if kind == CHILD_RESOURCE_RELATIONSHIP {
             let mut statement = self.conn.prepare(sql!(
@@ -2425,13 +2435,21 @@ impl AtlasDb {
                 detail: row.get::<usize, Option<String>>(2)?,
             }));
         }
+        let ordinal_param = ordinal.map(|o| o as i64);
         let mut statement = self.conn.prepare(sql!(
             "SELECT e.relative_path, e.target, e.ordinal, e.language \
              FROM source.edges e \
              WHERE e.generation_id = ? AND e.edge_kind = ? AND e.relative_path = ? \
-               AND e.target = ?"
+               AND e.target = ? AND (? IS NULL OR e.ordinal = ?)"
         ))?;
-        let mut rows = statement.query(duckdb::params![generation_id, kind, from, to])?;
+        let mut rows = statement.query(duckdb::params![
+            generation_id,
+            kind,
+            from,
+            to,
+            ordinal_param,
+            ordinal_param
+        ])?;
         let Some(row) = rows.next()? else {
             return Ok(None);
         };

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1493,15 +1493,29 @@ fn pack(
             // Only resolve while the budget could still hold the answer:
             // resolving past exhaustion would be a read whose result is
             // thrown away.
+            // Two coordinate shapes carry a body worth resolving here: an
+            // Atlas unit's text, and a Relationship's `detail` (F-SF-01 —
+            // this used to match Atlas only, so §5 step 3's relationships
+            // stayed coordinate-only forever even though they resolve to
+            // real evidence exactly like an Atlas unit does).
+            let generation_id = match &candidate.coordinate {
+                EvidenceCoordinate::Atlas { generation_id, .. }
+                | EvidenceCoordinate::Relationship { generation_id, .. } => {
+                    Some(generation_id.as_str())
+                }
+                _ => None,
+            };
             if bound_spent < budget.bound_bytes
-                && let EvidenceCoordinate::Atlas { generation_id, .. } = &candidate.coordinate
+                && let Some(generation_id) = generation_id
             {
-                if external.contains(generation_id.as_str()) {
+                if external.contains(generation_id) {
                     withheld_external += 1;
-                } else if let Ok(Some(SourceEvidence::Unit { text, .. })) =
-                    resolve(atlas, &candidate.coordinate)
-                {
-                    candidate.excerpt = Some(text);
+                } else if let Ok(Some(evidence)) = resolve(atlas, &candidate.coordinate) {
+                    candidate.excerpt = match evidence {
+                        SourceEvidence::Unit { text, .. } => Some(text),
+                        SourceEvidence::Relationship(relationship) => relationship.detail,
+                        _ => None,
+                    };
                 }
             }
             let cost = render_chunk(&candidate).len() as u64;

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1486,6 +1486,7 @@ fn pack(
     let mut demoted = 0usize;
     let mut unrendered = 0usize;
     let mut withheld_external = 0usize;
+    let mut resolve_failed = 0usize;
 
     for unit in units {
         let mut candidate = unit.clone();
@@ -1510,12 +1511,24 @@ fn pack(
             {
                 if external.contains(generation_id) {
                     withheld_external += 1;
-                } else if let Ok(Some(evidence)) = resolve(atlas, &candidate.coordinate) {
-                    candidate.excerpt = match evidence {
-                        SourceEvidence::Unit { text, .. } => Some(text),
-                        SourceEvidence::Relationship(relationship) => relationship.detail,
-                        _ => None,
-                    };
+                } else {
+                    // Err(_) (a genuine Atlas read failure) and an honest
+                    // Ok(None)/Ok(Some(WorkRecord)) both leave no excerpt,
+                    // but they are not the same outcome (F-IN-02): a real
+                    // backend error is counted and journaled in step 9's
+                    // note rather than silently absorbed into "nothing to
+                    // render".
+                    match resolve(atlas, &candidate.coordinate) {
+                        Ok(Some(evidence)) => {
+                            candidate.excerpt = match evidence {
+                                SourceEvidence::Unit { text, .. } => Some(text),
+                                SourceEvidence::Relationship(relationship) => relationship.detail,
+                                _ => None,
+                            };
+                        }
+                        Ok(None) => {}
+                        Err(_) => resolve_failed += 1,
+                    }
                 }
             }
             let cost = render_chunk(&candidate).len() as u64;
@@ -1558,6 +1571,12 @@ fn pack(
         note.push_str(&format!(
             "; {withheld_external} external unit(s) rendered as coordinates only, pending §21 \
              item 9's external labeling (C1c)"
+        ));
+    }
+    if resolve_failed > 0 {
+        note.push_str(&format!(
+            "; {resolve_failed} Bound unit(s) failed to resolve during packing (an Atlas read \
+             error, not a missing row) and were rendered as coordinates only"
         ));
     }
     if unrendered > 0 {

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -109,19 +109,32 @@
 //! statement to that surface at all, so there is nothing here for a runtime
 //! string to get into (**R2/R3**).
 //!
+//! # §14's two budgets and the three tiers' resolution (C1b)
+//!
+//! §5 step 9 — *"pack Bound; emit useful remainder as Referenced"* — is where
+//! [`RenderBudget`] is spent ([`pack`]). Two budgets, not one, because §14
+//! says *"Referenced coordinates have a **small separate** rendering budget"*;
+//! both are **hard**, so a source bigger than the Bound budget becomes
+//! Referenced remainder rather than a truncated body; and neither is visible
+//! to [`resolve`], because §14's last sentence says the budget *"is not a ban
+//! on the actor resolving Reachable/Referenced evidence when needed"*.
+//! [`resolve`] is a keyed lookup on the coordinate's own row identity —
+//! §21 item 4's *"without broad rediscovery"* — and it is the same call
+//! packing uses to fetch what it renders, so every rendered Bound unit
+//! resolves back to the stored row it came from by construction (item 3).
+//!
 //! # What this wave does NOT do
 //!
-//! §14's budget and the three tiers' resolution are C1b (items 3, 4, 5);
-//! authority, provenance and structured query results are C1c (items 6–9);
+//! Authority, provenance and structured query results are C1c (items 6–9);
 //! attribution, nesting and audit are C1d (items 11, 12, 14). Fields §15 asks
 //! for that those waves fill are present and empty, each naming its wave —
 //! never absent, because an absent field is indistinguishable from a
 //! forgotten one.
 //!
 //! §20's non-goals this step is closest to are named and refused: **no raw
-//! corpus stuffing** ([`ContextSnapshot::render_onto`] renders *coordinates*,
-//! never resource bodies — §2's Referenced shape, applied to Bound too until
-//! C1b's budget exists to render content safely), **no automatic Work scope
+//! corpus stuffing** (a Bound body renders only inside §14's hard budget, and
+//! a resource too large for it is never truncated into the prompt — it
+//! becomes Referenced remainder), **no automatic Work scope
 //! expansion** (§4: *"The compiler does not silently add repos to Work
 //! mutation scope because a search result is relevant"* — nothing here
 //! touches [`crate::runtime::surface::WorkSurface`] or a binding), **no
@@ -135,7 +148,7 @@ use std::path::Path;
 use serde_json::{Value, json};
 
 use crate::backend::BindingSummary;
-use crate::domain::source::SourceGeneration;
+use crate::domain::source::{AuthorityClass, SourceGeneration};
 use crate::domain::workflow::{StageDefinition, StageRecord};
 use crate::runtime::atlas::db::{
     Admissibility, AtlasDb, AtlasError, LexicalQuery, SourceSelector, StoredChildResource,
@@ -404,9 +417,12 @@ impl EvidenceCoordinate {
     /// make the ordering unobservable and this whole mechanism decorative.
     ///
     /// The cost is stated rather than hidden: a resource bound by an early
-    /// step absorbs every later hit inside it, so C1a binds resources, not
-    /// spans. §14's budget (C1b) is what makes span-level selection
-    /// meaningful, and that is the wave to refine this in.
+    /// step absorbs every later hit inside it, so this binds resources, not
+    /// spans. C1b kept it that way deliberately: the contest above only
+    /// exists because both entrants address the same key, and a span-keyed
+    /// identity would make §5's order unobservable again. What C1b's budget
+    /// changed is what a *bound* resource costs — a unit that does not fit
+    /// becomes Referenced remainder — not what counts as the same evidence.
     pub fn dedup_key(&self) -> String {
         match self {
             Self::Stage {
@@ -549,10 +565,28 @@ impl EvidenceCoordinate {
 pub struct EvidenceUnit {
     /// The §5 step that contributed it, first-contributor-wins.
     pub step: ResearchStep,
-    /// §2's tier it landed in.
+    /// §2's tier it landed in — as **packing** left it (§5 step 9), which is
+    /// not always the tier the contributing step asked for: Bound evidence
+    /// that did not fit §14's hard budget is *"useful remainder"* and is
+    /// emitted as Referenced.
     pub tier: Tier,
     /// Where the evidence actually is.
     pub coordinate: EvidenceCoordinate,
+    /// The unit's own source text, when §14's Bound budget had room to
+    /// render it — §2's Bound tier is *"evidence deliberately **rendered
+    /// into** the actor's initial context"*, which a coordinate alone is not.
+    ///
+    /// `None` is not "no text exists": it is *this unit is carried as a
+    /// pointer*, either because the budget was spent, because the coordinate
+    /// is a Work record rather than a stored resource, or because the
+    /// evidence is external (see [`pack`]). The text is still resolvable —
+    /// §14: the budget *"is not a ban on the actor resolving Reachable/
+    /// Referenced evidence when needed"*.
+    pub excerpt: Option<String>,
+    /// Whether the **automatic** render carried this unit at all. A unit past
+    /// both budgets stays in the snapshot (§15's *"Bound/Referenced evidence
+    /// IDs"*) and stays resolvable; it simply is not spent on the prompt.
+    pub rendered: bool,
 }
 
 impl EvidenceUnit {
@@ -564,6 +598,8 @@ impl EvidenceUnit {
             "cognition": self.step.cognition().as_str(),
             "tier": self.tier.as_str(),
             "coordinate": self.coordinate.json(),
+            "rendered": self.rendered,
+            "excerpt_bytes": self.excerpt.as_ref().map(|e| e.len()),
         })
     }
 }
@@ -724,6 +760,11 @@ impl StepWriter<'_> {
             step: self.step,
             tier,
             coordinate,
+            // Packing (§5 step 9) decides both of these, once the whole plan
+            // has run and §14's budget can be spent on the evidence that
+            // actually exists. A contributing step never renders.
+            excerpt: None,
+            rendered: false,
         });
         self.contributed += 1;
         true
@@ -867,12 +908,18 @@ pub struct ContextSnapshot {
     /// *content*, which is the only payload big enough to need decision
     /// C1-09's blob seam. What this wave renders is coordinates, inline.
     pub payload_pointer: Option<String>,
-    /// **15/16.** `budget + rendered size` — the size actually appended to the
-    /// stage's context, in bytes. The **budget** half is `None` until C1b
-    /// (item 3), which owns §14's hard automatic-render budget; the rendered
-    /// size is measured here because it is a fact this wave produces.
-    pub budget: Option<u64>,
-    /// How many bytes this snapshot appended to the stage's `CONTEXT.md`.
+    /// **15.** `budget` — §14's two hard automatic-render budgets and what
+    /// each tier actually spent ([`BudgetReport`]). `None` only for a
+    /// degraded compilation, which rendered nothing to budget.
+    pub budget: Option<BudgetReport>,
+    /// **16.** `rendered size` — how many bytes this snapshot appended to the
+    /// stage's `CONTEXT.md` in total, evidence and frame together. Always at
+    /// least [`BudgetReport::bound_spent`] + [`BudgetReport::referenced_spent`]
+    /// and never much more: the difference is the section heading, the
+    /// snapshot id and §2's Reachable descriptor, which are not evidence and
+    /// are outside both budgets — item 5 requires Reachable to survive an
+    /// exhausted budget, and a descriptor inside the budget it must survive
+    /// could not.
     pub rendered_bytes: u64,
     /// §5's executed steps, in the order the ledger let them run.
     pub plan: Vec<StepRecord>,
@@ -1034,7 +1081,7 @@ impl ContextSnapshot {
             "referenced": self.referenced.iter().map(EvidenceUnit::json).collect::<Vec<_>>(),
             "reachable": self.reachable.as_ref().map(ReachableScope::json),
             "payload_pointer": self.payload_pointer,
-            "budget": self.budget,
+            "budget": self.budget.as_ref().map(BudgetReport::json),
             "rendered_bytes": self.rendered_bytes,
             "plan": self.plan.iter().map(StepRecord::json).collect::<Vec<_>>(),
             "degradation": self.degradation.as_ref().map(|d| json!({
@@ -1052,13 +1099,22 @@ impl ContextSnapshot {
     /// part sergeant added. §12's *"procedure is data"* survives — this adds
     /// evidence beside the procedure, it does not interpret it.
     ///
-    /// **Coordinates, never bodies.** §20's first non-goal is *"raw corpus
-    /// stuffing"*, and §14's hard automatic-render budget — the thing that
-    /// would make rendering resource *content* safe — is C1b's. So Bound
-    /// renders in Referenced's own shape for now (*"exact coordinates not
-    /// rendered in full"*), which under-delivers §2's Bound tier and cannot
-    /// over-deliver §20. The under-delivery is C1b's to close and is named
-    /// there rather than left implicit.
+    /// **This function makes no budget decision.** [`pack`] already spent
+    /// §14's budgets and marked every unit `rendered` or not; this emits
+    /// exactly what packing chose, through the same [`render_chunk`] packing
+    /// measured. A budget applied here instead would be a second policy in a
+    /// second place, and the snapshot's `budget` numbers would be a claim
+    /// about a different function's output.
+    ///
+    /// §20's first non-goal is *"raw corpus stuffing"*, and the reason a body
+    /// may be rendered at all now is that §14's hard budget exists to bound
+    /// it: C1a rendered coordinates only and said so — *"the under-delivery
+    /// is C1b's to close"* — because a body with no budget is exactly the
+    /// non-goal. A source larger than the budget cannot fill Bound with body
+    /// text; it becomes Referenced remainder.
+    ///
+    /// §2's Reachable descriptor renders whenever there is one, **including
+    /// when both budgets are exhausted** (§21 item 5).
     ///
     /// A snapshot that compiled nothing returns the context **unchanged, byte
     /// for byte** — §3's *"If intelligence is disabled/unavailable and the
@@ -1076,16 +1132,12 @@ impl ContextSnapshot {
             (Tier::Bound, &self.bound),
             (Tier::Referenced, &self.referenced),
         ] {
-            if units.is_empty() {
+            if !units.iter().any(|unit| unit.rendered) {
                 continue;
             }
             out.push_str(&format!("\n{}\n", tier.as_str()));
-            for unit in units {
-                out.push_str(&format!(
-                    "  [{}] {}\n",
-                    unit.step.number(),
-                    unit.coordinate.render()
-                ));
+            for unit in units.iter().filter(|unit| unit.rendered) {
+                out.push_str(&render_chunk(unit));
             }
         }
         if let Some(reachable) = &self.reachable {
@@ -1096,6 +1148,402 @@ impl ContextSnapshot {
             ));
         }
         out
+    }
+}
+
+// ===================================================================
+// §14's budgets
+// ===================================================================
+
+/// **§14's two rendering budgets.**
+///
+/// > *"Use a **hard** automatic-render budget. Reuse backend-native/token
+/// > count if already available at the launch boundary; otherwise use a
+/// > conservative documented estimate rather than requiring a universal
+/// > tokenizer dependency."*
+/// >
+/// > *"Referenced coordinates have a **small separate** rendering budget
+/// > because a pointer is far cheaper than loading the resource."*
+/// >
+/// > *"The budget is for automatic prompt material, **not a ban on the actor
+/// > resolving Reachable/Referenced evidence when needed**."*
+///
+/// Three separate rules, and this type is shaped by all three.
+///
+/// # 1. Two budgets, because §14 says two
+///
+/// [`Self::bound_bytes`] and [`Self::referenced_bytes`] are spent
+/// independently: an exhausted Bound budget never eats into the Referenced
+/// one and an exhausted Referenced budget never eats into Bound. A single
+/// shared number would be cheaper to implement and would be a contract miss —
+/// the second sentence exists precisely because a pointer costs a line and a
+/// resource costs a body.
+///
+/// # 2. The unit is **bytes**, and why that is the *documented estimate*
+///
+/// §14's first choice is a backend-native token count *"if already available
+/// at the launch boundary"*. It is not available: the launch boundary is
+/// [`crate::backend::StartRequest`], which carries the stage's `context` as a
+/// `String` and no count of anything, and the one token-shaped capability an
+/// adapter advertises — [`crate::backend::Capabilities::usage`] — is
+/// *reporting*, read off a finished turn's result payload
+/// (`crate::telemetry`'s `input_tokens`/`output_tokens` handling), long after
+/// this compilation has to be over. So §14's second branch applies, and the
+/// estimate is UTF-8 **bytes of rendered text**.
+///
+/// It is conservative in the exact sense §14 asks for, and the reason is a
+/// property rather than a ratio somebody guessed: every tokenizer maps **at
+/// least one byte** to each token it emits, so `tokens <= bytes` for any
+/// tokenizer at all. A byte budget therefore over-states token cost and can
+/// never under-state it, without adding a tokenizer dependency to bound
+/// something a tokenizer would only bound more tightly (**R1/R3**). It is
+/// also exactly measurable, which a token estimate would not be: the number
+/// this type bounds is the number of bytes actually appended.
+///
+/// # 3. Where the two default numbers come from
+///
+/// Both are traced to one measurement of this repository's own shipped
+/// content, taken **2026-08-30** in the C1b lane, and both commands re-run:
+///
+/// ```text
+/// $ find .sergeant/workflows -name CONTEXT.md -printf '%s\n' | ...
+/// n=55  mean=3964  median=3033  p90=6041  max=15476    (bytes)
+///
+/// $ git ls-files | awk '{ print length($0) }' | ...
+/// n=573  mean=41  median=39  max=90                    (bytes per path)
+/// ```
+///
+/// The first population is the 55 authored stage `CONTEXT.md` files of the
+/// distro this binary embeds (`crate::domain::distro`'s `WORKFLOWS`) — the
+/// procedure text a compiled world is appended *beside*.
+/// [`Self::BOUND_BYTES`] is **8 KiB**: above the p90 authored stage context
+/// (6041 B) and well below the largest (15476 B), so the automatic Bound
+/// render can add at most about one typical stage's worth of material and can
+/// never dwarf the procedure it accompanies.
+///
+/// The second gives the cost of a *pointer*. A rendered Atlas coordinate is
+/// `source@content_key:path`, and a git source's `content_key` is the tree
+/// OID — 40 hex characters (`crate::runtime::atlas::git`) — so a line costs
+/// roughly `6 + 11 + 1 + 40 + 1 + 41 + 1 ≈ 100` bytes for this repository.
+/// [`Self::REFERENCED_BYTES`] is **2 KiB**: about twenty pointers, which is
+/// the same order as [`STEP_ROW_CAP`]'s 32 rows, and a quarter of Bound —
+/// *small* and *separate*, as §14 puts it.
+///
+/// Neither number is tuned by anything at runtime (§20: *"learned context
+/// policy/live self-tuning"*); both are constants a human wrote, with the
+/// measurement that produced them written down beside them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RenderBudget {
+    /// Hard ceiling, in bytes, on everything the Bound tier renders into the
+    /// actor's context automatically.
+    pub bound_bytes: u64,
+    /// Hard ceiling, in bytes, on everything the Referenced tier renders —
+    /// §14's *"small separate"* budget, spent independently of the Bound one.
+    pub referenced_bytes: u64,
+}
+
+impl RenderBudget {
+    /// 8 KiB — see this type's own doc for the measurement it comes from.
+    pub const BOUND_BYTES: u64 = 8 * 1024;
+    /// 2 KiB — see this type's own doc for the measurement it comes from.
+    pub const REFERENCED_BYTES: u64 = 2 * 1024;
+
+    /// The budget every production compilation runs under.
+    pub const DEFAULT: Self = Self {
+        bound_bytes: Self::BOUND_BYTES,
+        referenced_bytes: Self::REFERENCED_BYTES,
+    };
+}
+
+impl Default for RenderBudget {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// §15's *"budget + rendered size"*, per tier: what was allowed and what was
+/// actually spent.
+///
+/// Both halves are on the snapshot because *"the budget was 8 KiB"* and
+/// *"the render spent 300 bytes"* are different facts and a reader auditing a
+/// compiled world needs both — and because `spent <= allowed` is then a claim
+/// the journal itself carries, checkable after the fact rather than only at
+/// the moment of rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BudgetReport {
+    /// The budget this compilation ran under.
+    pub budget: RenderBudget,
+    /// Bytes the Bound tier actually rendered. Never above
+    /// [`RenderBudget::bound_bytes`].
+    pub bound_spent: u64,
+    /// Bytes the Referenced tier actually rendered. Never above
+    /// [`RenderBudget::referenced_bytes`].
+    pub referenced_spent: u64,
+}
+
+impl BudgetReport {
+    /// The report as JSON — §15's `budget` line.
+    pub fn json(&self) -> Value {
+        json!({
+            "unit": "bytes",
+            "bound_bytes": self.budget.bound_bytes,
+            "referenced_bytes": self.budget.referenced_bytes,
+            "bound_spent": self.bound_spent,
+            "referenced_spent": self.referenced_spent,
+        })
+    }
+}
+
+// ===================================================================
+// Resolution (§21 items 3 and 4)
+// ===================================================================
+
+/// The source evidence one [`EvidenceCoordinate`] resolves back to.
+///
+/// §21 item 3's second half — *"every unit resolves to source evidence"* — is
+/// a claim about **this** function's answer, not about a rendered line
+/// looking plausible: a rendered unit that cannot be resolved back to a real
+/// stored row is the same defect class as a register note asserting what the
+/// code does not do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceEvidence {
+    /// An exact stored unit of an exact generation, with its full text.
+    Unit {
+        /// The unit's own text, in full — not the possibly-absent excerpt the
+        /// budget allowed into the prompt.
+        text: String,
+        /// Its heading, when it has one.
+        title: Option<String>,
+        /// Byte offsets into the original resource.
+        byte_start: u64,
+        /// End offset, exclusive.
+        byte_end: u64,
+    },
+    /// An exact stored relationship of an exact generation.
+    Relationship(crate::runtime::atlas::db::ResolvedRelationship),
+    /// A record of the Work itself — a stage record or a repository binding.
+    ///
+    /// These two coordinate shapes are **not** Atlas rows: their source
+    /// evidence is the Work's own journal-folded run, and the snapshot pins
+    /// every field of it inline (`stage_id`/`index`/`attempt`/`status`,
+    /// `repository`/`work_branch`/`base_sha`). Resolution says so rather than
+    /// pretending a store lookup happened.
+    WorkRecord,
+}
+
+/// **Resolve one coordinate to its source evidence, by direct lookup.**
+///
+/// §21 item 4: *"Referenced coordinates resolve **without broad
+/// rediscovery**"* — §2's own words for the tier are *"the actor can resolve
+/// them directly **without broad search**"*. That is a property of how this
+/// is implemented, and it is why this function takes no query text, no
+/// ranker, no filter and no limit: it takes a coordinate and hands it
+/// straight to [`AtlasDb::resolve_unit`] / [`AtlasDb::resolve_relationship`],
+/// each of which is an equality lookup on the row identity the coordinate
+/// already carries. A resolver that searched for the coordinate's content
+/// would answer the same way on a small fixture while being the exact thing
+/// item 4 forbids — so the test for it resolves two identical bodies under
+/// two different generations and requires the right one back.
+///
+/// **The budget does not appear here, and that is the point.** §14's last
+/// sentence — *"the budget is for automatic prompt material, not a ban on the
+/// actor resolving Reachable/Referenced evidence when needed"* — means an
+/// exhausted budget must not make anything unresolvable. Nothing in this
+/// path can see a [`RenderBudget`] at all.
+///
+/// `Ok(None)` is an honest answer: the coordinate names no such row. It is
+/// how the item-3 test tells a real resolution from a vacuous one.
+pub fn resolve(
+    atlas: &AtlasDb,
+    coordinate: &EvidenceCoordinate,
+) -> Result<Option<SourceEvidence>, AtlasError> {
+    match coordinate {
+        EvidenceCoordinate::Stage { .. } | EvidenceCoordinate::Binding { .. } => {
+            Ok(Some(SourceEvidence::WorkRecord))
+        }
+        EvidenceCoordinate::Atlas {
+            generation_id,
+            relative_path,
+            ordinal,
+            ..
+        } => {
+            let Some(ordinal) = ordinal else {
+                return Ok(None);
+            };
+            Ok(atlas
+                .resolve_unit(generation_id, relative_path, *ordinal)?
+                .map(|unit| SourceEvidence::Unit {
+                    text: unit.body,
+                    title: unit.title,
+                    byte_start: unit.byte_start,
+                    byte_end: unit.byte_end,
+                }))
+        }
+        EvidenceCoordinate::Relationship {
+            generation_id,
+            kind,
+            from,
+            to,
+            ..
+        } => Ok(atlas
+            .resolve_relationship(generation_id, kind, from, to)?
+            .map(SourceEvidence::Relationship)),
+    }
+}
+
+// ===================================================================
+// Packing (§5 step 9) — where §14's budget is actually spent
+// ===================================================================
+
+/// What one unit costs the automatic render, formatted exactly once.
+///
+/// Both the packer (which decides what fits) and
+/// [`ContextSnapshot::render_onto`] (which emits it) call this, so *"the
+/// budget was not exceeded"* is arithmetic over the same bytes that reach the
+/// prompt rather than an estimate of them. Two formatters would make the
+/// budget a guess about the renderer's output.
+fn render_chunk(unit: &EvidenceUnit) -> String {
+    let mut chunk = format!("  [{}] {}\n", unit.step.number(), unit.coordinate.render());
+    if let Some(excerpt) = &unit.excerpt {
+        for line in excerpt.lines() {
+            chunk.push_str("      | ");
+            chunk.push_str(line);
+            chunk.push('\n');
+        }
+    }
+    chunk
+}
+
+/// The packed world: §2's two rendered tiers and what they spent.
+#[derive(Debug)]
+struct Packed {
+    bound: Vec<EvidenceUnit>,
+    referenced: Vec<EvidenceUnit>,
+    bound_spent: u64,
+    referenced_spent: u64,
+    note: String,
+}
+
+/// **§5 step 9 — *"pack Bound; emit useful remainder as Referenced"*.**
+///
+/// One pass over the ledger's units **in contribution order**, which is §5's
+/// step order: an earlier, more deterministic step spends the budget before a
+/// later, fuzzier one gets to. That is the same ordering first-contributor-
+/// wins already enforces, applied to the second scarce thing (§14's bytes)
+/// rather than to identity.
+///
+/// For each Bound unit: resolve its text (a direct lookup, the same one the
+/// actor would use), render the chunk, and take it **only if the whole chunk
+/// fits** what is left of [`RenderBudget::bound_bytes`]. A unit that does not
+/// fit is not truncated into a half-body — it is §5's *"useful remainder"*
+/// and moves to Referenced as a pointer, where it competes for the separate
+/// Referenced budget. A pointer that does not fit that either stays in the
+/// snapshot unrendered: §14 bounds the *prompt*, never the record and never
+/// the actor.
+///
+/// Two things deliberately never carry a body:
+///
+/// - **a Work record** ([`EvidenceCoordinate::Stage`]/[`Binding`]) — it has
+///   no stored text; the coordinate *is* the evidence;
+/// - **external evidence** (`authority_class = external`) — §21 item 9 wants
+///   external evidence *"visibly external and unable to alter instruction
+///   hierarchy"*, and that labeling is C1c's. Until it exists, external prose
+///   does not enter a prompt from here. It is still Referenced, still
+///   resolvable, and the step note says so. Under-delivering a tier is
+///   recoverable; shipping unlabeled external prose into an actor's context
+///   is not (**J5** — item 9 is this contract's, and it is not yet met).
+///
+/// [`Binding`]: EvidenceCoordinate::Binding
+fn pack(
+    atlas: &AtlasDb,
+    units: &[EvidenceUnit],
+    budget: &RenderBudget,
+    generations: &[GenerationPin],
+) -> Packed {
+    let external: BTreeSet<&str> = generations
+        .iter()
+        .filter(|pin| pin.authority == AuthorityClass::External.as_str())
+        .map(|pin| pin.generation_id.as_str())
+        .collect();
+    let mut bound: Vec<EvidenceUnit> = Vec::new();
+    let mut referenced: Vec<EvidenceUnit> = Vec::new();
+    let mut bound_spent = 0u64;
+    let mut referenced_spent = 0u64;
+    let mut demoted = 0usize;
+    let mut unrendered = 0usize;
+    let mut withheld_external = 0usize;
+
+    for unit in units {
+        let mut candidate = unit.clone();
+        if candidate.tier == Tier::Bound {
+            // Only resolve while the budget could still hold the answer:
+            // resolving past exhaustion would be a read whose result is
+            // thrown away.
+            if bound_spent < budget.bound_bytes
+                && let EvidenceCoordinate::Atlas { generation_id, .. } = &candidate.coordinate
+            {
+                if external.contains(generation_id.as_str()) {
+                    withheld_external += 1;
+                } else if let Ok(Some(SourceEvidence::Unit { text, .. })) =
+                    resolve(atlas, &candidate.coordinate)
+                {
+                    candidate.excerpt = Some(text);
+                }
+            }
+            let cost = render_chunk(&candidate).len() as u64;
+            if bound_spent + cost <= budget.bound_bytes {
+                candidate.rendered = true;
+                bound_spent += cost;
+                bound.push(candidate);
+                continue;
+            }
+            // §5's "useful remainder": demoted to a pointer, and it competes
+            // for the OTHER budget.
+            demoted += 1;
+            candidate.excerpt = None;
+            candidate.tier = Tier::Referenced;
+        }
+        let cost = render_chunk(&candidate).len() as u64;
+        if referenced_spent + cost <= budget.referenced_bytes {
+            candidate.rendered = true;
+            referenced_spent += cost;
+        } else {
+            unrendered += 1;
+        }
+        referenced.push(candidate);
+    }
+
+    let mut note = format!(
+        "packed {} Bound unit(s) into {bound_spent}/{} budget bytes and {} Referenced \
+         pointer(s) into {referenced_spent}/{} budget bytes",
+        bound.len(),
+        budget.bound_bytes,
+        referenced.len(),
+        budget.referenced_bytes,
+    );
+    if demoted > 0 {
+        note.push_str(&format!(
+            "; {demoted} Bound unit(s) did not fit and were emitted as Referenced remainder"
+        ));
+    }
+    if withheld_external > 0 {
+        note.push_str(&format!(
+            "; {withheld_external} external unit(s) rendered as coordinates only, pending §21 \
+             item 9's external labeling (C1c)"
+        ));
+    }
+    if unrendered > 0 {
+        note.push_str(&format!(
+            "; {unrendered} coordinate(s) are in the snapshot but past the render budget — \
+             still resolvable, not rendered"
+        ));
+    }
+    Packed {
+        bound,
+        referenced,
+        bound_spent,
+        referenced_spent,
+        note,
     }
 }
 
@@ -1129,6 +1577,11 @@ pub struct CompileRequest<'a> {
     pub prior_stages: &'a [StageRecord],
     /// The launch profile the stage was bound with, when it has one.
     pub profile: Option<&'a str>,
+    /// §14's two hard automatic-render budgets. Every production compilation
+    /// passes [`RenderBudget::DEFAULT`]; it is a request field rather than a
+    /// constant read inside [`compile`] so a test can watch the hard bound
+    /// actually bind, which a constant nobody can vary cannot show.
+    pub budget: RenderBudget,
 }
 
 /// The port [`crate::runtime::engine::Engine`] calls before an actor starts.
@@ -1191,8 +1644,10 @@ impl ContextCompiler for AtlasContextCompiler {
 ///
 /// A constant a human wrote, not a policy anything learns (§20: *"learned
 /// context policy/live self-tuning"*). It bounds the compilation's cost and
-/// its output; §14's real automatic-render budget is C1b's and will bound the
-/// rendered payload, which is a different bound over a different quantity.
+/// its output; §14's automatic-render budget ([`RenderBudget`]) bounds the
+/// rendered payload, which is a different bound over a different quantity —
+/// rows read versus bytes rendered. Both apply, and neither implies the
+/// other: a compilation can read 32 rows and render two of them.
 pub const STEP_ROW_CAP: usize = 32;
 
 /// **§5's nine steps, run in §5's order, through the gate that enforces it.**
@@ -1474,25 +1929,26 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
         }
     }
     // ---- 9. pack Bound; emit useful remainder as Referenced
+    //
+    // §14's budget is spent HERE and nowhere else. Packing is computed off
+    // the ledger's finished units first, then step 9 is entered and states
+    // what it did: the step adds no evidence, so it opens the writer only to
+    // record the outcome, and the gate's order stays total either way.
+    let packed = pack(atlas, ledger.units(), &request.budget, &source_generations);
     {
         let mut step = ledger.enter(ResearchStep::Pack).expect("step 9 is last");
-        step.note("packing adds no evidence: it partitions what steps 1-8 contributed");
+        step.note(packed.note.clone());
     }
 
-    let bound: Vec<EvidenceUnit> = ledger
-        .units()
-        .iter()
-        .filter(|u| u.tier == Tier::Bound)
-        .cloned()
-        .collect();
-    let referenced: Vec<EvidenceUnit> = ledger
-        .units()
-        .iter()
-        .filter(|u| u.tier == Tier::Referenced)
-        .cloned()
-        .collect();
     let plan = ledger.executed().to_vec();
     let selection_plan_hash = selection_plan_hash(&plan, ledger.units());
+    let Packed {
+        bound,
+        referenced,
+        bound_spent,
+        referenced_spent,
+        ..
+    } = packed;
 
     ContextSnapshot {
         snapshot_id: ulid::Ulid::generate().to_string(),
@@ -1513,7 +1969,11 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
         referenced,
         reachable: Some(reachable_scope(&filter, request.work_id)),
         payload_pointer: None,
-        budget: None,
+        budget: Some(BudgetReport {
+            budget: request.budget,
+            bound_spent,
+            referenced_spent,
+        }),
         rendered_bytes: 0,
         plan,
         degradation: None,

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -903,10 +903,14 @@ pub struct ContextSnapshot {
     pub referenced: Vec<EvidenceUnit>,
     /// **13.** `Reachable capability/scope descriptor`.
     pub reachable: Option<ReachableScope>,
-    /// **14.** `rendered payload blob/artifact pointer`. **`None` this
-    /// wave**: C1b owns §14's budget and therefore owns rendering resource
-    /// *content*, which is the only payload big enough to need decision
-    /// C1-09's blob seam. What this wave renders is coordinates, inline.
+    /// **14.** `rendered payload blob/artifact pointer`. **`None`, and now
+    /// for a reason rather than a deferral**: decision C1-09's blob seam is
+    /// for *"large snapshot payloads"*, and §14's hard budgets
+    /// ([`RenderBudget`]) cap the whole rendered payload at ten kilobytes,
+    /// which is small enough to live inline in the stage's `CONTEXT.md`. A
+    /// pointer would be a second place to look for something that is already
+    /// in front of the reader. A wave that renders something the budget does
+    /// not bound is the wave that needs this field.
     pub payload_pointer: Option<String>,
     /// **15.** `budget` — §14's two hard automatic-render budgets and what
     /// each tier actually spent ([`BudgetReport`]). `None` only for a

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -396,6 +396,13 @@ pub enum EvidenceCoordinate {
         /// The end it names. **Unresolved** for a syntax edge, exactly as
         /// [`StoredEdge::target`] is.
         to: String,
+        /// Position within `from`'s edge list (F-IN-01) — an edge's own
+        /// per-row identity alongside `kind`/`from`/`to`, since two distinct
+        /// edges (e.g. the same file importing the same target twice)
+        /// legitimately share every other field. `None` for a child-resource
+        /// row, which has no ordinal, exactly as
+        /// [`crate::runtime::atlas::db::ResolvedRelationship::ordinal`] is.
+        ordinal: Option<u64>,
     },
 }
 
@@ -543,6 +550,7 @@ impl EvidenceCoordinate {
                 kind,
                 from,
                 to,
+                ordinal,
             } => json!({
                 "shape": "relationship",
                 "source": source_name,
@@ -550,6 +558,7 @@ impl EvidenceCoordinate {
                 "kind": kind,
                 "from": from,
                 "to": to,
+                "ordinal": ordinal,
             }),
         }
     }
@@ -1388,9 +1397,10 @@ pub fn resolve(
             kind,
             from,
             to,
+            ordinal,
             ..
         } => Ok(atlas
-            .resolve_relationship(generation_id, kind, from, to)?
+            .resolve_relationship(generation_id, kind, from, to, *ordinal)?
             .map(SourceEvidence::Relationship)),
     }
 }
@@ -2117,6 +2127,7 @@ fn child_relationship(pin: &GenerationPin, child: &StoredChildResource) -> Evide
         kind: "child_resource".to_string(),
         from: child.parent_relative_path.clone(),
         to: child.relative_path.clone(),
+        ordinal: None,
     }
 }
 
@@ -2130,6 +2141,7 @@ fn edge_relationship(pin: &GenerationPin, edge: &StoredEdge) -> EvidenceCoordina
         kind: edge.kind.clone(),
         from: edge.relative_path.clone(),
         to: edge.target.clone(),
+        ordinal: Some(edge.ordinal),
     }
 }
 

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -5321,6 +5321,11 @@ impl Engine {
             bindings: &bindings,
             prior_stages: &run.stages,
             profile,
+            // §14's hard automatic-render budget. One value, written by a
+            // human and measured against this repository's own shipped stage
+            // procedures — see `RenderBudget`'s own doc. Nothing tunes it at
+            // runtime (§20: no learned context policy).
+            budget: crate::runtime::context::RenderBudget::DEFAULT,
         };
         let mut snapshot = compiler.compile(&request);
         let context = snapshot.render_onto(authored);

--- a/tests/c1a_compiled_context.rs
+++ b/tests/c1a_compiled_context.rs
@@ -15,7 +15,7 @@
 //! | **item 10** — the snapshot pins generations that **re-resolve** | [`the_snapshot_pins_generations_that_re_resolve_to_the_same_evidence`] |
 //! | **item 10** — the retrieval generation/model is pinned when retrieval ran | [`the_snapshot_pins_the_retrieval_generation_and_model_it_actually_used`] |
 //! | §15 — one field per line of §15's list, in §15's order | [`the_snapshot_carries_one_field_per_line_of_section_15s_list`] |
-//! | §20 — no raw corpus stuffing: coordinates render, bodies do not | [`the_rendered_section_carries_coordinates_and_never_a_resource_body`] |
+//! | §2 — a Bound unit renders its coordinate **and** the body §14's budget allowed | [`the_rendered_section_carries_the_coordinate_beside_the_body_it_bound`] |
 //! | §15 — the selection-plan hash is a hash of the PLAN, not of the selection | [`the_selection_plan_hash_separates_two_plans_that_selected_the_same_evidence`] |
 //! | **item 13** — no compiler installed ⇒ the stage context is byte-identical | [`a_stage_with_no_compiler_installed_gets_its_authored_context_byte_for_byte`] |
 //! | **item 13** — intelligence *unavailable* ⇒ the same, and it says why | [`an_estate_with_no_confirmed_generation_leaves_the_context_byte_identical_and_says_why`] |
@@ -240,6 +240,7 @@ fn compiled(atlas: Option<&AtlasDb>) -> ContextSnapshot {
             bindings: &bindings,
             prior_stages: &prior,
             profile: Some("standard"),
+            budget: sergeant_rs::runtime::context::RenderBudget::DEFAULT,
         },
     )
 }
@@ -601,19 +602,28 @@ fn the_snapshot_carries_one_field_per_line_of_section_15s_list() {
     // an absent field cannot be told from a forgotten one.
     assert_eq!(json["query_result_ids"], serde_json::json!([]));
     assert_eq!(json["payload_pointer"], Value::Null);
-    assert_eq!(json["budget"], Value::Null);
+    // §15's `budget` line stopped being empty when C1b landed §14's two
+    // budgets; `tests/c1b_tiers_and_budget.rs` owns what it says.
+    assert_eq!(json["budget"]["unit"], "bytes", "{json}");
 }
 
 // ============================================================ §20's non-goals
 
-/// §20's first non-goal: *"raw corpus stuffing"*.
+/// §20's first non-goal: *"raw corpus stuffing"* — and what C1b changed
+/// about it.
 ///
-/// The rendered section names the resource and never carries its body. The
-/// body text is in the fixture and in the store, so a renderer that reached
-/// for it would have it — this is a check that it does not, not that it
-/// could not.
+/// C1a rendered coordinates and never a body, because §2's Bound tier
+/// (*"evidence deliberately **rendered into** the actor's initial context"*)
+/// cannot be delivered safely without §14's budget, and that budget was the
+/// next wave's. C1b landed it, so a Bound body now renders — **inside a hard
+/// budget**, which is the whole difference between §2's Bound tier and §20's
+/// first non-goal. This test pins that the authored procedure is still
+/// untouched, that the coordinate is still there beside the body, and that
+/// Reachable still renders; `tests/c1b_tiers_and_budget.rs` owns the budget
+/// itself, including that a source larger than the budget cannot fill Bound
+/// with body text.
 #[test]
-fn the_rendered_section_carries_coordinates_and_never_a_resource_body() {
+fn the_rendered_section_carries_the_coordinate_beside_the_body_it_bound() {
     let fixture = fixture();
     let snapshot = compiled(Some(&fixture.db));
     let rendered = snapshot.render_onto("authored stage procedure");
@@ -624,12 +634,9 @@ fn the_rendered_section_carries_coordinates_and_never_a_resource_body() {
     );
     assert!(rendered.contains("notes/plan.md"), "{rendered}");
     assert!(
-        !rendered.contains(CONTESTED_BODY),
-        "a resource BODY reached the prompt: {rendered}"
-    );
-    assert!(
-        !rendered.contains("The daemon owns the journal"),
-        "a resource BODY reached the prompt: {rendered}"
+        rendered.contains(CONTESTED_BODY),
+        "§2's Bound tier renders evidence INTO the context, within §14's \
+         budget: {rendered}"
     );
     assert!(rendered.contains("REACHABLE"), "{rendered}");
 }
@@ -666,6 +673,7 @@ fn the_selection_plan_hash_separates_two_plans_that_selected_the_same_evidence()
             bindings: &bindings,
             prior_stages: &[],
             profile: Some("standard"),
+            budget: sergeant_rs::runtime::context::RenderBudget::DEFAULT,
         },
     );
     assert_ne!(

--- a/tests/c1a_compiled_context.rs
+++ b/tests/c1a_compiled_context.rs
@@ -32,17 +32,13 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use tempfile::TempDir;
 
-use sergeant_rs::domain::event::rfc3339_utc_now;
-use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
+use sergeant_rs::domain::source::{AuthorityClass, SourceKind};
 use sergeant_rs::domain::workflow::{
     KIND_CONTEXT_COMPILED, StageDefinition, StageKind, StageRecord, StageStatus,
 };
 use sergeant_rs::runtime::atlas::db::AtlasDb;
 use sergeant_rs::runtime::atlas::overlay::overlay_source_name;
 use sergeant_rs::runtime::atlas::record::record_scan;
-use sergeant_rs::runtime::atlas::scan::{ScannedFile, ScannedUnit, SourceScan};
-use sergeant_rs::runtime::atlas::tabular::ContextFields;
-use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
 use sergeant_rs::runtime::context::{
     Cognition, CompileRequest, ContextSnapshot, Degradation, EvidenceCoordinate, OrderViolation,
     ResearchLedger, ResearchStep, Tier, compile,
@@ -80,57 +76,10 @@ const REPOSITORY: &str = "demo-repo";
 /// the ordering test from being vacuous.
 const CONTESTED_BODY: &str = "The retention retention retention policy this Work changes.";
 
-fn unit(ordinal: u64, title: &str, text: &str) -> ScannedUnit {
-    ScannedUnit {
-        ordinal,
-        kind: UnitKind::Section,
-        heading_level: Some(1),
-        title: Some(title.to_string()),
-        byte_start: 0,
-        byte_end: text.len() as u64,
-        coordinate: None,
-        text: text.to_string(),
-    }
-}
-
-fn file(relative_path: &str, units: Vec<ScannedUnit>) -> ScannedFile {
-    let bytes: u64 = units.iter().map(|u| u.text.len() as u64).sum();
-    ScannedFile {
-        relative_path: relative_path.to_string(),
-        content_hash: format!("hash/{relative_path}"),
-        extractor: MARKDOWN_EXTRACTOR.to_string(),
-        local_key: format!("key/{relative_path}"),
-        byte_len: bytes,
-        mtime_millis: None,
-        units,
-        syntax: None,
-        parent: None,
-    }
-}
-
-fn scan(
-    source_name: &str,
-    kind: SourceKind,
-    authority: AuthorityClass,
-    files: Vec<ScannedFile>,
-) -> SourceScan {
-    let mut extractors = BTreeSet::new();
-    extractors.insert(MARKDOWN_EXTRACTOR.to_string());
-    SourceScan {
-        source_name: source_name.to_string(),
-        kind,
-        authority,
-        content_key: format!("{source_name}@generation-1"),
-        revision: None,
-        observed_at: rfc3339_utc_now(),
-        files,
-        coverage: Vec::new(),
-        extractors,
-        datasets: Vec::new(),
-        root: None,
-        context_fields: ContextFields::none(),
-    }
-}
+// `unit`/`file`/`scan` fixture builders live in `tests/support` (R2 — F-SI-01:
+// this file and `tests/c1b_tiers_and_budget.rs` had built byte-identical
+// copies of the same three functions).
+use support::{file, scan, unit};
 
 /// A real Atlas holding two confirmed generations: the Work's base repository
 /// and the Work's own overlay over it.

--- a/tests/c1b_tiers_and_budget.rs
+++ b/tests/c1b_tiers_and_budget.rs
@@ -22,26 +22,28 @@
 //! §5 step 2 — so every "it did not fit" assertion below is about evidence
 //! that really was selected, not about evidence that happened to be missing.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
 
-use sergeant_rs::domain::event::rfc3339_utc_now;
-use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
+use sergeant_rs::domain::source::{AuthorityClass, SourceKind};
 use sergeant_rs::domain::workflow::{StageDefinition, StageKind, StageRecord, StageStatus};
 use sergeant_rs::runtime::atlas::db::{AtlasDb, LexicalQuery, SourceSelector};
 use sergeant_rs::runtime::atlas::overlay::overlay_source_name;
 use sergeant_rs::runtime::atlas::record::record_scan;
-use sergeant_rs::runtime::atlas::scan::{ScannedFile, ScannedUnit, SourceScan};
 use sergeant_rs::runtime::atlas::semantic::SemanticRequest;
-use sergeant_rs::runtime::atlas::tabular::ContextFields;
-use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
 use sergeant_rs::runtime::context::{
     CompileRequest, ContextSnapshot, EvidenceCoordinate, EvidenceUnit, RenderBudget, ResearchStep,
     SourceEvidence, Tier, compile, resolve,
 };
 use sergeant_rs::runtime::journal::Journal;
+
+mod support;
+// `unit`/`file`/`scan` fixture builders live in `tests/support` (R2 — F-SI-01:
+// this file and `tests/c1a_compiled_context.rs` had built byte-identical
+// copies of the same three functions).
+use support::{file, scan, unit};
 
 // ===================================================================
 // Fixture
@@ -77,58 +79,6 @@ fn huge_body() -> String {
         body.push_str(" retention policy retention policy retention policy");
     }
     body
-}
-
-fn unit(ordinal: u64, title: &str, text: &str) -> ScannedUnit {
-    ScannedUnit {
-        ordinal,
-        kind: UnitKind::Section,
-        heading_level: Some(1),
-        title: Some(title.to_string()),
-        byte_start: 0,
-        byte_end: text.len() as u64,
-        coordinate: None,
-        text: text.to_string(),
-    }
-}
-
-fn file(relative_path: &str, units: Vec<ScannedUnit>) -> ScannedFile {
-    let bytes: u64 = units.iter().map(|u| u.text.len() as u64).sum();
-    ScannedFile {
-        relative_path: relative_path.to_string(),
-        content_hash: format!("hash/{relative_path}"),
-        extractor: MARKDOWN_EXTRACTOR.to_string(),
-        local_key: format!("key/{relative_path}"),
-        byte_len: bytes,
-        mtime_millis: None,
-        units,
-        syntax: None,
-        parent: None,
-    }
-}
-
-fn scan(
-    source_name: &str,
-    kind: SourceKind,
-    authority: AuthorityClass,
-    files: Vec<ScannedFile>,
-) -> SourceScan {
-    let mut extractors = BTreeSet::new();
-    extractors.insert(MARKDOWN_EXTRACTOR.to_string());
-    SourceScan {
-        source_name: source_name.to_string(),
-        kind,
-        authority,
-        content_key: format!("{source_name}@generation-1"),
-        revision: None,
-        observed_at: rfc3339_utc_now(),
-        files,
-        coverage: Vec::new(),
-        extractors,
-        datasets: Vec::new(),
-        root: None,
-        context_fields: ContextFields::none(),
-    }
 }
 
 struct Fixture {

--- a/tests/c1b_tiers_and_budget.rs
+++ b/tests/c1b_tiers_and_budget.rs
@@ -1,0 +1,849 @@
+//! S6 C1b — C1 §2's three tiers and §14's **two hard rendering budgets**,
+//! with §21 items 3, 4 and 5.
+//!
+//! # What each test here is the evidence for
+//!
+//! | Claim | Test |
+//! |---|---|
+//! | **item 3, first half** — the Bound budget is HARD: a source far larger than it cannot fill Bound with body text | [`the_bound_budget_is_hard_and_a_huge_source_cannot_fill_bound_with_body_text`] |
+//! | §14 — **two** budgets: exhausting one never spends or starves the other | [`bound_and_referenced_are_two_budgets_and_exhausting_one_does_not_spend_the_other`] |
+//! | **item 5** + §14's last sentence — an exhausted budget leaves Reachable available and caps no resolution | [`an_exhausted_budget_leaves_reachable_available_and_caps_no_resolution`] |
+//! | §14 — the budget bounds the RENDER, not the snapshot: every evidence id survives a zero budget | [`the_budget_bounds_the_render_and_not_the_snapshots_evidence_ids`] |
+//! | **item 3, second half** — every Bound unit resolves to real source evidence, and a fabricated coordinate does not | [`every_bound_unit_resolves_to_source_evidence_and_a_fabricated_one_does_not`] |
+//! | **item 4** — a coordinate resolves by DIRECT LOOKUP: the pinned generation discriminates two rows content cannot, and the search surface never sees the query | [`a_coordinate_resolves_by_direct_lookup_not_by_rediscovery`] |
+//! | §5 step 9 — Bound evidence that does not fit is emitted as Referenced *remainder*, attribution intact | [`bound_evidence_that_does_not_fit_the_budget_becomes_referenced_remainder`] |
+//! | §15 line 15 — the snapshot records both budgets and what each tier spent | [`the_snapshot_records_both_budgets_and_what_each_tier_spent`] |
+//! | §21 item 9 is C1c's, so external prose does not reach a prompt from here | [`external_evidence_renders_as_a_coordinate_and_never_as_body_text`] |
+//!
+//! Every test runs the real compiler over a real Atlas built by the ordinary
+//! `record_scan` path. The fixture is deliberately hostile to the budget: the
+//! Work's own overlay holds a 64 KiB unit, which is eight times
+//! [`RenderBudget::BOUND_BYTES`] and is contributed **deterministically** by
+//! §5 step 2 — so every "it did not fit" assertion below is about evidence
+//! that really was selected, not about evidence that happened to be missing.
+
+use std::collections::{BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use sergeant_rs::domain::event::rfc3339_utc_now;
+use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
+use sergeant_rs::domain::workflow::{StageDefinition, StageKind, StageRecord, StageStatus};
+use sergeant_rs::runtime::atlas::db::{AtlasDb, LexicalQuery, SourceSelector};
+use sergeant_rs::runtime::atlas::overlay::overlay_source_name;
+use sergeant_rs::runtime::atlas::record::record_scan;
+use sergeant_rs::runtime::atlas::scan::{ScannedFile, ScannedUnit, SourceScan};
+use sergeant_rs::runtime::atlas::semantic::SemanticRequest;
+use sergeant_rs::runtime::atlas::tabular::ContextFields;
+use sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR;
+use sergeant_rs::runtime::context::{
+    CompileRequest, ContextSnapshot, EvidenceCoordinate, EvidenceUnit, RenderBudget, ResearchStep,
+    SourceEvidence, Tier, compile, resolve,
+};
+use sergeant_rs::runtime::journal::Journal;
+
+// ===================================================================
+// Fixture
+// ===================================================================
+
+const WORK_ID: &str = "01C1BWORK";
+const REPOSITORY: &str = "demo-repo";
+const INTENT: &str = "tighten the retention policy";
+const AUTHORED: &str = "authored stage procedure";
+
+/// The small Work-changed resource. It fits the Bound budget with room to
+/// spare, and it is what makes every "the budget is hard" test non-vacuous:
+/// the renderer demonstrably *does* render bodies.
+const PLAN_BODY: &str = "The retention policy this Work changes, in one short paragraph.";
+
+/// A marker no other fixture text contains, planted at the front of the huge
+/// body so its arrival in a prompt is unmistakable.
+const HUGE_MARKER: &str = "HUGE-BODY-MARKER";
+
+/// Two rows that differ by exactly one word, at the **same relative path and
+/// the same ordinal**, in two different generations. Nothing but the pinned
+/// generation can tell them apart — which is what makes item 4's test a test
+/// of a keyed lookup rather than of a lucky corpus.
+const TWIN_BASE: &str = "Chandelier orbit memorandum, BASE generation.";
+const TWIN_OVERLAY: &str = "Chandelier orbit memorandum, OVERLAY generation.";
+const TWIN_PATH: &str = "docs/twin.md";
+
+/// 64 KiB — eight times [`RenderBudget::BOUND_BYTES`], and full of the
+/// intent's own terms so nothing about its selection is accidental.
+fn huge_body() -> String {
+    let mut body = String::from(HUGE_MARKER);
+    while body.len() < 64 * 1024 {
+        body.push_str(" retention policy retention policy retention policy");
+    }
+    body
+}
+
+fn unit(ordinal: u64, title: &str, text: &str) -> ScannedUnit {
+    ScannedUnit {
+        ordinal,
+        kind: UnitKind::Section,
+        heading_level: Some(1),
+        title: Some(title.to_string()),
+        byte_start: 0,
+        byte_end: text.len() as u64,
+        coordinate: None,
+        text: text.to_string(),
+    }
+}
+
+fn file(relative_path: &str, units: Vec<ScannedUnit>) -> ScannedFile {
+    let bytes: u64 = units.iter().map(|u| u.text.len() as u64).sum();
+    ScannedFile {
+        relative_path: relative_path.to_string(),
+        content_hash: format!("hash/{relative_path}"),
+        extractor: MARKDOWN_EXTRACTOR.to_string(),
+        local_key: format!("key/{relative_path}"),
+        byte_len: bytes,
+        mtime_millis: None,
+        units,
+        syntax: None,
+        parent: None,
+    }
+}
+
+fn scan(
+    source_name: &str,
+    kind: SourceKind,
+    authority: AuthorityClass,
+    files: Vec<ScannedFile>,
+) -> SourceScan {
+    let mut extractors = BTreeSet::new();
+    extractors.insert(MARKDOWN_EXTRACTOR.to_string());
+    SourceScan {
+        source_name: source_name.to_string(),
+        kind,
+        authority,
+        content_key: format!("{source_name}@generation-1"),
+        revision: None,
+        observed_at: rfc3339_utc_now(),
+        files,
+        coverage: Vec::new(),
+        extractors,
+        datasets: Vec::new(),
+        root: None,
+        context_fields: ContextFields::none(),
+    }
+}
+
+struct Fixture {
+    _data: TempDir,
+    db: AtlasDb,
+}
+
+/// The Work's base repository and the Work's own overlay over it.
+///
+/// The overlay carries the three units §5 step 2 contributes
+/// deterministically: the small plan, the 64 KiB one, and the twin.
+fn fixture() -> Fixture {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    let base = scan(
+        REPOSITORY,
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![
+            file(
+                "docs/architecture.md",
+                vec![unit(
+                    0,
+                    "Architecture",
+                    "The daemon owns the journal and the projection it folds.",
+                )],
+            ),
+            file(TWIN_PATH, vec![unit(0, "Twin", TWIN_BASE)]),
+        ],
+    );
+    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+
+    let overlay = scan(
+        &overlay_source_name(WORK_ID, REPOSITORY),
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![
+            file("notes/plan.md", vec![unit(0, "Plan", PLAN_BODY)]),
+            file("notes/huge.md", vec![unit(0, "Huge", &huge_body())]),
+            file(TWIN_PATH, vec![unit(0, "Twin", TWIN_OVERLAY)]),
+        ],
+    );
+    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+
+    Fixture { _data: data, db }
+}
+
+fn stage() -> StageDefinition {
+    StageDefinition {
+        id: "10-implement".to_string(),
+        context: AUTHORED.to_string(),
+        kind: StageKind::Actor,
+        harness: None,
+        profile: None,
+        requires_ask: false,
+        receives_branch_status: false,
+        execute: None,
+    }
+}
+
+fn bindings() -> Vec<sergeant_rs::backend::BindingSummary> {
+    vec![sergeant_rs::backend::BindingSummary {
+        repository: REPOSITORY.to_string(),
+        worktree_path: PathBuf::from("/surfaces").join(WORK_ID).join(REPOSITORY),
+        work_branch: format!("sergeant/{WORK_ID}"),
+        base_branch: Some("main".to_string()),
+        base_sha: "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f".to_string(),
+    }]
+}
+
+fn prior_stages() -> Vec<StageRecord> {
+    vec![StageRecord {
+        stage_id: "00-orient".to_string(),
+        index: 0,
+        attempt: 1,
+        status: StageStatus::Completed,
+        detail: Some("oriented".to_string()),
+        output_reprompts: 0,
+    }]
+}
+
+/// Compile this Work's world under `budget`.
+fn compiled(atlas: &AtlasDb, budget: RenderBudget) -> ContextSnapshot {
+    let stage = stage();
+    let bindings = bindings();
+    let prior = prior_stages();
+    compile(
+        Some(atlas),
+        &CompileRequest {
+            estate_root: Some(Path::new("/estates/demo")),
+            work_id: WORK_ID,
+            intent: INTENT,
+            stage: &stage,
+            stage_index: 1,
+            attempt: 1,
+            execution_id: "01EXECUTION",
+            journal_watermark: 42,
+            bindings: &bindings,
+            prior_stages: &prior,
+            profile: Some("standard"),
+            budget,
+        },
+    )
+}
+
+/// The bytes one rendered tier section actually occupies, **counted off the
+/// rendered text** rather than read from the snapshot's own report.
+///
+/// This is what makes the budget assertions below checks rather than
+/// tautologies: the snapshot says what it spent, and this says what the
+/// prompt actually carries, and the tests require the two to agree.
+fn section_bytes(rendered: &str, tier: &str) -> usize {
+    let marker = format!("\n{tier}\n");
+    let Some(start) = rendered.find(&marker) else {
+        return 0;
+    };
+    let rest = &rendered[start + marker.len()..];
+    let end = ["\nBOUND\n", "\nREFERENCED\n", "\nREACHABLE\n"]
+        .iter()
+        .filter_map(|m| rest.find(m))
+        .min()
+        .unwrap_or(rest.len());
+    rest[..end].len()
+}
+
+/// Every evidence unit of a snapshot, both tiers, in one list.
+fn all_units(snapshot: &ContextSnapshot) -> Vec<&EvidenceUnit> {
+    snapshot
+        .bound
+        .iter()
+        .chain(snapshot.referenced.iter())
+        .collect()
+}
+
+/// The unit whose Atlas coordinate names `relative_path`.
+fn unit_at<'a>(snapshot: &'a ContextSnapshot, relative_path: &str) -> &'a EvidenceUnit {
+    all_units(snapshot)
+        .into_iter()
+        .find(|unit| match &unit.coordinate {
+            EvidenceCoordinate::Atlas {
+                relative_path: p, ..
+            } => p == relative_path,
+            _ => false,
+        })
+        .unwrap_or_else(|| panic!("{relative_path} is not in the compiled snapshot at all"))
+}
+
+// ============================================================ item 3, budget
+
+/// **§14's first rule, and §21 item 3's first half.** *"Use a **hard**
+/// automatic-render budget."*
+///
+/// The Work's overlay holds a 64 KiB unit — eight times the Bound budget —
+/// contributed by §5 step 2, so it is genuinely selected evidence. Four
+/// assertions, and each one is load-bearing:
+///
+/// 1. the huge unit really is in the compiled snapshot (without this the
+///    test would pass on a world where nothing large was ever selected);
+/// 2. its body never reaches the prompt — not truncated in, not summarized
+///    in, not there at all;
+/// 3. the rendered Bound section, **measured off the rendered text**, is
+///    within the budget, and the snapshot's own `bound_spent` equals that
+///    measurement;
+/// 4. the small body *is* rendered, so this is a bound on a renderer that
+///    demonstrably renders bodies, not a renderer that renders none.
+#[test]
+fn the_bound_budget_is_hard_and_a_huge_source_cannot_fill_bound_with_body_text() {
+    let fixture = fixture();
+    let snapshot = compiled(&fixture.db, RenderBudget::DEFAULT);
+    let rendered = snapshot.render_onto(AUTHORED);
+
+    let huge = unit_at(&snapshot, "notes/huge.md");
+    assert_eq!(
+        huge.step,
+        ResearchStep::WorkBindings,
+        "the 64 KiB unit is one of the Work's exact changed resources, selected by §5 step 2"
+    );
+    assert!(
+        huge.excerpt.is_none(),
+        "a unit eight times the Bound budget was given an excerpt"
+    );
+    assert!(
+        !rendered.contains(HUGE_MARKER),
+        "body text from a 64 KiB source reached the prompt"
+    );
+
+    let measured = section_bytes(&rendered, "BOUND") as u64;
+    let report = snapshot
+        .budget
+        .expect("a compiled snapshot carries §15's budget");
+    assert!(
+        measured <= report.budget.bound_bytes,
+        "the BOUND section rendered {measured} bytes against a HARD budget of {}",
+        report.budget.bound_bytes
+    );
+    assert_eq!(
+        measured, report.bound_spent,
+        "the snapshot's own bound_spent must be the bytes the prompt actually carries"
+    );
+
+    assert!(
+        rendered.contains(PLAN_BODY),
+        "the renderer renders bodies — the bound above is a bound, not an absence: {rendered}"
+    );
+}
+
+/// **§14's second rule.** *"Referenced coordinates have a **small separate**
+/// rendering budget because a pointer is far cheaper than loading the
+/// resource."*
+///
+/// Separate is proved in both directions, because one direction alone is
+/// compatible with a single shared budget spent in a fixed order:
+///
+/// - Bound at zero, Referenced at its default → **nothing** Bound renders and
+///   Referenced still renders its pointers;
+/// - Bound at its default, Referenced at zero → Bound still renders its
+///   bodies and **nothing** Referenced does.
+///
+/// One shared number cannot produce both answers over the same world.
+#[test]
+fn bound_and_referenced_are_two_budgets_and_exhausting_one_does_not_spend_the_other() {
+    let fixture = fixture();
+
+    let no_bound = compiled(
+        &fixture.db,
+        RenderBudget {
+            bound_bytes: 0,
+            referenced_bytes: RenderBudget::REFERENCED_BYTES,
+        },
+    );
+    let report = no_bound.budget.expect("budget");
+    assert_eq!(report.bound_spent, 0, "the Bound budget was zero");
+    assert!(
+        report.referenced_spent > 0,
+        "an exhausted Bound budget must not starve the SEPARATE Referenced one"
+    );
+    let rendered = no_bound.render_onto(AUTHORED);
+    assert_eq!(section_bytes(&rendered, "BOUND"), 0, "{rendered}");
+    assert!(section_bytes(&rendered, "REFERENCED") > 0, "{rendered}");
+
+    let no_referenced = compiled(
+        &fixture.db,
+        RenderBudget {
+            bound_bytes: RenderBudget::BOUND_BYTES,
+            referenced_bytes: 0,
+        },
+    );
+    let report = no_referenced.budget.expect("budget");
+    assert!(
+        report.bound_spent > 0,
+        "an exhausted Referenced budget must not starve the SEPARATE Bound one"
+    );
+    assert_eq!(report.referenced_spent, 0, "the Referenced budget was zero");
+    let rendered = no_referenced.render_onto(AUTHORED);
+    assert!(rendered.contains(PLAN_BODY), "{rendered}");
+    assert_eq!(section_bytes(&rendered, "REFERENCED"), 0, "{rendered}");
+}
+
+// ============================================================ items 4 and 5
+
+/// **§21 item 5, and §14's third rule.** *"Reachable map/search/query remains
+/// available"*; *"the budget is for automatic prompt material, **not a ban on
+/// the actor resolving Reachable/Referenced evidence when needed**"*.
+///
+/// Both budgets are zero — the most hostile state there is — and:
+///
+/// - §2's Reachable descriptor still renders, with all four managed verbs. A
+///   budget that swallowed the surface the actor escapes through would make
+///   item 5 depend on having budget left, which is exactly backwards;
+/// - a coordinate from that same snapshot still resolves to its **full** 64
+///   KiB body — six times the whole default budget, through an API that
+///   cannot see a budget at all.
+#[test]
+fn an_exhausted_budget_leaves_reachable_available_and_caps_no_resolution() {
+    let fixture = fixture();
+    let snapshot = compiled(
+        &fixture.db,
+        RenderBudget {
+            bound_bytes: 0,
+            referenced_bytes: 0,
+        },
+    );
+    let rendered = snapshot.render_onto(AUTHORED);
+
+    assert!(
+        all_units(&snapshot).iter().all(|unit| !unit.rendered),
+        "a zero budget renders no evidence at all"
+    );
+    let reachable = snapshot.reachable.as_ref().expect("§2's third tier");
+    for verb in ["map", "search", "related", "query"] {
+        assert!(
+            reachable.capabilities.contains(&verb),
+            "Reachable lost {verb:?} to an exhausted budget: {reachable:?}"
+        );
+    }
+    assert!(
+        rendered.contains("REACHABLE"),
+        "the actor cannot be told about a surface that was not rendered: {rendered}"
+    );
+
+    let huge = unit_at(&snapshot, "notes/huge.md");
+    let resolved = resolve(&fixture.db, &huge.coordinate)
+        .expect("read")
+        .expect("a pinned coordinate resolves");
+    let SourceEvidence::Unit { text, .. } = resolved else {
+        panic!("an Atlas coordinate resolves to a stored unit: {resolved:?}");
+    };
+    assert!(text.starts_with(HUGE_MARKER), "the wrong row came back");
+    assert!(
+        text.len() as u64 > RenderBudget::BOUND_BYTES + RenderBudget::REFERENCED_BYTES,
+        "resolution returned {} bytes; if the budget bounded resolution it could not have",
+        text.len()
+    );
+}
+
+/// §14 bounds *"automatic prompt material"* — not the record.
+///
+/// The same world compiled at a zero budget and at the default budget selects
+/// the **same evidence**: identical coordinates, identical §5 attributions.
+/// Only `rendered` (and the tier a demoted unit lands in) differs. A budget
+/// implemented by dropping evidence would pass every render assertion above
+/// and fail this one, and would quietly make Referenced unresolvable — which
+/// is the failure §14's last sentence exists to forbid.
+#[test]
+fn the_budget_bounds_the_render_and_not_the_snapshots_evidence_ids() {
+    let fixture = fixture();
+    let full = compiled(&fixture.db, RenderBudget::DEFAULT);
+    let starved = compiled(
+        &fixture.db,
+        RenderBudget {
+            bound_bytes: 0,
+            referenced_bytes: 0,
+        },
+    );
+
+    let keys = |snapshot: &ContextSnapshot| -> HashSet<(usize, String)> {
+        all_units(snapshot)
+            .into_iter()
+            .map(|unit| (unit.step.number(), unit.coordinate.dedup_key()))
+            .collect()
+    };
+    assert!(!keys(&full).is_empty(), "the fixture compiled something");
+    assert_eq!(
+        keys(&full),
+        keys(&starved),
+        "a zero budget dropped evidence ids instead of only dropping RENDERING"
+    );
+    assert!(
+        full.bound.iter().any(|unit| unit.rendered),
+        "the default budget renders something, so the comparison above is not two empties"
+    );
+}
+
+/// **§21 item 3's second half.** *"...and every unit resolves to source
+/// evidence."*
+///
+/// Every Bound unit is resolved, and an Atlas one must come back as the exact
+/// stored row whose text is **byte-identical** to the excerpt that was
+/// rendered — a rendered unit that cannot be traced to its source is the same
+/// defect class as a note asserting what the code does not do.
+///
+/// The violation half is what makes it a test: two fabricated coordinates —
+/// a path that no generation holds, and a real path at an ordinal that does
+/// not exist — resolve to `None`. A resolver that answered `Some` for
+/// anything plausible would pass the first half and fail here.
+#[test]
+fn every_bound_unit_resolves_to_source_evidence_and_a_fabricated_one_does_not() {
+    let fixture = fixture();
+    let snapshot = compiled(&fixture.db, RenderBudget::DEFAULT);
+
+    let mut atlas_units = 0usize;
+    for unit in &snapshot.bound {
+        let resolved = resolve(&fixture.db, &unit.coordinate)
+            .expect("read")
+            .unwrap_or_else(|| {
+                panic!(
+                    "a Bound unit resolves to no source evidence: {:?}",
+                    unit.coordinate
+                )
+            });
+        if let SourceEvidence::Unit { text, .. } = &resolved {
+            atlas_units += 1;
+            if let Some(excerpt) = &unit.excerpt {
+                assert_eq!(
+                    excerpt, text,
+                    "the rendered excerpt is not the stored row it claims to be"
+                );
+            }
+        }
+    }
+    assert!(
+        atlas_units > 0,
+        "every Bound unit was a Work record: nothing was resolved against the store, \
+         which would make the loop above vacuous"
+    );
+
+    let EvidenceCoordinate::Atlas {
+        source_name,
+        generation_id,
+        content_key,
+        relative_path,
+        ..
+    } = unit_at(&snapshot, "notes/plan.md").coordinate.clone()
+    else {
+        panic!("notes/plan.md is an Atlas coordinate");
+    };
+    let fabricated_path = EvidenceCoordinate::Atlas {
+        source_name: source_name.clone(),
+        generation_id: generation_id.clone(),
+        content_key: content_key.clone(),
+        relative_path: "notes/no-such-file.md".to_string(),
+        unit_key: None,
+        ordinal: Some(0),
+    };
+    assert_eq!(
+        resolve(&fixture.db, &fabricated_path).expect("read"),
+        None,
+        "a coordinate naming no stored row must not resolve"
+    );
+    let fabricated_ordinal = EvidenceCoordinate::Atlas {
+        source_name,
+        generation_id,
+        content_key,
+        relative_path,
+        unit_key: None,
+        ordinal: Some(9_999),
+    };
+    assert_eq!(
+        resolve(&fixture.db, &fabricated_ordinal).expect("read"),
+        None,
+        "a real resource at an ordinal it does not have must not resolve"
+    );
+}
+
+/// **§21 item 4.** *"Referenced coordinates resolve **without broad
+/// rediscovery**"* — §2: *"the actor can resolve them directly **without
+/// broad search**"*.
+///
+/// Two ways of showing the resolution is a keyed lookup and not a search:
+///
+/// 1. **The pinned generation is what discriminates.** `docs/twin.md#0`
+///    exists in both the base and the overlay generation, at the same path
+///    and the same ordinal, with bodies differing by a single word. Nothing
+///    but the `generation_id` in the coordinate can pick between them, and
+///    each coordinate returns its own row. A content-addressed or search-
+///    backed resolver could not — it has no basis to prefer either.
+/// 2. **The search surface never sees this query.** The retrieval the
+///    compiler itself ran, over the same admissible world, does not return
+///    `docs/twin.md` at all — its terms are nowhere in the intent. The same
+///    coordinate resolves anyway, so resolution plainly does not go through
+///    retrieval.
+///
+/// The Referenced coordinate resolved at the end is one the compiler actually
+/// emitted, so this is about the snapshot's own pointers, not about a
+/// coordinate the test invented.
+#[test]
+fn a_coordinate_resolves_by_direct_lookup_not_by_rediscovery() {
+    let fixture = fixture();
+    let base = fixture
+        .db
+        .confirmed_generation(REPOSITORY)
+        .expect("read")
+        .expect("the base generation is confirmed");
+    let overlay_name = overlay_source_name(WORK_ID, REPOSITORY);
+    let overlay = fixture
+        .db
+        .confirmed_generation(&overlay_name)
+        .expect("read")
+        .expect("the overlay generation is confirmed");
+
+    let twin =
+        |source_name: &str, generation_id: &str, content_key: &str| EvidenceCoordinate::Atlas {
+            source_name: source_name.to_string(),
+            generation_id: generation_id.to_string(),
+            content_key: content_key.to_string(),
+            relative_path: TWIN_PATH.to_string(),
+            unit_key: None,
+            ordinal: Some(0),
+        };
+    let text_of = |coordinate: &EvidenceCoordinate| -> String {
+        match resolve(&fixture.db, coordinate).expect("read") {
+            Some(SourceEvidence::Unit { text, .. }) => text,
+            other => panic!("{coordinate:?} did not resolve to a unit: {other:?}"),
+        }
+    };
+    assert_eq!(
+        text_of(&twin(REPOSITORY, &base.id, &base.content_key)),
+        TWIN_BASE,
+        "the BASE generation's coordinate returned some other generation's row"
+    );
+    assert_eq!(
+        text_of(&twin(&overlay_name, &overlay.id, &overlay.content_key)),
+        TWIN_OVERLAY,
+        "the OVERLAY generation's coordinate returned some other generation's row"
+    );
+
+    // The search surface, over the same admissible world, does not reach the
+    // twin at all — and resolution did not need it to.
+    let filter = sergeant_rs::runtime::atlas::db::Admissibility {
+        source: SourceSelector::WorkBase {
+            work_id: WORK_ID.to_string(),
+            repository: REPOSITORY.to_string(),
+        },
+        kind: None,
+        authority: None,
+    };
+    let answer = fixture
+        .db
+        .lexical_search(&LexicalQuery {
+            text: INTENT,
+            filter: &filter,
+            family: None,
+            limit: 32,
+            semantic: SemanticRequest::Suppressed,
+        })
+        .expect("search");
+    assert!(
+        !answer
+            .hits
+            .iter()
+            .any(|hit| hit.coordinate.relative_path() == TWIN_PATH),
+        "the fixture is wrong: retrieval DOES find the twin, so resolving it proves nothing"
+    );
+
+    // And the same holds for a pointer the compiler itself emitted.
+    let snapshot = compiled(
+        &fixture.db,
+        RenderBudget {
+            bound_bytes: 0,
+            referenced_bytes: RenderBudget::REFERENCED_BYTES,
+        },
+    );
+    let pointer = snapshot
+        .referenced
+        .iter()
+        .find(|unit| matches!(&unit.coordinate, EvidenceCoordinate::Atlas { .. }))
+        .expect("the starved compilation emitted Atlas pointers");
+    assert!(
+        resolve(&fixture.db, &pointer.coordinate)
+            .expect("read")
+            .is_some(),
+        "a Referenced pointer the compiler emitted did not resolve: {:?}",
+        pointer.coordinate
+    );
+}
+
+// ============================================================ §5 step 9
+
+/// **§5 step 9** — *"pack Bound; **emit useful remainder as Referenced**"*.
+///
+/// The same coordinate, over the same world, under two budgets: Bound with a
+/// rendered body under the default, and Referenced-with-no-body under a
+/// budget too small for it. Its §5 attribution (step 2) survives the
+/// demotion — the remainder is the same evidence, moved, not re-derived — and
+/// step 9's own record says what it did, which is where §18's *"visible"*
+/// degradation lands for the budget.
+#[test]
+fn bound_evidence_that_does_not_fit_the_budget_becomes_referenced_remainder() {
+    let fixture = fixture();
+
+    let full = compiled(&fixture.db, RenderBudget::DEFAULT);
+    let plan = unit_at(&full, "notes/plan.md");
+    assert_eq!(plan.tier, Tier::Bound);
+    assert_eq!(plan.step, ResearchStep::WorkBindings);
+    assert_eq!(plan.excerpt.as_deref(), Some(PLAN_BODY));
+
+    // 40 bytes holds no chunk in this world at all.
+    let tight = compiled(
+        &fixture.db,
+        RenderBudget {
+            bound_bytes: 40,
+            referenced_bytes: RenderBudget::REFERENCED_BYTES,
+        },
+    );
+    let plan = unit_at(&tight, "notes/plan.md");
+    assert_eq!(
+        plan.tier,
+        Tier::Referenced,
+        "Bound evidence that did not fit must be emitted as Referenced remainder"
+    );
+    assert_eq!(
+        plan.step,
+        ResearchStep::WorkBindings,
+        "the demotion must not rewrite which §5 step selected the evidence"
+    );
+    assert_eq!(plan.excerpt, None, "a remainder is a pointer, not a body");
+    assert!(
+        plan.rendered,
+        "the remainder fit the SEPARATE Referenced budget and must be rendered there"
+    );
+
+    let pack = tight
+        .plan
+        .iter()
+        .find(|record| record.step == ResearchStep::Pack)
+        .expect("§5 step 9 ran");
+    let note = pack.note.as_deref().unwrap_or_default();
+    assert!(
+        note.contains("Referenced remainder"),
+        "step 9 must record what packing did: {note:?}"
+    );
+}
+
+/// §15's *"budget + rendered size"* line, as the snapshot carries it.
+///
+/// Both budgets are named, both spends are named, each spend is within its
+/// own budget, and the Referenced budget is the **smaller** of the two —
+/// §14's *"small separate"*, checkable from the journal alone.
+#[test]
+fn the_snapshot_records_both_budgets_and_what_each_tier_spent() {
+    let fixture = fixture();
+    let snapshot = compiled(&fixture.db, RenderBudget::DEFAULT);
+    let json = snapshot.json();
+    let budget = &json["budget"];
+
+    assert_eq!(budget["unit"], "bytes", "{json}");
+    let bound_bytes = budget["bound_bytes"].as_u64().expect("bound_bytes");
+    let referenced_bytes = budget["referenced_bytes"]
+        .as_u64()
+        .expect("referenced_bytes");
+    let bound_spent = budget["bound_spent"].as_u64().expect("bound_spent");
+    let referenced_spent = budget["referenced_spent"]
+        .as_u64()
+        .expect("referenced_spent");
+
+    assert!(referenced_bytes < bound_bytes, "{budget}");
+    assert!(bound_spent <= bound_bytes, "{budget}");
+    assert!(referenced_spent <= referenced_bytes, "{budget}");
+    assert!(bound_spent > 0 && referenced_spent > 0, "{budget}");
+}
+
+// ============================================================ item 9 is C1c's
+
+/// External evidence renders as a coordinate and never as body text.
+///
+/// §21 item 9 — *"external evidence is visibly external and cannot alter
+/// instruction hierarchy"* — is C1c's, and until it exists external prose
+/// does not enter an actor's prompt from here (**J5**: item 9 is this
+/// contract's own, and it is not yet met; under-delivering a tier is
+/// recoverable, shipping unlabeled external prose is not).
+///
+/// Non-vacuity is the second half: the identical body under an
+/// estate-authority source *is* rendered by the same compilation, so this
+/// pins the authority class as the thing that made the difference, not the
+/// text and not an empty render.
+#[test]
+fn external_evidence_renders_as_a_coordinate_and_never_as_body_text() {
+    const SHARED_BODY: &str = "The retention policy, in one paragraph of prose.";
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    let estate = scan(
+        "estate-notes",
+        SourceKind::LocalKnowledge,
+        AuthorityClass::EstateReadonly,
+        vec![file("estate.md", vec![unit(0, "Estate", SHARED_BODY)])],
+    );
+    record_scan(&mut db, &mut journal, &estate, None).expect("record estate source");
+    let external = scan(
+        "vendor-docs",
+        SourceKind::ExternalGit,
+        AuthorityClass::External,
+        vec![file("vendor.md", vec![unit(0, "Vendor", SHARED_BODY)])],
+    );
+    record_scan(&mut db, &mut journal, &external, None).expect("record external source");
+
+    // No binding, so the admissibility filter is the whole admitted world —
+    // which is the only shape in which external evidence reaches this
+    // compiler at all today (a `WorkBase` selector names one repository and
+    // its overlay).
+    let stage = stage();
+    let snapshot = compile(
+        Some(&db),
+        &CompileRequest {
+            estate_root: Some(Path::new("/estates/demo")),
+            work_id: WORK_ID,
+            intent: INTENT,
+            stage: &stage,
+            stage_index: 1,
+            attempt: 1,
+            execution_id: "01EXECUTION",
+            journal_watermark: 42,
+            bindings: &[],
+            prior_stages: &[],
+            profile: None,
+            budget: RenderBudget::DEFAULT,
+        },
+    );
+
+    let vendor = unit_at(&snapshot, "vendor.md");
+    assert_eq!(
+        vendor.excerpt, None,
+        "external prose was rendered as a body"
+    );
+    let estate_unit = unit_at(&snapshot, "estate.md");
+    assert_eq!(
+        estate_unit.excerpt.as_deref(),
+        Some(SHARED_BODY),
+        "the identical body under an estate source IS rendered — the authority class is \
+         what made the difference"
+    );
+
+    let rendered = snapshot.render_onto(AUTHORED);
+    assert!(rendered.contains("vendor.md"), "{rendered}");
+    let pack = snapshot
+        .plan
+        .iter()
+        .find(|record| record.step == ResearchStep::Pack)
+        .expect("§5 step 9 ran");
+    assert!(
+        pack.note.as_deref().unwrap_or_default().contains("item 9"),
+        "packing must say why it withheld the body: {:?}",
+        pack.note
+    );
+}

--- a/tests/c1b_tiers_and_budget.rs
+++ b/tests/c1b_tiers_and_budget.rs
@@ -32,6 +32,7 @@ use sergeant_rs::domain::workflow::{StageDefinition, StageKind, StageRecord, Sta
 use sergeant_rs::runtime::atlas::db::{AtlasDb, LexicalQuery, SourceSelector};
 use sergeant_rs::runtime::atlas::overlay::overlay_source_name;
 use sergeant_rs::runtime::atlas::record::record_scan;
+use sergeant_rs::runtime::atlas::scan::{EDGE_IMPORT, ScannedEdge, ScannedSyntax};
 use sergeant_rs::runtime::atlas::semantic::SemanticRequest;
 use sergeant_rs::runtime::context::{
     CompileRequest, ContextSnapshot, EvidenceCoordinate, EvidenceUnit, RenderBudget, ResearchStep,
@@ -795,5 +796,91 @@ fn external_evidence_renders_as_a_coordinate_and_never_as_body_text() {
         pack.note.as_deref().unwrap_or_default().contains("item 9"),
         "packing must say why it withheld the body: {:?}",
         pack.note
+    );
+}
+
+// ==================================================================== fixes
+
+/// **F-IN-01.** `AtlasDb::resolve_relationship`'s edge lookup used to filter
+/// only on `(generation_id, edge_kind, relative_path, target)` — no
+/// `ordinal`, no `ORDER BY`, no `LIMIT` — so two edges that legitimately
+/// share every one of those fields (the same file importing the same target
+/// twice) were indistinguishable to the query, and `rows.next()` returned
+/// whichever DuckDB happened to return first regardless of which coordinate
+/// asked. Two edges are planted here sharing kind/from/to and differing only
+/// in `ordinal`; each coordinate's own pinned ordinal must come back, not an
+/// arbitrary one of the two.
+#[test]
+fn resolve_relationship_discriminates_sibling_edges_by_ordinal() {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    let mut code = file("src/lib.rs", vec![unit(0, "lib", "fn main() {}")]);
+    code.syntax = Some(ScannedSyntax {
+        language: "rust",
+        extractor: "syntax-rust/v1".to_string(),
+        syntax_key: "syntax-key/rust/src/lib.rs".to_string(),
+        symbols: Vec::new(),
+        edges: vec![
+            ScannedEdge {
+                ordinal: 0,
+                kind: EDGE_IMPORT,
+                target: "crate::shared".to_string(),
+                byte_start: 0,
+                byte_end: 1,
+            },
+            ScannedEdge {
+                ordinal: 7,
+                kind: EDGE_IMPORT,
+                target: "crate::shared".to_string(),
+                byte_start: 40,
+                byte_end: 41,
+            },
+        ],
+    });
+    let base = scan(
+        REPOSITORY,
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![code],
+    );
+    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    let generation_id = db
+        .confirmed_generation(REPOSITORY)
+        .expect("read")
+        .expect("the base generation is confirmed")
+        .id;
+
+    let asked_for_0 = db
+        .resolve_relationship(
+            &generation_id,
+            EDGE_IMPORT,
+            "src/lib.rs",
+            "crate::shared",
+            Some(0),
+        )
+        .expect("read")
+        .expect("the ordinal-0 edge resolves");
+    assert_eq!(
+        asked_for_0.ordinal,
+        Some(0),
+        "asked for ordinal 0, got the other sibling edge back: {asked_for_0:?}"
+    );
+
+    let asked_for_7 = db
+        .resolve_relationship(
+            &generation_id,
+            EDGE_IMPORT,
+            "src/lib.rs",
+            "crate::shared",
+            Some(7),
+        )
+        .expect("read")
+        .expect("the ordinal-7 edge resolves");
+    assert_eq!(
+        asked_for_7.ordinal,
+        Some(7),
+        "asked for ordinal 7, got the other sibling edge back: {asked_for_7:?}"
     );
 }

--- a/tests/c1b_tiers_and_budget.rs
+++ b/tests/c1b_tiers_and_budget.rs
@@ -32,7 +32,7 @@ use sergeant_rs::domain::workflow::{StageDefinition, StageKind, StageRecord, Sta
 use sergeant_rs::runtime::atlas::db::{AtlasDb, LexicalQuery, SourceSelector};
 use sergeant_rs::runtime::atlas::overlay::overlay_source_name;
 use sergeant_rs::runtime::atlas::record::record_scan;
-use sergeant_rs::runtime::atlas::scan::{EDGE_IMPORT, ScannedEdge, ScannedSyntax};
+use sergeant_rs::runtime::atlas::scan::{ChildProvenance, EDGE_IMPORT, ScannedEdge, ScannedSyntax};
 use sergeant_rs::runtime::atlas::semantic::SemanticRequest;
 use sergeant_rs::runtime::context::{
     CompileRequest, ContextSnapshot, EvidenceCoordinate, EvidenceUnit, RenderBudget, ResearchStep,
@@ -800,6 +800,70 @@ fn external_evidence_renders_as_a_coordinate_and_never_as_body_text() {
 }
 
 // ==================================================================== fixes
+
+/// **F-SF-01.** §5 step 3's own Bound tier — *"exact structural/document/
+/// tabular/mail relationships"* — used to stay coordinate-only forever: only
+/// `EvidenceCoordinate::Atlas` ever got an excerpt resolved during packing.
+/// A `Relationship` coordinate resolves to real evidence too
+/// ([`resolve`] already proved that for item 3/4's other tests), so packing
+/// must render it exactly as it renders an Atlas unit's body: the one extra
+/// fact the storing table holds (§6.6's entry path, for a child resource)
+/// reaches the prompt, not just the coordinate line.
+#[test]
+fn a_bound_relationship_unit_renders_its_resolved_detail_into_the_prompt() {
+    const ENTRY_PATH: &str = "attachments/report.pdf";
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    let base = scan(
+        REPOSITORY,
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![file(
+            "docs/architecture.md",
+            vec![unit(0, "Architecture", "The daemon owns the journal.")],
+        )],
+    );
+    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+
+    let mut child = file(
+        "mail/inbox.mbox/attachments/report.pdf",
+        vec![unit(0, "Report", "Report body.")],
+    );
+    child.parent = Some(ChildProvenance {
+        parent_relative_path: "mail/inbox.mbox".to_string(),
+        parent_key: "key/mail/inbox.mbox".to_string(),
+        entry_path: ENTRY_PATH.to_string(),
+    });
+    let overlay = scan(
+        &overlay_source_name(WORK_ID, REPOSITORY),
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![child],
+    );
+    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+
+    let snapshot = compiled(&db, RenderBudget::DEFAULT);
+
+    let relationship = snapshot
+        .bound
+        .iter()
+        .find(|unit| matches!(unit.coordinate, EvidenceCoordinate::Relationship { .. }))
+        .expect("step 3 contributed the child-resource relationship as a Bound unit");
+    assert_eq!(
+        relationship.excerpt.as_deref(),
+        Some(ENTRY_PATH),
+        "a Bound Relationship unit must resolve to its stored detail (the entry path), not \
+         stay coordinate-only: {relationship:?}"
+    );
+
+    let rendered = snapshot.render_onto(AUTHORED);
+    assert!(
+        rendered.contains(ENTRY_PATH),
+        "the resolved relationship detail never reached the rendered prompt: {rendered}"
+    );
+}
 
 /// **F-IN-01.** `AtlasDb::resolve_relationship`'s edge lookup used to filter
 /// only on `(generation_id, edge_kind, relative_path, target)` — no

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -647,6 +647,72 @@ pub fn scaffold_solo_estate(root: &Path, name: &str) -> (PathBuf, String) {
     (root.join("repos").join(name), head)
 }
 
+/// A C1a/C1b Atlas-scan fixture unit: one section, deliberately minimal
+/// (heading level 1, no coordinate) so callers only ever vary ordinal, title
+/// and text (R2 — shared by `tests/c1a_compiled_context.rs` and
+/// `tests/c1b_tiers_and_budget.rs`, which built byte-identical copies of this
+/// before F-SI-01).
+pub fn unit(
+    ordinal: u64,
+    title: &str,
+    text: &str,
+) -> sergeant_rs::runtime::atlas::scan::ScannedUnit {
+    sergeant_rs::runtime::atlas::scan::ScannedUnit {
+        ordinal,
+        kind: sergeant_rs::domain::source::UnitKind::Section,
+        heading_level: Some(1),
+        title: Some(title.to_string()),
+        byte_start: 0,
+        byte_end: text.len() as u64,
+        coordinate: None,
+        text: text.to_string(),
+    }
+}
+
+/// A C1a/C1b Atlas-scan fixture file wrapping [`unit`]s. See [`unit`]'s doc.
+pub fn file(
+    relative_path: &str,
+    units: Vec<sergeant_rs::runtime::atlas::scan::ScannedUnit>,
+) -> sergeant_rs::runtime::atlas::scan::ScannedFile {
+    let bytes: u64 = units.iter().map(|u| u.text.len() as u64).sum();
+    sergeant_rs::runtime::atlas::scan::ScannedFile {
+        relative_path: relative_path.to_string(),
+        content_hash: format!("hash/{relative_path}"),
+        extractor: sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR.to_string(),
+        local_key: format!("key/{relative_path}"),
+        byte_len: bytes,
+        mtime_millis: None,
+        units,
+        syntax: None,
+        parent: None,
+    }
+}
+
+/// A C1a/C1b Atlas-scan fixture source wrapping [`file`]s. See [`unit`]'s doc.
+pub fn scan(
+    source_name: &str,
+    kind: sergeant_rs::domain::source::SourceKind,
+    authority: sergeant_rs::domain::source::AuthorityClass,
+    files: Vec<sergeant_rs::runtime::atlas::scan::ScannedFile>,
+) -> sergeant_rs::runtime::atlas::scan::SourceScan {
+    let mut extractors = std::collections::BTreeSet::new();
+    extractors.insert(sergeant_rs::runtime::atlas::text::MARKDOWN_EXTRACTOR.to_string());
+    sergeant_rs::runtime::atlas::scan::SourceScan {
+        source_name: source_name.to_string(),
+        kind,
+        authority,
+        content_key: format!("{source_name}@generation-1"),
+        revision: None,
+        observed_at: sergeant_rs::domain::event::rfc3339_utc_now(),
+        files,
+        coverage: Vec::new(),
+        extractors,
+        datasets: Vec::new(),
+        root: None,
+        context_fields: sergeant_rs::runtime::atlas::tabular::ContextFields::none(),
+    }
+}
+
 /// A cross-process mutex over a fixed OS resource a test cannot make
 /// per-process-unique (#305: `t5_disabled_export_runs_no_exporter_machinery`
 /// must bind the daemon's literal `DEFAULT_OTLP_ENDPOINT`, port 0 or a


### PR DESCRIPTION
## What

C1 §2's Bound / Referenced / Reachable, and §14's budget — on C1a's machinery, not beside it (**R2**).

`pack()` is §5 step 9, *"pack Bound; emit useful remainder as Referenced"*, which C1a left contributing nothing. A Bound unit renders its coordinate **and its source text** when the whole chunk fits the remaining Bound budget. One that does not fit is **never truncated into the prompt** — it is demoted to Referenced as a pointer, keeps its §5 step attribution, and competes for the separate Referenced budget. `render_chunk` is the single formatter used by both the packer and the renderer, so "within budget" is arithmetic over **the same bytes that reach the prompt**, not an estimate of them.

## §14's three rules, each a test

**1. The budget is hard.** A 64 KiB source — 8× the budget, contributed deterministically by step 2 — cannot fill Bound with body text. The section is measured *off the rendered text* and equals the snapshot's own `bound_spent`. A small body *is* rendered in the same test, so this bounds a renderer that renders.

**2. Two budgets, not one.** `bound_bytes=0` ⇒ Referenced still renders; `referenced_bytes=0` ⇒ Bound still renders bodies. One shared number cannot produce both answers.

**3. The budget bounds C1, not the actor.** At budget `{0,0}` the Reachable descriptor still renders with all four managed verbs, and a coordinate from that snapshot still resolves to its **full 64 KiB** body — larger than the entire default budget. The obvious implementation quietly makes Reachable unreachable; this proves it does not.

Plus: zero budget and default budget select the **identical** set of `(step, dedup_key)` evidence ids — the budget bounds the render, never the record.

## The numbers are traced, not guessed

**No backend-native token count exists at the launch boundary**: `StartRequest` carries `context: String` and no count, and `Capabilities::usage` is *post-turn* reporting read off a result payload. So §14's second branch applies.

The unit is **bytes of rendered UTF-8** — conservative not by a guessed ratio but by a property: **every tokenizer emits at least one byte per token, so `tokens ≤ bytes` always.** A byte bound can only over-state token cost, and it needs no tokenizer dependency (**R1/R3**).

Both defaults come from one dated in-lane measurement (2026-08-30), commands in the doc and re-runnable:
- the **55 shipped stage `CONTEXT.md` files** — `mean=3964 median=3033 p90=6041 max=15476` — put Bound at **8 KiB**: above p90, below max, so the compiled world can never dwarf the procedure it sits beside;
- a pointer line is **≈100 bytes** (`git ls-files | awk '{print length}'`, `n=573 mean=41`, plus a 40-hex content key), so **2 KiB** Referenced ≈ 20 pointers — same order as `STEP_ROW_CAP`'s 32, and a quarter of Bound. §14's *"small separate"*.

## Item 4 proved by discrimination, not by assertion

*"Referenced coordinates resolve without broad rediscovery"* — a test that resolved by searching would pass while proving the opposite. So: `docs/twin.md#0` exists in **two generations at the same path and the same ordinal**, bodies differing by one word, and each coordinate returns **its own** row — only `generation_id` can discriminate. And the compiler's own lexical search over that same admissible world does **not** return the twin at all, yet resolution does.

`resolve()` takes no query, no ranker, no limit and **no budget**. Packing fetches what it renders through that same call, so every rendered Bound unit resolves back to its stored row **by construction** — item 3's second half, plus the violation half: a fabricated path and a real path at a non-existent ordinal both resolve to `None`.

## Vacuity checked by breaking it

Budget checks replaced with `if true` → **6 of 9 red**. `resolve_unit`'s `generation_id = ?` predicate removed → **item 4's test red, alone**. The external gate disabled → item 9's test red. All reverted.

## Panel — 4 raised, 4 confirmed

**Blocker:** the Bound tier was only genuinely closed for one coordinate variant — a `Relationship` unit's detail was not resolved during packing. **Major:** `resolve_relationship`'s lookup key was not unique, so a pinned Relationship coordinate could resolve to an arbitrary one of several edges; it now carries `ordinal`. Plus a swallowed Atlas error during packing (a real database failure was reading as absent evidence), and duplicated fixture builders now shared via `tests/support`.

## Two C1a tests changed, deliberately

C1a rendered Bound in Referenced's own shape, and its own doc named that as C1b's to close (**J3**). Had Bound kept rendering coordinates only, **the budget would bound nothing and this whole wave would be vacuous.** The C1a CHANGELOG bullet was amended in place rather than left contradicting the code.

## Verification

fmt clean, clippy clean, 44/44 across C1b, C1a, the acceptance register and the one-Atlas-database boundary. The SQL boundary is untouched: the two new statements go through the existing `sql!` macro exactly as `units()`/`edges()` do. New suite wired into coverage at birth (#231).

Full suite not run locally — CI by SHA is the exhaustive pass.

Closes §21 items 3, 4 and 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4