### PR TITLE
feat(context): S6 C1d — attribution, nesting and audit (items 11, 12, 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1725,6 +1725,54 @@ them were dead code in every real installation.
   estate's F9 containment rule already refuses a `[[knowledge]]` path that
   resolves inside a repository mount, so read-only evidence cannot alias a
   mutation surface on the way in either.
+- **Managed context queries are attributed to the execution that issued
+  them** (C1 §16, §21 item 11, C1d). The compilation's own retrieval now
+  carries a third attribution — the Work, the repository **and the fresh
+  execution** — so two stage launches of one Work are told apart, which the
+  Work-level attribution could not do. `sgt search --work <id>` is unchanged
+  and still reports no execution, because a human's Work-scoped read has
+  none; the field is present and null there rather than borrowed. §16's
+  **seven** event kinds are all declared, in §16's own order:
+  `context.bound`, `context.referenced` and `context.query` are journaled per
+  compiled world, and `context.search_fallback` records — in A2 §15's own
+  word — a retrieval that landed on a narrower §18 rung than it asked for.
+  The remaining three are declared and emitted by nothing, each saying why:
+  `context.reference_resolved` (no surface gives an *execution* a resolve
+  verb yet, and journaling the compiler's own packing read under it would be
+  a false entry), `context.scope_expansion_requested` (§20 forbids automatic
+  expansion and nothing accepts §10's asked-for one) and
+  `context.contradiction_observed` (§9's detection does not exist, and
+  scoring disagreement would synthesize the consensus §9 forbids). **Record,
+  do not adapt**: no code reads these events, and no payload carries a score,
+  a sharpness or any other scalar — §16's *"record raw evidence rather than a
+  magic 'sharpness score'"*, which §20 states twice more.
+- **Nested leaves and causal child Work receive independent worlds** (C1 §17,
+  §21 item 12, C1d). Each nested leaf actor compiles its own snapshot under
+  its own composed stage id, its own execution and its own evidence — a leaf
+  that runs fourth binds strictly more stage-input evidence than one that
+  runs first, so four leaves are four worlds rather than four copies. A
+  container gets none, and cannot: a container is not a stage, and dropping a
+  `CONTEXT.md` into a container's directory is refused by name at load time.
+  A causal child Work compiles from its own Work coordinate and its own
+  `sergeant/<child>` binding and **inherits no byte of the parent's
+  transcript or prompt** (§20's *parent-prompt inheritance for child Work*),
+  proved adversarially against markers planted in the parent's procedure and
+  intent. What the child does get is §17's one permitted channel: the parent
+  causation as a **Referenced** pointer — the validated parent Work, the
+  parent execution and the parent's state — a coordinate with no field a
+  parent's prose could travel in.
+- **Produced artifacts retain enough coordinates for claim-level audit**
+  (C1 §19, §21 item 14, C1d). §19's chain now has a walked proof rather than
+  an assumption: from a quoted evidence line in the actor's prompt, through
+  the snapshot id the prompt names, into the journaled `context.compiled`
+  payload read back as bytes, to the source, generation, resource, unit
+  coordinate, heading, the normalizer's own slide/block address, the
+  extractor identity and the query provenance — and from there to the exact
+  stored row by keyed resolution, with the same coordinate under a different
+  generation resolving to nothing. **No claim graph was built**, because §19
+  says one is not required in Sprint 3 and that preserving exact coordinates
+  is the enabling invariant. §19's `page+bbox` arm is OCR's and stays absent
+  **by owner ruling**, present and null in every unit rather than omitted.
 
 
 ### Every document format the normalizer parses is routed (S6)

--- a/scripts/coverage/c2-suites.sh
+++ b/scripts/coverage/c2-suites.sh
@@ -406,3 +406,13 @@ cov_stage_end 1 "the c1b_tiers_and_budget test binary must write its own profile
 cov_stage_begin c2-c1c_authority_and_provenance
 cov_run cargo llvm-cov --no-report --test c1c_authority_and_provenance --locked || cov_fail "c1c_authority_and_provenance failed under instrumentation"
 cov_stage_end 1 "the c1c_authority_and_provenance test binary must write its own profile"
+
+# S6 C1d, wired at birth (the #231 lesson): C1 §21 items 11, 12 and 14 —
+# attribution, nesting and audit. Ten in-process tests over a real Atlas built
+# by the ordinary `record_scan` path (§16's seven event kinds, §17's parent
+# pointer, §19's chain walked from a rendered fragment to a resolved row),
+# plus two live-daemon tests over a real estate for §17's nested-leaf and
+# child-Work rules. No Docker, no subprocess. Floor 1.
+cov_stage_begin c2-c1d_attribution_nesting_audit
+cov_run cargo llvm-cov --no-report --test c1d_attribution_nesting_audit --locked || cov_fail "c1d_attribution_nesting_audit failed under instrumentation"
+cov_stage_end 1 "the c1d_attribution_nesting_audit test binary must write its own profile"

--- a/src/api.rs
+++ b/src/api.rs
@@ -6797,6 +6797,19 @@ pub const SSE_EVENT_KINDS: &[&str] = &[
     // kind per fresh execution, never one per evidence unit — the same
     // affordability argument `source.scanned` makes below.
     KIND_CONTEXT_COMPILED,
+    // C1 §16's seven audit kinds, in §16's own order. Three of them are
+    // declared-but-unemitted in this build (see each constant's doc); they
+    // are listed here anyway, because this list is the *vocabulary* an
+    // enumerating client subscribes to, and a client that learns a frame
+    // name only once something first emits it is a client that drops the
+    // first one.
+    workflow::KIND_CONTEXT_BOUND,
+    workflow::KIND_CONTEXT_REFERENCED,
+    workflow::KIND_CONTEXT_QUERY,
+    workflow::KIND_CONTEXT_REFERENCE_RESOLVED,
+    workflow::KIND_CONTEXT_SEARCH_FALLBACK,
+    workflow::KIND_CONTEXT_SCOPE_EXPANSION_REQUESTED,
+    workflow::KIND_CONTEXT_CONTRADICTION_OBSERVED,
     KIND_EXECUTION_RESERVED,
     KIND_EXECUTION_STARTED,
     KIND_EXECUTION_STOPPED,

--- a/src/api.rs
+++ b/src/api.rs
@@ -6772,82 +6772,88 @@ async fn forward_events(
 /// that wants "every journaled kind" still gets exactly this list; a client
 /// that wants "everything this stream can ever frame" also has to handle
 /// the two names in [`SSE_CONTROL_FRAMES`] below.
-pub const SSE_EVENT_KINDS: &[&str] = &[
-    KIND_WORK_SUBMITTED,
-    KIND_WORK_STARTED,
-    KIND_WORK_RESUMED,
-    KIND_WORK_WAITING,
-    KIND_WORK_NEEDS_INPUT,
-    KIND_WORK_BLOCKED,
-    KIND_WORK_COMPLETED,
-    KIND_WORK_FAILED,
-    KIND_WORK_CANCELED,
-    KIND_WORKFLOW_BOUND,
-    KIND_STAGE_ENTERED,
-    KIND_STAGE_COMPLETED,
-    KIND_STAGE_WAITING,
-    KIND_STAGE_NEEDS_INPUT,
-    KIND_STAGE_INPUT_RECEIVED,
-    KIND_STAGE_RESUMED,
-    KIND_STAGE_BLOCKED,
-    KIND_STAGE_FAILED,
-    KIND_STAGE_CANCELED,
-    KIND_STAGE_OUTPUT_MISSING,
-    // C1 §15: the compiled-context snapshot, journaled at stage entry. One
-    // kind per fresh execution, never one per evidence unit — the same
-    // affordability argument `source.scanned` makes below.
-    KIND_CONTEXT_COMPILED,
-    // C1 §16's seven audit kinds, in §16's own order. Three of them are
-    // declared-but-unemitted in this build (see each constant's doc); they
-    // are listed here anyway, because this list is the *vocabulary* an
-    // enumerating client subscribes to, and a client that learns a frame
-    // name only once something first emits it is a client that drops the
-    // first one.
-    workflow::KIND_CONTEXT_BOUND,
-    workflow::KIND_CONTEXT_REFERENCED,
-    workflow::KIND_CONTEXT_QUERY,
-    workflow::KIND_CONTEXT_REFERENCE_RESOLVED,
-    workflow::KIND_CONTEXT_SEARCH_FALLBACK,
-    workflow::KIND_CONTEXT_SCOPE_EXPANSION_REQUESTED,
-    workflow::KIND_CONTEXT_CONTRADICTION_OBSERVED,
-    KIND_EXECUTION_RESERVED,
-    KIND_EXECUTION_STARTED,
-    KIND_EXECUTION_STOPPED,
-    KIND_EXECUTION_ABANDONED,
-    KIND_EXECUTION_RECONCILED,
-    KIND_TURN_CEILING_INTERRUPTED,
-    KIND_TURN_ENVELOPE_EXTENDED,
-    KIND_SURFACE_MATERIALIZING,
-    KIND_SURFACE_MATERIALIZED,
-    KIND_SURFACE_TORN_DOWN,
-    KIND_CONVERSATION_USER,
-    KIND_CONVERSATION_ASSISTANT_COMPLETED,
-    KIND_CONVERSATION_ASK,
-    KIND_CONVERSATION_TURN_ENDED,
-    KIND_TOOL_REQUESTED,
-    KIND_TOOL_COMPLETED,
-    KIND_USAGE_UPDATED,
-    // W1: the codex adapter's one module-local kind (§1.2 of the spec) — a
-    // `pub const KIND_*`, unlike claude.rs's bare string-literal
-    // "conversation.turn.grammar_unmeasured", so it is journaled and must be
-    // named here for t6's bidirectional check to hold.
-    KIND_TURN_HARNESS_ERROR,
-    KIND_COMMAND_ACCEPTED,
-    KIND_COMMAND_REJECTED,
-    KIND_DAEMON_STARTED,
-    KIND_DAEMON_STOPPED,
-    KIND_BACKEND_PROBED,
-    KIND_ADMISSION_PAUSED,
-    KIND_ADMISSION_RESUMED,
-    crate::runtime::prune::KIND_PRUNE_INTENT,
-    crate::runtime::prune::KIND_PRUNE_COMPLETED,
-    // S3 X2: the one compact summary a completed source scan journals. Named
-    // here for the same reason as every kind above — a journaled kind absent
-    // from this list is a frame every enumerating client silently drops — and
-    // it is *one* kind per completed scan, never one per file, which is what
-    // makes putting it on the live stream affordable at all.
-    crate::domain::source::KIND_SOURCE_SCANNED,
-];
+pub static SSE_EVENT_KINDS: std::sync::LazyLock<Vec<&'static str>> =
+    std::sync::LazyLock::new(|| {
+        let mut kinds: Vec<&'static str> = vec![
+            KIND_WORK_SUBMITTED,
+            KIND_WORK_STARTED,
+            KIND_WORK_RESUMED,
+            KIND_WORK_WAITING,
+            KIND_WORK_NEEDS_INPUT,
+            KIND_WORK_BLOCKED,
+            KIND_WORK_COMPLETED,
+            KIND_WORK_FAILED,
+            KIND_WORK_CANCELED,
+            KIND_WORKFLOW_BOUND,
+            KIND_STAGE_ENTERED,
+            KIND_STAGE_COMPLETED,
+            KIND_STAGE_WAITING,
+            KIND_STAGE_NEEDS_INPUT,
+            KIND_STAGE_INPUT_RECEIVED,
+            KIND_STAGE_RESUMED,
+            KIND_STAGE_BLOCKED,
+            KIND_STAGE_FAILED,
+            KIND_STAGE_CANCELED,
+            KIND_STAGE_OUTPUT_MISSING,
+            // C1 §15: the compiled-context snapshot, journaled at stage
+            // entry. One kind per fresh execution, never one per evidence
+            // unit — the same affordability argument `source.scanned` makes
+            // below.
+            KIND_CONTEXT_COMPILED,
+        ];
+        // C1 §16's seven audit kinds, in §16's own order — reused from
+        // `workflow::CONTEXT_AUDIT_KINDS` rather than retyped here, so a
+        // future reorder or addition to that array cannot silently drift
+        // from this list (R2, F-SI-01). Three of them are
+        // declared-but-unemitted in this build (see each constant's doc);
+        // they are listed here anyway, because this list is the
+        // *vocabulary* an enumerating client subscribes to, and a client
+        // that learns a frame name only once something first emits it is a
+        // client that drops the first one.
+        kinds.extend_from_slice(&workflow::CONTEXT_AUDIT_KINDS);
+        kinds.extend([
+            KIND_EXECUTION_RESERVED,
+            KIND_EXECUTION_STARTED,
+            KIND_EXECUTION_STOPPED,
+            KIND_EXECUTION_ABANDONED,
+            KIND_EXECUTION_RECONCILED,
+            KIND_TURN_CEILING_INTERRUPTED,
+            KIND_TURN_ENVELOPE_EXTENDED,
+            KIND_SURFACE_MATERIALIZING,
+            KIND_SURFACE_MATERIALIZED,
+            KIND_SURFACE_TORN_DOWN,
+            KIND_CONVERSATION_USER,
+            KIND_CONVERSATION_ASSISTANT_COMPLETED,
+            KIND_CONVERSATION_ASK,
+            KIND_CONVERSATION_TURN_ENDED,
+            KIND_TOOL_REQUESTED,
+            KIND_TOOL_COMPLETED,
+            KIND_USAGE_UPDATED,
+            // W1: the codex adapter's one module-local kind (§1.2 of the
+            // spec) — a `pub const KIND_*`, unlike claude.rs's bare
+            // string-literal "conversation.turn.grammar_unmeasured", so it
+            // is journaled and must be named here for t6's bidirectional
+            // check to hold.
+            KIND_TURN_HARNESS_ERROR,
+            KIND_COMMAND_ACCEPTED,
+            KIND_COMMAND_REJECTED,
+            KIND_DAEMON_STARTED,
+            KIND_DAEMON_STOPPED,
+            KIND_BACKEND_PROBED,
+            KIND_ADMISSION_PAUSED,
+            KIND_ADMISSION_RESUMED,
+            crate::runtime::prune::KIND_PRUNE_INTENT,
+            crate::runtime::prune::KIND_PRUNE_COMPLETED,
+            // S3 X2: the one compact summary a completed source scan
+            // journals. Named here for the same reason as every kind above
+            // — a journaled kind absent from this list is a frame every
+            // enumerating client silently drops — and it is *one* kind per
+            // completed scan, never one per file, which is what makes
+            // putting it on the live stream affordable at all.
+            crate::domain::source::KIND_SOURCE_SCANNED,
+        ]);
+        kinds
+    });
 
 /// Frame names this stream sends that are **not** journaled `KIND_*` events
 /// — deliberately outside [`SSE_EVENT_KINDS`]'s contract (see its doc

--- a/src/domain/workflow.rs
+++ b/src/domain/workflow.rs
@@ -137,6 +137,128 @@ pub const KIND_STAGE_OUTPUT_MISSING: &str = "stage.output_missing";
 /// compiler installed journals nothing at all, which is the other, stronger
 /// half of §21 item 13: the existing stage launch path with nothing added.
 pub const KIND_CONTEXT_COMPILED: &str = "context.compiled";
+
+// ===================================================================
+// C1 §16 — actor queries are evidence
+// ===================================================================
+//
+// §16 lists **seven** event kinds verbatim, and all seven are declared here,
+// in §16's own order, so a reader of the contract finds every line of its
+// list in one place:
+//
+// ```text
+// context.bound
+// context.referenced
+// context.query
+// context.reference_resolved
+// context.search_fallback
+// context.scope_expansion_requested
+// context.contradiction_observed
+// ```
+//
+// **Four are emitted by this build and three are declared-but-unemitted**,
+// each saying which surface would emit it and why nothing does yet. That
+// split is stated rather than hidden for the same reason
+// [`crate::runtime::context::EvidenceProvenance::ocr`] is present and null:
+// an absent kind is indistinguishable from a forgotten one, and a reader of
+// §16 checking whether Sergeant records its list needs the answer for all
+// seven, not for the subset that happened to be easy.
+//
+// **What §16 bounds.** Its own purpose clause is *"This later lets Sergeant
+// analyze where compiled worlds were insufficient **without self-tuning
+// during Sprint 3**"*, and its own instruction is *"Record raw evidence
+// rather than a magic 'sharpness score'"* — which §20 repeats as two separate
+// non-goals (*learned context policy/live self-tuning*, *universal scalar
+// sharpness score*). So every payload below is raw coordinates and raw
+// stated status. **Nothing here is scored, ranked, aggregated into a quality
+// number, or read back by the compiler.** No code in this crate consumes
+// these events at all; they are a record for a later reader, which is
+// exactly what "record, do not adapt" means.
+
+/// §16's `context.bound` — the Bound evidence one compiled world actually
+/// carried into one fresh execution, attributed to that execution.
+///
+/// One event per compilation, never one per unit: the evidence coordinates
+/// ride in the payload as a list. That is the same affordability argument
+/// [`KIND_CONTEXT_COMPILED`] and `source.scanned` already make, and it is
+/// what keeps a nine-step plan with [`crate::runtime::context::STEP_ROW_CAP`]
+/// rows per step from journaling hundreds of events per stage entry.
+pub const KIND_CONTEXT_BOUND: &str = "context.bound";
+/// §16's `context.referenced` — the Referenced coordinates the same
+/// compilation emitted, attributed to the same execution. Separate from
+/// [`KIND_CONTEXT_BOUND`] because §2's two tiers are different facts about
+/// what the actor was given: a body it was handed versus a pointer it may
+/// resolve.
+pub const KIND_CONTEXT_REFERENCED: &str = "context.referenced";
+/// §16's `context.query` — a **managed** retrieval call issued for one
+/// execution, carrying A2 §13's query identity and the execution attribution
+/// ([`crate::runtime::atlas::trace::Attribution::Execution`]).
+///
+/// This is the destination `crate::runtime::atlas::trace`'s own doc named:
+/// *"persisting the trace of a **managed** search — one a Work's own
+/// execution issued — is C1/S6's, where a managed retrieval call has a Work
+/// execution to attach the row to."* An unmanaged `sgt search` still
+/// journals nothing, so H13.2's pure-reader property is untouched.
+pub const KIND_CONTEXT_QUERY: &str = "context.query";
+/// §16's `context.reference_resolved` — **declared, and emitted by nothing
+/// in this build.**
+///
+/// The fact it would record is *the actor went and resolved a Referenced
+/// coordinate*, which is §14's *"not a ban on the actor resolving
+/// Reachable/Referenced evidence when needed"* actually being exercised. In
+/// this release there is no surface through which an execution resolves one:
+/// `crate::runtime::context::resolve` is called by the compiler's own packing
+/// step, before the actor exists, and journaling *that* under this kind would
+/// be recording the compiler's read as if it were the actor's — a false
+/// entry in exactly the record §16 exists to make trustworthy. The wave that
+/// gives an execution a managed resolve verb is the wave that emits this.
+pub const KIND_CONTEXT_REFERENCE_RESOLVED: &str = "context.reference_resolved";
+/// §16's `context.search_fallback` — the managed retrieval for one execution
+/// ran on a **narrower ladder rung than it asked for**: §18's *"A1 + lexical
+/// A2"* where *"A1 + full A2"* was requested.
+///
+/// Raw evidence, not a score: the payload states
+/// [`crate::runtime::atlas::semantic::SemanticStatus`]'s own word for why
+/// (`not_installed` | `disabled`), which is A2 §15's required honesty about
+/// the answer, carried onto the execution that got it.
+pub const KIND_CONTEXT_SEARCH_FALLBACK: &str = "context.search_fallback";
+/// §16's `context.scope_expansion_requested` — **declared, and emitted by
+/// nothing in this build.**
+///
+/// §20's third non-goal is *automatic Work scope expansion*, and §4 states
+/// the rule the compiler obeys: *"The compiler does not silently add repos to
+/// Work mutation scope because a search result is relevant."* So there is no
+/// automatic expansion for this kind to record, by design. What it is
+/// reserved for is the *asked-for* case §10 allows — *"an actor can request
+/// an additional bounded query when judgment discovers one is needed"* — and
+/// no surface accepts such a request today. Emitting it from the compiler
+/// would mean inventing an expansion request nobody made.
+pub const KIND_CONTEXT_SCOPE_EXPANSION_REQUESTED: &str = "context.scope_expansion_requested";
+/// §16's `context.contradiction_observed` — **declared, and emitted by
+/// nothing in this build.**
+///
+/// §9's contradiction is two evidence sources *disagreeing* — *"knowledge
+/// says: payments-worker owns retries / source shows: payments-api owns
+/// current implementation"* — and this build has no detector for that.
+/// Deciding that two excerpts disagree is a judgment, and §9's own answer is
+/// that *"the actor gets the conflict as a judgment problem"*; a compiler
+/// that scored disagreement would be synthesizing the consensus §9 forbids,
+/// and the scalar §16 and §20 both refuse. The kind is named so the record
+/// has a place for the fact when a wave lands a detector whose evidence is
+/// exact coordinates rather than a similarity number.
+pub const KIND_CONTEXT_CONTRADICTION_OBSERVED: &str = "context.contradiction_observed";
+
+/// Every kind §16 lists, in §16's own order — what a test compares the
+/// contract's seven lines against.
+pub const CONTEXT_AUDIT_KINDS: [&str; 7] = [
+    KIND_CONTEXT_BOUND,
+    KIND_CONTEXT_REFERENCED,
+    KIND_CONTEXT_QUERY,
+    KIND_CONTEXT_REFERENCE_RESOLVED,
+    KIND_CONTEXT_SEARCH_FALLBACK,
+    KIND_CONTEXT_SCOPE_EXPANSION_REQUESTED,
+    KIND_CONTEXT_CONTRADICTION_OBSERVED,
+];
 /// The named `needs_input` reason #260 Q3 requires when a stage's declared
 /// `output/` artifact is still missing after its one bounded re-prompt:
 /// carried in the `stage.needs_input`/`work.needs_input` payload's

--- a/src/runtime/atlas/trace.rs
+++ b/src/runtime/atlas/trace.rs
@@ -157,6 +157,30 @@ pub enum Attribution {
         /// The repository the Work's search was scoped to.
         repository: String,
     },
+    /// **C1 §16's attribution**: a managed call issued *by an execution* —
+    /// the compiled-context step's own retrieval, run for one fresh actor
+    /// start.
+    ///
+    /// > *"Managed `map/search/related/query` calls can be attributed to the
+    /// > current execution."* (§16)
+    ///
+    /// A third variant rather than an `Option<String>` bolted onto
+    /// [`Self::Work`], for exactly the reason this enum has variants at all
+    /// (see the type's own doc): `sgt search --work <id>` is a human's
+    /// Work-scoped read and genuinely has **no** execution, so an optional
+    /// field would make *"this call had no execution"* and *"nobody filled
+    /// this in"* the same value. They are different facts, and §16's whole
+    /// point is telling which compiled world — which is to say, which
+    /// execution — a query belonged to.
+    Execution {
+        /// The Work the execution belongs to.
+        work_id: String,
+        /// The repository its world was scoped to.
+        repository: String,
+        /// **The execution itself** — the fresh actor start this query's
+        /// compiled world was built for.
+        execution_id: String,
+    },
 }
 
 /// A2 §13's field 3: *"source-generation filter"* — the A2 §2 stage-1
@@ -367,6 +391,16 @@ impl SearchTrace {
                     "managed": true,
                     "work": work_id,
                     "repository": repository,
+                    // Present and null rather than omitted: a Work-scoped
+                    // CLI search really has no execution, and an absent key
+                    // would be indistinguishable from a dropped one.
+                    "execution": serde_json::Value::Null,
+                }),
+                Attribution::Execution { work_id, repository, execution_id } => serde_json::json!({
+                    "managed": true,
+                    "work": work_id,
+                    "repository": repository,
+                    "execution": execution_id,
                 }),
             },
             "source_generation_filter": {

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -123,13 +123,44 @@
 //! packing uses to fetch what it renders, so every rendered Bound unit
 //! resolves back to the stored row it came from by construction (item 3).
 //!
+//! # §16's attribution and §17's nesting (C1d)
+//!
+//! §16 asks that *"managed map/search/related/query calls can be attributed
+//! to the **current execution**"*, so the compilation's own retrieval is
+//! issued under [`Attribution::Execution`] — the variant `sgt search --work`
+//! cannot use, because a human's Work-scoped read has no execution to name.
+//! §16's seven event kinds are declared in
+//! [`crate::domain::workflow`] and the four this build can honestly emit are
+//! derived by [`ContextSnapshot::audit_events`] and committed by the engine
+//! beside the snapshot. **Record, do not adapt**: nothing in this crate reads
+//! one of those events, and no payload carries a scalar — §16's own *"raw
+//! evidence rather than a magic 'sharpness score'"* and §20's two separate
+//! prohibitions.
+//!
+//! §17's five rules land as: the compilation step already runs per
+//! `StageKind::Actor` **leaf**, so a nested leaf's snapshot is separate by
+//! construction and a container — which is not a stage at all (W1-02) and
+//! cannot acquire a `CONTEXT.md`
+//! ([`crate::domain::workflow::WorkflowError::NestedPackageWithContext`]) —
+//! gets none; a causal child compiles its own world from its own Work
+//! coordinate and bindings; and the parent reaches it through exactly one
+//! channel, [`EvidenceCoordinate::ParentWork`] at §2's **Referenced** tier —
+//! a coordinate with no field for the parent's prompt, intent or transcript,
+//! because §17's fourth rule and §20's *parent-prompt inheritance for child
+//! Work* forbid one.
+//!
 //! # What this wave does NOT do
 //!
-//! Authority, provenance and structured query results are C1c (items 6–9);
-//! attribution, nesting and audit are C1d (items 11, 12, 14). Fields §15 asks
-//! for that those waves fill are present and empty, each naming its wave —
-//! never absent, because an absent field is indistinguishable from a
-//! forgotten one.
+//! **No claim graph.** §19 bounds item 14 itself: *"A full first-class claim
+//! graph is **not required** in Sprint 3; preserving exact evidence
+//! coordinates in snapshots/artifacts is the **enabling invariant**."* So the
+//! coordinates and their provenance survive verbatim into the journaled
+//! snapshot — `tests/c1d_attribution_nesting_audit.rs` walks §19's chain from
+//! a rendered fragment through that artifact to the resolved stored row — and
+//! nothing here stores, indexes or infers a claim.
+//!
+//! §19's `page+bbox` arm is OCR's and is **deferred by owner ruling**, named
+//! absent rather than omitted on [`EvidenceProvenance::ocr`].
 //!
 //! §20's non-goals this step is closest to are named and refused: **no raw
 //! corpus stuffing** (a Bound body renders only inside §14's hard budget, and
@@ -461,6 +492,46 @@ pub enum EvidenceCoordinate {
         /// answer covers.
         truncated: bool,
     },
+    /// **§17's fifth rule**: *"parent causation/output **may be Referenced**
+    /// when needed"* — the causal parent of a child Work, as a coordinate.
+    ///
+    /// This is the *permitted channel*, and it is what makes §17's fourth
+    /// rule survivable. That rule — *"child Work does **not inherit** the
+    /// parent's entire transcript/prompt"*, which §20 states again as the
+    /// non-goal *parent-prompt inheritance for child Work* — would leave a
+    /// child unable to say anything at all about why it exists if there were
+    /// no channel; §17 supplies one, and bounds it to §2's **Referenced**
+    /// tier: *"known-relevant exact coordinates **not rendered in full**"*.
+    ///
+    /// So this variant carries **coordinates and nothing else**. There is
+    /// deliberately no field here for the parent's intent, its prompt, its
+    /// stage `CONTEXT.md`, its compiled world or its transcript: a child that
+    /// needs the parent's output resolves it from these coordinates
+    /// (`sgt work show <parent>`), exactly as every other Referenced unit is
+    /// resolved. A field carrying parent prose would be the non-goal wearing
+    /// this rule's name, which is why the prohibition gets an adversarial
+    /// test rather than a comment.
+    ///
+    /// [`pack`] never gives it a body — [`resolve`] answers
+    /// [`SourceEvidence::WorkRecord`] for it, like the two other Work-record
+    /// shapes — so the bytes it costs the prompt are one pointer line.
+    ParentWork {
+        /// The **validated** parent Work (`Work::parent_work_id`) — W1 §6's
+        /// journal-checked relation, never the client's raw claim. A claim
+        /// that did not validate is journaled as
+        /// `Work::causation_unverified` and never reaches here, so this
+        /// coordinate cannot assert a lineage the daemon refused.
+        parent_work_id: String,
+        /// Which execution of the parent spent its causation env on this
+        /// submission, when the claim named one. `None` is the coarser
+        /// relation W1 §6 allows, not a dropped field.
+        parent_execution_id: Option<String>,
+        /// The parent's folded Work state at the instant this world was
+        /// compiled — the one fact about the parent's *causation* a child
+        /// cannot get from the coordinate alone, and a state word, not
+        /// output text.
+        state: String,
+    },
 }
 
 /// §10's `query_result_id`: a content hash over the six identities that make
@@ -542,6 +613,7 @@ impl EvidenceCoordinate {
                 query_identity,
                 ..
             } => format!("query/{generation_id}/{relative_path}/{query_identity}"),
+            Self::ParentWork { parent_work_id, .. } => format!("parent/{parent_work_id}"),
         }
     }
 
@@ -551,7 +623,7 @@ impl EvidenceCoordinate {
     /// is no Atlas source behind it.
     pub fn source_name(&self) -> Option<&str> {
         match self {
-            Self::Stage { .. } | Self::Binding { .. } => None,
+            Self::Stage { .. } | Self::Binding { .. } | Self::ParentWork { .. } => None,
             Self::Atlas { source_name, .. }
             | Self::Relationship { source_name, .. }
             | Self::QueryResult { source_name, .. } => Some(source_name),
@@ -562,7 +634,7 @@ impl EvidenceCoordinate {
     /// Atlas row. `None` for a Work record.
     pub fn generation_id(&self) -> Option<&str> {
         match self {
-            Self::Stage { .. } | Self::Binding { .. } => None,
+            Self::Stage { .. } | Self::Binding { .. } | Self::ParentWork { .. } => None,
             Self::Atlas { generation_id, .. }
             | Self::Relationship { generation_id, .. }
             | Self::QueryResult { generation_id, .. } => Some(generation_id),
@@ -572,7 +644,7 @@ impl EvidenceCoordinate {
     /// The pinned generation's content identity — §11's `generation: <sha>`.
     pub fn content_key(&self) -> Option<&str> {
         match self {
-            Self::Stage { .. } | Self::Binding { .. } => None,
+            Self::Stage { .. } | Self::Binding { .. } | Self::ParentWork { .. } => None,
             Self::Atlas { content_key, .. } | Self::QueryResult { content_key, .. } => {
                 Some(content_key)
             }
@@ -587,7 +659,7 @@ impl EvidenceCoordinate {
     /// this evidence is.
     pub fn path_coordinate(&self) -> Option<String> {
         match self {
-            Self::Stage { .. } | Self::Binding { .. } => None,
+            Self::Stage { .. } | Self::Binding { .. } | Self::ParentWork { .. } => None,
             Self::Atlas {
                 relative_path,
                 unit_key,
@@ -675,6 +747,18 @@ impl EvidenceCoordinate {
                 result_columns.join(", "),
                 if *truncated { ", truncated" } else { "" },
             ),
+            Self::ParentWork {
+                parent_work_id,
+                parent_execution_id,
+                state,
+            } => match parent_execution_id {
+                Some(execution) => format!(
+                    "parent work {parent_work_id} [{state}] — caused by its execution {execution}"
+                ),
+                None => format!(
+                    "parent work {parent_work_id} [{state}] — no parent execution was claimed"
+                ),
+            },
         }
     }
 
@@ -768,6 +852,18 @@ impl EvidenceCoordinate {
                 "result_rows": result_rows,
                 "row_limit": row_limit,
                 "truncated": truncated,
+            }),
+            Self::ParentWork {
+                parent_work_id,
+                parent_execution_id,
+                state,
+            } => json!({
+                "shape": "parent_work",
+                "parent_work": parent_work_id,
+                // Present and null when the claim named no execution: the
+                // coarser relation W1 §6 allows is an answer, not a gap.
+                "parent_execution": parent_execution_id,
+                "parent_state": state,
             }),
         }
     }
@@ -1480,6 +1576,134 @@ impl ContextSnapshot {
         })
     }
 
+    /// **§16's audit record for this compilation** — `(kind, payload)` pairs
+    /// the engine commits to the journal beside
+    /// [`crate::domain::workflow::KIND_CONTEXT_COMPILED`].
+    ///
+    /// > *"Managed `map/search/related/query` calls can be attributed to the
+    /// > current execution. **Record raw evidence rather than a magic
+    /// > 'sharpness score'**"* … *"This later lets Sergeant analyze where
+    /// > compiled worlds were insufficient **without self-tuning during
+    /// > Sprint 3**."* (§16)
+    ///
+    /// # Record, do not adapt
+    ///
+    /// Every payload below is raw: evidence coordinates as the plan
+    /// contributed them, the query's own text/hash identity, and
+    /// [`SemanticStatus`]'s own stated word. **Nothing is scored, weighted,
+    /// aggregated or fed back.** Nothing in this crate reads these events —
+    /// they are written for a later human or a later analysis, and the
+    /// compiler's behaviour is byte-identical whether or not anybody ever
+    /// reads them. That is the shape §16's *"without self-tuning"* and §20's
+    /// two separate prohibitions (*learned context policy/live self-tuning*,
+    /// *universal scalar sharpness score*) jointly require.
+    ///
+    /// # Which of §16's seven kinds appear here
+    ///
+    /// Four, and only when the fact each records actually happened:
+    ///
+    /// | §16 kind | emitted when |
+    /// |---|---|
+    /// | `context.bound` | this compilation bound any evidence |
+    /// | `context.referenced` | it emitted any Referenced coordinate |
+    /// | `context.query` | steps 6/7's managed retrieval ran |
+    /// | `context.search_fallback` | that retrieval landed on a narrower §18 rung than it asked for |
+    ///
+    /// The other three are declared and emitted by nothing in this build,
+    /// each for a stated reason on its own constant
+    /// ([`crate::domain::workflow::KIND_CONTEXT_REFERENCE_RESOLVED`],
+    /// [`crate::domain::workflow::KIND_CONTEXT_SCOPE_EXPANSION_REQUESTED`],
+    /// [`crate::domain::workflow::KIND_CONTEXT_CONTRADICTION_OBSERVED`]).
+    ///
+    /// A **degraded** compilation emits none of the four: it bound nothing,
+    /// referenced nothing and ran no query, and inventing an empty
+    /// `context.bound` for it would put a row in the audit record for
+    /// something that did not happen. §18's degradation is already visible —
+    /// on the `context.compiled` snapshot, which is journaled either way.
+    pub fn audit_events(&self) -> Vec<(&'static str, Value)> {
+        let mut events: Vec<(&'static str, Value)> = Vec::new();
+        // The execution attribution §16 is about, on every event, so an
+        // analysis never has to correlate through a second table to learn
+        // which fresh actor start a row belongs to.
+        let attribution = json!({
+            "managed": true,
+            "work": self.coordinate.work_id,
+            "stage": self.coordinate.stage_id,
+            "attempt": self.coordinate.attempt,
+            "execution": self.coordinate.execution_id,
+        });
+        for (kind, tier, units) in [
+            (
+                crate::domain::workflow::KIND_CONTEXT_BOUND,
+                Tier::Bound,
+                &self.bound,
+            ),
+            (
+                crate::domain::workflow::KIND_CONTEXT_REFERENCED,
+                Tier::Referenced,
+                &self.referenced,
+            ),
+        ] {
+            if units.is_empty() {
+                continue;
+            }
+            events.push((
+                kind,
+                json!({
+                    "attribution": attribution,
+                    "context_snapshot_id": self.snapshot_id,
+                    "tier": tier.as_str(),
+                    // Raw coordinates: the §5 step that contributed each one,
+                    // its dedup identity, whether the render budget carried
+                    // it, and the coordinate itself. No excerpt text — the
+                    // journal records what world was presented, and the text
+                    // is resolvable from the coordinate.
+                    "evidence": units
+                        .iter()
+                        .map(|unit| json!({
+                            "step": unit.step.number(),
+                            "evidence_id": unit.coordinate.dedup_key(),
+                            "rendered": unit.rendered,
+                            "coordinate": unit.coordinate.json(),
+                        }))
+                        .collect::<Vec<_>>(),
+                }),
+            ));
+        }
+        if let Some(trace) = &self.retrieval {
+            events.push((
+                crate::domain::workflow::KIND_CONTEXT_QUERY,
+                json!({
+                    "attribution": attribution,
+                    "context_snapshot_id": self.snapshot_id,
+                    // A2 §13's full trace, which already carries its own
+                    // `attribution` field — the `Attribution::Execution`
+                    // this compilation issued the search under. Both are
+                    // here on purpose: the outer one is §16's, uniform
+                    // across all four kinds; the inner one is A2 §13's, and
+                    // a reader comparing them is checking exactly the claim
+                    // item 11 makes.
+                    "trace": trace.json(),
+                }),
+            ));
+            if trace.semantic != SemanticStatus::Applied {
+                events.push((
+                    crate::domain::workflow::KIND_CONTEXT_SEARCH_FALLBACK,
+                    json!({
+                        "attribution": attribution,
+                        "context_snapshot_id": self.snapshot_id,
+                        // The raw stated reason, in A2 §15's own three
+                        // words — not a quality number about the answer.
+                        "requested": "lexical+semantic",
+                        "applied": "lexical",
+                        "semantic_status": trace.semantic.as_str(),
+                    }),
+                ));
+            }
+        }
+        events
+    }
+
     /// Append the compiled world to a stage's authored `CONTEXT.md`.
     ///
     /// **Appended, never substituted**, exactly as the branch-status fact is
@@ -1722,13 +1946,15 @@ pub enum SourceEvidence {
     QueryResult(DatasetFact),
     /// An exact stored relationship of an exact generation.
     Relationship(crate::runtime::atlas::db::ResolvedRelationship),
-    /// A record of the Work itself — a stage record or a repository binding.
+    /// A record of the Work itself — a stage record, a repository binding,
+    /// or (§17) the causal parent Work.
     ///
-    /// These two coordinate shapes are **not** Atlas rows: their source
+    /// These three coordinate shapes are **not** Atlas rows: their source
     /// evidence is the Work's own journal-folded run, and the snapshot pins
     /// every field of it inline (`stage_id`/`index`/`attempt`/`status`,
-    /// `repository`/`work_branch`/`base_sha`). Resolution says so rather than
-    /// pretending a store lookup happened.
+    /// `repository`/`work_branch`/`base_sha`,
+    /// `parent_work_id`/`parent_execution_id`/`state`). Resolution says so
+    /// rather than pretending a store lookup happened.
     WorkRecord,
 }
 
@@ -1759,9 +1985,9 @@ pub fn resolve(
     coordinate: &EvidenceCoordinate,
 ) -> Result<Option<SourceEvidence>, AtlasError> {
     match coordinate {
-        EvidenceCoordinate::Stage { .. } | EvidenceCoordinate::Binding { .. } => {
-            Ok(Some(SourceEvidence::WorkRecord))
-        }
+        EvidenceCoordinate::Stage { .. }
+        | EvidenceCoordinate::Binding { .. }
+        | EvidenceCoordinate::ParentWork { .. } => Ok(Some(SourceEvidence::WorkRecord)),
         EvidenceCoordinate::Atlas {
             generation_id,
             relative_path,
@@ -2190,11 +2416,36 @@ pub struct CompileRequest<'a> {
     pub prior_stages: &'a [StageRecord],
     /// The launch profile the stage was bound with, when it has one.
     pub profile: Option<&'a str>,
+    /// **§17's fifth rule** — the causal parent of this Work, when the
+    /// daemon validated one at submit. `None` for an ordinary Work, which is
+    /// most of them: a Work with no parent has no parent coordinate, and
+    /// that is the observable difference §17's tests turn on.
+    pub parent: Option<ParentCausation<'a>>,
     /// §14's two hard automatic-render budgets. Every production compilation
     /// passes [`RenderBudget::DEFAULT`]; it is a request field rather than a
     /// constant read inside [`compile`] so a test can watch the hard bound
     /// actually bind, which a constant nobody can vary cannot show.
     pub budget: RenderBudget,
+}
+
+/// **§17's causal parent, as the compiler is given it.**
+///
+/// Every field is a coordinate or a state word the engine read off the
+/// **journal-folded** Work record (`Work::parent_work_id`,
+/// `Work::parent_execution_id` — W1 §6's *validated* relation, not the
+/// client's claim). There is no field for the parent's intent, prompt,
+/// context or transcript, and that absence is the contract: §17's fourth
+/// rule and §20's *parent-prompt inheritance for child Work* both forbid one,
+/// so the type a compiler is handed cannot express it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParentCausation<'a> {
+    /// The validated parent Work id.
+    pub work_id: &'a str,
+    /// The parent execution that spent its causation env, when one was
+    /// claimed and validated.
+    pub execution_id: Option<&'a str>,
+    /// The parent's folded Work state right now.
+    pub state: &'a str,
 }
 
 /// The port [`crate::runtime::engine::Engine`] calls before an actor starts.
@@ -2414,6 +2665,24 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
                 },
             );
         }
+        // **§17's fifth rule, the permitted channel.** A causal child Work
+        // gets the parent's causation as a **Referenced** coordinate — a
+        // pointer, never a body — beside its own exact bindings, because
+        // *"causal child Work gets its own Work/source/context binding"* is
+        // the rule immediately above it and this is a fact about *this*
+        // Work's binding, not about the parent's world. Nothing of the
+        // parent's prompt, intent or transcript can travel this way: the
+        // coordinate has no field for one (see [`ParentCausation`]).
+        if let Some(parent) = request.parent {
+            step.contribute(
+                Tier::Referenced,
+                EvidenceCoordinate::ParentWork {
+                    parent_work_id: parent.work_id.to_string(),
+                    parent_execution_id: parent.execution_id.map(str::to_string),
+                    state: parent.state.to_string(),
+                },
+            );
+        }
         // "changed resources" is exactly the Work's own overlay generation —
         // a worktree scanned against its base holds only what the Work
         // changed (S5 W1b/W1d). Nothing here reads the surface: the overlay
@@ -2516,10 +2785,21 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
     }
     // ---- 6/7. A2 lexical retrieval, then A2 semantic retrieval if
     //           installed/needed — S5's own pipeline, consumed (R2).
+    //
+    // **§21 item 11 / §16's attribution.** *"Managed map/search/related/query
+    // calls can be attributed to the current execution."* This retrieval is
+    // managed by construction — it is issued by the compiler for one fresh
+    // actor start — so it is attributed to that **execution**, not merely to
+    // the Work: `Attribution::Execution` is the variant `sgt search --work`
+    // cannot use, because a human's Work-scoped read has no execution to
+    // name (see the enum's own doc). Attributing to the Work alone would
+    // make two stage launches of one Work indistinguishable, which is
+    // exactly the question §16 exists to answer.
     let attribution = match &repository {
-        Some(repository) => Attribution::Work {
+        Some(repository) => Attribution::Execution {
             work_id: request.work_id.to_string(),
             repository: repository.clone(),
+            execution_id: request.execution_id.to_string(),
         },
         None => Attribution::Unmanaged,
     };

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -5377,8 +5377,29 @@ impl Engine {
         // attributed to this execution (§21 item 11). A degraded compilation
         // journals the snapshot and no audit events — see
         // `ContextSnapshot::audit_events`.
-        let mut events: Vec<(&'static str, Value)> = vec![(KIND_CONTEXT_COMPILED, snapshot.json())];
-        events.extend(snapshot.audit_events());
+        let audit_events = snapshot.audit_events();
+        // F-IN-01: the caller below commits `context.compiled` and each
+        // audit event as separate, non-transactional journal writes — a
+        // mid-sequence commit failure can leave fewer audit rows for this
+        // `execution_id` than this compilation actually produced, and that
+        // truncation is otherwise indistinguishable from a compilation that
+        // legitimately bound/referenced/queried nothing (§16's own
+        // documented degraded case). Naming the count this compilation
+        // produced, on the one event committed first and always (degraded
+        // or not), lets a reader compare it against the audit rows actually
+        // observed for the execution and tell the two apart — a raw fact
+        // recorded alongside the rest of §15's snapshot, not a policy
+        // change to how or whether anything commits.
+        let mut compiled_payload = snapshot.json();
+        if let Value::Object(ref mut map) = compiled_payload {
+            map.insert(
+                "audit_event_count".to_string(),
+                Value::from(audit_events.len()),
+            );
+        }
+        let mut events: Vec<(&'static str, Value)> =
+            vec![(KIND_CONTEXT_COMPILED, compiled_payload)];
+        events.extend(audit_events);
         (context, events)
     }
 }

--- a/src/runtime/engine.rs
+++ b/src/runtime/engine.rs
@@ -3994,7 +3994,7 @@ impl Engine {
         // reads `StartRequest.context` for it — compiling a snapshot it
         // cannot see would be unasked-for scope doing unread work.
         // ---------------------------------------------------------------
-        let (context, snapshot) = if stage.kind == StageKind::Actor {
+        let (context, context_events) = if stage.kind == StageKind::Actor {
             self.compile_stage_context(
                 core,
                 work_id,
@@ -4009,10 +4009,10 @@ impl Engine {
                 &authored,
             )
         } else {
-            (authored.clone(), None)
+            (authored.clone(), Vec::new())
         };
-        if let Some(snapshot) = snapshot {
-            self.commit(core, work_id, KIND_CONTEXT_COMPILED, snapshot)?;
+        for (kind, payload) in context_events {
+            self.commit(core, work_id, kind, payload)?;
         }
         let request = StartRequest {
             work_id: work_id.to_string(),
@@ -5300,12 +5300,51 @@ impl Engine {
         run: &WorkRun,
         profile: Option<&str>,
         authored: &str,
-    ) -> (String, Option<Value>) {
+    ) -> (String, Vec<(&'static str, Value)>) {
         let Some(compiler) = self.context_compiler.as_ref() else {
-            return (authored.to_string(), None);
+            return (authored.to_string(), Vec::new());
         };
         let estate_root = Self::work_estate_root(core, work_id);
         let bindings = surface.binding_summary();
+        // **C1 §17's fifth rule**: *"parent causation/output may be
+        // Referenced when needed"*. Read off the journal-folded Work record
+        // — `Work::parent_work_id`/`parent_execution_id` are W1 §6's
+        // *validated* relation, so a claim the daemon refused
+        // (`causation_unverified`) can never become a coordinate. The
+        // parent's state comes from `state_view`, which answers from the
+        // slim index and is never evicted, so a child compiled after its
+        // parent went terminal still gets the real state rather than a
+        // missing one.
+        //
+        // Coordinates only. Nothing here reads the parent's intent, prompt,
+        // context or transcript — §17's fourth rule and §20's
+        // *parent-prompt inheritance for child Work* forbid it, and
+        // `ParentCausation` has no field one could travel in.
+        let parent_state = {
+            let registry = core.registry.state();
+            registry
+                .works
+                .get(work_id)
+                .and_then(|work| {
+                    work.parent_work_id
+                        .clone()
+                        .map(|parent| (parent, work.parent_execution_id.clone()))
+                })
+                .map(|(parent_work_id, parent_execution_id)| {
+                    let state = registry
+                        .state_view(&parent_work_id)
+                        .map(|state| state.as_str().to_string())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    (parent_work_id, parent_execution_id, state)
+                })
+        };
+        let parent = parent_state.as_ref().map(|(work, execution, state)| {
+            crate::runtime::context::ParentCausation {
+                work_id: work.as_str(),
+                execution_id: execution.as_deref(),
+                state: state.as_str(),
+            }
+        });
         let request = crate::runtime::context::CompileRequest {
             estate_root: estate_root.as_deref(),
             work_id,
@@ -5321,6 +5360,7 @@ impl Engine {
             bindings: &bindings,
             prior_stages: &run.stages,
             profile,
+            parent,
             // §14's hard automatic-render budget. One value, written by a
             // human and measured against this repository's own shipped stage
             // procedures — see `RenderBudget`'s own doc. Nothing tunes it at
@@ -5330,7 +5370,16 @@ impl Engine {
         let mut snapshot = compiler.compile(&request);
         let context = snapshot.render_onto(authored);
         snapshot.rendered_bytes = context.len().saturating_sub(authored.len()) as u64;
-        (context, Some(snapshot.json()))
+        // §15's snapshot first, then §16's audit record for the same
+        // compilation. Two contracts, two kinds, one ordered list the caller
+        // commits in order: `context.compiled` is *what world was presented*
+        // and C1 §16's kinds are *what the managed calls that built it did*,
+        // attributed to this execution (§21 item 11). A degraded compilation
+        // journals the snapshot and no audit events — see
+        // `ContextSnapshot::audit_events`.
+        let mut events: Vec<(&'static str, Value)> = vec![(KIND_CONTEXT_COMPILED, snapshot.json())];
+        events.extend(snapshot.audit_events());
+        (context, events)
     }
 }
 

--- a/tests/c1a_compiled_context.rs
+++ b/tests/c1a_compiled_context.rs
@@ -189,6 +189,7 @@ fn compiled(atlas: Option<&AtlasDb>) -> ContextSnapshot {
             bindings: &bindings,
             prior_stages: &prior,
             profile: Some("standard"),
+            parent: None,
             budget: sergeant_rs::runtime::context::RenderBudget::DEFAULT,
         },
     )
@@ -522,11 +523,16 @@ fn the_snapshot_pins_the_retrieval_generation_and_model_it_actually_used() {
     assert_eq!(trace.query.text, "tighten the retention policy");
     assert_eq!(
         trace.attribution,
-        sergeant_rs::runtime::atlas::trace::Attribution::Work {
+        // Sharpened by C1d (§21 item 11 / §16: *"attributed to the current
+        // execution"*). C1a asserted `Attribution::Work` here, which was
+        // managed but a coordinate too coarse — it could not tell two stage
+        // launches of one Work apart.
+        sergeant_rs::runtime::atlas::trace::Attribution::Execution {
             work_id: WORK_ID.to_string(),
             repository: REPOSITORY.to_string(),
+            execution_id: "01EXECUTION".to_string(),
         },
-        "a search a Work's own execution issued is a MANAGED search (§13)"
+        "a search a Work's own execution issued is a MANAGED search (§13), attributed to that          execution (§16)"
     );
     assert!(
         !trace.retrieval_generation.generations.is_empty(),
@@ -624,6 +630,7 @@ fn the_selection_plan_hash_separates_two_plans_that_selected_the_same_evidence()
             bindings: &bindings,
             prior_stages: &[],
             profile: Some("standard"),
+            parent: None,
             budget: sergeant_rs::runtime::context::RenderBudget::DEFAULT,
         },
     );

--- a/tests/c1b_tiers_and_budget.rs
+++ b/tests/c1b_tiers_and_budget.rs
@@ -182,6 +182,7 @@ fn compiled(atlas: &AtlasDb, budget: RenderBudget) -> ContextSnapshot {
             bindings: &bindings,
             prior_stages: &prior,
             profile: Some("standard"),
+            parent: None,
             budget,
         },
     )
@@ -770,6 +771,7 @@ fn external_and_estate_bodies_render_differently_only_because_of_authority_class
             bindings: &[],
             prior_stages: &[],
             profile: None,
+            parent: None,
             budget: RenderBudget::DEFAULT,
         },
     );

--- a/tests/c1c_authority_and_provenance.rs
+++ b/tests/c1c_authority_and_provenance.rs
@@ -123,6 +123,7 @@ fn compiled(
             bindings: bound_to,
             prior_stages: prior,
             profile: Some("standard"),
+            parent: None,
             budget: RenderBudget::DEFAULT,
         },
     )

--- a/tests/c1d_attribution_nesting_audit.rs
+++ b/tests/c1d_attribution_nesting_audit.rs
@@ -1,0 +1,1327 @@
+//! S6 C1d — C1 §21 items **11, 12 and 14**: attribution, nesting and audit.
+//!
+//! # What each test here is the evidence for
+//!
+//! | Claim | Test |
+//! |---|---|
+//! | **item 11** — §16's seven kinds are declared verbatim, in §16's own order, and every one is on the stream's published vocabulary | [`the_seven_event_kinds_are_section_16s_own_list_in_section_16s_own_order`] |
+//! | **item 11** — a managed context query is attributed to the **execution**, not merely to the Work: two launches of one stage are told apart, and `sgt search --work`'s Work-scoped read still has no execution | [`a_managed_context_query_is_attributed_to_the_execution_not_merely_the_work`] |
+//! | **item 11** — the audit record is **raw evidence**: coordinates, query identity and A2 §15's stated status, and no scalar anywhere | [`the_audit_record_is_raw_evidence_and_carries_no_sharpness_scalar`] |
+//! | **item 11** — a search that landed on a narrower §18 rung than it asked for records that, and one that did not does not | [`a_search_fallback_is_recorded_only_when_the_answer_actually_degraded`] |
+//! | **item 11** — a degraded compilation records no audit event at all | [`a_degraded_compilation_records_no_audit_event`] |
+//! | **item 12, rule 5** — a causal child's parent causation is **Referenced**, as a pointer, and its absence for an ordinary Work is the observable difference | [`a_causal_childs_parent_causation_is_referenced_as_a_pointer`] |
+//! | **item 12, rule 2, structurally** — a container cannot acquire an actor procedure of its own; the identical file one directory down loads fine | [`a_container_cannot_acquire_an_actor_procedure_and_a_leaf_can`] |
+//! | **item 14** — a rendered claim fragment traces through the journaled artifact to its exact source evidence, and every link of §19's chain survives | [`a_rendered_claim_fragment_traces_through_the_artifact_to_its_source_evidence`] |
+//! | **item 14** — §19's `page+bbox` arm is absent **by owner ruling**, present and null rather than omitted | [`section_19s_page_and_bbox_arm_is_absent_by_owner_ruling`] |
+//! | **item 12, rules 1 and 2, live** — each nested leaf actor gets its own snapshot under its composed id, and the container that closes on them gets none | [`each_nested_leaf_actor_gets_its_own_snapshot_and_the_container_gets_none`] |
+//! | **item 12, rules 3 and 4, live and adversarially** — a causal child gets its own Work/source/context binding and inherits no byte of the parent's prompt, while rule 5's pointer still reaches it | [`a_child_work_inherits_no_parent_prompt_and_gets_its_own_binding`] |
+//!
+//! # What this wave deliberately did **not** build
+//!
+//! **No claim graph** (§19: *"A full first-class claim graph is **not
+//! required** in Sprint 3; preserving exact evidence coordinates in
+//! snapshots/artifacts is the **enabling invariant**"*). Item 14's test walks
+//! §19's chain by hand, from a rendered fragment to the journaled snapshot to
+//! the resolved source row, to show a later wave *could* build one — and
+//! builds nothing that stores or indexes claims.
+//!
+//! **No self-tuning and no sharpness score** (§16: *"Record raw evidence
+//! rather than a magic 'sharpness score'"*, *"without self-tuning during
+//! Sprint 3"*; §20: *learned context policy/live self-tuning*, *universal
+//! scalar sharpness score*). Nothing in this crate reads a `context.*` audit
+//! event, and [`the_audit_record_is_raw_evidence_and_carries_no_sharpness_scalar`]
+//! is the tripwire on the payload shape.
+//!
+//! **Three of §16's seven kinds are declared and emitted by nothing**, each
+//! with the reason on its own constant: `context.reference_resolved` (no
+//! surface gives an *execution* a resolve verb yet, and journaling the
+//! compiler's own packing read under it would be a false entry),
+//! `context.scope_expansion_requested` (§20 forbids automatic expansion and
+//! no surface accepts §10's asked-for one), and
+//! `context.contradiction_observed` (§9's detection does not exist, and
+//! scoring disagreement is the synthesized consensus §9 forbids).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use sergeant_rs::domain::source::{AuthorityClass, SourceKind, UnitKind};
+use sergeant_rs::domain::workflow::{
+    CONTEXT_AUDIT_KINDS, KIND_CONTEXT_BOUND, KIND_CONTEXT_COMPILED, KIND_CONTEXT_QUERY,
+    KIND_CONTEXT_SEARCH_FALLBACK, StageDefinition, StageKind, StageRecord, StageStatus,
+    WorkflowDefinition, WorkflowError,
+};
+use sergeant_rs::runtime::atlas::db::AtlasDb;
+use sergeant_rs::runtime::atlas::overlay::overlay_source_name;
+use sergeant_rs::runtime::atlas::record::record_scan;
+use sergeant_rs::runtime::atlas::scan::{ScannedFile, ScannedUnit};
+use sergeant_rs::runtime::atlas::semantic::SemanticStatus;
+use sergeant_rs::runtime::atlas::trace::Attribution;
+use sergeant_rs::runtime::context::{
+    CompileRequest, ContextSnapshot, DATA_PREFIX, EvidenceCoordinate, ParentCausation,
+    RenderBudget, SourceEvidence, Tier, compile, resolve,
+};
+use sergeant_rs::runtime::journal::Journal;
+
+mod support;
+use support::{file, scan, unit};
+
+// ===================================================================
+// Fixture
+// ===================================================================
+
+const WORK_ID: &str = "01C1DWORK";
+const REPOSITORY: &str = "demo-repo";
+const INTENT: &str = "trace the retention policy to its evidence";
+const EXECUTION: &str = "01EXECUTIONALPHA";
+
+const AUTHORED: &str = "# Stage procedure (authored)\n\n1. Read the retention policy.\n";
+
+fn stage() -> StageDefinition {
+    StageDefinition {
+        id: "10-implement".to_string(),
+        context: AUTHORED.to_string(),
+        kind: StageKind::Actor,
+        harness: None,
+        profile: None,
+        requires_ask: false,
+        receives_branch_status: false,
+        execute: None,
+    }
+}
+
+fn bindings() -> Vec<sergeant_rs::backend::BindingSummary> {
+    vec![sergeant_rs::backend::BindingSummary {
+        repository: REPOSITORY.to_string(),
+        worktree_path: PathBuf::from("/surfaces").join(WORK_ID).join(REPOSITORY),
+        work_branch: format!("sergeant/{WORK_ID}"),
+        base_branch: Some("main".to_string()),
+        base_sha: "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f".to_string(),
+    }]
+}
+
+fn prior_stages() -> Vec<StageRecord> {
+    vec![StageRecord {
+        stage_id: "00-orient".to_string(),
+        index: 0,
+        attempt: 1,
+        status: StageStatus::Completed,
+        detail: Some("oriented".to_string()),
+        output_reprompts: 0,
+    }]
+}
+
+/// Compile one world for `execution_id`, with `parent` as §17's causation.
+fn compiled_for(
+    atlas: &AtlasDb,
+    execution_id: &str,
+    parent: Option<ParentCausation<'_>>,
+) -> ContextSnapshot {
+    let stage = stage();
+    let bindings = bindings();
+    let prior = prior_stages();
+    compile(
+        Some(atlas),
+        &CompileRequest {
+            estate_root: Some(Path::new("/estates/demo")),
+            work_id: WORK_ID,
+            intent: INTENT,
+            stage: &stage,
+            stage_index: 1,
+            attempt: 1,
+            execution_id,
+            journal_watermark: 42,
+            bindings: &bindings,
+            prior_stages: &prior,
+            profile: Some("standard"),
+            parent,
+            budget: RenderBudget::DEFAULT,
+        },
+    )
+}
+
+/// The extractor and native coordinate item 14's chain has to carry — a
+/// normalized Office excerpt, whose byte span is not its address (A2 §9).
+const OFFICE_EXTRACTOR: &str = "office-docx/v3";
+const NATIVE: &str = "slide:12/block:3";
+const CLAIM_FRAGMENT: &str = "retention defaults to thirty days for archived collections";
+
+/// A world with an estate base generation and this Work's overlay, the
+/// overlay carrying one normalized Office unit (the fragment item 14 traces)
+/// and one ordinary Markdown unit beside it.
+fn evidence_world() -> (TempDir, AtlasDb) {
+    let data = tempfile::tempdir().expect("data dir");
+    let mut journal = Journal::open(data.path()).expect("journal");
+    let mut db = AtlasDb::open(data.path()).expect("atlas");
+
+    let base = scan(
+        REPOSITORY,
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![file(
+            "docs/architecture.md",
+            vec![unit(0, "Architecture", "The daemon owns the journal.")],
+        )],
+    );
+    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+
+    let deck = ScannedFile {
+        relative_path: "decks/retention.pptx".to_string(),
+        content_hash: "hash/decks/retention.pptx".to_string(),
+        extractor: OFFICE_EXTRACTOR.to_string(),
+        local_key: "key/decks/retention.pptx".to_string(),
+        byte_len: 4096,
+        mtime_millis: None,
+        units: vec![ScannedUnit {
+            ordinal: 0,
+            kind: UnitKind::Section,
+            heading_level: Some(2),
+            title: Some("Retention".to_string()),
+            byte_start: 1024,
+            byte_end: 1024 + CLAIM_FRAGMENT.len() as u64,
+            coordinate: Some(NATIVE.to_string()),
+            text: CLAIM_FRAGMENT.to_string(),
+        }],
+        syntax: None,
+        parent: None,
+    };
+    let overlay = scan(
+        &overlay_source_name(WORK_ID, REPOSITORY),
+        SourceKind::EstateGit,
+        AuthorityClass::EstateMutable,
+        vec![
+            deck,
+            file(
+                "notes/plan.md",
+                vec![unit(0, "Plan", "The retention policy, in one paragraph.")],
+            ),
+        ],
+    );
+    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    (data, db)
+}
+
+/// The event payloads a compilation would journal, keyed by kind.
+fn audit(snapshot: &ContextSnapshot) -> Vec<(&'static str, Value)> {
+    snapshot.audit_events()
+}
+
+fn payload_of<'a>(events: &'a [(&'static str, Value)], kind: &str) -> Option<&'a Value> {
+    events
+        .iter()
+        .find(|(k, _)| *k == kind)
+        .map(|(_, payload)| payload)
+}
+
+/// Every key name anywhere in a JSON value, however deep.
+fn keys(value: &Value, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                out.insert(key.clone());
+                keys(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                keys(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+// ============================================================ item 11
+
+/// **§16's list, verbatim and in order.**
+///
+/// §16 prints seven kinds in a fenced block. `CONTEXT_AUDIT_KINDS` is that
+/// block, and this compares the two rather than trusting that a wave which
+/// implemented four of them remembered the other three. A kind renamed,
+/// dropped or reordered turns this red.
+///
+/// The second half is the one that makes the declaration *reachable*: every
+/// journaled kind must be on the SSE stream's published vocabulary, or an
+/// enumerating client silently drops the frame. `m6_surfaces::t6` enforces
+/// that for the whole crate; this states it for §16's seven specifically, so
+/// a reader of item 11 sees it here.
+#[test]
+fn the_seven_event_kinds_are_section_16s_own_list_in_section_16s_own_order() {
+    assert_eq!(
+        CONTEXT_AUDIT_KINDS,
+        [
+            "context.bound",
+            "context.referenced",
+            "context.query",
+            "context.reference_resolved",
+            "context.search_fallback",
+            "context.scope_expansion_requested",
+            "context.contradiction_observed",
+        ],
+        "§16 lists seven kinds in this order; the code must say the same seven words"
+    );
+    for kind in CONTEXT_AUDIT_KINDS {
+        assert!(
+            sergeant_rs::api::SSE_EVENT_KINDS.contains(&kind),
+            "{kind:?} is declared but is not on the stream's published vocabulary"
+        );
+    }
+}
+
+/// **§21 item 11.** *"actor context queries are attributable **to
+/// execution**"*, and §16: *"Managed map/search/related/query calls can be
+/// attributed to the **current execution**."*
+///
+/// The observable claim is that two launches of the *same stage of the same
+/// Work* are told apart. So the same world is compiled twice under two
+/// execution ids, and the `context.query` audit record — plus A2 §13's own
+/// trace inside it — must name each one. A compiler that attributed to the
+/// Work alone would produce two identical attributions here and pass nothing.
+///
+/// The other half is what keeps the field from being filled unconditionally:
+/// `sgt search --work <id>` is a human's Work-scoped read with genuinely no
+/// execution, and its attribution renders `execution: null`. Two different
+/// answers from one enum, which is why §16's attribution got a third variant
+/// rather than an `Option` on the existing one.
+#[test]
+fn a_managed_context_query_is_attributed_to_the_execution_not_merely_the_work() {
+    let (_data, db) = evidence_world();
+
+    let first = compiled_for(&db, "01EXECUTIONONE", None);
+    let second = compiled_for(&db, "01EXECUTIONTWO", None);
+
+    for (snapshot, execution) in [(&first, "01EXECUTIONONE"), (&second, "01EXECUTIONTWO")] {
+        let trace = snapshot
+            .retrieval
+            .as_ref()
+            .expect("steps 6/7 ran a managed search");
+        assert_eq!(
+            trace.attribution,
+            Attribution::Execution {
+                work_id: WORK_ID.to_string(),
+                repository: REPOSITORY.to_string(),
+                execution_id: execution.to_string(),
+            },
+            "the managed search must be attributed to the execution that issued it"
+        );
+        let events = audit(snapshot);
+        let query = payload_of(&events, KIND_CONTEXT_QUERY).expect("context.query was recorded");
+        assert_eq!(
+            query["attribution"]["execution"].as_str(),
+            Some(execution),
+            "§16's own attribution: {query}"
+        );
+        assert_eq!(
+            query["trace"]["attribution"]["execution"].as_str(),
+            Some(execution),
+            "A2 §13 field 2, on the persisted trace: {query}"
+        );
+        assert_eq!(query["attribution"]["work"].as_str(), Some(WORK_ID));
+        assert_eq!(query["attribution"]["stage"].as_str(), Some("10-implement"));
+    }
+
+    // The whole point: the two records differ, and differ in the execution.
+    let one = audit(&first);
+    let two = audit(&second);
+    assert_ne!(
+        payload_of(&one, KIND_CONTEXT_QUERY).expect("first")["attribution"]["execution"],
+        payload_of(&two, KIND_CONTEXT_QUERY).expect("second")["attribution"]["execution"],
+        "two launches of one stage must not carry the same attribution"
+    );
+
+    // And the Work-scoped CLI read still has no execution to name — present
+    // and null, never a filled-in-by-default id.
+    let cli = sergeant_rs::runtime::atlas::trace::SearchTrace {
+        attribution: Attribution::Work {
+            work_id: WORK_ID.to_string(),
+            repository: REPOSITORY.to_string(),
+        },
+        ..first
+            .retrieval
+            .clone()
+            .expect("a trace to vary one field of")
+    };
+    assert_eq!(
+        cli.json()["attribution"]["execution"],
+        Value::Null,
+        "an unmanaged-by-an-execution Work search must say so, not borrow an execution"
+    );
+}
+
+/// **§16's own instruction, as a tripwire.** *"Record **raw evidence** rather
+/// than a magic 'sharpness score'"* — which §20 states twice more (*learned
+/// context policy/live self-tuning*, *universal scalar sharpness score*).
+///
+/// Two assertions, and both are about shape rather than intent:
+///
+/// 1. the record really is raw — every `context.bound` entry carries the §5
+///    step that contributed it, its evidence id and its full coordinate, and
+///    that set of ids is exactly the snapshot's own Bound set (so the record
+///    is the evidence, not a summary of it);
+/// 2. no payload of any §16 kind carries a key naming a score, a sharpness,
+///    a quality or a sufficiency. That is the shape a "magic scalar" would
+///    have to arrive in, and it fails the moment someone adds one.
+#[test]
+fn the_audit_record_is_raw_evidence_and_carries_no_sharpness_scalar() {
+    let (_data, db) = evidence_world();
+    let snapshot = compiled_for(&db, EXECUTION, None);
+    let events = audit(&snapshot);
+
+    let bound = payload_of(&events, KIND_CONTEXT_BOUND).expect("context.bound was recorded");
+    let recorded: BTreeSet<String> = bound["evidence"]
+        .as_array()
+        .expect("evidence array")
+        .iter()
+        .map(|e| {
+            assert!(
+                e["step"].is_number(),
+                "every entry names the §5 step that contributed it: {e}"
+            );
+            assert!(
+                e["coordinate"]["shape"].is_string(),
+                "every entry carries its full coordinate: {e}"
+            );
+            e["evidence_id"].as_str().expect("evidence id").to_string()
+        })
+        .collect();
+    let expected: BTreeSet<String> = snapshot
+        .bound
+        .iter()
+        .map(|unit| unit.coordinate.dedup_key())
+        .collect();
+    assert!(!expected.is_empty(), "the fixture bound nothing to record");
+    assert_eq!(
+        recorded, expected,
+        "the audit record must be the Bound evidence itself, not a digest of it"
+    );
+
+    let mut names = BTreeSet::new();
+    for (_, payload) in &events {
+        keys(payload, &mut names);
+    }
+    for forbidden in ["sharpness", "score", "quality", "sufficiency", "relevance"] {
+        let hit: Vec<&String> = names
+            .iter()
+            .filter(|name| name.to_ascii_lowercase().contains(forbidden))
+            .collect();
+        assert!(
+            hit.is_empty(),
+            "§16 records raw evidence, never a magic scalar; found {hit:?}"
+        );
+    }
+}
+
+/// **§16's `context.search_fallback`, on both sides.**
+///
+/// The compilation always asks for the full A2 ladder. On a host with no
+/// semantic assets the answer comes back on §18's narrower rung
+/// (`SemanticStatus::NotInstalled`), and that is recorded with A2 §15's own
+/// word — *raw stated status*, not a number about answer quality.
+///
+/// The non-vacuous half is the other side: the same snapshot with the
+/// semantic half reported `Applied` records **no** fallback while still
+/// recording the query. A test that only asserted the event exists would
+/// pass just as well against a compiler that emitted it unconditionally.
+#[test]
+fn a_search_fallback_is_recorded_only_when_the_answer_actually_degraded() {
+    let (_data, db) = evidence_world();
+    let mut snapshot = compiled_for(&db, EXECUTION, None);
+    assert_eq!(
+        snapshot
+            .retrieval
+            .as_ref()
+            .expect("a managed search ran")
+            .semantic,
+        SemanticStatus::NotInstalled,
+        "this fixture host installs no semantic assets"
+    );
+
+    let degraded = audit(&snapshot);
+    let fallback = payload_of(&degraded, KIND_CONTEXT_SEARCH_FALLBACK)
+        .expect("the narrower rung must be recorded");
+    assert_eq!(fallback["semantic_status"].as_str(), Some("not_installed"));
+    assert_eq!(fallback["applied"].as_str(), Some("lexical"));
+    assert_eq!(
+        fallback["attribution"]["execution"].as_str(),
+        Some(EXECUTION),
+        "the fallback belongs to an execution, like every other §16 record"
+    );
+
+    if let Some(trace) = snapshot.retrieval.as_mut() {
+        trace.semantic = SemanticStatus::Applied;
+    }
+    let full = audit(&snapshot);
+    assert!(
+        payload_of(&full, KIND_CONTEXT_SEARCH_FALLBACK).is_none(),
+        "an answer that did not degrade must record no fallback: {full:?}"
+    );
+    assert!(
+        payload_of(&full, KIND_CONTEXT_QUERY).is_some(),
+        "the query itself is still recorded either way"
+    );
+}
+
+/// A compilation that compiled nothing records **no** §16 event.
+///
+/// §18's degradation is already visible on the `context.compiled` snapshot,
+/// which the engine journals either way. Emitting an empty `context.bound`
+/// beside it would put a row in the audit record for a binding that never
+/// happened — which is precisely the record §16 exists to make trustworthy.
+#[test]
+fn a_degraded_compilation_records_no_audit_event() {
+    let empty = AtlasDb::open_in_memory().expect("atlas");
+    let snapshot = compiled_for(&empty, EXECUTION, None);
+    assert!(snapshot.degradation.is_some(), "the fixture is degraded");
+    assert!(
+        snapshot.audit_events().is_empty(),
+        "nothing happened, so nothing is recorded"
+    );
+}
+
+// ============================================================ item 12
+
+/// **§17's fifth rule.** *"parent causation/output **may be Referenced** when
+/// needed."*
+///
+/// The permitted channel, as an observable difference: the same world is
+/// compiled twice, once for an ordinary Work and once for a causal child.
+/// The child's snapshot carries exactly one extra unit — a **Referenced**
+/// `parent_work` coordinate naming the parent Work and the parent execution
+/// — and it renders into the prompt as a pointer line under `REFERENCED`.
+/// The ordinary Work's snapshot carries none, which is the half that makes
+/// this a difference rather than an assertion about a string being present.
+///
+/// The tier is the contract. §2's Referenced is *"known-relevant exact
+/// coordinates **not rendered in full**"*, so the parent reaches the child as
+/// a coordinate and nothing else — resolution answers
+/// [`SourceEvidence::WorkRecord`], the same as this Work's own stage and
+/// binding records, and packing gives it no body.
+#[test]
+fn a_causal_childs_parent_causation_is_referenced_as_a_pointer() {
+    let (_data, db) = evidence_world();
+
+    let ordinary = compiled_for(&db, EXECUTION, None);
+    let child = compiled_for(
+        &db,
+        EXECUTION,
+        Some(ParentCausation {
+            work_id: "01PARENTWORK",
+            execution_id: Some("01PARENTEXEC"),
+            state: "completed",
+        }),
+    );
+
+    let parents_of = |snapshot: &ContextSnapshot| -> Vec<EvidenceCoordinate> {
+        snapshot
+            .bound
+            .iter()
+            .chain(snapshot.referenced.iter())
+            .filter(|unit| matches!(unit.coordinate, EvidenceCoordinate::ParentWork { .. }))
+            .map(|unit| {
+                assert_eq!(
+                    unit.tier,
+                    Tier::Referenced,
+                    "§17 permits the parent as Referenced, never Bound: {unit:?}"
+                );
+                assert!(
+                    unit.excerpt.is_none(),
+                    "a pointer carries no body: {unit:?}"
+                );
+                unit.coordinate.clone()
+            })
+            .collect()
+    };
+
+    assert!(
+        parents_of(&ordinary).is_empty(),
+        "a Work with no causal parent has no parent coordinate"
+    );
+    assert_eq!(
+        parents_of(&child),
+        vec![EvidenceCoordinate::ParentWork {
+            parent_work_id: "01PARENTWORK".to_string(),
+            parent_execution_id: Some("01PARENTEXEC".to_string()),
+            state: "completed".to_string(),
+        }],
+        "the child's world names its parent exactly once"
+    );
+
+    // It reaches the prompt, as a pointer under REFERENCED.
+    let rendered = child.render_onto(AUTHORED);
+    assert!(
+        rendered.contains(
+            "parent work 01PARENTWORK [completed] — caused by its execution \
+             01PARENTEXEC"
+        ),
+        "the parent pointer never reached the prompt: {rendered}"
+    );
+    assert!(
+        !ordinary.render_onto(AUTHORED).contains("parent work"),
+        "an ordinary Work's prompt must not mention a parent it does not have"
+    );
+
+    // And it resolves the way a Work record resolves: no store lookup, no
+    // body, no pretence that one happened.
+    let coordinate = parents_of(&child).remove(0);
+    assert_eq!(
+        resolve(&db, &coordinate).expect("resolution"),
+        Some(SourceEvidence::WorkRecord)
+    );
+}
+
+/// **§17's second rule, structurally.** *"a container stage has **no** actor
+/// snapshot unless it contains an explicit actor leaf."*
+///
+/// A snapshot is compiled for a [`StageDefinition`] and for nothing else, and
+/// a container is not a stage at all (W1-02: *"A container is **not** a
+/// stage: it has no `StageDefinition`"*). What this pins is that a container
+/// cannot *acquire* one: dropping the identical `CONTEXT.md` into a container
+/// directory is refused by name at load time, so "the container itself got an
+/// actor snapshot" is not a state this codebase can reach — while the same
+/// bytes one directory down, in a leaf, load fine and become that leaf's
+/// procedure.
+///
+/// That pair is the point. An absence assertion would pass against a loader
+/// that accepted the file and quietly ignored it; this one fails unless the
+/// refusal is real *and* the acceptance is real.
+#[test]
+fn a_container_cannot_acquire_an_actor_procedure_and_a_leaf_can() {
+    const PROCEDURE: &str = "read the code and report";
+
+    let root = TempDir::new().expect("tempdir");
+    let package = root.path().join("nested");
+    write_package(&package, "nested", &["00-orient", "10-investigate"]);
+    write_stage(&package, "00-orient", "orient the work");
+    let container = package.join("10-investigate");
+    write_package(&container, "10-investigate", &["00-lead"]);
+    write_stage(&container, "00-lead", PROCEDURE);
+
+    // The leaf's procedure loads and is that leaf's context.
+    let loaded = WorkflowDefinition::load_dir(&package).expect("the nested package loads");
+    let leaf = loaded
+        .stages
+        .iter()
+        .find(|s| s.id == "10-investigate/00-lead")
+        .expect("the composed leaf id");
+    assert_eq!(leaf.context, PROCEDURE);
+    assert_eq!(leaf.kind, StageKind::Actor);
+    assert!(
+        loaded
+            .containers
+            .iter()
+            .any(|c| c.container_id == "10-investigate"),
+        "the container is a real, named boundary in this workflow: {:?}",
+        loaded.containers
+    );
+
+    // The identical bytes in the container's own directory are refused.
+    std::fs::write(container.join("CONTEXT.md"), PROCEDURE).expect("container CONTEXT.md");
+    let err = WorkflowDefinition::load_dir(&package)
+        .expect_err("a container may not carry an actor procedure");
+    assert!(
+        matches!(
+            &err,
+            WorkflowError::NestedPackageWithContext { stage, .. } if stage == "10-investigate"
+        ),
+        "the refusal must name the container: {err}"
+    );
+}
+
+// ============================================================ item 14
+
+/// **§21 item 14.** *"produced artifacts retain enough evidence coordinates
+/// for later **claim-level audit**"* — §19's chain, walked by hand:
+///
+/// ```text
+/// claim/output fragment
+///   -> evidence coordinates
+///      source / generation / resource
+///      heading/slide/row/message/query-result
+///      extractor/query provenance
+/// ```
+///
+/// The walk starts where a claim actually starts — a line of text in the
+/// actor's prompt — and goes through the **journaled artifact** (the
+/// `context.compiled` payload, round-tripped through the same serialization
+/// the journal writes) to the exact stored row. Nothing in the walk consults
+/// the in-memory snapshot the compilation produced; that is the difference
+/// between *"the coordinates exist"* and *"the coordinates survived into the
+/// artifact"*, which is the invariant §19 says is the enabling one.
+///
+/// It stops where §19 stops: *"A full first-class claim graph is **not
+/// required** in Sprint 3."* There is no graph here and this wave built none
+/// — the test shows one **could** be built, by building the one edge by hand.
+///
+/// The last step is what makes it non-vacuous: the coordinate is resolved
+/// against Atlas and must return the exact unit, and the same coordinate with
+/// its generation altered must return `None`. A chain that "worked" by
+/// finding any row with matching text would fail that second half.
+#[test]
+fn a_rendered_claim_fragment_traces_through_the_artifact_to_its_source_evidence() {
+    let (_data, db) = evidence_world();
+    let snapshot = compiled_for(&db, EXECUTION, None);
+
+    // --- 1. the claim/output fragment, as the actor saw it.
+    let rendered = snapshot.render_onto(AUTHORED);
+    let fragment_line = rendered
+        .lines()
+        .find(|line| line.contains(CLAIM_FRAGMENT))
+        .unwrap_or_else(|| panic!("the evidence never reached the prompt:\n{rendered}"));
+    assert!(
+        fragment_line.starts_with(DATA_PREFIX),
+        "evidence body is quoted as data: {fragment_line:?}"
+    );
+    // The snapshot id is in the prompt, so a produced artifact can cite the
+    // world it was written against without anyone remembering it.
+    assert!(
+        rendered.contains(&format!("snapshot: {}", snapshot.snapshot_id)),
+        "the prompt must name the snapshot a later audit joins on: {rendered}"
+    );
+
+    // --- 2. the journaled artifact, read back as bytes rather than reused.
+    let artifact: Value = serde_json::from_str(&snapshot.json().to_string()).expect("round trip");
+    assert_eq!(
+        artifact["context_snapshot_id"].as_str(),
+        Some(snapshot.snapshot_id.as_str())
+    );
+    let unit = artifact["bound"]
+        .as_array()
+        .expect("bound units")
+        .iter()
+        .find(|u| u["coordinate"]["relative_path"] == "decks/retention.pptx")
+        .expect("the deck's unit survived into the artifact");
+
+    // --- 3. every link of §19's chain, off the artifact alone.
+    let coordinate = &unit["coordinate"];
+    assert_eq!(coordinate["shape"].as_str(), Some("atlas"));
+    assert_eq!(
+        coordinate["source"].as_str(),
+        Some(overlay_source_name(WORK_ID, REPOSITORY).as_str()),
+        "source"
+    );
+    let generation_id = coordinate["generation_id"]
+        .as_str()
+        .expect("generation")
+        .to_string();
+    assert!(coordinate["content_key"].is_string(), "generation identity");
+    assert_eq!(
+        coordinate["relative_path"].as_str(),
+        Some("decks/retention.pptx"),
+        "resource"
+    );
+    let ordinal = coordinate["ordinal"].as_u64().expect("row/unit coordinate");
+    let provenance = &unit["provenance"];
+    assert_eq!(
+        provenance["extractor"].as_str(),
+        Some(OFFICE_EXTRACTOR),
+        "extractor provenance"
+    );
+    assert_eq!(
+        provenance["native_coordinate"].as_str(),
+        Some(NATIVE),
+        "§19's slide/heading arm: the normalizer's own address"
+    );
+    assert_eq!(provenance["title"].as_str(), Some("Retention"));
+    assert_eq!(provenance["heading_level"].as_u64(), Some(2));
+    assert_eq!(
+        provenance["byte_span"].as_array().map(|s| s.len()),
+        Some(2),
+        "the byte span survived"
+    );
+    assert_eq!(
+        provenance["authority_class"].as_str(),
+        Some(AuthorityClass::EstateMutable.as_str())
+    );
+
+    // --- 4. the coordinate, rebuilt from the artifact, resolves to the
+    //        exact stored row the fragment came from.
+    let rebuilt = EvidenceCoordinate::Atlas {
+        source_name: coordinate["source"].as_str().expect("source").to_string(),
+        generation_id: generation_id.clone(),
+        content_key: coordinate["content_key"]
+            .as_str()
+            .expect("content key")
+            .to_string(),
+        relative_path: "decks/retention.pptx".to_string(),
+        unit_key: coordinate["unit_key"].as_str().map(str::to_string),
+        ordinal: Some(ordinal),
+    };
+    match resolve(&db, &rebuilt).expect("resolution") {
+        Some(SourceEvidence::Unit {
+            text,
+            native_coordinate,
+            extractor,
+            ..
+        }) => {
+            assert!(
+                text.contains(CLAIM_FRAGMENT),
+                "the resolved row must be the one the claim quoted: {text:?}"
+            );
+            assert_eq!(native_coordinate.as_deref(), Some(NATIVE));
+            assert_eq!(extractor.as_deref(), Some(OFFICE_EXTRACTOR));
+        }
+        other => panic!("the artifact's coordinate did not resolve to its source: {other:?}"),
+    }
+
+    // --- 5. and the resolution is a keyed lookup, not a text hunt: the same
+    //        coordinate under a generation that does not hold it answers None.
+    let elsewhere = EvidenceCoordinate::Atlas {
+        source_name: coordinate["source"].as_str().expect("source").to_string(),
+        generation_id: format!("{generation_id}-not-a-generation"),
+        content_key: coordinate["content_key"]
+            .as_str()
+            .expect("content key")
+            .to_string(),
+        relative_path: "decks/retention.pptx".to_string(),
+        unit_key: coordinate["unit_key"].as_str().map(str::to_string),
+        ordinal: Some(ordinal),
+    };
+    assert_eq!(
+        resolve(&db, &elsewhere).expect("resolution"),
+        None,
+        "a coordinate is resolved by identity; finding the text anyway would not be an audit"
+    );
+}
+
+/// **§19's `page+bbox` arm — absent by owner ruling, and said so.**
+///
+/// §19's chain lists `heading/slide/row/message/**page+bbox**/query-result`.
+/// The `page+bbox` arm is OCR's, and OCR is the one thing the owner ruled
+/// outside 0.3.0, so this build derives no OCR evidence for it to describe.
+///
+/// The failure mode being guarded is §20's *"hiding normalizer/OCR provenance
+/// for prompt aesthetics"*: an **omitted** key is indistinguishable from a
+/// dropped fact. So every unit in the journaled artifact carries the `ocr`
+/// key, present and null, and its meaning is documented on the field — *no
+/// OCR evidence was derived*, never *provenance was dropped*. Exactly the
+/// shape C1c gave `EvidenceProvenance::ocr`, restated here because item 14's
+/// reader is looking at §19's chain rather than at item 8's list.
+#[test]
+fn section_19s_page_and_bbox_arm_is_absent_by_owner_ruling() {
+    let (_data, db) = evidence_world();
+    let snapshot = compiled_for(&db, EXECUTION, None);
+    let artifact: Value = serde_json::from_str(&snapshot.json().to_string()).expect("round trip");
+
+    let mut checked = 0usize;
+    for tier in ["bound", "referenced"] {
+        for unit in artifact[tier].as_array().expect("tier array") {
+            let provenance = &unit["provenance"];
+            assert!(
+                provenance.get("ocr").is_some(),
+                "the ocr key must be present, not omitted: {provenance}"
+            );
+            assert_eq!(
+                provenance["ocr"],
+                Value::Null,
+                "this build derives no OCR evidence; a non-null here would be fabricated"
+            );
+            checked += 1;
+        }
+    }
+    assert!(checked > 0, "the fixture produced no unit to check");
+}
+
+// ===================================================================
+// Nested-workflow fixture helpers (m11's shapes, R2)
+// ===================================================================
+
+/// Write one workflow package's own `workflow.toml`, creating its directory.
+fn write_package(dir: &Path, name: &str, stages: &[&str]) {
+    std::fs::create_dir_all(dir).expect("package dir");
+    let declared: Vec<String> = stages.iter().map(|id| format!("{id:?}")).collect();
+    std::fs::write(
+        dir.join("workflow.toml"),
+        format!(
+            "[workflow]\nname = {name:?}\nversion = \"1\"\nstages = [{}]\n",
+            declared.join(", ")
+        ),
+    )
+    .expect("workflow.toml");
+}
+
+/// An actor stage: a directory with a `CONTEXT.md`, which is its procedure.
+fn write_stage(package: &Path, id: &str, context: &str) {
+    let dir = package.join(id);
+    std::fs::create_dir_all(&dir).expect("stage dir");
+    std::fs::write(dir.join("CONTEXT.md"), context).expect("CONTEXT.md");
+}
+
+// ===================================================================
+// Live estate — §17's rules 1, 2, 3 and 4 against a real daemon
+// ===================================================================
+
+const FAKE: &str = sergeant_rs::backend::fake::FAKE_BACKEND_NAME;
+
+/// Seed `data_dir`'s Atlas with one estate-readonly knowledge generation,
+/// **before the daemon opens it**.
+///
+/// Without this every live compilation is §18's `no_confirmed_generation`
+/// rung and every snapshot is empty — which would let the nesting tests below
+/// pass by compiling nothing at all, the exact vacuity C1c found on item 6.
+/// With it, each leaf's compilation runs §5's nine steps for real and its
+/// snapshot has content to differ in.
+///
+/// Opened and dropped before `daemon::start_with`: one Atlas file is one
+/// DuckDB instance, and the daemon's own handle must be the only one open on
+/// it (`AtlasDb::open`'s contract).
+fn seed_atlas(data_dir: &Path) {
+    let mut journal = Journal::open(data_dir).expect("journal");
+    let mut db = AtlasDb::open(data_dir).expect("atlas");
+    let knowledge = scan(
+        "estate-notes",
+        SourceKind::LocalKnowledge,
+        AuthorityClass::EstateReadonly,
+        vec![file(
+            "policy.md",
+            vec![unit(
+                0,
+                "Retention policy",
+                "The estate's retention policy is thirty days and is changed only by ADR.",
+            )],
+        )],
+    );
+    record_scan(&mut db, &mut journal, &knowledge, None).expect("record knowledge source");
+}
+
+async fn start(
+    data_dir: &Path,
+    registry: sergeant_rs::backend::BackendRegistry,
+) -> sergeant_rs::daemon::DaemonHandle {
+    sergeant_rs::daemon::start_with(
+        data_dir,
+        sergeant_rs::daemon::DaemonConfig {
+            backends: std::sync::Arc::new(registry),
+            default_backend: Some(FAKE.to_string()),
+            claude: None,
+            ..sergeant_rs::daemon::DaemonConfig::default()
+        },
+    )
+    .await
+    .expect("daemon start")
+}
+
+fn one_fake(
+    script: impl IntoIterator<Item = sergeant_rs::backend::fake::FakeStep>,
+) -> (
+    sergeant_rs::backend::BackendRegistry,
+    sergeant_rs::backend::fake::FakeBackend,
+) {
+    let fake = sergeant_rs::backend::fake::FakeBackend::scripted(FAKE, script);
+    (
+        sergeant_rs::backend::BackendRegistry::new().with(std::sync::Arc::new(fake.clone())),
+        fake,
+    )
+}
+
+/// Submit one Work and return `(work id, the 201 body)`.
+async fn submit(
+    handle: &sergeant_rs::daemon::DaemonHandle,
+    estate: &Path,
+    workflow: &str,
+    intent: &str,
+    claimed_parent: Option<&str>,
+) -> (String, Value) {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .expect("client");
+    let mut body = serde_json::json!({
+        "command_id": ulid::Ulid::generate().to_string(),
+        "intent": intent,
+        "estate_root": estate,
+        "origin": {"client": "cli", "cwd": estate},
+        "workflow": workflow,
+    });
+    if let Some(parent) = claimed_parent {
+        body["claimed_parent_work_id"] = Value::String(parent.to_string());
+    }
+    let response = client
+        .post(format!("{}/v1/work", handle.endpoint))
+        .bearer_auth(&handle.token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = response.status();
+    let value: Value = response.json().await.expect("json body");
+    assert_eq!(status, 201, "submit rejected: {value}");
+    assert_eq!(value["work"]["state"], "completed", "{value}");
+    (
+        value["work"]["id"].as_str().expect("work id").to_string(),
+        value,
+    )
+}
+
+fn events_of(data_dir: &Path, work_id: &str, kind: &str) -> Vec<sergeant_rs::domain::event::Event> {
+    Journal::replay_data_dir(data_dir)
+        .expect("replay")
+        .map(|e| e.expect("event"))
+        .filter(|e| e.work_id.as_deref() == Some(work_id) && e.kind == kind)
+        .collect()
+}
+
+/// **§17's first two rules, live.**
+///
+/// > *"each W1 nested leaf actor gets a **separate** context snapshot"*
+/// > *"a container stage has **no** actor snapshot unless it contains an
+/// > explicit actor leaf"*
+///
+/// The fixture is m11's two-level shape: a container `10-investigate` holding
+/// two actor leaves, between two ordinary top-level leaves. Four actor leaves
+/// run; one container closes on the last of its two.
+///
+/// **The difference:** each of the four leaves journals its own
+/// `context.compiled`, with its own snapshot id, its own execution, its own
+/// composed stage id — *and its own content*. The last assertion is the one
+/// that makes them separate rather than merely four copies: §5 step 1
+/// contributes this run's prior stage records, so a leaf that runs fourth
+/// binds strictly more stage-input evidence than one that runs first. Four
+/// snapshots compiled once and reused would be identical there.
+///
+/// **The non-difference:** `10-investigate` is demonstrably present in this
+/// run — it is the literal parent segment of two of those composed stage ids,
+/// journaled by the engine itself — and **no** snapshot names it. The
+/// container gets nothing while its leaves each get one, which is the pair
+/// "no snapshot for the container" has to be proved as; asserting the absence
+/// alone would pass just as well against a run that compiled nothing at all,
+/// and the seeded Atlas plus the content assertions above are what rule that
+/// out.
+#[tokio::test]
+async fn each_nested_leaf_actor_gets_its_own_snapshot_and_the_container_gets_none() {
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    let (_repo, _head) = support::scaffold_solo_estate(&estate, "solo");
+
+    let package = estate.join(".sergeant/workflows/nested");
+    write_package(
+        &package,
+        "nested",
+        &["00-orient", "10-investigate", "20-implement"],
+    );
+    write_stage(&package, "00-orient", "orient the work");
+    write_stage(&package, "20-implement", "implement it");
+    let investigate = package.join("10-investigate");
+    write_package(&investigate, "10-investigate", &["00-lead", "10-code"]);
+    write_stage(&investigate, "00-lead", "lead the investigation");
+    write_stage(&investigate, "10-code", "read the code");
+
+    seed_atlas(data.path());
+
+    let (registry, fake) = one_fake([
+        sergeant_rs::backend::fake::FakeStep::complete_with("oriented"),
+        sergeant_rs::backend::fake::FakeStep::complete_with("led"),
+        sergeant_rs::backend::fake::FakeStep::complete_with("read"),
+        sergeant_rs::backend::fake::FakeStep::complete_with("implemented"),
+    ]);
+    let handle = start(data.path(), registry).await;
+    let (work_id, _) = submit(
+        &handle,
+        &estate,
+        "nested",
+        "compile a world for every nested leaf",
+        None,
+    )
+    .await;
+
+    let leaves = [
+        "00-orient",
+        "10-investigate/00-lead",
+        "10-investigate/10-code",
+        "20-implement",
+    ];
+    let starts = fake.starts();
+    assert_eq!(starts.len(), 4, "four actor leaves ran: {starts:?}");
+
+    let snapshots = events_of(data.path(), &work_id, KIND_CONTEXT_COMPILED);
+    assert_eq!(
+        snapshots.len(),
+        4,
+        "one snapshot per nested leaf actor, no more and no fewer"
+    );
+
+    let stage_ids: Vec<String> = snapshots
+        .iter()
+        .map(|e| {
+            e.payload["coordinate"]["stage"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        stage_ids, leaves,
+        "each snapshot names its own composed leaf"
+    );
+
+    // Separate: distinct identities, and distinct *content*.
+    let ids: BTreeSet<&str> = snapshots
+        .iter()
+        .map(|e| e.payload["context_snapshot_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids.len(), 4, "four snapshots, four identities");
+    let executions: BTreeSet<&str> = snapshots
+        .iter()
+        .map(|e| e.payload["coordinate"]["execution"].as_str().unwrap())
+        .collect();
+    assert_eq!(executions.len(), 4, "each names its own fresh execution");
+    for (snapshot, start) in snapshots.iter().zip(starts.iter()) {
+        assert_eq!(
+            snapshot.payload["coordinate"]["execution"].as_str(),
+            Some(start.execution_id.as_str())
+        );
+        assert!(
+            snapshot.payload["degradation"].is_null(),
+            "the seeded world must compile for real, or this proves nothing: {}",
+            snapshot.payload
+        );
+    }
+    let stage_inputs: Vec<u64> = snapshots
+        .iter()
+        .map(|e| {
+            e.payload["plan"]
+                .as_array()
+                .expect("the §5 plan")
+                .iter()
+                .find(|step| step["step"] == 1)
+                .expect("step 1")["contributed"]
+                .as_u64()
+                .expect("count")
+        })
+        .collect();
+    assert_eq!(
+        stage_inputs,
+        vec![0, 1, 2, 3],
+        "each leaf compiled its own world: step 1 binds this run's prior stages, so a leaf \
+         that ran later binds strictly more — four copies of one snapshot could not"
+    );
+
+    // **§21 item 11, live.** §16's audit record is journaled beside each
+    // snapshot and is attributed to that leaf's own execution — which is the
+    // half `audit_events`' unit tests cannot show, because they never reach
+    // the journal. `context.query` is per execution, so four leaves means
+    // four records naming four different executions.
+    for kind in [KIND_CONTEXT_BOUND, KIND_CONTEXT_QUERY] {
+        let recorded = events_of(data.path(), &work_id, kind);
+        assert_eq!(
+            recorded.len(),
+            4,
+            "{kind} must be journaled once per compiled leaf: {recorded:?}"
+        );
+        let attributed: Vec<&str> = recorded
+            .iter()
+            .map(|e| e.payload["attribution"]["execution"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            attributed,
+            starts
+                .iter()
+                .map(|s| s.execution_id.as_str())
+                .collect::<Vec<_>>(),
+            "{kind} must name the execution that issued it"
+        );
+    }
+
+    // The container: present in this run, and named by no snapshot.
+    assert!(
+        stage_ids
+            .iter()
+            .filter(|id| id.starts_with("10-investigate/"))
+            .count()
+            == 2,
+        "the container really is in this run — two composed leaf ids are under it: {stage_ids:?}"
+    );
+    assert!(
+        !stage_ids.iter().any(|id| id == "10-investigate"),
+        "a container is not a stage and gets no actor snapshot: {stage_ids:?}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// **§17's third and fourth rules, live and adversarially — with the fifth as
+/// the channel that makes the fourth survivable.**
+///
+/// > *"causal child Work gets its **own** Work/source/context binding"*
+/// > *"child Work does **not inherit** the parent's entire transcript/prompt"*
+/// > *"parent causation/output **may be Referenced** when needed"*
+///
+/// §20 states the fourth again as a non-goal — *parent-prompt inheritance for
+/// child Work* — so it is tested adversarially rather than commented: the
+/// parent's stage procedure and the parent's intent each carry a marker
+/// string that exists nowhere else in the estate, and the test first proves
+/// those markers really did reach the parent's prompt. Then the child is
+/// submitted with a validated causation claim, and **no byte of either
+/// marker** may appear in the child's prompt, the child's intent, or the
+/// child's journaled snapshot. A test that only checked the child's prompt
+/// looked reasonable would pass against a compiler that copied the parent's
+/// world into it.
+///
+/// What the child *does* get is rule 3 and rule 5: its own Work coordinate,
+/// its own binding on its own `sergeant/<child>` branch, its own snapshot id
+/// and execution — and one **Referenced** pointer naming the parent Work.
+/// That pointer is the whole permitted channel: a coordinate, resolvable on
+/// demand, carrying no parent prose at all.
+#[tokio::test]
+async fn a_child_work_inherits_no_parent_prompt_and_gets_its_own_binding() {
+    const PARENT_PROMPT_MARKER: &str = "ZZPARENTPROCEDUREMARKERZZ";
+    const PARENT_INTENT_MARKER: &str = "ZZPARENTINTENTMARKERZZ";
+
+    let repos = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("tempdir");
+    let estate = repos.path().join("solo-estate");
+    let (_repo, _head) = support::scaffold_solo_estate(&estate, "solo");
+
+    let parent_package = estate.join(".sergeant/workflows/parentflow");
+    write_package(&parent_package, "parentflow", &["00-only"]);
+    write_stage(
+        &parent_package,
+        "00-only",
+        &format!("the parent's own procedure: {PARENT_PROMPT_MARKER}"),
+    );
+    let child_package = estate.join(".sergeant/workflows/childflow");
+    write_package(&child_package, "childflow", &["00-only"]);
+    write_stage(&child_package, "00-only", "the child's own procedure");
+
+    seed_atlas(data.path());
+
+    let (registry, fake) = one_fake([
+        sergeant_rs::backend::fake::FakeStep::complete_with("parent done"),
+        sergeant_rs::backend::fake::FakeStep::complete_with("child done"),
+    ]);
+    let handle = start(data.path(), registry).await;
+
+    let (parent_id, _) = submit(
+        &handle,
+        &estate,
+        "parentflow",
+        &format!("the parent's intent: {PARENT_INTENT_MARKER}"),
+        None,
+    )
+    .await;
+    let (child_id, child_body) = submit(
+        &handle,
+        &estate,
+        "childflow",
+        "the child's own intent",
+        Some(&parent_id),
+    )
+    .await;
+    assert_ne!(parent_id, child_id);
+    assert_eq!(
+        child_body["work"]["parent_work_id"].as_str(),
+        Some(parent_id.as_str()),
+        "the causation claim must have validated, or rule 5 has nothing to carry: {child_body}"
+    );
+
+    let starts = fake.starts();
+    assert_eq!(starts.len(), 2, "{starts:?}");
+    let (parent_start, child_start) = (&starts[0], &starts[1]);
+
+    // The markers really were in the parent's prompt. Without this the
+    // absence below would prove nothing.
+    assert!(
+        parent_start.context.contains(PARENT_PROMPT_MARKER),
+        "the parent's own procedure never reached its prompt: {:?}",
+        parent_start.context
+    );
+    assert!(parent_start.intent.contains(PARENT_INTENT_MARKER));
+
+    // §17 rule 4 / §20's non-goal: none of it reaches the child.
+    for marker in [PARENT_PROMPT_MARKER, PARENT_INTENT_MARKER] {
+        assert!(
+            !child_start.context.contains(marker),
+            "the child inherited the parent's prompt ({marker}): {:?}",
+            child_start.context
+        );
+        assert!(
+            !child_start.intent.contains(marker),
+            "the child inherited the parent's intent ({marker}): {:?}",
+            child_start.intent
+        );
+    }
+    assert!(
+        child_start.context.contains("the child's own procedure"),
+        "the child still gets its own procedure: {:?}",
+        child_start.context
+    );
+
+    let child_snapshots = events_of(data.path(), &child_id, KIND_CONTEXT_COMPILED);
+    assert_eq!(child_snapshots.len(), 1, "{child_snapshots:?}");
+    let payload = &child_snapshots[0].payload;
+    let serialized = payload.to_string();
+    for marker in [PARENT_PROMPT_MARKER, PARENT_INTENT_MARKER] {
+        assert!(
+            !serialized.contains(marker),
+            "the parent's prose reached the child's compiled world ({marker}): {payload}"
+        );
+    }
+
+    // §17 rule 3: its own Work/source/context binding.
+    assert!(
+        payload["degradation"].is_null(),
+        "the child's world must compile for real: {payload}"
+    );
+    assert_eq!(
+        payload["coordinate"]["work"].as_str(),
+        Some(child_id.as_str())
+    );
+    let parent_payload = &events_of(data.path(), &parent_id, KIND_CONTEXT_COMPILED)[0].payload;
+    assert_ne!(
+        payload["context_snapshot_id"], parent_payload["context_snapshot_id"],
+        "two Works, two snapshots"
+    );
+    assert_ne!(
+        payload["coordinate"]["execution"],
+        parent_payload["coordinate"]["execution"]
+    );
+    let child_branch = payload["bound"]
+        .as_array()
+        .expect("bound")
+        .iter()
+        .find_map(|u| {
+            (u["coordinate"]["shape"] == "binding")
+                .then(|| u["coordinate"]["work_branch"].as_str().unwrap().to_string())
+        })
+        .expect("the child's own repository binding");
+    assert_eq!(child_branch, format!("sergeant/{child_id}"));
+
+    // §17 rule 5: the permitted channel reached it, as a Referenced pointer.
+    let parent_units: Vec<&Value> = payload["referenced"]
+        .as_array()
+        .expect("referenced")
+        .iter()
+        .filter(|u| u["coordinate"]["shape"] == "parent_work")
+        .collect();
+    assert_eq!(
+        parent_units.len(),
+        1,
+        "exactly one parent pointer: {payload}"
+    );
+    assert_eq!(
+        parent_units[0]["coordinate"]["parent_work"].as_str(),
+        Some(parent_id.as_str())
+    );
+    assert!(
+        parent_units[0]["excerpt_bytes"].is_null(),
+        "a pointer carries no body: {}",
+        parent_units[0]
+    );
+    assert!(
+        child_start
+            .context
+            .contains(&format!("parent work {parent_id}")),
+        "the pointer must actually reach the child's prompt: {:?}",
+        child_start.context
+    );
+
+    // And the parent, which has none, carries no such coordinate at all.
+    assert!(
+        !parent_payload.to_string().contains("parent_work"),
+        "a Work with no causal parent names none: {parent_payload}"
+    );
+
+    handle.shutdown().await;
+}

--- a/tests/m6_surfaces.rs
+++ b/tests/m6_surfaces.rs
@@ -3943,7 +3943,7 @@ fn t6_the_sse_vocabulary_is_stated_once_and_stays_complete() {
         );
     }
     let names: Vec<&str> = declared.iter().map(|(kind, _)| kind.as_str()).collect();
-    for kind in sergeant_rs::api::SSE_EVENT_KINDS {
+    for kind in sergeant_rs::api::SSE_EVENT_KINDS.iter() {
         assert!(
             names.contains(kind),
             "api::SSE_EVENT_KINDS lists {kind:?}, which no KIND_* constant declares"


### PR DESCRIPTION
## Item 11 — attribution to the *execution*, not merely the Work

`Attribution::Execution { work_id, repository, execution_id }` — a third variant rather than an `Option` on `Work` (**R7**, with R2 checked: the type is reused and its own doc already argues variants over an Option). `sgt search --work` genuinely has no execution, so an optional field would collapse *"no execution"* and *"nobody filled this in"* into one value.

**All seven of §16's kinds are declared verbatim, in §16's order.** Four are emitted (`context.bound`, `context.referenced`, `context.query`, `context.search_fallback`), derived by a pure `ContextSnapshot::audit_events()` and committed beside `context.compiled`.

**Three are named-not-implemented, each for a contract reason:**
- `context.reference_resolved` — no surface gives an *execution* a resolve verb, and journaling the compiler's own packing read under it **would be a false entry in the record §16 exists to make trustworthy**;
- `context.scope_expansion_requested` — §20 forbids automatic expansion and nothing accepts §10's asked-for one;
- `context.contradiction_observed` — §9 detection does not exist, and scoring disagreement is the synthesized consensus §9 forbids.

**Record-do-not-adapt is structural:** nothing in the crate reads a `context.*` event, and no payload carries a scalar. Pinned by a test asserting no payload key anywhere names score/sharpness/quality/sufficiency/relevance.

## Item 12 — and the vacuity trap it was warned about

C1c found item 6 was at risk of passing *by never selecting the evidence it is about*. "A container stage has no actor snapshot" has the same shape: a correct outcome **and** a way to pass by doing nothing.

So the live test **seeds Atlas before daemon start**, making every leaf compile for real (degradation asserted null — an unseeded run would have passed an absence assertion while compiling nothing).

- **The difference:** four leaves, four snapshot ids, four executions, and §5 step 1 contributing `[0, 1, 2, 3]` — a leaf running fourth binds strictly more stage-input evidence, so **four copies of one snapshot could not pass**.
- **The non-difference:** the container owns two of those composed stage ids in the journal — proving it is live in this run — and names **zero** snapshots.

Rule 2 is also proved structurally: the *identical* `CONTEXT.md` is **refused by name** in a container and **accepted** in a leaf.

Rule 5 (the permitted channel) is `EvidenceCoordinate::ParentWork`, contributed at §5 step 2 in the **Referenced** tier from the *validated* parent ids. **The coordinate has no field a parent's prompt, intent or transcript could travel in — that absence is the contract**, and §20's parent-prompt-inheritance non-goal is tested adversarially: the markers are proved present in the parent's prompt and intent *first*, then required absent from the child's prompt, intent and journaled snapshot.

## Item 14 — no production code, deliberately

§19: *"A full first-class claim graph is **not required** in Sprint 3; preserving exact evidence coordinates in snapshots/artifacts is the **enabling invariant**."* The coordinates already survive from C1a–C1c, so the deliverable is a walked proof and the doc saying where the chain runs. **No type was manufactured to have something to show** (R1).

The proof never touches the in-memory snapshot after rendering: prompt fragment → snapshot id → journaled payload **read back as bytes** → source, generation, resource, unit coordinate, heading, native slide/block address, extractor → keyed resolution to the exact row. And the same coordinate under a **mutated generation resolves to `None`**, so *"found a row with matching text"* cannot pass.

§19's page+bbox arm is OCR's and is **absent by owner ruling** — the `ocr` key present and null on every unit of the artifact, never omitted.

## Panel

2 confirmed, both minor: the seven kinds were retyped independently in `SSE_EVENT_KINDS` with nothing tying the two lists together (now extended from `CONTEXT_AUDIT_KINDS`, so §16's segment cannot drift); and the audit trail's expected event count is now named on `context.compiled`, so a mid-sequence failure is detectable rather than silently short.

## Gaps, stated

1. The live child test validates a **Work-only** causation claim, because `validate_claimed_causation` accepts an execution only while the parent still holds it. The execution-bearing coordinate is proved in-process instead. Both shapes are contract-legal (W1 §6 permits the coarser relation); only one is exercised live.
2. Three of §16's seven kinds are emitted by nothing — the brief's own wording is *"implement or NAME each"*, and each reason is a contract constraint.
3. Item 14 added no production code, for the reason §19 gives.

## One existing test changed, with the reason inline

`c1a_compiled_context::the_snapshot_pins_the_retrieval_generation_and_model_it_actually_used` asserted `Attribution::Work`. Item 11 requires the sharpening — Work-level attribution cannot tell two launches of one Work apart — so the expectation was updated rather than a compatibility variant added.

## Verification

fmt clean, clippy `-D warnings` clean, **64/64** across all four S6 suites and the acceptance register. Also green: `m6_surfaces` (incl. t6's SSE vocabulary), `m11_nested_workflow`, `m12_child_work`, `m3_execution`, `m5_projections`, `f_doctrine_skew`, `--lib` (1350). New suite wired at birth (#231).

**SQL boundary untouched** — no statement added, no Atlas signature takes `query: &str`, the item-13 guard did not fire.

Full suite not run locally — CI by SHA is the exhaustive pass.

Closes §21 items 11, 12 and 14. **All fourteen C1 acceptance items are now claimed; the closeout walks them.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4