### PR TITLE
D1: the estate axis — A2 §2 stage 1's missing first filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,30 @@ head, so every gate below is proven at every sprint boundary even though
 nothing is actually tagged or published until the program-completion
 release.
 
+### Estate isolation in retrieval (S6)
+
+- **`sgt search`, `sgt related` and compiled context no longer read another
+  estate's indexed code.** Atlas is host-scoped — one daemon, one store,
+  every estate ever addressed on this host writing into it — and A2 §2's
+  admissibility pipeline names *"source / **estate** / Work generation
+  filter"* as its first operation. The estate half was never implemented:
+  from one estate, a search returned another estate's private functions as
+  the top hit (measured 2026-08-30). Generations now carry the estate they
+  were indexed for (`source.generation_estates`), and every admissibility
+  query filters on it before any ranking.
+- The estate axis is **default-deny**, unlike the content-kind and authority
+  axes beside it: a filter that names no estate admits nothing, and there is
+  no "every estate" value. Reading another estate's world means addressing
+  that estate, which runs the ordinary admission check.
+- `external_git` sources stay host-scoped and readable from every estate,
+  which is A1 §9's deliberate design and not the defect; `sgt intelligence
+  status` still spans every admitted estate, which is H1 §5's.
+- **Upgrade note: re-scan.** A generation indexed by an earlier build carries
+  no estate coordinate, and a generation whose origin was never recorded
+  cannot be attributed to one after the fact. Those generations are
+  inadmissible from every estate until `sgt intelligence scan` runs again —
+  fail-closed rather than admitting evidence whose owner is unknown.
+
 ### Host runtime (S1)
 
 - One Sergeant daemon per user installation now serves every admitted

--- a/scripts/coverage/c3-spawning-suites.sh
+++ b/scripts/coverage/c3-spawning-suites.sh
@@ -193,3 +193,17 @@ cov_run cargo llvm-cov --no-report --test w7_container_children --locked || cov_
 cov_stage_end 2 "w7_container_children dispatches real sgt-atlas-worker subprocesses from four \
 real scans (a zip, a zip-inside-a-mail chain, an unclaimed-extension child, and a four-level \
 nested archive); more than the test binary's own profile must arrive, or no subprocess flushed"
+
+# S6 D1, wired at birth (the #231 lesson, same as y1-y4/y8/w7 above): A2 §2
+# stage 1's estate axis, proven across TWO estates on ONE host daemon — the
+# seam no suite crossed before, and the one the leak lived in. Every test here
+# either drives real `sgt` client processes against a spawned daemon (search,
+# related, intelligence scan, from each estate in turn) or builds an
+# `Admissibility` directly against a real store. Floor 2, not higher, for the
+# same reason y1-y4's is: the test binary's own profile plus at least one
+# flushed subprocess.
+cov_stage_begin c3-d1_estate_isolation
+cov_run cargo llvm-cov --no-report --test d1_estate_isolation --locked || cov_fail "d1_estate_isolation failed under instrumentation"
+cov_stage_end 2 "d1_estate_isolation spawns a real daemon and drives real sgt search/related/scan \
+clients from two separate estate roots; more than the test binary's own profile must arrive, or \
+no subprocess flushed"

--- a/src/api.rs
+++ b/src/api.rs
@@ -5166,37 +5166,6 @@ async fn run_work_overlay_hook(
         }
     }
 
-    // **S6 D1 — whose world is this overlay?** A Work's surface belongs to
-    // exactly one estate, and `WorkIndexRow::estate_root` is where that
-    // coordinate already lives (H1 touch point #6: folded once from the
-    // `work.submitted` envelope's `workspace_id`). Read it rather than
-    // inventing one.
-    //
-    // A Work with **no** recorded estate root — a pre-Phase-C line still in
-    // the journal — gets no overlay generation at all, and `--work` reports
-    // `BaseOnly` for it, which is exactly true. The alternative would be
-    // recording an overlay of unknown provenance, and there is no estate it
-    // could honestly be admitted from; an unbound generation is inadmissible
-    // everywhere anyway, so writing one would only be a lie with rows behind
-    // it.
-    let estate_binding = {
-        let core = CoreGuard::acquire(&state.core).await;
-        let root = core
-            .registry
-            .state()
-            .work_index
-            .get(&work_id)
-            .and_then(|row| row.estate_root.clone());
-        root.map(crate::domain::source::EstateBinding::Estate)
-    };
-    let Some(estate_binding) = estate_binding else {
-        tracing::error!(
-            work_id = %work_id,
-            "this Work records no estate root, so its surface cannot be bound to an estate;              no overlay generation is written and `--work` stays base-only"
-        );
-        return;
-    };
-
     // F-IN-01: from here on this task is actually reading the surface (a
     // git tree listing, diff, and blob read per binding, next), so a newer
     // coalescing hook queued for this Work must no longer be dropped on the
@@ -5246,6 +5215,40 @@ async fn run_work_overlay_hook(
             }
         };
         let mut core = CoreGuard::acquire(&state.core).await;
+        // **S6 D1 — whose world is this overlay?** A Work's surface belongs to
+        // exactly one estate, and `WorkIndexRow::estate_root` is where that
+        // coordinate already lives (H1 touch point #6: folded once from the
+        // `work.submitted` envelope's `workspace_id`). Read it rather than
+        // inventing one — and read it under the `CoreGuard` this arm was
+        // already taking, never a second one of its own. An extra acquire on
+        // this path is an extra acquire on the *surface-bind* path, which is
+        // the submission burst path: `tests/m2_daemon_api.rs::
+        // t12_submission_throughput_has_an_automated_floor` measured exactly
+        // that regression when this read had its own guard (14-15 units
+        // against a 12.0 ceiling on an idle host, base 4.6 s → 8.2 s), and
+        // passes with the read folded in here.
+        //
+        // A Work with **no** recorded estate root — a pre-Phase-C line still
+        // in the journal — gets no overlay generation at all, and `--work`
+        // reports `BaseOnly` for it, which is exactly true. There is no
+        // estate an overlay of unknown provenance could honestly be admitted
+        // from, and an unbound generation is inadmissible everywhere anyway,
+        // so writing one would only be a lie with rows behind it.
+        let estate_root = core
+            .registry
+            .state()
+            .work_index
+            .get(&work_id)
+            .and_then(|row| row.estate_root.clone());
+        let Some(estate_root) = estate_root else {
+            tracing::error!(
+                work_id = %work_id,
+                "this Work records no estate root, so its surface cannot be bound to an \
+                 estate; no overlay generation is written and `--work` stays base-only"
+            );
+            continue;
+        };
+        let estate_binding = crate::domain::source::EstateBinding::Estate(estate_root);
         let recorded = with_existing_atlas_write(&state, |atlas| {
             record_scan(
                 atlas,

--- a/src/api.rs
+++ b/src/api.rs
@@ -5166,6 +5166,37 @@ async fn run_work_overlay_hook(
         }
     }
 
+    // **S6 D1 — whose world is this overlay?** A Work's surface belongs to
+    // exactly one estate, and `WorkIndexRow::estate_root` is where that
+    // coordinate already lives (H1 touch point #6: folded once from the
+    // `work.submitted` envelope's `workspace_id`). Read it rather than
+    // inventing one.
+    //
+    // A Work with **no** recorded estate root — a pre-Phase-C line still in
+    // the journal — gets no overlay generation at all, and `--work` reports
+    // `BaseOnly` for it, which is exactly true. The alternative would be
+    // recording an overlay of unknown provenance, and there is no estate it
+    // could honestly be admitted from; an unbound generation is inadmissible
+    // everywhere anyway, so writing one would only be a lie with rows behind
+    // it.
+    let estate_binding = {
+        let core = CoreGuard::acquire(&state.core).await;
+        let root = core
+            .registry
+            .state()
+            .work_index
+            .get(&work_id)
+            .and_then(|row| row.estate_root.clone());
+        root.map(crate::domain::source::EstateBinding::Estate)
+    };
+    let Some(estate_binding) = estate_binding else {
+        tracing::error!(
+            work_id = %work_id,
+            "this Work records no estate root, so its surface cannot be bound to an estate;              no overlay generation is written and `--work` stays base-only"
+        );
+        return;
+    };
+
     // F-IN-01: from here on this task is actually reading the surface (a
     // git tree listing, diff, and blob read per binding, next), so a newer
     // coalescing hook queued for this Work must no longer be dropped on the
@@ -5216,7 +5247,13 @@ async fn run_work_overlay_hook(
         };
         let mut core = CoreGuard::acquire(&state.core).await;
         let recorded = with_existing_atlas_write(&state, |atlas| {
-            record_scan(atlas, &mut core.journal, &scanned.scan, None)
+            record_scan(
+                atlas,
+                &mut core.journal,
+                &scanned.scan,
+                None,
+                &estate_binding,
+            )
         })
         .await;
         // The scan appended `source.scanned` straight to the journal;
@@ -5305,6 +5342,13 @@ async fn intelligence_scan(
         Ok(root) => root,
         Err((status, body)) => return (status, Json(body)).into_response(),
     };
+    // **S6 D1 — A2 §2 stage 1's estate coordinate.** `root` is the canonical
+    // exact estate root this request addressed (`admit_addressed_estate`), and
+    // it is the same string `SearchQuery::admissibility` binds at query time —
+    // one resolver, one spelling, so a recorded binding and a queried
+    // admission cannot drift apart.
+    let estate_binding =
+        crate::domain::source::EstateBinding::Estate(root.to_string_lossy().into_owned());
     let estate =
         match Estate::from_config_allow_empty(&root.join(crate::domain::estate::MANIFEST_FILE)) {
             Ok(estate) => estate,
@@ -5400,7 +5444,13 @@ async fn intelligence_scan(
         let counts = scanned.scan.counts();
         let mut core = CoreGuard::acquire(&state.core).await;
         let outcome = with_atlas_write(&state, |atlas| {
-            record_scan(atlas, &mut core.journal, &scanned.scan, None)
+            record_scan(
+                atlas,
+                &mut core.journal,
+                &scanned.scan,
+                None,
+                &estate_binding,
+            )
         })
         .await;
         // The scan appended `source.scanned` straight to the journal;
@@ -5472,7 +5522,7 @@ async fn intelligence_scan(
         // the next source.
         let mut core = CoreGuard::acquire(&state.core).await;
         let outcome = with_atlas_write(&state, |atlas| {
-            record_scan(atlas, &mut core.journal, &scan, None)
+            record_scan(atlas, &mut core.journal, &scan, None, &estate_binding)
         })
         .await;
         // The scan appended `source.scanned` straight to the journal;
@@ -6023,6 +6073,19 @@ async fn map_references(State(state): State<ApiState>, Query(query): Query<MapQu
 /// are `const`s no request can reach).
 #[derive(Debug, Deserialize)]
 struct SearchQuery {
+    /// **A2 §2 stage 1's estate coordinate** — the exact canonical estate
+    /// root this search is asked *from*, the same `?estate_root=` every
+    /// other estate-scoped GET carries.
+    ///
+    /// Not one of A2 §14's flags, and not a selector a user types: it is the
+    /// address of the world the question is asked in. Atlas is host-scoped
+    /// (one daemon, one store, every estate ever addressed on this host), so
+    /// without it a search has no way to tell whose evidence it is reading —
+    /// which is exactly how S6 D1's cross-estate leak worked. Absent, the
+    /// request is refused rather than answered widely; see
+    /// [`SearchQuery::admissibility`].
+    #[serde(default)]
+    estate_root: Option<PathBuf>,
     /// The query text (`sgt search <query>`).
     #[serde(default)]
     q: Option<String>,
@@ -6176,8 +6239,20 @@ impl SearchQuery {
                 atlas_trace::Attribution::Unmanaged,
             ),
         };
+        // **A2 §2 stage 1, and the one axis that denies by default.**
+        // `admit_addressed_estate` is the same admission gate every other
+        // estate-scoped route runs, so a root that does not admit is refused
+        // here rather than silently widening the world; a request that named
+        // no estate at all is refused too (`NOT_FOUND`, "the operation has
+        // no object"). Falling back to "every estate" is the defect this
+        // exists to close, not an available fallback.
+        let estate = match admit_addressed_estate(state, self.estate_root.as_deref(), "searching") {
+            Ok(estate) => atlas_db::EstateAdmission::of(&estate.root),
+            Err((status, body)) => return Err(Box::new((status, Json(body)).into_response())),
+        };
         Ok((
             atlas_db::Admissibility {
+                estate,
                 source,
                 kind,
                 // A2 §2's stage 2. `None` narrows nothing, and no selector
@@ -8123,6 +8198,9 @@ mod tests {
                     context_fields: crate::runtime::atlas::tabular::ContextFields::none(),
                 },
                 None,
+                &crate::domain::source::EstateBinding::Estate(
+                    data_dir.to_string_lossy().into_owned(),
+                ),
             )
             .expect("scan and record");
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1856,9 +1856,15 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
             // side effect (ADR 0009's no-spawn posture, the same one
             // `sgt map` takes).
             let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
+            // S6 D1: A2 §2 stage 1's estate coordinate rides with every
+            // query. `search` was already estate-scoped at this end — it
+            // refuses outside an estate root, like every non-host-scoped verb
+            // — but the daemon never learned *which* estate was asking, and
+            // Atlas is host-scoped. This is that missing half.
             let path = format!(
-                "/v1/search?q={}{}",
+                "/v1/search?q={}{}{}",
                 crate::api::urlencode(&query),
+                estate_query_param(&estate),
                 selectors.query_string()
             );
             let result = client.get(&path).await?;
@@ -1875,8 +1881,9 @@ async fn dispatch(sgt: Sgt) -> Result<(), CliError> {
         } => {
             let client = observe_connect(&host_root, estate_root_opt(&estate)).await?;
             let path = format!(
-                "/v1/related?coordinate={}{}",
+                "/v1/related?coordinate={}{}{}",
                 crate::api::urlencode(&coordinate),
+                estate_query_param(&estate),
                 selectors.query_string()
             );
             let result = client.get(&path).await?;
@@ -2266,6 +2273,23 @@ fn estate_root(estate: &Option<EstateRoot>) -> PathBuf {
 /// the matched command turned out to be in.
 fn estate_root_opt(estate: &Option<EstateRoot>) -> Option<&Path> {
     estate.as_ref().map(|e| e.path.as_path())
+}
+
+/// `&estate_root=<canonical root>` for a GET whose query string already
+/// started — A2 §2 stage 1's estate coordinate on `sgt search`/`sgt related`.
+///
+/// Empty when no root was admitted, which is not a fallback to "every
+/// estate": the daemon refuses a search that addressed no estate, because
+/// Atlas is host-scoped and an unaddressed query has no world to be about
+/// (S6 D1).
+fn estate_query_param(estate: &Option<EstateRoot>) -> String {
+    match estate_root_opt(estate) {
+        Some(root) => format!(
+            "&estate_root={}",
+            crate::api::urlencode(&root.to_string_lossy())
+        ),
+        None => String::new(),
+    }
 }
 
 /// The most an `--intent-file` may hold (#166).

--- a/src/domain/source.rs
+++ b/src/domain/source.rs
@@ -151,6 +151,119 @@ impl std::fmt::Display for AuthorityClass {
     }
 }
 
+// ---------------------------------------------------------------------
+// S6 D1 — A2 §2 stage 1's **estate** axis.
+// ---------------------------------------------------------------------
+
+/// The estate coordinate a generation was indexed **for** — A2 §2 stage 1's
+/// *"source / **estate** / Work generation filter"*, recorded at scan time
+/// so a query can filter on it.
+///
+/// # Why this exists
+///
+/// Atlas is host-scoped: one daemon, one `atlas.duckdb`, every estate ever
+/// addressed on this host writing into it ([`crate::api`]'s `data_dir`).
+/// Until S6 D1 nothing recorded *which* estate a generation came from, so
+/// `sgt search` from estate A returned estate B's indexed code as hit #1
+/// (measured 2026-08-30, `knowledge/evidence/resources/host-atlas-series/
+/// estate-isolation-absent-2026-08-30.md`). `README.md`: *"An estate is the
+/// exact directory containing `sergeant.toml`. It can hold one repository
+/// or hundreds without combining histories."* Estates do not combine, and
+/// two estates on one host are not one world.
+///
+/// The shared store is deliberate and stays (one Atlas database, no
+/// `ATTACH` — A1 §5); what was missing is the **query-time** filter, and
+/// this is the fact that filter needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EstateBinding {
+    /// Indexed for exactly one estate, named by its **canonical exact
+    /// root** — the same string every estate-scoped route resolves through
+    /// `admit_addressed_estate`, so the recorded value and the queried
+    /// value are produced by one resolver rather than two spellings.
+    Estate(String),
+    /// Host-scoped **by design**, and readable from every estate on this
+    /// host: an `external_git` source acquired through
+    /// `POST /v1/intelligence/sources`, which reads no `estate_root` at all
+    /// (A1 §9, and that handler's own doc). This variant is the one and
+    /// only way a generation is admissible outside the estate that scanned
+    /// it, and it is never chosen for `estate_git` or `local_knowledge`
+    /// bytes — those are the estate's own.
+    Host,
+}
+
+/// The `estate_scope` column value for a host-scoped generation.
+pub const ESTATE_SCOPE_HOST: &str = "host";
+
+/// The `estate_scope` column value for an estate-bound generation.
+pub const ESTATE_SCOPE_ESTATE: &str = "estate";
+
+impl EstateBinding {
+    /// The `(estate_scope, estate_root)` pair this binding stores.
+    pub fn columns(&self) -> (&'static str, Option<&str>) {
+        match self {
+            Self::Estate(root) => (ESTATE_SCOPE_ESTATE, Some(root.as_str())),
+            Self::Host => (ESTATE_SCOPE_HOST, None),
+        }
+    }
+}
+
+/// A2 §2 stage 1's estate axis **on the query side** — the one
+/// default-**DENY** field of
+/// [`Admissibility`](crate::runtime::atlas::db::Admissibility).
+///
+/// # Read this before assuming it behaves like the other axes
+///
+/// `Admissibility::kind` and `Admissibility::authority` both document
+/// *"`None` admits every kind — narrows only what a caller explicitly asked
+/// to narrow"*. **This axis is the opposite, deliberately.** An estate axis
+/// that defaulted to "admit everything" would leave the S6 D1 leak exactly
+/// where it was found: every existing consumer omitted the estate, so a
+/// default-allow axis would have changed nothing. So:
+///
+/// * [`Self::NoEstate`] — the `Default` — admits **nothing at all**. Not
+///   "every estate": a caller that could not name an estate root gets an
+///   empty world, because "I do not know whose evidence this is" is not a
+///   licence to read all of it.
+/// * [`Self::Estate`] admits that one estate's generations plus the
+///   generations recorded [`EstateBinding::Host`] — and nothing else.
+///
+/// There is no "every estate" variant, and adding one would be a
+/// confidentiality regression, not a feature: reading another estate's
+/// world is done by *addressing that estate*, which is an explicit act with
+/// its own admission check.
+///
+/// A generation with **no** binding row at all — one indexed by a build
+/// older than S6 D1 — is inadmissible from everywhere. That is fail-closed
+/// on purpose and is repaired by `sgt intelligence scan`, which records the
+/// binding; admitting an unattributable generation is precisely the defect.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum EstateAdmission {
+    /// Admits nothing. The `Default`, so a construction site that forgets
+    /// this axis fails closed rather than leaking.
+    #[default]
+    NoEstate,
+    /// Admits exactly this canonical estate root's generations, plus
+    /// [`EstateBinding::Host`] ones.
+    Estate(String),
+}
+
+impl EstateAdmission {
+    /// The estate root this admission binds into the SQL predicate, or
+    /// `None` for [`Self::NoEstate`] — which the predicate's own `? IS NOT
+    /// NULL` turns into "admit nothing", host-scoped rows included.
+    pub fn bind(&self) -> Option<&str> {
+        match self {
+            Self::NoEstate => None,
+            Self::Estate(root) => Some(root.as_str()),
+        }
+    }
+
+    /// The admission an addressed estate root earns.
+    pub fn of(root: &std::path::Path) -> Self {
+        Self::Estate(root.to_string_lossy().into_owned())
+    }
+}
+
 /// One exact observed world for one source (§3).
 ///
 /// `id` is opaque and unique per observation; `content_key` is what makes two

--- a/src/domain/source.rs
+++ b/src/domain/source.rs
@@ -161,8 +161,8 @@ impl std::fmt::Display for AuthorityClass {
 ///
 /// # Why this exists
 ///
-/// Atlas is host-scoped: one daemon, one `atlas.duckdb`, every estate ever
-/// addressed on this host writing into it ([`crate::api`]'s `data_dir`).
+/// Atlas is host-scoped: one daemon, one Atlas database file, every estate
+/// ever addressed on this host writing into it ([`crate::api`]'s `data_dir`).
 /// Until S6 D1 nothing recorded *which* estate a generation came from, so
 /// `sgt search` from estate A returned estate B's indexed code as hit #1
 /// (measured 2026-08-30, `knowledge/evidence/resources/host-atlas-series/

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -130,9 +130,21 @@ use crate::domain::event::{Event, unix_millis};
 use crate::domain::execution::{
     KIND_EXECUTION_RECONCILED, KIND_EXECUTION_STARTED, KIND_EXECUTION_STOPPED,
 };
+/// A2 §2 stage 1's estate axis, re-exported beside [`Admissibility`] — every
+/// caller that builds a filter has to name it, and naming it beside the
+/// struct it is a field of is what keeps that from being a scavenger hunt.
+pub use crate::domain::source::EstateAdmission;
 use crate::domain::source::{
-    AuthorityClass, Coverage, CoverageRow, SourceGeneration, SourceKind, UnitKind,
+    AuthorityClass, Coverage, CoverageRow, EstateBinding, SourceGeneration, SourceKind, UnitKind,
 };
+
+/// S6 D1: the single estate this file's own unit tests record and query
+/// under. The **cross-estate** case — the one this axis exists for — is an
+/// end-to-end suite (`tests/d1_estate_isolation.rs`), not a unit test here,
+/// because the leak was in what the daemon passed to this filter, not in
+/// this filter's arithmetic.
+#[cfg(test)]
+const TEST_ESTATE: &str = "/estates/db-unit";
 use crate::domain::work::{KIND_WORK_SUBMITTED, WorkState};
 use crate::domain::workflow::{
     KIND_STAGE_BLOCKED, KIND_STAGE_CANCELED, KIND_STAGE_COMPLETED, KIND_STAGE_ENTERED,
@@ -568,6 +580,11 @@ SET lock_configuration = true;\n";
 ///   promise — and keeps the reported-never-silent eviction discipline
 ///   identical to every other table's.
 const TABLE_DDL: &str = "\
+CREATE TABLE IF NOT EXISTS source.generation_estates (\n\
+  generation_id TEXT NOT NULL,\n\
+  estate_scope  TEXT NOT NULL,\n\
+  estate_root   TEXT\n\
+);\n\
 CREATE TABLE IF NOT EXISTS source.generations (\n\
   generation_id    TEXT NOT NULL,\n\
   source_name      TEXT NOT NULL,\n\
@@ -749,6 +766,39 @@ const STATE_CONFIRMED: &str = "confirmed";
 /// because "this world was observed and is no longer indexed" is evidence.
 const STATE_EVICTED: &str = "evicted";
 
+/// A2 §2 stage 1's **estate** clause, over the `g` alias — the first thing
+/// the admissibility predicate asks, because A2 §2 puts the
+/// *"source / estate / Work generation filter"* first and nothing may rank
+/// before it (A2 §8).
+///
+/// Two binds, both the same estate root:
+///
+/// ```text
+/// (?estate IS NOT NULL) AND EXISTS (binding row for g whose scope is
+///                                   `host`, or whose root = ?estate)
+/// ```
+///
+/// **The `? IS NOT NULL` guard is the default-deny half and is not
+/// redundant.** With no estate named
+/// ([`EstateAdmission::NoEstate`](crate::domain::source::EstateAdmission::NoEstate),
+/// the `Default`), the bind is SQL `NULL` and this clause is false for every
+/// row — host-scoped rows included. Without it, an unnamed estate would
+/// still have admitted every `EstateBinding::Host` generation, which is a
+/// smaller leak but the same class of one.
+///
+/// A generation with **no** row in `source.generation_estates` — anything
+/// indexed by a build older than S6 D1 — fails the `EXISTS` and is
+/// inadmissible everywhere. Fail-closed, repaired by re-scanning; see
+/// [`EstateAdmission`](crate::domain::source::EstateAdmission)'s own doc.
+macro_rules! admissible_estate_clause {
+    () => {
+        "? IS NOT NULL \
+         AND EXISTS (SELECT 1 FROM source.generation_estates ge \
+                     WHERE ge.generation_id = g.generation_id \
+                       AND (ge.estate_scope = 'host' OR ge.estate_root = ?))"
+    };
+}
+
 /// A2 §2's composed stage-1/2/4 admissibility predicate over the `g` alias,
 /// as a **compile-time literal** the three W2 statements below splice in with
 /// `concat!`.
@@ -763,18 +813,21 @@ const STATE_EVICTED: &str = "evicted";
 /// [`AtlasDb::admissibility_binds`], in this order:
 ///
 /// ```text
-/// state, overlay-exclude LIKE, source_name x2, overlay-admit x2,
+/// state, estate x2, overlay-exclude LIKE, source_name x2, overlay-admit x2,
 /// content_key x2, source_kind x2, authority_class x2
 /// ```
 macro_rules! admissible_generations_where {
     () => {
-        "g.state = ? \
-         AND ( (g.source_name NOT LIKE ? \
+        concat!(
+            "g.state = ? AND ",
+            admissible_estate_clause!(),
+            " AND ( (g.source_name NOT LIKE ? \
                 AND (? IS NULL OR g.source_name = ?)) \
                OR (? IS NOT NULL AND g.source_name = ?) ) \
          AND (? IS NULL OR g.content_key = ?) \
          AND (? IS NULL OR g.source_kind = ?) \
          AND (? IS NULL OR g.authority_class = ?)"
+        )
     };
 }
 
@@ -1816,8 +1869,12 @@ impl AtlasDb {
     /// nothing has confirmed would be indistinguishable from a completed one
     /// after the state column was promoted — the atomic batch is what makes
     /// "provisional" mean "all of it, or none of it, awaiting a summary".
-    pub fn stage_scan(&mut self, scan: &SourceScan) -> Result<ScanCommit, AtlasError> {
-        self.stage_scan_impl(scan, None)
+    pub fn stage_scan(
+        &mut self,
+        scan: &SourceScan,
+        estate: &EstateBinding,
+    ) -> Result<ScanCommit, AtlasError> {
+        self.stage_scan_impl(scan, estate, None)
     }
 
     /// [`Self::stage_scan`] for an `external_git` scan, with A1 §9's
@@ -1830,14 +1887,16 @@ impl AtlasDb {
     pub fn stage_external_git_scan(
         &mut self,
         scan: &SourceScan,
+        estate: &EstateBinding,
         provenance: &ExternalGitProvenance,
     ) -> Result<ScanCommit, AtlasError> {
-        self.stage_scan_impl(scan, Some(provenance))
+        self.stage_scan_impl(scan, estate, Some(provenance))
     }
 
     fn stage_scan_impl(
         &mut self,
         scan: &SourceScan,
+        estate: &EstateBinding,
         provenance: Option<&ExternalGitProvenance>,
     ) -> Result<ScanCommit, AtlasError> {
         // Asked before the `content_key` comparison below, because the two
@@ -1864,6 +1923,7 @@ impl AtlasDb {
                 },
                 &scan.observed_at,
             )?;
+            bind_generation_estate(&self.conn, &current.id, estate)?;
             return Ok(ScanCommit::RootUnavailable {
                 generation_id: current.id,
                 content_key: current.content_key,
@@ -1874,6 +1934,18 @@ impl AtlasDb {
             && current.content_key == scan.content_key
             && self.generation_extractors(&current.id)? == scan.extractors
         {
+            // **The two-estates-one-world case.** A generation is reached by
+            // content key, so a second estate that declares a source whose
+            // bytes hash identically gets `Unchanged` and stages nothing —
+            // and would then have no binding row of its own, leaving it
+            // unable to see a world it legitimately indexed. So the binding
+            // is recorded here too, which is why
+            // `source.generation_estates` is many-rows-per-generation rather
+            // than a column on `source.generations`: two estates can have
+            // observed the same world, and each one's claim on it is its
+            // own row. It is not a widening — an estate only ever gets a row
+            // for a generation its own scan actually produced or matched.
+            bind_generation_estate(&self.conn, &current.id, estate)?;
             return Ok(ScanCommit::Unchanged {
                 generation_id: current.id,
                 content_key: current.content_key,
@@ -1919,6 +1991,14 @@ impl AtlasDb {
                 &extractors,
             ],
         )?;
+        // S6 D1 — A2 §2 stage 1's estate coordinate, written inside the SAME
+        // staging transaction as the generation row it describes, for the
+        // reason `git.provenance` is (module doc): a binding written as a
+        // follow-up could be lost while the generation survived, and a
+        // generation with no binding row is inadmissible from every estate.
+        // "Half-recorded" would therefore read as "indexed but invisible",
+        // which is the silent partial this store refuses everywhere else.
+        bind_generation_estate(&tx, &generation_id, estate)?;
         // The symbol *index* is a rollup across the whole generation, so it is
         // accumulated as the files are written and inserted once — not once
         // per file, which would make `occurrences` a per-file count wearing a
@@ -3284,8 +3364,11 @@ impl AtlasDb {
         let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
         let overlay_admit = filter.source.overlay_admit_source_name();
+        let estate = filter.estate.bind();
         vec![
             Duck::Text(STATE_CONFIRMED.to_string()),
+            optional_text(estate),
+            optional_text(estate),
             Duck::Text(overlay_exclude_like()),
             optional_text(source_name),
             optional_text(source_name),
@@ -5367,6 +5450,43 @@ fn parse_rows(stored: &str) -> Vec<Vec<Option<String>>> {
     serde_json::from_str(stored).unwrap_or_default()
 }
 
+/// **S6 D1 — record A2 §2 stage 1's estate coordinate for one generation.**
+///
+/// Idempotent by construction: the row is written only when this exact
+/// `(generation_id, scope, root)` claim is not already there, so a re-scan
+/// that lands on `ScanCommit::Unchanged` does not accumulate duplicates and
+/// a second estate's identical world adds exactly one row.
+///
+/// The absence of a row is meaningful and is *not* repaired here: a
+/// generation staged by a build older than S6 D1 has none, and is
+/// inadmissible from every estate until it is re-scanned. Backfilling one
+/// would mean inventing an estate for evidence whose origin was never
+/// recorded — the invented answer A2 §2's "never approximate" forbids, and
+/// on the confidentiality axis the expensive direction to be wrong in.
+fn bind_generation_estate(
+    conn: &impl Statements,
+    generation_id: &str,
+    estate: &EstateBinding,
+) -> Result<(), AtlasError> {
+    let (scope, root) = estate.columns();
+    conn.prepare_cached(sql!(
+        "INSERT INTO source.generation_estates (generation_id, estate_scope, estate_root) \
+         SELECT ?, ?, ? WHERE NOT EXISTS ( \
+           SELECT 1 FROM source.generation_estates \
+            WHERE generation_id = ? AND estate_scope = ? \
+              AND estate_root IS NOT DISTINCT FROM ?)"
+    ))?
+    .execute(duckdb::params![
+        generation_id,
+        scope,
+        root,
+        generation_id,
+        scope,
+        root
+    ])?;
+    Ok(())
+}
+
 /// Insert one coverage observation.
 fn insert_coverage(
     conn: &impl Statements,
@@ -5884,8 +6004,26 @@ pub struct StoredReference {
 /// retrieve/rank).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Admissibility {
+    /// Stage 1's **estate** half — `--source`/`--source@sha`/`--work` name
+    /// a source, and this names the *estate whose world those are read in*.
+    ///
+    /// **The one default-DENY axis in this struct, and it must stay that
+    /// way.** [`Self::kind`] and [`Self::authority`] below both say "`None`
+    /// admits every value — narrows only what a caller explicitly asked to
+    /// narrow"; this field is the deliberate opposite, because an estate
+    /// axis that defaulted to admit-everything would have left S6 D1's
+    /// measured cross-estate leak untouched (every consumer omitted the
+    /// estate — that omission is the defect). [`EstateAdmission::NoEstate`]
+    /// is the `Default` and admits **nothing**;
+    /// [`EstateAdmission::Estate`] admits one canonical estate root plus
+    /// the generations recorded
+    /// [`EstateBinding::Host`](crate::domain::source::EstateBinding::Host).
+    /// There is no "every estate" value. See
+    /// [`EstateAdmission`](crate::domain::source::EstateAdmission).
+    pub estate: EstateAdmission,
     /// Stage 1: which source(s) may be seen at all — `--source`/
-    /// `--source@sha`/`--work`, or none of those (every source).
+    /// `--source@sha`/`--work`, or none of those (every source *within
+    /// [`Self::estate`]*, never across estates).
     pub source: SourceSelector,
     /// Stage 4: the optional repo/knowledge/external grouping
     /// (`--type repo|knowledge|external`), the same [`SourceKind`] axis
@@ -5904,6 +6042,24 @@ pub struct Admissibility {
     /// asked to narrow; there is no implicit default-deny beyond what
     /// `source`/`kind` already select.
     pub authority: Option<AuthorityClass>,
+}
+
+impl Admissibility {
+    /// Everything one estate may see: [`EstateAdmission::Estate`] on the
+    /// estate axis, and every other axis left at its own admit-everything
+    /// default.
+    ///
+    /// This — not `Admissibility::default()` — is the ordinary starting
+    /// point for a filter. `default()` is deliberately *empty*: its estate
+    /// axis is [`EstateAdmission::NoEstate`], which admits nothing, so a
+    /// construction site that forgets the estate fails closed instead of
+    /// reading every estate on the host.
+    pub fn within_estate(estate_root: impl Into<String>) -> Self {
+        Self {
+            estate: EstateAdmission::Estate(estate_root.into()),
+            ..Self::default()
+        }
+    }
 }
 
 /// A2 §2's stage-1 source/estate/Work-generation selector. Stage 4's
@@ -6388,24 +6544,34 @@ impl Admissible<'_> {
         let (source_name, content_key) = filter.source.bindings();
         let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
+        // A2 §2 stage 1's estate axis. `None` here is `EstateAdmission::NoEstate`
+        // and the predicate's `? IS NOT NULL` makes it admit nothing at all.
+        let estate = filter.estate.bind();
         let overlay_exclude = overlay_exclude_like();
         let overlay_admit = filter.source.overlay_admit_source_name();
         let out = self.reader.rows(
             read_sql!(
                 "SELECT generation_id, source_name, source_kind, authority_class, content_key, \
                         observed_at \
-                 FROM source.generations \
-                 WHERE state = ? \
-                   AND ( (source_name NOT LIKE ? \
-                          AND (? IS NULL OR source_name = ?)) \
-                         OR (? IS NOT NULL AND source_name = ?) ) \
-                   AND (? IS NULL OR content_key = ?) \
-                   AND (? IS NULL OR source_kind = ?) \
-                   AND (? IS NULL OR authority_class = ?) \
-                 ORDER BY source_name, observed_at DESC, generation_id DESC LIMIT ?"
+                 FROM source.generations g \
+                 WHERE g.state = ? \
+                   AND ? IS NOT NULL \
+                   AND EXISTS (SELECT 1 FROM source.generation_estates ge \
+                               WHERE ge.generation_id = g.generation_id \
+                                 AND (ge.estate_scope = 'host' \
+                                      OR ge.estate_root = ?)) \
+                   AND ( (g.source_name NOT LIKE ? \
+                          AND (? IS NULL OR g.source_name = ?)) \
+                         OR (? IS NOT NULL AND g.source_name = ?) ) \
+                   AND (? IS NULL OR g.content_key = ?) \
+                   AND (? IS NULL OR g.source_kind = ?) \
+                   AND (? IS NULL OR g.authority_class = ?) \
+                 ORDER BY g.source_name, g.observed_at DESC, g.generation_id DESC LIMIT ?"
             ),
             duckdb::params![
                 STATE_CONFIRMED,
+                estate,
+                estate,
                 overlay_exclude,
                 source_name,
                 source_name,
@@ -6481,6 +6647,7 @@ impl Admissible<'_> {
         let (source_name, content_key) = filter.source.bindings();
         let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
+        let estate = filter.estate.bind();
         let [doc_a, doc_b, doc_c] = DOCUMENT_EXTRACTOR_IDENTITIES;
         let overlay_exclude = overlay_exclude_like();
         let overlay_admit = filter.source.overlay_admit_source_name();
@@ -6493,6 +6660,11 @@ impl Admissible<'_> {
                  JOIN source.files f ON f.generation_id = u.generation_id \
                                      AND f.relative_path = u.relative_path \
                  WHERE g.state = ? \
+                   AND ? IS NOT NULL \
+                   AND EXISTS (SELECT 1 FROM source.generation_estates ge \
+                               WHERE ge.generation_id = g.generation_id \
+                                 AND (ge.estate_scope = 'host' \
+                                      OR ge.estate_root = ?)) \
                    AND (f.extractor IN (?, ?, ?) OR f.extractor LIKE ?) \
                    AND ( (g.source_name NOT LIKE ? \
                           AND (? IS NULL OR g.source_name = ?)) \
@@ -6504,6 +6676,8 @@ impl Admissible<'_> {
             ),
             duckdb::params![
                 STATE_CONFIRMED,
+                estate,
+                estate,
                 doc_a,
                 doc_b,
                 doc_c,
@@ -6585,6 +6759,9 @@ impl Admissible<'_> {
         let (source_name, content_key) = filter.source.bindings();
         let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
+        // A2 §2 stage 1's estate axis. `None` here is `EstateAdmission::NoEstate`
+        // and the predicate's `? IS NOT NULL` makes it admit nothing at all.
+        let estate = filter.estate.bind();
         let overlay_exclude = overlay_exclude_like();
         let overlay_admit = filter.source.overlay_admit_source_name();
         let out = self.reader.rows(
@@ -6593,6 +6770,11 @@ impl Admissible<'_> {
                         o.ordinal, o.label, o.name, o.byte_start, o.byte_end \
                  FROM source.occurrences o JOIN source.generations g USING (generation_id) \
                  WHERE g.state = ? \
+                   AND ? IS NOT NULL \
+                   AND EXISTS (SELECT 1 FROM source.generation_estates ge \
+                               WHERE ge.generation_id = g.generation_id \
+                                 AND (ge.estate_scope = 'host' \
+                                      OR ge.estate_root = ?)) \
                    AND o.extractor LIKE ? \
                    AND ( (g.source_name NOT LIKE ? \
                           AND (? IS NULL OR g.source_name = ?)) \
@@ -6604,6 +6786,8 @@ impl Admissible<'_> {
             ),
             duckdb::params![
                 STATE_CONFIRMED,
+                estate,
+                estate,
                 CODE_EXTRACTOR_LIKE,
                 overlay_exclude,
                 source_name,
@@ -6661,6 +6845,9 @@ impl Admissible<'_> {
         let (source_name, content_key) = filter.source.bindings();
         let source_kind = filter.kind.map(SourceKind::as_str);
         let authority = filter.authority.map(AuthorityClass::as_str);
+        // A2 §2 stage 1's estate axis. `None` here is `EstateAdmission::NoEstate`
+        // and the predicate's `? IS NOT NULL` makes it admit nothing at all.
+        let estate = filter.estate.bind();
         let overlay_exclude = overlay_exclude_like();
         let overlay_admit = filter.source.overlay_admit_source_name();
         let out = self.reader.rows(
@@ -6669,6 +6856,11 @@ impl Admissible<'_> {
                         d.dataset_key, d.byte_len, d.columns, d.row_count, d.truncated, d.row_units \
                  FROM source.datasets d JOIN source.generations g USING (generation_id) \
                  WHERE g.state = ? \
+                   AND ? IS NOT NULL \
+                   AND EXISTS (SELECT 1 FROM source.generation_estates ge \
+                               WHERE ge.generation_id = g.generation_id \
+                                 AND (ge.estate_scope = 'host' \
+                                      OR ge.estate_root = ?)) \
                    AND ( (g.source_name NOT LIKE ? \
                           AND (? IS NULL OR g.source_name = ?)) \
                          OR (? IS NOT NULL AND g.source_name = ?) ) \
@@ -6679,6 +6871,8 @@ impl Admissible<'_> {
             ),
             duckdb::params![
                 STATE_CONFIRMED,
+                estate,
+                estate,
                 overlay_exclude,
                 source_name,
                 source_name,
@@ -8769,7 +8963,10 @@ mod tests {
             "a read-only open must see the generation the write path confirmed"
         );
 
-        let write = reader.stage_scan(&scan_of("notes", "# Two\n"));
+        let write = reader.stage_scan(
+            &scan_of("notes", "# Two\n"),
+            &EstateBinding::Estate(TEST_ESTATE.to_string()),
+        );
         assert!(
             write.is_err(),
             "a connection opened AccessMode::ReadOnly must refuse a write, proving this is a \
@@ -8839,7 +9036,10 @@ mod tests {
 
     /// Stage and confirm one generation, returning its id.
     fn record(db: &mut AtlasDb, scan: &SourceScan, event: &str) -> String {
-        let ScanCommit::Staged { generation_id } = db.stage_scan(scan).expect("stage") else {
+        let ScanCommit::Staged { generation_id } = db
+            .stage_scan(scan, &EstateBinding::Estate(TEST_ESTATE.to_string()))
+            .expect("stage")
+        else {
             panic!("expected a staged generation");
         };
         db.confirm_scan(&generation_id, event).expect("confirm");
@@ -8873,8 +9073,13 @@ mod tests {
         let mut db = AtlasDb::open(dir.path()).expect("open");
         let scan = external_scan_of("upstream", "# One\n", "tree-oid-1");
         let expected = provenance("commit-sha-1");
-        let ScanCommit::Staged { generation_id } =
-            db.stage_external_git_scan(&scan, &expected).expect("stage")
+        let ScanCommit::Staged { generation_id } = db
+            .stage_external_git_scan(
+                &scan,
+                &EstateBinding::Estate(TEST_ESTATE.to_string()),
+                &expected,
+            )
+            .expect("stage")
         else {
             panic!("expected staged");
         };
@@ -8926,7 +9131,11 @@ mod tests {
         let ScanCommit::Staged {
             generation_id: first_id,
         } = db
-            .stage_external_git_scan(&first, &provenance("commit-1"))
+            .stage_external_git_scan(
+                &first,
+                &EstateBinding::Estate(TEST_ESTATE.to_string()),
+                &provenance("commit-1"),
+            )
             .expect("stage first")
         else {
             panic!("expected staged");
@@ -8937,7 +9146,11 @@ mod tests {
         let ScanCommit::Staged {
             generation_id: second_id,
         } = db
-            .stage_external_git_scan(&second, &provenance("commit-2"))
+            .stage_external_git_scan(
+                &second,
+                &EstateBinding::Estate(TEST_ESTATE.to_string()),
+                &provenance("commit-2"),
+            )
             .expect("stage second")
         else {
             panic!("expected staged");
@@ -9062,7 +9275,12 @@ mod tests {
         }];
         assert!(unreachable.root_unavailable().is_some(), "fixture");
 
-        let commit = atlas.stage_scan(&unreachable).expect("stage");
+        let commit = atlas
+            .stage_scan(
+                &unreachable,
+                &EstateBinding::Estate(TEST_ESTATE.to_string()),
+            )
+            .expect("stage");
         assert!(
             matches!(&commit, ScanCommit::RootUnavailable { generation_id, .. } if *generation_id == good),
             "{commit:?}"
@@ -9104,7 +9322,9 @@ mod tests {
         emptied.content_key = crate::domain::source::generation_key(&BTreeMap::new());
         emptied.coverage.clear();
         assert!(matches!(
-            atlas.stage_scan(&emptied).expect("stage"),
+            atlas
+                .stage_scan(&emptied, &EstateBinding::Estate(TEST_ESTATE.to_string()))
+                .expect("stage"),
             ScanCommit::Staged { .. }
         ));
     }
@@ -9118,7 +9338,10 @@ mod tests {
         let staged = {
             let mut atlas = AtlasDb::open(dir.path()).expect("atlas");
             let ScanCommit::Staged { generation_id } = atlas
-                .stage_scan(&scan_of("notes", "# Pending\n"))
+                .stage_scan(
+                    &scan_of("notes", "# Pending\n"),
+                    &EstateBinding::Estate(TEST_ESTATE.to_string()),
+                )
                 .expect("stage")
             else {
                 panic!("expected a staged generation");
@@ -9212,7 +9435,7 @@ mod tests {
         let before = db
             .lexical_search(&LexicalQuery {
                 text: "PaymentRetryPolicy",
-                filter: &Admissibility::default(),
+                filter: &Admissibility::within_estate(TEST_ESTATE),
                 family: None,
                 limit: 10,
                 semantic: SemanticRequest::Requested,
@@ -9232,7 +9455,7 @@ mod tests {
         let after = db
             .lexical_search(&LexicalQuery {
                 text: "PaymentRetryPolicy",
-                filter: &Admissibility::default(),
+                filter: &Admissibility::within_estate(TEST_ESTATE),
                 family: None,
                 limit: 10,
                 semantic: SemanticRequest::Requested,

--- a/src/runtime/atlas/db.rs
+++ b/src/runtime/atlas/db.rs
@@ -6550,24 +6550,21 @@ impl Admissible<'_> {
         let overlay_exclude = overlay_exclude_like();
         let overlay_admit = filter.source.overlay_admit_source_name();
         let out = self.reader.rows(
-            read_sql!(
+            read_sql!(concat!(
                 "SELECT generation_id, source_name, source_kind, authority_class, content_key, \
                         observed_at \
                  FROM source.generations g \
                  WHERE g.state = ? \
-                   AND ? IS NOT NULL \
-                   AND EXISTS (SELECT 1 FROM source.generation_estates ge \
-                               WHERE ge.generation_id = g.generation_id \
-                                 AND (ge.estate_scope = 'host' \
-                                      OR ge.estate_root = ?)) \
-                   AND ( (g.source_name NOT LIKE ? \
+                   AND ",
+                admissible_estate_clause!(),
+                " AND ( (g.source_name NOT LIKE ? \
                           AND (? IS NULL OR g.source_name = ?)) \
                          OR (? IS NOT NULL AND g.source_name = ?) ) \
                    AND (? IS NULL OR g.content_key = ?) \
                    AND (? IS NULL OR g.source_kind = ?) \
                    AND (? IS NULL OR g.authority_class = ?) \
                  ORDER BY g.source_name, g.observed_at DESC, g.generation_id DESC LIMIT ?"
-            ),
+            )),
             duckdb::params![
                 STATE_CONFIRMED,
                 estate,
@@ -6652,7 +6649,7 @@ impl Admissible<'_> {
         let overlay_exclude = overlay_exclude_like();
         let overlay_admit = filter.source.overlay_admit_source_name();
         let out = self.reader.rows(
-            read_sql!(
+            read_sql!(concat!(
                 "SELECT g.source_name, u.relative_path, u.local_key, u.ordinal, u.unit_kind, \
                         u.heading_level, u.title, u.byte_start, u.byte_end, u.body \
                  FROM source.units u \
@@ -6660,12 +6657,9 @@ impl Admissible<'_> {
                  JOIN source.files f ON f.generation_id = u.generation_id \
                                      AND f.relative_path = u.relative_path \
                  WHERE g.state = ? \
-                   AND ? IS NOT NULL \
-                   AND EXISTS (SELECT 1 FROM source.generation_estates ge \
-                               WHERE ge.generation_id = g.generation_id \
-                                 AND (ge.estate_scope = 'host' \
-                                      OR ge.estate_root = ?)) \
-                   AND (f.extractor IN (?, ?, ?) OR f.extractor LIKE ?) \
+                   AND ",
+                admissible_estate_clause!(),
+                " AND (f.extractor IN (?, ?, ?) OR f.extractor LIKE ?) \
                    AND ( (g.source_name NOT LIKE ? \
                           AND (? IS NULL OR g.source_name = ?)) \
                          OR (? IS NOT NULL AND g.source_name = ?) ) \
@@ -6673,7 +6667,7 @@ impl Admissible<'_> {
                    AND (? IS NULL OR g.source_kind = ?) \
                    AND (? IS NULL OR g.authority_class = ?) \
                  ORDER BY g.source_name, u.relative_path, u.ordinal LIMIT ?"
-            ),
+            )),
             duckdb::params![
                 STATE_CONFIRMED,
                 estate,
@@ -6765,17 +6759,14 @@ impl Admissible<'_> {
         let overlay_exclude = overlay_exclude_like();
         let overlay_admit = filter.source.overlay_admit_source_name();
         let out = self.reader.rows(
-            read_sql!(
+            read_sql!(concat!(
                 "SELECT g.source_name, o.relative_path, o.syntax_key, o.extractor, o.language, \
                         o.ordinal, o.label, o.name, o.byte_start, o.byte_end \
                  FROM source.occurrences o JOIN source.generations g USING (generation_id) \
                  WHERE g.state = ? \
-                   AND ? IS NOT NULL \
-                   AND EXISTS (SELECT 1 FROM source.generation_estates ge \
-                               WHERE ge.generation_id = g.generation_id \
-                                 AND (ge.estate_scope = 'host' \
-                                      OR ge.estate_root = ?)) \
-                   AND o.extractor LIKE ? \
+                   AND ",
+                admissible_estate_clause!(),
+                " AND o.extractor LIKE ? \
                    AND ( (g.source_name NOT LIKE ? \
                           AND (? IS NULL OR g.source_name = ?)) \
                          OR (? IS NOT NULL AND g.source_name = ?) ) \
@@ -6783,7 +6774,7 @@ impl Admissible<'_> {
                    AND (? IS NULL OR g.source_kind = ?) \
                    AND (? IS NULL OR g.authority_class = ?) \
                  ORDER BY g.source_name, o.relative_path, o.ordinal LIMIT ?"
-            ),
+            )),
             duckdb::params![
                 STATE_CONFIRMED,
                 estate,
@@ -6851,24 +6842,21 @@ impl Admissible<'_> {
         let overlay_exclude = overlay_exclude_like();
         let overlay_admit = filter.source.overlay_admit_source_name();
         let out = self.reader.rows(
-            read_sql!(
+            read_sql!(concat!(
                     "SELECT g.source_name, d.relative_path, d.format, d.content_hash, d.reader, \
                         d.dataset_key, d.byte_len, d.columns, d.row_count, d.truncated, d.row_units \
                  FROM source.datasets d JOIN source.generations g USING (generation_id) \
                  WHERE g.state = ? \
-                   AND ? IS NOT NULL \
-                   AND EXISTS (SELECT 1 FROM source.generation_estates ge \
-                               WHERE ge.generation_id = g.generation_id \
-                                 AND (ge.estate_scope = 'host' \
-                                      OR ge.estate_root = ?)) \
-                   AND ( (g.source_name NOT LIKE ? \
+                   AND ",
+                admissible_estate_clause!(),
+                " AND ( (g.source_name NOT LIKE ? \
                           AND (? IS NULL OR g.source_name = ?)) \
                          OR (? IS NOT NULL AND g.source_name = ?) ) \
                    AND (? IS NULL OR g.content_key = ?) \
                    AND (? IS NULL OR g.source_kind = ?) \
                    AND (? IS NULL OR g.authority_class = ?) \
                  ORDER BY g.source_name, d.relative_path LIMIT ?"
-            ),
+            )),
             duckdb::params![
                 STATE_CONFIRMED,
                 estate,

--- a/src/runtime/atlas/record.rs
+++ b/src/runtime/atlas/record.rs
@@ -21,6 +21,7 @@
 use std::collections::BTreeMap;
 
 use crate::domain::event::{EventDraft, EventSource};
+use crate::domain::source::EstateBinding;
 use crate::domain::source::KIND_SOURCE_SCANNED;
 use crate::runtime::atlas::db::{AtlasDb, AtlasError, ScanCommit};
 use crate::runtime::atlas::deny::BadPattern;
@@ -132,8 +133,15 @@ pub fn scan_and_record(
     journal: &mut Journal,
     source: &KnowledgeSource,
     workspace_id: Option<&str>,
+    estate: &EstateBinding,
 ) -> Result<ScanRecord, ScanRecordError> {
-    record_scan(db, journal, &scan_local_knowledge(source)?, workspace_id)
+    record_scan(
+        db,
+        journal,
+        &scan_local_knowledge(source)?,
+        workspace_id,
+        estate,
+    )
 }
 
 /// [`scan_and_record`] for one estate-git source: the same three steps, over a
@@ -155,9 +163,10 @@ pub fn scan_and_record_estate_git(
     journal: &mut Journal,
     source: &EstateGitSource,
     workspace_id: Option<&str>,
+    estate: &EstateBinding,
 ) -> Result<(ScanRecord, Option<EstateDriftObservation>), ScanRecordError> {
     let scanned = scan_estate_git(source)?;
-    let record = record_scan(db, journal, &scanned.scan, workspace_id)?;
+    let record = record_scan(db, journal, &scanned.scan, workspace_id, estate)?;
     Ok((record, scanned.drift))
 }
 
@@ -206,11 +215,19 @@ pub fn record_external_git_scan(
     acquired: &crate::runtime::atlas::external_git::ExternalGitScan,
     workspace_id: Option<&str>,
 ) -> Result<ScanRecord, ScanRecordError> {
+    // **`EstateBinding::Host`, and only here.** An external Git source is
+    // acquired through `POST /v1/intelligence/sources`, which reads no
+    // `estate_root` at all (A1 §9, and S6 D1's brief names that as
+    // deliberate, not the defect). It is the one source kind whose bytes are
+    // host-scoped by design, so it is the one kind whose generations are
+    // admissible from every estate on this host. Every other kind's estate
+    // is named by its caller.
     record_scan_impl(
         db,
         journal,
         &acquired.scan,
         workspace_id,
+        &EstateBinding::Host,
         Some(&acquired.provenance),
     )
 }
@@ -225,9 +242,10 @@ pub fn scan_and_record_overlay(
     journal: &mut Journal,
     overlay: &WorkOverlay,
     workspace_id: Option<&str>,
+    estate: &EstateBinding,
 ) -> Result<ScanRecord, ScanRecordError> {
     let scanned = scan_work_overlay(overlay)?;
-    record_scan(db, journal, &scanned.scan, workspace_id)
+    record_scan(db, journal, &scanned.scan, workspace_id, estate)
 }
 
 /// **F1's crash-window coupling itself**, over an already-completed scan of
@@ -238,8 +256,9 @@ pub fn record_scan(
     journal: &mut Journal,
     scan: &SourceScan,
     workspace_id: Option<&str>,
+    estate: &EstateBinding,
 ) -> Result<ScanRecord, ScanRecordError> {
-    record_scan_impl(db, journal, scan, workspace_id, None)
+    record_scan_impl(db, journal, scan, workspace_id, estate, None)
 }
 
 /// [`record_scan`]'s actual body, widened to carry
@@ -252,11 +271,12 @@ fn record_scan_impl(
     journal: &mut Journal,
     scan: &SourceScan,
     workspace_id: Option<&str>,
+    estate: &EstateBinding,
     provenance: Option<&crate::runtime::atlas::external_git::ExternalGitProvenance>,
 ) -> Result<ScanRecord, ScanRecordError> {
     let staged = match provenance {
-        Some(provenance) => db.stage_external_git_scan(scan, provenance)?,
-        None => db.stage_scan(scan)?,
+        Some(provenance) => db.stage_external_git_scan(scan, estate, provenance)?,
+        None => db.stage_scan(scan, estate)?,
     };
     let staged = match staged {
         ScanCommit::Unchanged {

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -182,7 +182,7 @@ use crate::backend::BindingSummary;
 use crate::domain::source::{AuthorityClass, SourceGeneration};
 use crate::domain::workflow::{StageDefinition, StageRecord};
 use crate::runtime::atlas::db::{
-    Admissibility, AtlasDb, AtlasError, DatasetFact, LexicalQuery, SourceSelector,
+    Admissibility, AtlasDb, AtlasError, DatasetFact, EstateAdmission, LexicalQuery, SourceSelector,
     StoredChildResource, StoredDataset, StoredEdge, StoredUnit,
 };
 use crate::runtime::atlas::overlay::overlay_source_name;
@@ -2537,8 +2537,28 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
     // the research plan. A world with no confirmed generation is §18's
     // "unavailable" rung, answered before a single step runs.
     let repository = request.bindings.first().map(|b| b.repository.clone());
+    // **§4's first compiler input, made load-bearing (S6 D1).** *"estate
+    // coordinate"* heads §4's list and §3 resolves *"Work/estate/source
+    // generations"* in that order, but until S6 D1 nothing downstream could
+    // act on it: `Admissibility` had no estate axis, so a compilation in one
+    // estate could bind another estate's evidence into a snapshot — the same
+    // absent filter `sgt search` leaked through. The coordinate the snapshot
+    // already renders (`SnapshotCoordinate::estate_root`, above) is now the
+    // one the admissibility filter binds, so what a snapshot *says* it was
+    // compiled in and what it was *allowed to read* are the same fact rather
+    // than two.
+    //
+    // A request that carries no estate root compiles a snapshot that reads
+    // nothing (`EstateAdmission::NoEstate` admits nothing) and lands on §18's
+    // `NoConfirmedGeneration` rung — reported degradation, not a silent
+    // widening to every estate on the host.
+    let estate = match request.estate_root {
+        Some(root) => EstateAdmission::of(root),
+        None => EstateAdmission::NoEstate,
+    };
     let filter = match &repository {
         Some(repository) => Admissibility {
+            estate: estate.clone(),
             source: SourceSelector::WorkBase {
                 work_id: request.work_id.to_string(),
                 repository: repository.clone(),
@@ -2546,7 +2566,10 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
             kind: None,
             authority: None,
         },
-        None => Admissibility::default(),
+        None => Admissibility {
+            estate: estate.clone(),
+            ..Admissibility::default()
+        },
     };
     let admitted = match atlas.admissible_generations(&filter, STEP_ROW_CAP) {
         Ok(admitted) => admitted,
@@ -2591,7 +2614,14 @@ pub fn compile(atlas: Option<&AtlasDb>, request: &CompileRequest<'_>) -> Context
     // the first one did.
     if repository.is_some() {
         for authority in [AuthorityClass::EstateReadonly, AuthorityClass::External] {
+            // The knowledge/external passes are the ones that most needed
+            // the estate axis: `SourceSelector::Any` deliberately spans every
+            // source name, so before S6 D1 they spanned every *estate*'s
+            // knowledge sources too. The authority narrowing was never a
+            // containment boundary — it says what class of bytes may be read,
+            // not whose.
             let pass = Admissibility {
+                estate: estate.clone(),
                 source: SourceSelector::Any,
                 kind: None,
                 authority: Some(authority),

--- a/tests/c1a_compiled_context.rs
+++ b/tests/c1a_compiled_context.rs
@@ -35,7 +35,7 @@
 /// filter that does nothing (that is exactly how the leak survived: this
 /// file's ancestors all passed).
 #[allow(dead_code)]
-const D1_ESTATE: &str = "/estates/c1a_compiled_context";
+const D1_ESTATE: &str = "/estates/demo";
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};

--- a/tests/c1a_compiled_context.rs
+++ b/tests/c1a_compiled_context.rs
@@ -26,6 +26,17 @@
 //! everything above them runs the compiler over a real Atlas built by the
 //! ordinary `record_scan` path. Neither substitutes for the other.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/c1a_compiled_context";
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -123,7 +134,14 @@ fn fixture() -> Fixture {
             ),
         ],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
 
     let overlay = scan(
         &overlay_source_name(WORK_ID, REPOSITORY),
@@ -131,7 +149,14 @@ fn fixture() -> Fixture {
         AuthorityClass::EstateMutable,
         vec![file("notes/plan.md", vec![unit(0, "Plan", CONTESTED_BODY)])],
     );
-    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &overlay,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record overlay");
 
     Fixture { _data: data, db }
 }

--- a/tests/c1b_tiers_and_budget.rs
+++ b/tests/c1b_tiers_and_budget.rs
@@ -31,7 +31,7 @@
 /// filter that does nothing (that is exactly how the leak survived: this
 /// file's ancestors all passed).
 #[allow(dead_code)]
-const D1_ESTATE: &str = "/estates/c1b_tiers_and_budget";
+const D1_ESTATE: &str = "/estates/demo";
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};

--- a/tests/c1b_tiers_and_budget.rs
+++ b/tests/c1b_tiers_and_budget.rs
@@ -22,6 +22,17 @@
 //! §5 step 2 — so every "it did not fit" assertion below is about evidence
 //! that really was selected, not about evidence that happened to be missing.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/c1b_tiers_and_budget";
+
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -112,7 +123,14 @@ fn fixture() -> Fixture {
             file(TWIN_PATH, vec![unit(0, "Twin", TWIN_BASE)]),
         ],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
 
     let overlay = scan(
         &overlay_source_name(WORK_ID, REPOSITORY),
@@ -124,7 +142,14 @@ fn fixture() -> Fixture {
             file(TWIN_PATH, vec![unit(0, "Twin", TWIN_OVERLAY)]),
         ],
     );
-    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &overlay,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record overlay");
 
     Fixture { _data: data, db }
 }
@@ -582,6 +607,7 @@ fn a_coordinate_resolves_by_direct_lookup_not_by_rediscovery() {
     // The search surface, over the same admissible world, does not reach the
     // twin at all — and resolution did not need it to.
     let filter = sergeant_rs::runtime::atlas::db::Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: WORK_ID.to_string(),
             repository: REPOSITORY.to_string(),
@@ -742,14 +768,28 @@ fn external_and_estate_bodies_render_differently_only_because_of_authority_class
         AuthorityClass::EstateReadonly,
         vec![file("estate.md", vec![unit(0, "Estate", SHARED_BODY)])],
     );
-    record_scan(&mut db, &mut journal, &estate, None).expect("record estate source");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &estate,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record estate source");
     let external = scan(
         "vendor-docs",
         SourceKind::ExternalGit,
         AuthorityClass::External,
         vec![file("vendor.md", vec![unit(0, "Vendor", SHARED_BODY)])],
     );
-    record_scan(&mut db, &mut journal, &external, None).expect("record external source");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &external,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record external source");
 
     // No binding, so the admissibility filter is the whole admitted world —
     // which is the only shape in which external evidence reaches this
@@ -868,7 +908,14 @@ fn a_bound_relationship_unit_renders_its_resolved_detail_into_the_prompt() {
             vec![unit(0, "Architecture", "The daemon owns the journal.")],
         )],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
 
     let mut child = file(
         "mail/inbox.mbox/attachments/report.pdf",
@@ -885,7 +932,14 @@ fn a_bound_relationship_unit_renders_its_resolved_detail_into_the_prompt() {
         AuthorityClass::EstateMutable,
         vec![child],
     );
-    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &overlay,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record overlay");
 
     let snapshot = compiled(&db, RenderBudget::DEFAULT);
 
@@ -952,7 +1006,14 @@ fn resolve_relationship_discriminates_sibling_edges_by_ordinal() {
         AuthorityClass::EstateMutable,
         vec![code],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
     let generation_id = db
         .confirmed_generation(REPOSITORY)
         .expect("read")

--- a/tests/c1c_authority_and_provenance.rs
+++ b/tests/c1c_authority_and_provenance.rs
@@ -29,6 +29,17 @@
 //! prompt aesthetics"*). The **native/extractor** half of item 8 is fully
 //! delivered and is what the tests above check.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/c1c_authority_and_provenance";
+
 use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
@@ -193,7 +204,14 @@ fn injection_world(body: &str) -> (TempDir, AtlasDb) {
             )],
         )],
     );
-    record_scan(&mut db, &mut journal, &estate, None).expect("record estate source");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &estate,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record estate source");
 
     let external = scan(
         "vendor-docs",
@@ -201,7 +219,14 @@ fn injection_world(body: &str) -> (TempDir, AtlasDb) {
         AuthorityClass::External,
         vec![file("AGENTS.md", vec![unit(0, "Retention", body)])],
     );
-    record_scan(&mut db, &mut journal, &external, None).expect("record external source");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &external,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record external source");
     (data, db)
 }
 
@@ -480,7 +505,14 @@ fn a_document_excerpt_carries_extractor_native_coordinate_and_heading() {
             vec![unit(0, "Architecture", "The daemon owns the journal.")],
         )],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
     let overlay = scan(
         &overlay_source_name(WORK_ID, REPOSITORY),
         SourceKind::EstateGit,
@@ -493,7 +525,14 @@ fn a_document_excerpt_carries_extractor_native_coordinate_and_heading() {
             ),
         ],
     );
-    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &overlay,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record overlay");
 
     let snapshot = compiled(&db, &bindings(), &prior_stages());
     let docx = unit_at(&snapshot, "decks/current-state.docx");
@@ -617,7 +656,14 @@ fn dataset_world(rows: usize) -> (TempDir, TempDir, AtlasDb) {
         ignore: Vec::new(),
         context_fields: ContextFields::declared(&["ticket".to_string()]),
     };
-    scan_and_record(&mut db, &mut journal, &source, None).expect("scan and record");
+    scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("scan and record");
     (data, knowledge, db)
 }
 
@@ -805,6 +851,7 @@ fn a_bound_query_result_and_a_retrieved_row_join_on_the_dataset_key() {
         .lexical_search(&LexicalQuery {
             text: "INC0000007",
             filter: &sergeant_rs::runtime::atlas::db::Admissibility {
+                estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
                 source: SourceSelector::Named("library".to_string()),
                 kind: None,
                 authority: None,
@@ -860,7 +907,14 @@ fn knowledge_evidence_is_selected_without_widening_the_works_mutation_scope() {
                 vec![unit(0, "Architecture", "The daemon owns the journal.")],
             )],
         );
-        record_scan(&mut db, &mut journal, &base, None).expect("record base");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &base,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record base");
         let overlay = scan(
             &overlay_source_name(WORK_ID, REPOSITORY),
             SourceKind::EstateGit,
@@ -870,7 +924,14 @@ fn knowledge_evidence_is_selected_without_widening_the_works_mutation_scope() {
                 vec![unit(0, "Plan", "The retention policy this Work changes.")],
             )],
         );
-        record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &overlay,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record overlay");
         if with_knowledge {
             std::fs::write(
                 knowledge.path().join("cases.csv"),
@@ -883,7 +944,14 @@ fn knowledge_evidence_is_selected_without_widening_the_works_mutation_scope() {
                 ignore: Vec::new(),
                 context_fields: ContextFields::declared(&["case".to_string()]),
             };
-            scan_and_record(&mut db, &mut journal, &source, None).expect("scan knowledge");
+            scan_and_record(
+                &mut db,
+                &mut journal,
+                &source,
+                None,
+                &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+            )
+            .expect("scan knowledge");
         }
         (data, knowledge, db)
     }
@@ -990,7 +1058,14 @@ fn a_second_repository_mount_is_never_admitted_however_relevant_it_is() {
             vec![unit(0, "Architecture", "The daemon owns the journal.")],
         )],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
     // The bait: a different mount, saturated with the intent's own words.
     let other = scan(
         "other-repo",
@@ -1005,7 +1080,14 @@ fn a_second_repository_mount_is_never_admitted_however_relevant_it_is() {
             )],
         )],
     );
-    record_scan(&mut db, &mut journal, &other, None).expect("record the other mount");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &other,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record the other mount");
     std::fs::write(
         knowledge.path().join("cases.csv"),
         "case,outcome\nC-1,retained\n",
@@ -1021,6 +1103,7 @@ fn a_second_repository_mount_is_never_admitted_however_relevant_it_is() {
             context_fields: ContextFields::declared(&["case".to_string()]),
         },
         None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
     )
     .expect("scan knowledge");
 

--- a/tests/c1c_authority_and_provenance.rs
+++ b/tests/c1c_authority_and_provenance.rs
@@ -38,7 +38,7 @@
 /// filter that does nothing (that is exactly how the leak survived: this
 /// file's ancestors all passed).
 #[allow(dead_code)]
-const D1_ESTATE: &str = "/estates/c1c_authority_and_provenance";
+const D1_ESTATE: &str = "/estates/demo";
 
 use std::path::{Path, PathBuf};
 

--- a/tests/c1d_attribution_nesting_audit.rs
+++ b/tests/c1d_attribution_nesting_audit.rs
@@ -41,6 +41,17 @@
 //! `context.contradiction_observed` (§9's detection does not exist, and
 //! scoring disagreement is the synthesized consensus §9 forbids).
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/c1d_attribution_nesting_audit";
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -165,7 +176,14 @@ fn evidence_world() -> (TempDir, AtlasDb) {
             vec![unit(0, "Architecture", "The daemon owns the journal.")],
         )],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
 
     let deck = ScannedFile {
         relative_path: "decks/retention.pptx".to_string(),
@@ -199,7 +217,14 @@ fn evidence_world() -> (TempDir, AtlasDb) {
             ),
         ],
     );
-    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &overlay,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record overlay");
     (data, db)
 }
 
@@ -882,7 +907,14 @@ fn seed_atlas(data_dir: &Path) {
             )],
         )],
     );
-    record_scan(&mut db, &mut journal, &knowledge, None).expect("record knowledge source");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &knowledge,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record knowledge source");
 }
 
 async fn start(

--- a/tests/c1d_attribution_nesting_audit.rs
+++ b/tests/c1d_attribution_nesting_audit.rs
@@ -50,7 +50,7 @@
 /// filter that does nothing (that is exactly how the leak survived: this
 /// file's ancestors all passed).
 #[allow(dead_code)]
-const D1_ESTATE: &str = "/estates/c1d_attribution_nesting_audit";
+const D1_ESTATE: &str = "/estates/demo";
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -891,7 +891,7 @@ const FAKE: &str = sergeant_rs::backend::fake::FAKE_BACKEND_NAME;
 /// Opened and dropped before `daemon::start_with`: one Atlas file is one
 /// DuckDB instance, and the daemon's own handle must be the only one open on
 /// it (`AtlasDb::open`'s contract).
-fn seed_atlas(data_dir: &Path) {
+fn seed_atlas(data_dir: &Path, estate_root: &Path) {
     let mut journal = Journal::open(data_dir).expect("journal");
     let mut db = AtlasDb::open(data_dir).expect("atlas");
     let knowledge = scan(
@@ -912,7 +912,13 @@ fn seed_atlas(data_dir: &Path) {
         &mut journal,
         &knowledge,
         None,
-        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        // S6 D1: this world is compiled by a real daemon addressed at a real
+        // estate root, so the generation is bound to that root — not to a
+        // stand-in constant, which the estate axis would (correctly) refuse
+        // to admit from anywhere.
+        &sergeant_rs::domain::source::EstateBinding::Estate(
+            estate_root.to_string_lossy().into_owned(),
+        ),
     )
     .expect("record knowledge source");
 }
@@ -1040,7 +1046,7 @@ async fn each_nested_leaf_actor_gets_its_own_snapshot_and_the_container_gets_non
     write_stage(&investigate, "00-lead", "lead the investigation");
     write_stage(&investigate, "10-code", "read the code");
 
-    seed_atlas(data.path());
+    seed_atlas(data.path(), &estate);
 
     let (registry, fake) = one_fake([
         sergeant_rs::backend::fake::FakeStep::complete_with("oriented"),
@@ -1217,7 +1223,7 @@ async fn a_child_work_inherits_no_parent_prompt_and_gets_its_own_binding() {
     write_package(&child_package, "childflow", &["00-only"]);
     write_stage(&child_package, "00-only", "the child's own procedure");
 
-    seed_atlas(data.path());
+    seed_atlas(data.path(), &estate);
 
     let (registry, fake) = one_fake([
         sergeant_rs::backend::fake::FakeStep::complete_with("parent done"),

--- a/tests/d1_estate_isolation.rs
+++ b/tests/d1_estate_isolation.rs
@@ -1,0 +1,544 @@
+//! **S6 D1 — the estate axis: A2 §2 stage 1, end to end across two estates.**
+//!
+//! # The seam this file exists to close
+//!
+//! Thirty-five test files invoke `sgt` through `CARGO_BIN_EXE_sgt`, and
+//! `tests/w5_h1_acceptance.rs` already drives *two* estates against one host
+//! daemon. What no file did was cross two estates **on the intelligence
+//! path**: `tests/w5_search_surface.rs` is single-estate by construction (its
+//! own `fn estate() -> Estate`), and its header concedes *"The live-estate
+//! acceptance is not in this file."* Multi-estate coverage and intelligence
+//! coverage both existed and had never intersected. That intersection is the
+//! entire content of this file, and its absence is why a search from one
+//! estate returned another estate's private code as hit #1 with a green
+//! suite behind it (measured 2026-08-30,
+//! `knowledge/evidence/resources/host-atlas-series/
+//! estate-isolation-absent-2026-08-30.md`).
+//!
+//! # Why every assertion here has two halves
+//!
+//! *"A search from A returns no unit from B"* is **vacuous on its own**: it
+//! passes when search returns nothing at all, so a change that broke
+//! retrieval outright would show green and the guard would report the
+//! confidentiality boundary as intact. Every isolation assertion below
+//! therefore also asserts that the *same* query still returns A's own
+//! matching units. One query, both halves, or it is not a test.
+//!
+//! # No clock decides anything here
+//!
+//! There is no deadline, no elapsed-time assertion and no ratio. `sgt
+//! intelligence scan` answers when the scan is recorded, so the test waits on
+//! that answer rather than on a duration. The one `sleep` is a polling
+//! *cadence* while waiting for the daemon to publish its descriptor — it sets
+//! how often to look, never whether the result is correct, and a daemon that
+//! never starts hangs the test, which is the runner's problem to bound.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+use sergeant_rs::domain::source::{AuthorityClass, EstateAdmission, EstateBinding, SourceKind};
+use sergeant_rs::runtime::atlas::db::{Admissibility, AtlasDb, SourceSelector};
+use sergeant_rs::runtime::atlas::record::record_scan;
+use sergeant_rs::runtime::journal::Journal;
+
+mod support;
+use support::DataDir;
+
+const SGT: &str = env!("CARGO_BIN_EXE_sgt");
+
+/// A term present in **both** estates' fixtures, so one query has something
+/// to find on each side. This is what makes the positive half of every
+/// assertion below real: a query that only ever matched one estate could not
+/// tell "isolated" from "broken".
+const SHARED_TERM: &str = "zzq7marker";
+
+/// Estate A's own token, present nowhere else.
+const ALPHA_TOKEN: &str = "SECRETTOKEN_ALPHA_ZZQ7";
+
+/// Estate B's own token — the string the original measurement retrieved from
+/// A, and the one no answer to A may ever contain again.
+const BETA_TOKEN: &str = "SECRETTOKEN_BETA_ZZQ7";
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// Run `sgt` addressed at one exact estate root against one host data dir.
+fn sgt(data_dir: &Path, estate_root: &Path, args: &[&str]) -> Output {
+    Command::new(SGT)
+        .arg("-C")
+        .arg(estate_root)
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args(args)
+        .output()
+        .expect("run sgt")
+}
+
+/// `sgt --json …`, parsed. Panics with both streams on a non-zero exit, so a
+/// refusal shows its own message rather than a JSON parse error.
+fn sgt_json(data_dir: &Path, estate_root: &Path, args: &[&str]) -> Value {
+    let mut argv = vec!["--json"];
+    argv.extend_from_slice(args);
+    let out = sgt(data_dir, estate_root, &argv);
+    assert!(
+        out.status.success(),
+        "sgt {args:?} failed: {}{}",
+        stdout(&out),
+        stderr(&out)
+    );
+    serde_json::from_str(&stdout(&out)).expect("sgt --json emits json")
+}
+
+/// The `source` name of every hit in a `sgt search`/`sgt related` answer.
+fn hit_sources(answer: &Value) -> Vec<String> {
+    answer["hits"]
+        .as_array()
+        .expect("hits array")
+        .iter()
+        .map(|h| h["source"].as_str().expect("hit source").to_string())
+        .collect()
+}
+
+/// Two estates on one host daemon, each with one repository mount carrying
+/// [`SHARED_TERM`] plus its own private token, both scanned.
+struct TwoEstates {
+    data_dir: DataDir,
+    alpha: tempfile::TempDir,
+    beta: tempfile::TempDir,
+}
+
+impl TwoEstates {
+    fn alpha(&self) -> &Path {
+        self.alpha.path()
+    }
+    fn beta(&self) -> &Path {
+        self.beta.path()
+    }
+}
+
+fn fixture_source(token: &str) -> String {
+    format!("pub fn {SHARED_TERM}_fn() {{ let _ = \"{token}\"; }}\n")
+}
+
+/// Build both estates, spawn one daemon on one data dir, scan both.
+///
+/// One `--data-dir` is the whole point: it is what makes one host daemon and
+/// one host-scoped Atlas store, which is the configuration the leak was
+/// measured in. Nothing here is contrived — it is what two `sgt` estates on
+/// one developer machine do by default.
+fn two_estates() -> TwoEstates {
+    let data_dir = DataDir::new();
+    let alpha = tempfile::TempDir::new().expect("alpha tempdir");
+    let beta = tempfile::TempDir::new().expect("beta tempdir");
+    support::scaffold_estate(alpha.path(), "d1-alpha", &["src-alpha"]);
+    support::scaffold_estate(beta.path(), "d1-beta", &["src-beta"]);
+
+    for (root, repo, token) in [
+        (alpha.path(), "src-alpha", ALPHA_TOKEN),
+        (beta.path(), "src-beta", BETA_TOKEN),
+    ] {
+        let mount = root.join("repos").join(repo);
+        std::fs::write(mount.join("lib.rs"), fixture_source(token)).expect("write fixture");
+        support::git(&mount, &["add", "."]);
+        support::git(&mount, &["commit", "-m", "fixture"]);
+    }
+
+    spawn_daemon(data_dir.path());
+
+    for root in [alpha.path(), beta.path()] {
+        let out = sgt(data_dir.path(), root, &["intelligence", "scan"]);
+        assert!(
+            out.status.success(),
+            "scan of {} failed: {}{}",
+            root.display(),
+            stdout(&out),
+            stderr(&out)
+        );
+        assert!(
+            stdout(&out).contains("recorded"),
+            "scan of {} recorded nothing: {}",
+            root.display(),
+            stdout(&out)
+        );
+    }
+
+    TwoEstates {
+        data_dir,
+        alpha,
+        beta,
+    }
+}
+
+/// Start one host daemon on `data_dir` and wait until it has published its
+/// descriptor.
+///
+/// The wait is on **recorded state** — the descriptor file the daemon writes
+/// when it is serving — not on a duration. The 25 ms sleep is polling cadence
+/// and nothing else: no branch below reads a clock, and a daemon that never
+/// publishes hangs this test rather than failing it on a timer, which is the
+/// honest outcome (the runner bounds hangs; a deadline assertion would turn a
+/// slow host into a false failure).
+#[allow(clippy::zombie_processes)]
+fn spawn_daemon(data_dir: &Path) {
+    let child = Command::new(SGT)
+        .arg("--data-dir")
+        .arg(data_dir)
+        .arg("daemon")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn sgt daemon");
+    std::thread::spawn(move || {
+        let mut child = child;
+        let _ = child.wait();
+    });
+    while sergeant_rs::daemon::read_descriptor(data_dir)
+        .expect("read descriptor")
+        .is_none()
+    {
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+}
+
+// =====================================================================
+// 1. `sgt search` — the measured leak.
+// =====================================================================
+
+/// **The guard, both halves, one query.**
+///
+/// From estate A, a search for a term both estates contain must return A's
+/// own units *and* none of B's. Dropping either half makes the test
+/// worthless: without the negative there is no boundary, and without the
+/// positive an empty answer would pass.
+///
+/// This is the exact configuration of the 2026-08-30 measurement — two
+/// estates, one `--data-dir`, one daemon — and before the estate axis landed
+/// it failed on the negative half with `src-beta/code:lib.rs#0` in the
+/// answer.
+#[test]
+fn a_search_from_one_estate_sees_its_own_units_and_none_of_the_other_estates() {
+    let rig = two_estates();
+
+    let answer = sgt_json(rig.data_dir.path(), rig.alpha(), &["search", SHARED_TERM]);
+    let sources = hit_sources(&answer);
+
+    // (b) the positive half — this query really does retrieve.
+    assert!(
+        sources.iter().any(|s| s == "src-alpha"),
+        "estate A's own matching units disappeared from its own search — the \
+         isolation half below would pass vacuously on this answer: {sources:?}"
+    );
+    // (a) the negative half — and it retrieves nothing of B's.
+    assert!(
+        !sources.iter().any(|s| s == "src-beta"),
+        "estate B's units are admissible from estate A (A2 §2 stage 1): {sources:?}"
+    );
+
+    // The token itself, not just the source name: the rendered answer must
+    // carry no byte of B's private content.
+    let rendered = serde_json::to_string(&answer).expect("render");
+    assert!(
+        !rendered.contains(BETA_TOKEN),
+        "estate B's private token reached estate A's answer: {rendered}"
+    );
+
+    // And the mirror image, so this cannot pass by A simply being empty of
+    // everything: B sees its own and none of A's.
+    let from_beta = sgt_json(rig.data_dir.path(), rig.beta(), &["search", SHARED_TERM]);
+    let beta_sources = hit_sources(&from_beta);
+    assert!(
+        beta_sources.iter().any(|s| s == "src-beta"),
+        "estate B cannot see its own units: {beta_sources:?}"
+    );
+    assert!(
+        !beta_sources.iter().any(|s| s == "src-alpha"),
+        "estate A's units are admissible from estate B: {beta_sources:?}"
+    );
+}
+
+/// A search that names B's private token by hand, from A, returns nothing of
+/// B's — and A's own units still answer a query that names A's token.
+///
+/// The first half is the literal repro command from the measurement; the
+/// second is what stops it being vacuous.
+#[test]
+fn naming_the_other_estates_secret_from_this_one_retrieves_nothing_of_theirs() {
+    let rig = two_estates();
+
+    let leak = sgt_json(rig.data_dir.path(), rig.alpha(), &["search", BETA_TOKEN]);
+    assert!(
+        !hit_sources(&leak).iter().any(|s| s == "src-beta"),
+        "the measured leak is still open: {:?}",
+        hit_sources(&leak)
+    );
+
+    let own = sgt_json(rig.data_dir.path(), rig.alpha(), &["search", ALPHA_TOKEN]);
+    assert!(
+        hit_sources(&own).iter().any(|s| s == "src-alpha"),
+        "estate A cannot retrieve its own token, so the assertion above proves \
+         nothing: {:?}",
+        hit_sources(&own)
+    );
+}
+
+// =====================================================================
+// 2. `sgt related` — the same admissibility path, verified by running it.
+// =====================================================================
+
+/// `related` is not a second implementation of the filter — it takes the same
+/// [`Admissibility`] — but "same code path" is a claim, and this runs it.
+///
+/// Both halves again: A's own anchor still yields A's neighbours (the answer
+/// is not empty), and B's coordinate is not resolvable from A at all —
+/// `related` refuses it as an inadmissible unit rather than answering from
+/// another estate's world.
+#[test]
+fn related_resolves_this_estates_anchor_and_refuses_the_other_estates_coordinate() {
+    let rig = two_estates();
+
+    let own = sgt_json(
+        rig.data_dir.path(),
+        rig.alpha(),
+        &["related", "src-alpha/code:lib.rs#0"],
+    );
+    assert_eq!(
+        own["anchor"]["source"].as_str(),
+        Some("src-alpha"),
+        "estate A cannot anchor on its own unit: {own}"
+    );
+    assert!(
+        !hit_sources(&own).iter().any(|s| s == "src-beta"),
+        "estate B's units are related-reachable from estate A: {:?}",
+        hit_sources(&own)
+    );
+
+    let across = sgt(
+        rig.data_dir.path(),
+        rig.alpha(),
+        &["related", "src-beta/code:lib.rs#0"],
+    );
+    assert!(
+        !across.status.success(),
+        "estate A resolved estate B's coordinate: {}",
+        stdout(&across)
+    );
+    let refusal = format!("{}{}", stdout(&across), stderr(&across));
+    assert!(
+        refusal.contains("no admissible unit"),
+        "the refusal should name inadmissibility, not something else: {refusal}"
+    );
+    assert!(
+        !refusal.contains(BETA_TOKEN),
+        "the refusal leaked the content it refused: {refusal}"
+    );
+
+    // Positive control for that refusal: the identical command from B — the
+    // estate that owns the coordinate — succeeds. Without this, "related
+    // refuses" would also be satisfied by `related` being broken.
+    let from_owner = sgt_json(
+        rig.data_dir.path(),
+        rig.beta(),
+        &["related", "src-beta/code:lib.rs#0"],
+    );
+    assert_eq!(
+        from_owner["anchor"]["source"].as_str(),
+        Some("src-beta"),
+        "estate B cannot anchor on its own unit either, so the refusal above is \
+         not evidence of isolation: {from_owner}"
+    );
+}
+
+// =====================================================================
+// 3. C1's compiled-context selection (C1 §4: "estate coordinate").
+// =====================================================================
+
+/// Record one generation for `estate`, in `db`.
+fn record_for(db: &mut AtlasDb, journal: &mut Journal, source: &str, estate: &str, token: &str) {
+    let scan = support::scan(
+        source,
+        SourceKind::LocalKnowledge,
+        AuthorityClass::EstateReadonly,
+        vec![support::file(
+            "notes.md",
+            vec![support::unit(0, "Notes", &format!("{SHARED_TERM} {token}"))],
+        )],
+    );
+    record_scan(
+        db,
+        journal,
+        &scan,
+        None,
+        &EstateBinding::Estate(estate.to_string()),
+    )
+    .expect("record");
+}
+
+/// **C1 §4 names `estate coordinate` as the compiler's first input.** A
+/// snapshot compiled in one estate must not bind another estate's evidence.
+///
+/// Driven at the admissibility layer the compiler actually calls, over one
+/// store holding both estates' generations — the compiler's own two
+/// `SourceSelector::Any` authority passes (knowledge and external) are the
+/// widest reach it has, and this is exactly the filter they now carry.
+///
+/// Both halves: the pass admits estate A's knowledge generation, and admits
+/// no generation of B's.
+#[test]
+fn a_compilations_admissibility_pass_binds_only_the_addressed_estates_evidence() {
+    let data_dir = DataDir::new();
+    let mut journal = Journal::open(data_dir.path()).expect("journal");
+    let mut db = AtlasDb::open(data_dir.path()).expect("atlas");
+
+    record_for(
+        &mut db,
+        &mut journal,
+        "alpha-notes",
+        "/estates/alpha",
+        ALPHA_TOKEN,
+    );
+    record_for(
+        &mut db,
+        &mut journal,
+        "beta-notes",
+        "/estates/beta",
+        BETA_TOKEN,
+    );
+
+    // Exactly the filter `runtime::context::compile` builds for its
+    // knowledge pass, with the estate coordinate the request carried.
+    let pass = Admissibility {
+        estate: EstateAdmission::Estate("/estates/alpha".to_string()),
+        source: SourceSelector::Any,
+        kind: None,
+        authority: Some(AuthorityClass::EstateReadonly),
+    };
+    let admitted = db.admissible_generations(&pass, 32).expect("admissible");
+    let names: Vec<&str> = admitted
+        .hits
+        .iter()
+        .map(|g| g.source_name.as_str())
+        .collect();
+
+    assert!(
+        names.contains(&"alpha-notes"),
+        "the compiler cannot see its own estate's knowledge source: {names:?}"
+    );
+    assert!(
+        !names.contains(&"beta-notes"),
+        "a compilation in estate alpha can bind estate beta's evidence: {names:?}"
+    );
+
+    // The unit body, not just the generation: nothing of B's text is
+    // reachable through the same filter.
+    let units = db.admissible_units(&pass, 32).expect("units");
+    let bodies: String = units.hits.iter().map(|u| u.unit.body.clone()).collect();
+    assert!(
+        bodies.contains(ALPHA_TOKEN),
+        "the positive half is empty, so the negative half below is vacuous: {bodies:?}"
+    );
+    assert!(
+        !bodies.contains(BETA_TOKEN),
+        "estate beta's knowledge text is admissible in an alpha compilation: {bodies:?}"
+    );
+}
+
+// =====================================================================
+// 4. The default is DENY — the property the whole axis rests on.
+// =====================================================================
+
+/// `Admissibility::default()` admits **nothing**, not everything.
+///
+/// This is the one structural difference between the estate axis and its two
+/// neighbours (`kind` and `authority`, whose `None` admits every value), and
+/// it is the difference the fix depends on: an estate axis that defaulted to
+/// admit-everything would have left every existing consumer — all of which
+/// omitted the estate — reading every estate exactly as before. Deleting the
+/// `? IS NOT NULL` guard from the predicate turns this test red.
+#[test]
+fn an_admissibility_that_names_no_estate_admits_nothing() {
+    let data_dir = DataDir::new();
+    let mut journal = Journal::open(data_dir.path()).expect("journal");
+    let mut db = AtlasDb::open(data_dir.path()).expect("atlas");
+    record_for(
+        &mut db,
+        &mut journal,
+        "alpha-notes",
+        "/estates/alpha",
+        ALPHA_TOKEN,
+    );
+
+    let nothing = db
+        .admissible_generations(&Admissibility::default(), 32)
+        .expect("admissible");
+    assert!(
+        nothing.hits.is_empty(),
+        "an unaddressed filter admitted {} generation(s) — the estate axis is \
+         default-allow, which is the defect, not the fix",
+        nothing.hits.len()
+    );
+
+    // Positive control: the same store, addressed, is not empty. Without
+    // this the assertion above would also pass on a store that holds nothing.
+    let admitted = db
+        .admissible_generations(&Admissibility::within_estate("/estates/alpha"), 32)
+        .expect("admissible");
+    assert_eq!(
+        admitted.hits.len(),
+        1,
+        "the store the assertion above ran against was empty, so it proved \
+         nothing"
+    );
+}
+
+/// A search that addresses no estate is **refused**, not answered widely.
+///
+/// The daemon route is estate-scoped now; `?estate_root=` absent is the same
+/// "no estate addressed" refusal every other estate-scoped route gives, and
+/// specifically not an answer over every estate on the host.
+#[test]
+fn a_search_that_addresses_no_estate_is_refused_rather_than_answered_widely() {
+    let rig = two_estates();
+    let descriptor = sergeant_rs::daemon::read_descriptor(rig.data_dir.path())
+        .expect("read descriptor")
+        .expect("a daemon is serving");
+    // Through the crate's own client, deliberately with **no** estate root
+    // named (`ApiClient::new` addresses none until `with_estate_root` says
+    // so) — this is the request shape the CLI can no longer produce and the
+    // daemon must still refuse on its own account.
+    let client =
+        sergeant_rs::api::ApiClient::new(&descriptor.endpoint, &descriptor.token).expect("client");
+    let answer = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+        .block_on(async { client.get(&format!("/v1/search?q={SHARED_TERM}")).await });
+    let body = match answer {
+        Ok(value) => serde_json::to_string(&value).expect("render"),
+        Err(e) => format!("{e}"),
+    };
+    assert!(
+        !body.contains(ALPHA_TOKEN) && !body.contains(BETA_TOKEN),
+        "an unaddressed search answered from the host's estates: {body}"
+    );
+}
+
+/// Guard-rail for this file itself: the fixtures really are distinguishable.
+///
+/// If both estates' bytes were identical, every isolation assertion above
+/// would pass for the wrong reason.
+#[test]
+fn the_two_estates_fixtures_are_actually_different() {
+    assert_ne!(ALPHA_TOKEN, BETA_TOKEN);
+    assert!(fixture_source(ALPHA_TOKEN).contains(SHARED_TERM));
+    assert!(fixture_source(BETA_TOKEN).contains(SHARED_TERM));
+    assert!(!fixture_source(ALPHA_TOKEN).contains(BETA_TOKEN));
+    let _: PathBuf = PathBuf::from("/estates/alpha");
+}

--- a/tests/d1_estate_isolation.rs
+++ b/tests/d1_estate_isolation.rs
@@ -520,14 +520,26 @@ fn a_search_that_addresses_no_estate_is_refused_rather_than_answered_widely() {
         .build()
         .expect("runtime")
         .block_on(async { client.get(&format!("/v1/search?q={SHARED_TERM}")).await });
-    let body = match answer {
-        Ok(value) => serde_json::to_string(&value).expect("render"),
-        Err(e) => format!("{e}"),
-    };
-    assert!(
-        !body.contains(ALPHA_TOKEN) && !body.contains(BETA_TOKEN),
-        "an unaddressed search answered from the host's estates: {body}"
-    );
+    // The actual refusal, not a proxy for it: an unaddressed request must
+    // come back as `admit_addressed_estate`'s own "no estate addressed"
+    // shape (`src/api.rs`) — HTTP 404, error code `no_estate` — never a
+    // 2xx `Value`. Checking only that the two tokens are absent from the
+    // rendered output is not this test: a `no_estate` error's own body
+    // never contains either token, but so does *any* successful search
+    // response, since hits carry path/symbol/coordinate metadata only and
+    // never a unit's raw source text — so that check alone would pass
+    // whether or not the request was actually refused.
+    match answer {
+        Err(sergeant_rs::api::ClientError::Api { status, code, .. }) => {
+            assert_eq!(status, 404, "wrong refusal status");
+            assert_eq!(code, "no_estate", "wrong refusal code");
+        }
+        Ok(value) => panic!(
+            "an unaddressed search was answered instead of refused: {}",
+            serde_json::to_string(&value).expect("render")
+        ),
+        Err(e) => panic!("expected a structured `no_estate` refusal, got: {e}"),
+    }
 }
 
 /// Guard-rail for this file itself: the fixtures really are distinguishable.

--- a/tests/w1_deterministic_filter.rs
+++ b/tests/w1_deterministic_filter.rs
@@ -28,6 +28,17 @@
 //! extraction; this suite proves what the ADMISSIBILITY FILTER does with
 //! it.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w1_deterministic_filter";
+
 use std::collections::BTreeSet;
 
 use tempfile::TempDir;
@@ -204,7 +215,14 @@ fn estate() -> Estate {
             ),
         ],
     );
-    record_scan(&mut db, &mut journal, &repo_a, None).expect("record repo-a");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &repo_a,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record repo-a");
 
     let repo_b = scan(
         "repo-b",
@@ -218,7 +236,14 @@ fn estate() -> Estate {
             Some(syntax("rust", "syntax-rust/v1", "function", "widget_b")),
         )],
     );
-    record_scan(&mut db, &mut journal, &repo_b, None).expect("record repo-b");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &repo_b,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record repo-b");
 
     let notes = scan(
         "notes",
@@ -232,7 +257,14 @@ fn estate() -> Estate {
             None,
         )],
     );
-    record_scan(&mut db, &mut journal, &notes, None).expect("record notes");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &notes,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record notes");
 
     let vendor = scan(
         "vendor-lib",
@@ -251,7 +283,14 @@ fn estate() -> Estate {
             )),
         )],
     );
-    record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &vendor,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record vendor-lib");
 
     Estate {
         _data: data,
@@ -262,6 +301,7 @@ fn estate() -> Estate {
 
 fn named(source_name: &str) -> Admissibility {
     Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named(source_name.to_string()),
         kind: None,
         authority: None,
@@ -326,6 +366,7 @@ fn a_named_source_filter_admits_only_that_sources_generation() {
 fn an_exact_generation_pin_matches_its_own_key_and_returns_nothing_for_a_stale_one() {
     let estate = estate();
     let exact = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Exact {
             source_name: "repo-a".to_string(),
             content_key: REPO_A_KEY.to_string(),
@@ -341,6 +382,7 @@ fn an_exact_generation_pin_matches_its_own_key_and_returns_nothing_for_a_stale_o
     assert_eq!(hit.hits[0].source_name, "repo-a");
 
     let stale = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Exact {
             source_name: "repo-a".to_string(),
             content_key: "repo-a@a-key-nothing-was-ever-confirmed-under".to_string(),
@@ -395,8 +437,14 @@ fn a_superseded_generation_does_not_leak_through_any_admissible_method() {
             Some(syntax("rust", "syntax-rust/v1", "function", "widget_a_v2")),
         )],
     );
-    let recorded = record_scan(&mut estate.db, &mut estate.journal, &repo_a_v2, None)
-        .expect("record repo-a v2");
+    let recorded = record_scan(
+        &mut estate.db,
+        &mut estate.journal,
+        &repo_a_v2,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record repo-a v2");
     let evicted = match recorded {
         ScanRecord::Recorded { evicted, .. } => evicted,
         other => panic!("expected a recorded, superseding scan of repo-a, got {other:?}"),
@@ -457,6 +505,7 @@ fn a_superseded_generation_does_not_leak_through_any_admissible_method() {
     // like the never-confirmed stale key above, but this key WAS once the
     // real confirmed generation's own.
     let stale_exact = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Exact {
             source_name: "repo-a".to_string(),
             content_key: REPO_A_KEY.to_string(),
@@ -486,6 +535,7 @@ fn a_superseded_generation_does_not_leak_through_any_admissible_method() {
 fn a_knowledge_kind_selector_admits_only_local_knowledge_sources() {
     let estate = estate();
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Any,
         kind: Some(SourceKind::LocalKnowledge),
         authority: None,
@@ -518,6 +568,7 @@ fn stage_4_composes_with_a_named_source_and_with_a_work_base_selector() {
     // both halves of the composed filter agree — the generation is
     // admitted.
     let matching = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named("repo-a".to_string()),
         kind: Some(SourceKind::EstateGit),
         authority: None,
@@ -534,6 +585,7 @@ fn stage_4_composes_with_a_named_source_and_with_a_work_base_selector() {
     // proving `kind` genuinely narrows a `Named` selector's own answer
     // rather than being ignored once a source name is given.
     let disagreeing = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named("repo-a".to_string()),
         kind: Some(SourceKind::LocalKnowledge),
         authority: None,
@@ -551,6 +603,7 @@ fn stage_4_composes_with_a_named_source_and_with_a_work_base_selector() {
     // selector this finding named specifically as inexpressible before this
     // fix: `--work <id> --type repo` still reads repo-a's base generation.
     let work_and_kind = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: "01WORKID000000000000000000".to_string(),
             repository: "repo-a".to_string(),
@@ -580,6 +633,7 @@ fn stage_4_composes_with_a_named_source_and_with_a_work_base_selector() {
 fn an_authority_filter_excludes_external_content_when_not_requested() {
     let estate = estate();
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Any,
         kind: None,
         authority: Some(AuthorityClass::EstateMutable),
@@ -600,6 +654,7 @@ fn an_authority_filter_excludes_external_content_when_not_requested() {
 fn an_authority_filter_for_external_admits_only_the_external_source() {
     let estate = estate();
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Any,
         kind: None,
         authority: Some(AuthorityClass::External),
@@ -691,7 +746,7 @@ fn the_authority_axis_earns_no_selector_only_while_it_is_a_function_of_source_ki
     );
 }
 
-/// A bare `Admissibility::default()` — `SourceSelector::Any`, no authority
+/// A bare `Admissibility::within_estate(D1_ESTATE)` — `SourceSelector::Any`, no authority
 /// — is "every confirmed generation this store holds": the un-narrowed
 /// case has to stay complete, or every negative test above would be
 /// meaningless (it would be indistinguishable from a filter that excludes
@@ -701,7 +756,7 @@ fn an_unfiltered_admissibility_admits_every_confirmed_source() {
     let estate = estate();
     let generations = estate
         .db
-        .admissible_generations(&Admissibility::default(), 500)
+        .admissible_generations(&Admissibility::within_estate(D1_ESTATE), 500)
         .expect("admissible generations");
     let mut names: Vec<&str> = generations
         .hits
@@ -916,6 +971,7 @@ fn document_extractor_identities_matches_every_known_document_adapter_constant()
 fn a_work_base_selector_reads_like_its_named_repository_and_states_base_only_without_an_overlay() {
     let estate = estate();
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: "01WORKID000000000000000000".to_string(),
             repository: "repo-a".to_string(),
@@ -951,6 +1007,7 @@ fn a_non_work_selector_reports_not_work_scoped() {
         SourceSelector::Any,
     ] {
         let filter = Admissibility {
+            estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
             source: selector.clone(),
             kind: None,
             authority: None,
@@ -1009,7 +1066,14 @@ fn a_toml_files_config_content_lives_in_the_code_lane_and_also_leaves_a_document
     let data = tempfile::tempdir().expect("data dir");
     let mut journal = Journal::open(data.path()).expect("journal");
     let mut db = AtlasDb::open(data.path()).expect("atlas");
-    record_scan(&mut db, &mut journal, &scanned, None).expect("record manifest");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &scanned,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record manifest");
 
     let filter = named("manifest");
 
@@ -1072,8 +1136,22 @@ fn a_source_filter_excludes_another_sources_dataset() {
     let data = tempfile::tempdir().expect("data dir");
     let mut journal = Journal::open(data.path()).expect("journal");
     let mut db = AtlasDb::open(data.path()).expect("atlas");
-    record_scan(&mut db, &mut journal, &scan_a, None).expect("record data-a");
-    record_scan(&mut db, &mut journal, &scan_b, None).expect("record data-b");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &scan_a,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record data-a");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &scan_b,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record data-b");
 
     let hits = db
         .admissible_datasets(&named("data-a"), 500)
@@ -1154,7 +1232,14 @@ fn a_work_filter_admits_its_own_overlay_and_no_other_works() {
             Some(syntax("rust", "syntax-rust/v1", "function", "widget_base")),
         )],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
 
     // Two overlay generations over that same base, one per Work, each under
     // its own `work:<id>/<repo>` source coordinate.
@@ -1179,7 +1264,14 @@ fn a_work_filter_admits_its_own_overlay_and_no_other_works() {
                 Some(syntax("rust", "syntax-rust/v1", "function", symbol)),
             )],
         );
-        let recorded = record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+        let recorded = record_scan(
+            &mut db,
+            &mut journal,
+            &overlay,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record overlay");
         assert!(
             matches!(recorded, ScanRecord::Recorded { .. }),
             "the fixture must actually be journaled and confirmed, or the exclusions below \
@@ -1188,6 +1280,7 @@ fn a_work_filter_admits_its_own_overlay_and_no_other_works() {
     }
 
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: MINE.to_string(),
             repository: "repo-a".to_string(),
@@ -1301,7 +1394,14 @@ fn a_work_filter_does_not_admit_its_own_overlay_over_a_different_repository() {
                 Some(syntax("rust", "syntax-rust/v1", "function", "base")),
             )],
         );
-        record_scan(&mut db, &mut journal, &base, None).expect("record base");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &base,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record base");
 
         let overlay = scan(
             &sergeant_rs::runtime::atlas::overlay::overlay_source_name(MINE, repo),
@@ -1320,7 +1420,14 @@ fn a_work_filter_does_not_admit_its_own_overlay_over_a_different_repository() {
                 )),
             )],
         );
-        let recorded = record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+        let recorded = record_scan(
+            &mut db,
+            &mut journal,
+            &overlay,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record overlay");
         assert!(
             matches!(recorded, ScanRecord::Recorded { .. }),
             "the fixture must actually land, or the exclusion below proves nothing: {recorded:?}"
@@ -1331,6 +1438,7 @@ fn a_work_filter_does_not_admit_its_own_overlay_over_a_different_repository() {
     // own repo-a overlay, and must NOT admit repo-b's base or MINE's own
     // repo-b overlay — the repository name is a real filter, not decoration.
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: MINE.to_string(),
             repository: "repo-a".to_string(),
@@ -1401,7 +1509,14 @@ fn work_scope_declares_base_only_when_the_answer_cannot_structurally_carry_overl
             Some(syntax("rust", "syntax-rust/v1", "function", "base")),
         )],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
 
     let overlay = scan(
         &sergeant_rs::runtime::atlas::overlay::overlay_source_name(MINE, "repo-a"),
@@ -1415,7 +1530,14 @@ fn work_scope_declares_base_only_when_the_answer_cannot_structurally_carry_overl
             Some(syntax("rust", "syntax-rust/v1", "function", "overlaid")),
         )],
     );
-    let recorded = record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    let recorded = record_scan(
+        &mut db,
+        &mut journal,
+        &overlay,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record overlay");
     assert!(matches!(recorded, ScanRecord::Recorded { .. }));
 
     let work_base = SourceSelector::WorkBase {
@@ -1425,6 +1547,7 @@ fn work_scope_declares_base_only_when_the_answer_cannot_structurally_carry_overl
 
     // The overlay genuinely stands, and an unnarrowed --work answer says so.
     let unnarrowed = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: work_base.clone(),
         kind: None,
         authority: None,
@@ -1453,6 +1576,7 @@ fn work_scope_declares_base_only_when_the_answer_cannot_structurally_carry_overl
     // A kind narrowing to anything but EstateGit excludes every row an
     // overlay could ever have written.
     let knowledge_narrowed = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: work_base.clone(),
         kind: Some(SourceKind::LocalKnowledge),
         authority: None,
@@ -1468,6 +1592,7 @@ fn work_scope_declares_base_only_when_the_answer_cannot_structurally_carry_overl
 
     // An authority narrowing to anything but EstateMutable does the same.
     let authority_narrowed = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: work_base,
         kind: None,
         authority: Some(AuthorityClass::External),

--- a/tests/w1b_overlay_lifecycle_trigger.rs
+++ b/tests/w1b_overlay_lifecycle_trigger.rs
@@ -27,6 +27,17 @@
 //! duration as the thing under test — only that a state is eventually
 //! reached, generously bounded, on the slowest supported target.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w1b_overlay_lifecycle_trigger";
+
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -321,11 +332,12 @@ async fn a_bound_work_surface_is_scanned_as_an_overlay_and_evicted_when_it_retir
     //    stated on the answer — never a stale claim about a surface that no
     //    longer exists.
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: work_id.clone(),
             repository: "product".to_string(),
         },
-        ..Admissibility::default()
+        ..Admissibility::within_estate(D1_ESTATE)
     };
     let admitted = db
         .admissible_generations(&filter, 500)
@@ -449,11 +461,12 @@ fn an_overlay_scan_failure_degrades_to_base_only_and_is_reported() {
          staging an empty one would make --work claim an overlay it never read"
     );
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: work_id.to_string(),
             repository: "product".to_string(),
         },
-        ..Admissibility::default()
+        ..Admissibility::within_estate(D1_ESTATE)
     };
     assert_eq!(
         db.admissible_generations(&filter, 500)

--- a/tests/w1c_one_atlas_database.rs
+++ b/tests/w1c_one_atlas_database.rs
@@ -33,6 +33,17 @@
 //! contract depends on staying absent. [`lock_order_is_atlas_then_analytics`]
 //! pins that structurally rather than leaving it prose-only.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w1c_one_atlas_database";
+
 use std::collections::BTreeSet;
 
 use serde_json::json;
@@ -159,6 +170,7 @@ fn one_statement_joins_ops_work_identity_to_source_generations() {
         &mut journal,
         &scan("repo-a", "repo-a@key-1", "fn base() {}\n"),
         None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
     )
     .expect("record base");
     record_scan(
@@ -170,6 +182,7 @@ fn one_statement_joins_ops_work_identity_to_source_generations() {
             "fn overlaid() {}\n",
         ),
         None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
     )
     .expect("record overlay");
 
@@ -269,6 +282,7 @@ fn deleting_atlas_duckdb_rebuilds_ops_and_loses_source_facts() {
         &mut event_log,
         &scan("repo-a", "repo-a@key-1", "fn base() {}\n"),
         None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
     )
     .expect("record base");
     let sources_before = db.indexed_sources().expect("indexed sources");

--- a/tests/w1d_overlay_freshness.rs
+++ b/tests/w1d_overlay_freshness.rs
@@ -36,16 +36,10 @@
 //! `tests/w1d_overlay_scan_measurement.rs`, which is `#[ignore]`d and never
 //! part of a pass/fail claim.
 
-/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
-/// single-estate: every generation it records is bound to this one root and
-/// every filter it builds is admitted from it. The cross-estate case — two
-/// estates on one host daemon, which is where the axis actually earns its
-/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
-/// here, because a suite that never crosses estates cannot notice an estate
-/// filter that does nothing (that is exactly how the leak survived: this
-/// file's ancestors all passed).
-#[allow(dead_code)]
-const D1_ESTATE: &str = "/estates/w1d_overlay_freshness";
+// S6 D1: this suite's one filter is admitted from its own real estate root
+// (see the `Admissibility::within_estate` call below), because the daemon
+// recorded these generations under that exact root. The cross-estate case is
+// `tests/d1_estate_isolation.rs`.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -384,13 +378,16 @@ async fn a_running_works_modified_file_is_findable_through_work_scope() {
     //    stand at this point, which is exactly the state under test.
     handle.shutdown().await;
     let db = AtlasDb::open(data.path()).expect("atlas");
+    // S6 D1: the estate coordinate is the one the daemon recorded these
+    // generations under — this test's own real estate root, resolved by the
+    // same `admit_addressed_estate` gate the request went through. A
+    // stand-in constant would admit nothing, which is the point of the axis.
     let filter = Admissibility {
-        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: work_id.clone(),
             repository: "product".to_string(),
         },
-        ..Admissibility::within_estate(D1_ESTATE)
+        ..Admissibility::within_estate(estate.path().to_string_lossy().into_owned())
     };
     let admitted = db.admissible_units(&filter, 500).expect("admissible units");
     assert!(

--- a/tests/w1d_overlay_freshness.rs
+++ b/tests/w1d_overlay_freshness.rs
@@ -36,6 +36,17 @@
 //! `tests/w1d_overlay_scan_measurement.rs`, which is `#[ignore]`d and never
 //! part of a pass/fail claim.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w1d_overlay_freshness";
+
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -374,11 +385,12 @@ async fn a_running_works_modified_file_is_findable_through_work_scope() {
     handle.shutdown().await;
     let db = AtlasDb::open(data.path()).expect("atlas");
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: work_id.clone(),
             repository: "product".to_string(),
         },
-        ..Admissibility::default()
+        ..Admissibility::within_estate(D1_ESTATE)
     };
     let admitted = db.admissible_units(&filter, 500).expect("admissible units");
     assert!(

--- a/tests/w2_lexical_retrieval.rs
+++ b/tests/w2_lexical_retrieval.rs
@@ -33,6 +33,17 @@
 //! the whole mail adapter deleted. A family's provenance test has to land the
 //! family the way production lands it.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w2_lexical_retrieval";
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -250,7 +261,14 @@ fn estate() -> Estate {
             "short_description".to_string(),
         ]),
     };
-    scan_and_record(&mut db, &mut journal, &knowledge, None).expect("record knowledge");
+    scan_and_record(
+        &mut db,
+        &mut journal,
+        &knowledge,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record knowledge");
 
     // The mail source is REAL: this repo's own `.eml` fixture, walked
     // through the real supervised worker subprocess the production `.eml`
@@ -284,7 +302,14 @@ fn estate() -> Estate {
         "the mail fixture must have routed through the real mail adapter: {:?}",
         mailbox.extractors
     );
-    record_scan(&mut db, &mut journal, &mailbox, None).expect("record mailbox");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &mailbox,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record mailbox");
 
     let decoy = decoy_body();
     let vendor = hand_built_scan(
@@ -298,7 +323,14 @@ fn estate() -> Estate {
             vec![document_unit(None, &decoy)],
         )],
     );
-    record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &vendor,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record vendor-lib");
 
     Estate {
         _data: data,
@@ -312,6 +344,7 @@ fn estate() -> Estate {
 /// Only the `knowledge` source: the world the six-form tests run in.
 fn only_knowledge() -> Admissibility {
     Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named("knowledge".to_string()),
         kind: None,
         authority: None,
@@ -500,6 +533,7 @@ fn lexical_search_returns_a_document_unit_with_exact_a1_provenance() {
 fn lexical_search_returns_mail_units_with_exact_a1_provenance() {
     let estate = estate();
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named("mailbox".to_string()),
         kind: None,
         authority: None,
@@ -638,7 +672,7 @@ fn lexical_search_returns_a_selected_row_text_unit_with_exact_a1_provenance() {
 #[test]
 fn an_inadmissible_unit_with_a_perfect_lexical_match_is_never_returned() {
     let estate = estate();
-    let unfiltered = Admissibility::default();
+    let unfiltered = Admissibility::within_estate(D1_ESTATE);
     let wide = estate.search("PaymentRetryPolicy", &unfiltered, None);
     assert_eq!(
         wide.hits.first().map(|hit| hit.source_name.as_str()),
@@ -650,12 +684,14 @@ fn an_inadmissible_unit_with_a_perfect_lexical_match_is_never_returned() {
 
     for filter in [
         Admissibility {
+            estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
             source: SourceSelector::Any,
             kind: None,
             authority: Some(AuthorityClass::EstateReadonly),
         },
         only_knowledge(),
         Admissibility {
+            estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
             source: SourceSelector::Any,
             kind: Some(SourceKind::LocalKnowledge),
             authority: None,
@@ -705,7 +741,14 @@ fn another_works_overlay_unit_never_surfaces_through_a_lexical_query() {
             )
         }],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
 
     for (work_id, symbol) in [(MINE, "widget_mine"), (OTHER, "widget_theirs")] {
         let overlay = hand_built_scan(
@@ -722,7 +765,14 @@ fn another_works_overlay_unit_never_surfaces_through_a_lexical_query() {
                 )
             }],
         );
-        let recorded = record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+        let recorded = record_scan(
+            &mut db,
+            &mut journal,
+            &overlay,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record overlay");
         assert!(
             matches!(recorded, ScanRecord::Recorded { .. }),
             "the overlay fixture must be journaled and confirmed: {recorded:?}"
@@ -730,6 +780,7 @@ fn another_works_overlay_unit_never_surfaces_through_a_lexical_query() {
     }
 
     let mine = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: MINE.to_string(),
             repository: "repo-a".to_string(),
@@ -765,6 +816,7 @@ fn another_works_overlay_unit_never_surfaces_through_a_lexical_query() {
     );
 
     let named = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named("repo-a".to_string()),
         kind: None,
         authority: None,
@@ -813,9 +865,10 @@ fn another_works_overlay_unit_never_surfaces_through_a_lexical_query() {
 fn every_generation_a_lexical_hit_cites_is_one_the_admissibility_filter_admits() {
     let estate = estate();
     for filter in [
-        Admissibility::default(),
+        Admissibility::within_estate(D1_ESTATE),
         only_knowledge(),
         Admissibility {
+            estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
             source: SourceSelector::Any,
             kind: None,
             authority: Some(AuthorityClass::EstateReadonly),
@@ -862,7 +915,7 @@ fn a_query_with_no_terms_returns_no_hits_rather_than_the_whole_corpus() {
 #[test]
 fn the_same_query_over_the_same_generations_returns_the_same_ordered_result() {
     let estate = estate();
-    let filter = Admissibility::default();
+    let filter = Admissibility::within_estate(D1_ESTATE);
     let first = estate.search("PaymentRetryPolicy INC0012345 payments", &filter, None);
     for _ in 0..5 {
         let again = estate.search("PaymentRetryPolicy INC0012345 payments", &filter, None);
@@ -906,10 +959,17 @@ fn equal_scores_are_broken_by_the_stated_key_not_by_row_arrival_order() {
                 vec![document_unit(None, "PaymentRetryPolicy")],
             )],
         );
-        record_scan(&mut db, &mut journal, &scan, None).expect("record tie fixture");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &scan,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record tie fixture");
     }
 
-    let filter = Admissibility::default();
+    let filter = Admissibility::within_estate(D1_ESTATE);
     let answer = db
         .lexical_search(&LexicalQuery {
             text: "PaymentRetryPolicy",
@@ -965,8 +1025,14 @@ fn a_superseded_generations_postings_are_evicted_with_it() {
             "short_description".to_string(),
         ]),
     };
-    let recorded = scan_and_record(&mut estate.db, &mut estate.journal, &knowledge, None)
-        .expect("re-record knowledge");
+    let recorded = scan_and_record(
+        &mut estate.db,
+        &mut estate.journal,
+        &knowledge,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("re-record knowledge");
     assert!(
         matches!(recorded, ScanRecord::Recorded { .. }),
         "the re-scan must actually supersede: {recorded:?}"
@@ -1009,7 +1075,7 @@ fn a_superseded_generations_postings_are_evicted_with_it() {
 #[test]
 fn the_lexical_index_rebuilds_from_the_a1_rows_it_derives_from() {
     let mut estate = estate();
-    let filter = Admissibility::default();
+    let filter = Admissibility::within_estate(D1_ESTATE);
     let before = estate.search("PaymentRetryPolicy INC0012345", &filter, None);
     let outcome = estate.db.reindex_lexical().expect("reindex");
     assert!(outcome.indexed > 0, "the rebuild must actually index units");
@@ -1030,7 +1096,11 @@ fn the_lexical_index_rebuilds_from_the_a1_rows_it_derives_from() {
 #[test]
 fn a_bounded_answer_states_whether_the_posting_scan_was_capped() {
     let estate = estate();
-    let answer = estate.search("PaymentRetryPolicy", &Admissibility::default(), None);
+    let answer = estate.search(
+        "PaymentRetryPolicy",
+        &Admissibility::within_estate(D1_ESTATE),
+        None,
+    );
     assert!(
         !answer.truncated,
         "this corpus is far under the cap; a true flag here means the cap logic is wrong"
@@ -1068,12 +1138,19 @@ fn a_bounded_answer_reports_true_when_the_posting_scan_is_actually_capped() {
         "bulk@key-1",
         vec![scanned_file("bulk.md", MARKDOWN_EXTRACTOR, units)],
     );
-    record_scan(&mut db, &mut journal, &bulk, None).expect("record bulk");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &bulk,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record bulk");
 
     let answer = db
         .lexical_search(&LexicalQuery {
             text: "needleterm",
-            filter: &Admissibility::default(),
+            filter: &Admissibility::within_estate(D1_ESTATE),
             family: None,
             limit: MAX_ROWS,
             semantic: SemanticRequest::Requested,

--- a/tests/w3_semantic_degradation.rs
+++ b/tests/w3_semantic_degradation.rs
@@ -31,6 +31,17 @@
 //! unit-tested in `src/runtime/atlas/semantic.rs` against a constructed
 //! model value; it is the *host* that has none.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w3_semantic_degradation";
+
 use std::collections::BTreeSet;
 use std::path::Path;
 
@@ -80,6 +91,7 @@ impl Estate {
 
 fn only_knowledge() -> Admissibility {
     Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named("knowledge".to_string()),
         kind: None,
         authority: None,
@@ -146,7 +158,14 @@ fn estate() -> Estate {
         root: None,
         context_fields: ContextFields::none(),
     };
-    record_scan(&mut db, &mut journal, &scan, None).expect("record knowledge");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &scan,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record knowledge");
     Estate { _data: data, db }
 }
 

--- a/tests/w3b_semantic_retrieval.rs
+++ b/tests/w3b_semantic_retrieval.rs
@@ -58,6 +58,17 @@
 //! `not_installed` case below would race the others, and that is why this
 //! repository's runner is nextest.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w3b_semantic_retrieval";
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -299,7 +310,14 @@ fn estate(with_decoy: bool) -> Estate {
         ignore: Vec::new(),
         context_fields: ContextFields::none(),
     };
-    scan_and_record(&mut db, &mut journal, &knowledge, None).expect("record knowledge");
+    scan_and_record(
+        &mut db,
+        &mut journal,
+        &knowledge,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record knowledge");
 
     if with_decoy {
         let vendor = hand_built_scan(
@@ -314,7 +332,14 @@ fn estate(with_decoy: bool) -> Estate {
                 )],
             )],
         );
-        record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &vendor,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record vendor-lib");
     }
 
     Estate {
@@ -326,6 +351,7 @@ fn estate(with_decoy: bool) -> Estate {
 
 fn only_knowledge() -> Admissibility {
     Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named("knowledge".to_string()),
         kind: None,
         authority: None,
@@ -334,6 +360,7 @@ fn only_knowledge() -> Admissibility {
 
 fn everything() -> Admissibility {
     Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Any,
         kind: None,
         authority: None,
@@ -540,7 +567,14 @@ fn tied_semantic_scores_are_broken_by_the_stated_key_not_by_scan_order() {
         AuthorityClass::EstateReadonly,
         vec![scanned_file("zzz.md", vec![document_unit(tied)]), code],
     );
-    record_scan(&mut db, &mut journal, &scan, None).expect("record");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &scan,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
 
     let filter = only_knowledge();
     let answer = db

--- a/tests/w3b_semantic_scan_measurement.rs
+++ b/tests/w3b_semantic_scan_measurement.rs
@@ -28,6 +28,17 @@
 //! is what the numbers demonstrate, and nothing here says anything about a
 //! corpus two orders of magnitude larger than the largest run below.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w3b_semantic_scan_measurement";
+
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -140,9 +151,17 @@ fn exact_cosine_scan_cost_by_corpus_size() {
         let data = tempfile::tempdir().expect("data dir");
         let mut journal = Journal::open(data.path()).expect("journal");
         let mut db = AtlasDb::open(data.path()).expect("atlas");
-        record_scan(&mut db, &mut journal, &scan(units), None).expect("record");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &scan(units),
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record");
 
         let filter = Admissibility {
+            estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
             source: SourceSelector::Named("knowledge".to_string()),
             kind: None,
             authority: None,

--- a/tests/w4_rrf_fusion.rs
+++ b/tests/w4_rrf_fusion.rs
@@ -42,6 +42,17 @@
 //! content is byte-identical to the base's, must not be marked Work-changed
 //! (F-SF-01).
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w4_rrf_fusion";
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -587,6 +598,7 @@ impl Estate {
 
 fn named(source: &str) -> Admissibility {
     Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named(source.to_string()),
         kind: None,
         authority: None,
@@ -594,7 +606,7 @@ fn named(source: &str) -> Admissibility {
 }
 
 fn everything() -> Admissibility {
-    Admissibility::default()
+    Admissibility::within_estate(D1_ESTATE)
 }
 
 fn labelled(answer: &FusedAnswer) -> Vec<String> {
@@ -656,7 +668,14 @@ fn knowledge_estate(with_decoy: bool) -> Estate {
         ignore: Vec::new(),
         context_fields: ContextFields::none(),
     };
-    scan_and_record(&mut db, &mut journal, &knowledge, None).expect("record knowledge");
+    scan_and_record(
+        &mut db,
+        &mut journal,
+        &knowledge,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record knowledge");
     if with_decoy {
         let vendor = hand_built_scan(
             "vendor-lib",
@@ -670,7 +689,14 @@ fn knowledge_estate(with_decoy: bool) -> Estate {
                 )],
             )],
         );
-        record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &vendor,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record vendor-lib");
     }
     Estate {
         _data: data,
@@ -824,6 +850,7 @@ fn every_one_of_a2_section_8s_nine_signals_actually_fires() {
     observe(&knowledge.fused(
         "asynchronous settlement",
         &Admissibility {
+            estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
             source: SourceSelector::Any,
             kind: Some(SourceKind::LocalKnowledge),
             authority: None,
@@ -845,6 +872,7 @@ fn every_one_of_a2_section_8s_nine_signals_actually_fires() {
     let answer = work.fused(
         "settlement",
         &Admissibility {
+            estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
             source: SourceSelector::WorkBase {
                 work_id: "01WORK".to_string(),
                 repository: "repo-a".to_string(),
@@ -904,7 +932,14 @@ fn code_estate() -> Estate {
             code_file("payments/aaa_retry_test.rs", "retry_charge", &[]),
         ],
     );
-    record_scan(&mut db, &mut journal, &scan, None).expect("record repo-a");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &scan,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record repo-a");
     Estate {
         _data: data,
         _root: None,
@@ -938,7 +973,14 @@ fn overlay_estate(overlay_text: &str, overlay_hash: &str) -> Estate {
             )],
         )],
     );
-    record_scan(&mut db, &mut journal, &base, None).expect("record base");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &base,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record base");
     let overlay = hand_built_scan(
         "work:01WORK/repo-a",
         SourceKind::EstateGit,
@@ -949,7 +991,14 @@ fn overlay_estate(overlay_text: &str, overlay_hash: &str) -> Estate {
             vec![document_unit(overlay_text)],
         )],
     );
-    record_scan(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &overlay,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record overlay");
     Estate {
         _data: data,
         _root: None,
@@ -974,6 +1023,7 @@ fn an_overlay_unit_whose_content_matches_the_base_is_not_marked_work_changed() {
         "hash/docs/ledger.md/base",
     );
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: "01WORK".to_string(),
             repository: "repo-a".to_string(),
@@ -1012,6 +1062,7 @@ fn a_work_changed_unit_is_promoted_over_its_unchanged_base() {
         "hash/docs/ledger.md/edited-by-work",
     );
     let filter = Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::WorkBase {
             work_id: "01WORK".to_string(),
             repository: "repo-a".to_string(),
@@ -1160,6 +1211,7 @@ fn the_three_filter_shaped_signals_are_uniform_because_admissibility_already_app
     let typed = estate.fused(
         "settlement",
         &Admissibility {
+            estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
             source: SourceSelector::Any,
             kind: Some(SourceKind::LocalKnowledge),
             authority: None,

--- a/tests/w4c_service_doctor.rs
+++ b/tests/w4c_service_doctor.rs
@@ -12,6 +12,17 @@
 //! GIT_BIN_ENV`'s sibling, `SGT_SYSTEMCTL_BIN`) to exercise the capability
 //! probe without a real systemd user session.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w4c_service_doctor";
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -752,7 +763,14 @@ fn atlas_doctor_row_names_online_only_and_warns_when_it_is_the_only_gap() {
             ignore: Vec::new(),
             context_fields: Default::default(),
         };
-        scan_and_record(&mut db, &mut journal, &source, None).expect("scan and record");
+        scan_and_record(
+            &mut db,
+            &mut journal,
+            &source,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("scan and record");
     }
 
     let home = tempfile::TempDir::new().expect("fake home");

--- a/tests/w5_search_surface.rs
+++ b/tests/w5_search_surface.rs
@@ -32,6 +32,17 @@
 //! Neither substitutes for the other and this file does not pretend to be
 //! both.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w5_search_surface";
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -245,7 +256,14 @@ fn estate() -> Estate {
     // would report the `.docx` `unsupported` and item 6 would be testing
     // nothing.
     let scan = scan_local_knowledge_with_worker(&library, &worker()).expect("scan library");
-    record_scan(&mut db, &mut journal, &scan, None).expect("record library");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &scan,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record library");
 
     let vendor = hand_built_scan(
         "vendor-lib",
@@ -254,7 +272,14 @@ fn estate() -> Estate {
         "docs/vendor.md",
         "Heading conventions in the vendor's own manual: Heading, Heading, Heading.",
     );
-    record_scan(&mut db, &mut journal, &vendor, None).expect("record vendor-lib");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &vendor,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record vendor-lib");
 
     Estate {
         _data: data,
@@ -264,11 +289,12 @@ fn estate() -> Estate {
 }
 
 fn any() -> Admissibility {
-    Admissibility::default()
+    Admissibility::within_estate(D1_ESTATE)
 }
 
 fn only_library() -> Admissibility {
     Admissibility {
+        estate: sergeant_rs::domain::source::EstateAdmission::Estate(D1_ESTATE.to_string()),
         source: SourceSelector::Named("library".to_string()),
         kind: None,
         authority: None,

--- a/tests/w7_container_children.rs
+++ b/tests/w7_container_children.rs
@@ -26,6 +26,17 @@
 //!
 //! Every test below names the claim it pins. The negative ones are the point.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/w7_container_children";
+
 use std::io::{Cursor, Write as _};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -337,7 +348,14 @@ fn a_csv_inside_a_zip_reaches_the_relational_lane_a_loose_csv_reaches() {
     {
         let mut db = AtlasDb::open(data_dir.path()).expect("open atlas");
         let mut journal = Journal::open(data_dir.path()).expect("open journal");
-        record_scan(&mut db, &mut journal, &scan, None).expect("record");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &scan,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record");
     }
     let db = AtlasDb::open(data_dir.path()).expect("reopen atlas");
     let stored = db
@@ -449,7 +467,14 @@ Content-Transfer-Encoding: base64\r\n\r\n"
     {
         let mut db = AtlasDb::open(data_dir.path()).expect("open atlas");
         let mut journal = Journal::open(data_dir.path()).expect("open journal");
-        record_scan(&mut db, &mut journal, &scan, None).expect("record");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &scan,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record");
     }
     let conn =
         duckdb::Connection::open(atlas_db_path(data_dir.path())).expect("read the recorded store");
@@ -562,7 +587,14 @@ fn a_landed_childs_parent_coordinate_is_persisted_in_its_own_table() {
     {
         let mut db = AtlasDb::open(data_dir.path()).expect("open atlas");
         let mut journal = Journal::open(data_dir.path()).expect("open journal");
-        record_scan(&mut db, &mut journal, &scan, None).expect("record");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &scan,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record");
     }
 
     let conn =
@@ -638,7 +670,14 @@ fn the_parent_coordinate_is_readable_through_the_daemons_own_bounded_reader() {
     {
         let mut db = AtlasDb::open(data_dir.path()).expect("open atlas");
         let mut journal = Journal::open(data_dir.path()).expect("open journal");
-        record_scan(&mut db, &mut journal, &scan, None).expect("record");
+        record_scan(
+            &mut db,
+            &mut journal,
+            &scan,
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record");
     }
 
     let db = AtlasDb::open(data_dir.path()).expect("reopen atlas");

--- a/tests/x2_knowledge_sources.rs
+++ b/tests/x2_knowledge_sources.rs
@@ -23,6 +23,17 @@
 //!   reconciliation promotes rather than evicts. Both-present is a rule in
 //!   both directions — journal-present/database-evicted breaks it too.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/x2_knowledge_sources";
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -274,7 +285,14 @@ fn a_scan_records_once_reuses_an_unchanged_generation_and_evicts_a_changed_one()
     let mut db = AtlasDb::open(data.path()).expect("atlas");
     let mut journal = Journal::open(data.path()).expect("journal");
 
-    let first = scan_and_record(&mut db, &mut journal, &source, None).expect("scan");
+    let first = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("scan");
     let ScanRecord::Recorded {
         generation_id: first_generation,
         evicted,
@@ -308,7 +326,14 @@ fn a_scan_records_once_reuses_an_unchanged_generation_and_evicts_a_changed_one()
 
     // A re-scan of unchanged bytes: no new generation, no new summary, no
     // eviction. Ruling §4 stated as behavior.
-    let again = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let again = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("rescan");
     assert!(
         matches!(&again, ScanRecord::Unchanged { generation_id, .. } if *generation_id == first_generation),
         "an unchanged source must reuse its generation, got {again:?}"
@@ -322,7 +347,14 @@ fn a_scan_records_once_reuses_an_unchanged_generation_and_evicts_a_changed_one()
     // Edit one byte: a new generation, and the old one evicted with a row
     // that says so rather than simply vanishing.
     std::fs::write(notes.path().join("index.md"), "# Index\n\nedited\n").expect("write");
-    let third = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let third = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("rescan");
     let ScanRecord::Recorded {
         generation_id: second_generation,
         evicted,
@@ -380,7 +412,14 @@ fn the_scan_summary_is_one_compact_event_with_provenance_and_no_path_list() {
     ]);
     let mut db = AtlasDb::open(data.path()).expect("atlas");
     let mut journal = Journal::open(data.path()).expect("journal");
-    scan_and_record(&mut db, &mut journal, &source("notes", notes.path()), None).expect("scan");
+    scan_and_record(
+        &mut db,
+        &mut journal,
+        &source("notes", notes.path()),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("scan");
 
     let summaries = scan_summaries(data.path());
     assert_eq!(summaries.len(), 1);
@@ -509,8 +548,14 @@ async fn source_facts_survive_a_real_daemon_restart() {
     let generation = {
         let mut db = AtlasDb::open(data.path()).expect("atlas");
         let mut journal = Journal::open(data.path()).expect("journal");
-        let record = scan_and_record(&mut db, &mut journal, &source("notes", notes.path()), None)
-            .expect("scan");
+        let record = scan_and_record(
+            &mut db,
+            &mut journal,
+            &source("notes", notes.path()),
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("scan");
         let ScanRecord::Recorded { generation_id, .. } = record else {
             panic!("expected a recorded generation");
         };
@@ -603,7 +648,13 @@ async fn a_crash_between_the_rows_and_the_summary_reports_neither() {
         let scan = scan_local_knowledge(&source).expect("scan");
         // Step 1 only. The process "dies" here: no journal append, no
         // confirmation.
-        match db.stage_scan(&scan).expect("stage") {
+        match db
+            .stage_scan(
+                &scan,
+                &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+            )
+            .expect("stage")
+        {
             sergeant_rs::runtime::atlas::db::ScanCommit::Staged { generation_id } => generation_id,
             other => panic!("expected a staged generation, got {other:?}"),
         }
@@ -666,7 +717,14 @@ async fn a_crash_between_the_rows_and_the_summary_reports_neither() {
     // window, it does not poison the source.
     let mut db = AtlasDb::open(data.path()).expect("atlas");
     let mut journal = Journal::open(data.path()).expect("journal");
-    let record = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let record = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("rescan");
     assert!(matches!(record, ScanRecord::Recorded { .. }), "{record:?}");
     assert!(!db.units("notes", 100).expect("units").is_empty());
     data.reap();
@@ -701,7 +759,13 @@ async fn a_crash_after_the_summary_but_before_confirmation_completes_the_scan() 
         let mut journal = Journal::open(data.path()).expect("journal");
         let scan = scan_local_knowledge(&source).expect("scan");
         // Step 1.
-        let staged = match db.stage_scan(&scan).expect("stage") {
+        let staged = match db
+            .stage_scan(
+                &scan,
+                &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+            )
+            .expect("stage")
+        {
             sergeant_rs::runtime::atlas::db::ScanCommit::Staged { generation_id } => generation_id,
             other => panic!("expected a staged generation, got {other:?}"),
         };
@@ -758,7 +822,14 @@ async fn a_crash_after_the_summary_but_before_confirmation_completes_the_scan() 
     // a re-scan of unchanged bytes reuses it rather than churning a new one.
     let mut db = AtlasDb::open(data.path()).expect("atlas");
     let mut journal = Journal::open(data.path()).expect("journal");
-    let again = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let again = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("rescan");
     assert!(
         matches!(&again, ScanRecord::Unchanged { generation_id, .. } if *generation_id == staged),
         "{again:?}"
@@ -789,7 +860,14 @@ fn an_unreachable_root_keeps_the_generation_it_cannot_rescan() {
 
     let mut db = AtlasDb::open(data.path()).expect("atlas");
     let mut journal = Journal::open(data.path()).expect("journal");
-    let first = scan_and_record(&mut db, &mut journal, &source, None).expect("scan");
+    let first = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("scan");
     let ScanRecord::Recorded { generation_id, .. } = first else {
         panic!("expected a recorded generation, got {first:?}");
     };
@@ -799,7 +877,14 @@ fn an_unreachable_root_keeps_the_generation_it_cannot_rescan() {
     // The drive goes away.
     std::fs::remove_dir_all(&root).expect("remove the root");
 
-    let second = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let second = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("rescan");
     let ScanRecord::RootUnavailable {
         generation_id: still,
         detail,
@@ -856,7 +941,14 @@ fn an_unreachable_root_keeps_the_generation_it_cannot_rescan() {
         "# Index\n\nbody\n\n## Deep\n\nmore\n",
     )
     .expect("write");
-    let third = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let third = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("rescan");
     assert!(
         matches!(&third, ScanRecord::Unchanged { generation_id: id, .. } if *id == generation_id),
         "{third:?}"
@@ -865,7 +957,14 @@ fn an_unreachable_root_keeps_the_generation_it_cannot_rescan() {
     // But a root that is genuinely readable and genuinely empty is a real
     // observation, and it does supersede.
     std::fs::remove_file(root.join("index.md")).expect("remove");
-    let fourth = scan_and_record(&mut db, &mut journal, &source, None).expect("rescan");
+    let fourth = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("rescan");
     assert!(
         matches!(&fourth, ScanRecord::Recorded { evicted, .. } if evicted.as_deref() == Some(generation_id.as_str())),
         "an emptied-but-readable root is evidence of emptiness: {fourth:?}"
@@ -898,7 +997,14 @@ fn case_variants_of_the_denied_families_never_reach_a_unit() {
     ]);
     let mut db = AtlasDb::open(data.path()).expect("atlas");
     let mut journal = Journal::open(data.path()).expect("journal");
-    scan_and_record(&mut db, &mut journal, &source("notes", notes.path()), None).expect("scan");
+    scan_and_record(
+        &mut db,
+        &mut journal,
+        &source("notes", notes.path()),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("scan");
 
     let units = db.units("notes", 100).expect("units");
     assert!(

--- a/tests/x3a_git_plumbing.rs
+++ b/tests/x3a_git_plumbing.rs
@@ -17,6 +17,17 @@
 //! * **F6's intelligence lane has a real consumer, and it is not the execution
 //!   lane.**
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/x3a_git_plumbing";
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -237,8 +248,14 @@ fn stored_estate_git_keys_are_blob_oids_and_a_rescan_evicts_nothing() {
     let mut db = AtlasDb::open(data.path()).expect("open atlas");
     let mut journal = journal_at(data.path());
 
-    let (recorded, drift) =
-        scan_and_record_estate_git(&mut db, &mut journal, &src, None).expect("record");
+    let (recorded, drift) = scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &src,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
     assert!(drift.is_none());
     let generation = match &recorded {
         ScanRecord::Recorded {
@@ -279,7 +296,14 @@ fn stored_estate_git_keys_are_blob_oids_and_a_rescan_evicts_nothing() {
     );
 
     // Re-scanning the same commit is the same world: ruling §4 evicts nothing.
-    let (again, _) = scan_and_record_estate_git(&mut db, &mut journal, &src, None).expect("rescan");
+    let (again, _) = scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &src,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("rescan");
     assert!(
         matches!(&again, ScanRecord::Unchanged { generation_id, .. } if *generation_id == generation),
         "an unchanged tree churned a generation: {again:?}"
@@ -295,8 +319,14 @@ fn a_new_commit_with_an_identical_tree_is_the_same_generation() {
     let (_dir, mount, shas) = repo(&[&[("a.md", "# A\n")]]);
     let mut db = AtlasDb::open(data.path()).expect("open atlas");
     let mut journal = journal_at(data.path());
-    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &shas[0]), None)
-        .expect("record");
+    scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &shas[0]),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
 
     // An empty commit: new SHA, new message, byte-identical tree.
     git(
@@ -306,9 +336,14 @@ fn a_new_commit_with_an_identical_tree_is_the_same_generation() {
     .expect("empty commit");
     let second = git(&mount, &["rev-parse", "HEAD"]).expect("head");
     assert_ne!(second, shas[0]);
-    let (record, _) =
-        scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &second), None)
-            .expect("record");
+    let (record, _) = scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &second),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
     assert!(
         matches!(record, ScanRecord::Unchanged { .. }),
         "a commit that changed no source byte evicted a generation: {record:?}"
@@ -343,8 +378,14 @@ fn a_work_overlay_is_scoped_to_its_work_and_evicted_with_it() {
     let mut journal = journal_at(data.path());
     // A plain estate-git generation for the same repository, which must
     // survive the Work's eviction untouched.
-    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &base), None)
-        .expect("record mount");
+    scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &base),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record mount");
 
     let overlay = WorkOverlay {
         work_id: "01WORK".to_string(),
@@ -353,8 +394,14 @@ fn a_work_overlay_is_scoped_to_its_work_and_evicted_with_it() {
         base_sha: base.clone(),
         ignore: Vec::new(),
     };
-    let recorded =
-        scan_and_record_overlay(&mut db, &mut journal, &overlay, None).expect("record overlay");
+    let recorded = scan_and_record_overlay(
+        &mut db,
+        &mut journal,
+        &overlay,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record overlay");
     let overlay_generation = match &recorded {
         ScanRecord::Recorded { generation_id, .. } => generation_id.clone(),
         other => panic!("expected a recorded overlay, got {other:?}"),

--- a/tests/x3b_syntax_wiring.rs
+++ b/tests/x3b_syntax_wiring.rs
@@ -24,6 +24,17 @@
 //! * **F6: it runs on the intelligence lane**, over X3a's batched blobs.
 //! * **F1/ruling §4: the rows live and die with their generation.**
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/x3b_syntax_wiring";
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -111,9 +122,14 @@ fn recorded_polyglot() -> (TempDir, TempDir, PathBuf, AtlasDb, String) {
     let (repo_dir, mount, sha) = repo(POLYGLOT);
     let data = tempfile::tempdir().expect("data");
     let (mut db, mut journal) = store(data.path());
-    let (record, _) =
-        scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None)
-            .expect("record");
+    let (record, _) = scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &sha),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
     let ScanRecord::Recorded { generation_id, .. } = record else {
         panic!("expected a recorded generation, got {record:?}");
     };
@@ -239,7 +255,14 @@ fn one_name_in_two_files_is_one_symbol_and_two_occurrences() {
     ]);
     let data = tempfile::tempdir().expect("data");
     let (mut db, mut journal) = store(data.path());
-    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+    scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &sha),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
 
     let symbols = db.symbols("product", 100).expect("symbols");
     let shared: Vec<_> = symbols.iter().filter(|s| s.name == "shared").collect();
@@ -385,7 +408,14 @@ fn a_language_this_build_does_not_claim_is_unsupported_not_almost_parsed() {
     ]);
     let data = tempfile::tempdir().expect("data");
     let (mut db, mut journal) = store(data.path());
-    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+    scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &sha),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
 
     let coverage = db.coverage("product", 100).expect("coverage");
     let tsx = coverage
@@ -423,7 +453,14 @@ fn a_file_a_grammar_cannot_parse_is_an_error_row_with_no_partial_symbols() {
     ]);
     let data = tempfile::tempdir().expect("data");
     let (mut db, mut journal) = store(data.path());
-    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+    scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &sha),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
 
     let coverage = db.coverage("product", 100).expect("coverage");
     let broken = coverage
@@ -481,7 +518,14 @@ fn the_scan_summary_counts_symbols_and_edges() {
     let (_repo, mount, sha) = repo(POLYGLOT);
     let data = tempfile::tempdir().expect("data");
     let (mut db, mut journal) = store(data.path());
-    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+    scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &sha),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
 
     let summary = journal
         .replay_from_floor()
@@ -555,7 +599,14 @@ async fn extraction_on_the_intelligence_lane_produces_the_same_symbols() {
     // And the rows the lane's scan produces record exactly as the direct one's
     // do — one writer, whichever route the scan took.
     let (mut db, mut journal) = store(data.path());
-    record_scan(&mut db, &mut journal, &on_lane.scan, None).expect("record");
+    record_scan(
+        &mut db,
+        &mut journal,
+        &on_lane.scan,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
     assert!(!db.symbols("product", 500).expect("symbols").is_empty());
 }
 
@@ -568,14 +619,26 @@ fn evicting_a_generation_takes_its_syntax_rows_with_it() {
     let (_repo, mount, sha) = repo(&[("a.rs", "pub fn first() {}\n")]);
     let data = tempfile::tempdir().expect("data");
     let (mut db, mut journal) = store(data.path());
-    scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None).expect("record");
+    scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &sha),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
     assert_eq!(db.symbols("product", 100).expect("symbols").len(), 1);
 
     // A second commit changes the bytes, so ruling §4 evicts the predecessor.
     let next = commit(&mount, &[("a.rs", "pub fn second() {}\n")], "two");
-    let (record, _) =
-        scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &next), None)
-            .expect("record");
+    let (record, _) = scan_and_record_estate_git(
+        &mut db,
+        &mut journal,
+        &source(&mount, &next),
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
     let ScanRecord::Recorded { evicted, .. } = record else {
         panic!("expected a recorded generation, got {record:?}");
     };
@@ -611,8 +674,14 @@ fn syntax_rows_survive_reopening_the_store() {
     let data = tempfile::tempdir().expect("data");
     {
         let (mut db, mut journal) = store(data.path());
-        scan_and_record_estate_git(&mut db, &mut journal, &source(&mount, &sha), None)
-            .expect("record");
+        scan_and_record_estate_git(
+            &mut db,
+            &mut journal,
+            &source(&mount, &sha),
+            None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+        )
+        .expect("record");
     }
     let db = AtlasDb::open(data.path()).expect("reopen");
     let symbols = db.symbols("product", 100).expect("symbols");

--- a/tests/x4_tabular_map.rs
+++ b/tests/x4_tabular_map.rs
@@ -43,6 +43,17 @@
 //! The `sgt map --help` subprocess still pins F11's *named deferral* —
 //! `map neighbors` and `map changed` must not exist yet.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/x4_tabular_map";
+
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
@@ -94,7 +105,14 @@ fn record(source: &KnowledgeSource) -> Recorded {
     let data = tempfile::tempdir().expect("data dir");
     let mut journal = Journal::open(data.path()).expect("journal");
     let mut db = AtlasDb::open(data.path()).expect("atlas");
-    let record = scan_and_record(&mut db, &mut journal, source, None).expect("scan and record");
+    let record = scan_and_record(
+        &mut db,
+        &mut journal,
+        source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("scan and record");
     Recorded {
         _data: data,
         db,
@@ -546,6 +564,7 @@ fn f10a_a_declared_allowlist_exposes_only_its_columns_with_stable_row_identity()
         &mut journal,
         &source("support", dir.path(), &["title"]),
         None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
     )
     .expect("re-scan");
     let after = db.row_units("support", MAX_ROWS).expect("row units");
@@ -610,6 +629,7 @@ fn f10a_narrowing_an_allowlist_retracts_the_units_it_exposed() {
         &mut journal,
         &source("support", dir.path(), &["title"]),
         None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
     )
     .expect("re-scan");
     let ScanRecord::Recorded { evicted, .. } = &record else {
@@ -1116,6 +1136,7 @@ async fn f11_the_map_surface_answers_over_http_and_through_the_verb() {
             &mut journal,
             &source("team notes", root.path(), &[]),
             None,
+            &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
         )
         .expect("scan and record");
     }

--- a/tests/x5_a1a_acceptance.rs
+++ b/tests/x5_a1a_acceptance.rs
@@ -103,6 +103,17 @@
 //! ("no silent pass") applies to the DISPATCH half of a capability just as
 //! much as to the capability's own existence.
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/x5_a1a_acceptance";
+
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -1238,7 +1249,14 @@ fn a1a_item_3_a_knowledge_source_is_indexed_without_becoming_a_repo_or_getting_a
         ignore: Vec::new(),
         context_fields: Default::default(),
     };
-    let record = scan_and_record(&mut db, &mut journal, &source, None).expect("scan");
+    let record = scan_and_record(
+        &mut db,
+        &mut journal,
+        &source,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("scan");
     let generation = match record {
         ScanRecord::Recorded { generation_id, .. } => generation_id,
         other => panic!("a readable source must record a generation, got {other:?}"),

--- a/tests/y8_adapter_dispatch.rs
+++ b/tests/y8_adapter_dispatch.rs
@@ -14,6 +14,17 @@
 //! [`run_worker`]: sergeant_rs::runtime::atlas::worker::run_worker
 //! [`scan_local_knowledge_on_lane`]: sergeant_rs::runtime::atlas::lane::scan_local_knowledge_on_lane
 
+/// **S6 D1 — A2 §2 stage 1's estate coordinate.** This suite is
+/// single-estate: every generation it records is bound to this one root and
+/// every filter it builds is admitted from it. The cross-estate case — two
+/// estates on one host daemon, which is where the axis actually earns its
+/// keep — is `tests/d1_estate_isolation.rs`, deliberately not folded in
+/// here, because a suite that never crosses estates cannot notice an estate
+/// filter that does nothing (that is exactly how the leak survived: this
+/// file's ancestors all passed).
+#[allow(dead_code)]
+const D1_ESTATE: &str = "/estates/y8_adapter_dispatch";
+
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -467,7 +478,14 @@ fn a_real_scan_dispatches_docx_zip_and_eml_through_the_worker_and_the_recorded_g
     let data_dir = TempDir::new().expect("data dir");
     let mut db = AtlasDb::open(data_dir.path()).expect("open atlas");
     let mut journal = Journal::open(data_dir.path()).expect("open journal");
-    let record = record_scan(&mut db, &mut journal, &scan, None).expect("record");
+    let record = record_scan(
+        &mut db,
+        &mut journal,
+        &scan,
+        None,
+        &sergeant_rs::domain::source::EstateBinding::Estate(D1_ESTATE.to_string()),
+    )
+    .expect("record");
     assert!(
         matches!(
             record,


### PR DESCRIPTION
Two estates admitted to one host daemon read each other's indexed code. Measured on this box and reproduced in the lane before any code was written: from estate alpha, searching beta's private token returned `src-beta/code:lib.rs#0 rust function beta_marker_zzq7` as hit #1. `sgt related` leaked both ways.

**Cause.** A2 §2's pipeline names `source / estate / Work generation filter` as the first operation, before ranking. `Admissibility` had three fields — source, kind, authority — and its own doc comment transcribed stage 1 as `--source/--source@sha/--work`. Estate was dropped at the point someone wrote down what stage 1 meant, and every consumer inherited it.

**Scope: all three surfaces** — `sgt search`, `sgt related`, and C1's compiled-context selection (C1 §4 names `estate coordinate` as a compiler input).

**Default-deny, deliberately.** `EstateAdmission` has no "every estate" value at all; `NoEstate` is the `Default` and admits nothing, host-scoped rows included. This is the opposite of the `kind`/`authority` convention beside it — both doc comments say so, because the next reader will assume otherwise. `Admissibility::within_estate(root)` is the ordinary constructor.

**Enforced before ranking (A2 §8).** The estate clause is the first thing all five admissibility predicates ask, so `related` and semantic retrieval inherit it structurally rather than re-implementing it.

**Left alone by contract:** `sgt intelligence status` still spans every admitted estate (H1 §5's host-scoped bucket, "host/cache summary"), and host-scoped storage in `intelligence_add_source` is deliberate — the defect was the absent query-time filter, not the shared store.

## Non-vacuity, proven both directions

A plan-panel refuter confirmed the obvious guard is vacuous: "A returns no unit from B" passes when search returns nothing at all. Both halves are asserted, and both were measured by breaking the fix on purpose.

Clause always-true (pre-fix semantics) — 5 of 8 red, negative halves firing:
```
estate B's units are admissible from estate A (A2 §2 stage 1): ["src-alpha","src-beta","src-alpha","src-beta"]
a compilation in estate alpha can bind estate beta's evidence: ["alpha-notes","beta-notes"]
an unaddressed filter admitted 1 generation(s) — the estate axis is default-allow, which is the defect, not the fix
```

Clause always-false (retrieval broken outright) — the positive halves fire, the half a negative-only guard would miss:
```
estate A's own matching units disappeared from its own search — the isolation half below would pass vacuously on this answer: []
estate A cannot retrieve its own token, so the assertion above proves nothing: []
```

## The seam this lived in

Not "the binary is untested" — 35 test files invoke it via `CARGO_BIN_EXE_sgt`. The gap was exact: **no test crossed two estates on the intelligence path.** `w5_h1_acceptance.rs` is multi-estate but tests Work submission; `w5_search_surface.rs` is single-estate and its own header concedes the live-estate acceptance is not in it. Both kinds of coverage existed and had never intersected. `tests/d1_estate_isolation.rs` closes that seam.

**#231:** the suite is wired into `c3-spawning-suites.sh`. The wave initially claimed nextest auto-discovery satisfied this; that is test execution, not Gate D coverage membership, and `coverage_stage_membership` was red until it was wired properly.

**No clock decides correctness** — no deadline loop, no wall-clock or ratio assertion; the one `sleep(25ms)` is daemon-descriptor polling cadence and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgiAeucyX9WTzmLqVvboE4